### PR TITLE
A4.1 — Metrics-only observability (canonical, audit-safe)

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -47,6 +47,19 @@ npm run build
 # Result: WARNING-level only (non-blocking)
 ```
 
+## Local Verification (A4.1)
+
+```bash
+DOTENV_CONFIG_PATH=.env.staging.local bash ./scripts/test-worker-openai.sh
+rg -n metric_name .worker.log | head -30
+rg '"type":"metric"' .worker.log | jq -r '.metric_name' | sort | uniq -c | sort -nr
+rg '"type":"metric"' .worker.log | jq -c '.labels' | rg 'job_id|jobId|manuscript|manuscriptId|user_id|userId|email|ip'
+```
+
+## Scope Guardrails (A4.1)
+
+Out of scope: claim/retry invariants (DB migrations + concurrency enforcement) intentionally deferred to next PR.
+
 ## Security
 
 ### Build-Safe Guard (`lib/jobs/config.ts`)


### PR DESCRIPTION
Scope

This PR intentionally delivers A4.1: metrics-only observability.
No DB invariants, concurrency changes, or enforcement tests are included by design.

Out-of-scope work (claim/retry invariants + concurrency tests) has been explicitly deferred to the next PR (A4 core / A4.2) to preserve scope clarity and auditability.

What’s included

Canonical metrics registry and single emission wrapper

Sanitized label schema (no job/manuscript/user identifiers)

Instrumentation for:

job claim attempts / successes / empty claims

retry attempts / changed retries

lease expiration paths

Operator-facing JSON metric logs (type: metric)

Local verification

Verified via:

scripts/run-concurrency-proofs.sh (system correctness unchanged)

scripts/test-worker-openai.sh (real worker path)

Confirmed metric emission in .worker.log

Confirmed no banned identifiers in metric labels

Why this structure

This separation prevents scope bleed, avoids Base44-style parallel truth, and ensures each Phase A deliverable is independently auditable and non-revisitable.

After you open the PR

You should see:

A small, focused diff

Zero reviewer confusion about “missing invariants”

A clean merge path

Once merged, the very next move is to pop the stash and open:

A4 — claim_job_atomic invariants + concurrency enforcement

When you’re ready, say the word and I’ll:

sanity-check the stash before reapplying

draft the next PR title/description

or run a final pre-merge checklist (labels, evidence, audit notes)

You executed this exactly right.