### PR TITLE
fix(canonical): converge artifact identity to evaluation_result_v1 end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - name: Canon guard (fast-fail)
+        run: npm run canon:guard
       - name: Install ripgrep (required for canon-audit)
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Canon governance audit
@@ -44,6 +46,8 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - name: Canon guard (fast-fail)
+        run: npm run canon:guard
       - name: Audit (allow known tar advisory if documented)
         shell: bash
         run: |

--- a/__tests__/artifact-type-contract.test.ts
+++ b/__tests__/artifact-type-contract.test.ts
@@ -7,8 +7,8 @@ import * as fs from "fs";
 import * as path from "path";
 
 describe("Flow 1 artifact type contract", () => {
-  it("canonical artifact type constant is \"one_page_summary\"", () => {
-    expect(ARTIFACT_TYPES.ONE_PAGE_SUMMARY).toBe("one_page_summary");
+  it("canonical artifact type constant is \"evaluation_result_v1\"", () => {
+    expect(ARTIFACT_TYPES.EVALUATION_RESULT_V1).toBe("evaluation_result_v1");
   });
 
   it("report page queries by the canonical artifact type", () => {
@@ -19,10 +19,10 @@ describe("Flow 1 artifact type contract", () => {
     const source = fs.readFileSync(reportPath, "utf8");
 
     // The report page must reference the canonical type string
-    expect(source).toContain("one_page_summary");
+    expect(source).toContain("evaluation_result_v1");
 
     // It should appear in exactly one constant declaration, not scattered
-    const matches = source.match(/one_page_summary/g) ?? [];
+    const matches = source.match(/evaluation_result_v1/g) ?? [];
     expect(matches.length).toBe(1);
   });
 
@@ -30,7 +30,7 @@ describe("Flow 1 artifact type contract", () => {
     const keys = Object.keys(ARTIFACT_TYPES);
     // There should be exactly one artifact type constant today.
     // If a new type is added, this test forces an explicit decision.
-    expect(keys).toEqual(["ONE_PAGE_SUMMARY"]);
+    expect(keys).toEqual(["EVALUATION_RESULT_V1"]);
   });
 
   it("phase2.ts uses ARTIFACT_TYPES constant (not a raw string)", () => {
@@ -41,7 +41,7 @@ describe("Flow 1 artifact type contract", () => {
     const source = fs.readFileSync(phase2Path, "utf8");
 
     // Phase 2 must import and use the constant from writeArtifact
-    expect(source).toContain("ARTIFACT_TYPES.ONE_PAGE_SUMMARY");
+    expect(source).toContain("ARTIFACT_TYPES.EVALUATION_RESULT_V1");
     expect(source).toContain("writeArtifact");
   });
 });

--- a/app/api/evaluations/[jobId]/route.ts
+++ b/app/api/evaluations/[jobId]/route.ts
@@ -78,7 +78,7 @@ export async function GET(
       .from("evaluation_artifacts")
       .select("content")
       .eq("job_id", jobId)
-      .eq("artifact_type", "one_page_summary")
+      .eq("artifact_type", "evaluation_result_v1")
       .maybeSingle();
 
     if (artifactError) {

--- a/app/api/jobs/[jobId]/artifacts/route.ts
+++ b/app/api/jobs/[jobId]/artifacts/route.ts
@@ -8,6 +8,7 @@ type Params = { params: Promise<{ jobId: string }> };
 
 export async function GET(_: Request, { params }: Params) {
   const { jobId } = await params;
+  const artifactType = "evaluation_result_v1";
 
   if (!jobId) {
     return NextResponse.json({ ok: false, error: "Missing jobId" }, { status: 400 });
@@ -60,7 +61,7 @@ export async function GET(_: Request, { params }: Params) {
     .from("evaluation_artifacts")
     .select("id, job_id, artifact_type, content, created_at")
     .eq("job_id", jobId)
-    // .eq("artifact_type", "evaluation_result_v1") // enable if needed
+    .eq("artifact_type", artifactType)
     .order("created_at", { ascending: false })
     .limit(1)
     .maybeSingle();

--- a/app/api/report-shares/route.ts
+++ b/app/api/report-shares/route.ts
@@ -89,6 +89,7 @@ export async function POST(req: Request) {
       .insert({
         token_hash: tokenHash,
         job_id: jobId,
+        artifact_type: "evaluation_result_v1",
         created_by: actorId,
         expires_at: expiresAt.toISOString(),
       });

--- a/app/evaluate/[jobId]/report/page.tsx
+++ b/app/evaluate/[jobId]/report/page.tsx
@@ -4,10 +4,10 @@
 import { useEffect, useState } from "react";
 
 /**
- * Canonical artifact type for Flow 1 one-page summary.
+ * Canonical artifact type for Flow 1 evaluation result.
  * Governance: This page must reference the contract-defined artifact type.
  */
-const REPORT_ARTIFACT_TYPE = "one_page_summary";
+const REPORT_ARTIFACT_TYPE = "evaluation_result_v1";
 
 type Ok = {
   ok: true;

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -16,7 +16,7 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 
-const ARTIFACT_TYPE = "one_page_summary";
+const ARTIFACT_TYPE = "evaluation_result_v1";
 
 type RubricAxis = {
   key: string;

--- a/lib/artifacts/writeArtifact.ts
+++ b/lib/artifacts/writeArtifact.ts
@@ -10,7 +10,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 
 /** Canonical artifact_type constants. Every writer MUST use these. */
 export const ARTIFACT_TYPES = {
-  ONE_PAGE_SUMMARY: "one_page_summary",
+  EVALUATION_RESULT_V1: "evaluation_result_v1",
 } as const;
 
 export type ArtifactType =

--- a/lib/jobs/phase2.ts
+++ b/lib/jobs/phase2.ts
@@ -278,7 +278,7 @@ Generated: ${generatedAt}
   const sourceHash = `sha256:${sha256Json({
     manuscript_id: manuscriptId,
     job_id: jobId,
-    artifact_type: ARTIFACT_TYPES.ONE_PAGE_SUMMARY,
+    artifact_type: ARTIFACT_TYPES.EVALUATION_RESULT_V1,
     content: artifactContent,
   })}`;
 
@@ -315,7 +315,7 @@ async function persistOutput(
   const artifactId = await writeArtifact({
     job_id: jobId,
     manuscript_id: manuscriptId,
-    artifact_type: ARTIFACT_TYPES.ONE_PAGE_SUMMARY,
+    artifact_type: ARTIFACT_TYPES.EVALUATION_RESULT_V1,
     artifact_version: "v1",
     content: result.artifactContent,
     source_phase: PHASES.PHASE_2,

--- a/scripts/canon-guard.sh
+++ b/scripts/canon-guard.sh
@@ -56,12 +56,28 @@ fi
 [[ -f "$ROOT/docs/JOB_CONTRACT_v1.md" ]] || fail "Missing docs/JOB_CONTRACT_v1.md (required CANON contract)."
 
 # 4) Enforce canonical artifact identity in runtime code paths.
-# Hard gate: legacy one_page_summary must not appear in active app/lib runtime tree.
-# Historical references in docs/tests/migrations are handled outside this scope.
-if rg -n --hidden --glob '!**/*.test.*' --glob '!**/__tests__/**' "one_page_summary" "$ROOT/app" "$ROOT/lib" >/dev/null 2>&1; then
-  echo "Detected forbidden runtime artifact type references:" >&2
-  rg -n --hidden --glob '!**/*.test.*' --glob '!**/__tests__/**' "one_page_summary" "$ROOT/app" "$ROOT/lib" >&2 || true
+# Explicit allowlist scope:
+# - Enforced paths: app/, lib/
+# - Allowed legacy references elsewhere: docs/, __tests__/, historical migrations
+RUNTIME_PATHS=("$ROOT/app" "$ROOT/lib")
+RUNTIME_GLOBS=(
+  "--glob" "**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}"
+  "--glob" "!**/*.test.*"
+  "--glob" "!**/__tests__/**"
+)
+
+# 4a) Broad token ban (catches direct literal drift)
+if rg -n --hidden "${RUNTIME_GLOBS[@]}" "one_page_summary" "${RUNTIME_PATHS[@]}" >/dev/null 2>&1; then
+  echo "Detected forbidden runtime token references:" >&2
+  rg -n --hidden "${RUNTIME_GLOBS[@]}" "one_page_summary" "${RUNTIME_PATHS[@]}" >&2 || true
   fail "Runtime canonical drift: found one_page_summary in app/lib. Use evaluation_result_v1 only."
+fi
+
+# 4b) Artifact-type assignment/query ban (operator-proof semantic check)
+if rg -n --hidden "${RUNTIME_GLOBS[@]}" "artifact_type[^\n]*one_page_summary|eq\(\s*[\"']artifact_type[\"']\s*,\s*[\"']one_page_summary[\"']\s*\)" "${RUNTIME_PATHS[@]}" >/dev/null 2>&1; then
+  echo "Detected forbidden artifact_type canonical assignments/queries:" >&2
+  rg -n --hidden "${RUNTIME_GLOBS[@]}" "artifact_type[^\n]*one_page_summary|eq\(\s*[\"']artifact_type[\"']\s*,\s*[\"']one_page_summary[\"']\s*\)" "${RUNTIME_PATHS[@]}" >&2 || true
+  fail "Runtime canonical drift: artifact_type must never use one_page_summary in app/lib."
 fi
 
 echo "✅ Canon Guard passed."

--- a/scripts/canon-guard.sh
+++ b/scripts/canon-guard.sh
@@ -57,9 +57,16 @@ fi
 
 # 4) Enforce canonical artifact identity in runtime code paths.
 # Explicit allowlist scope:
-# - Enforced paths: app/, lib/
+# - Enforced paths: app/, lib/, src/ (when present)
 # - Allowed legacy references elsewhere: docs/, __tests__/, historical migrations
-RUNTIME_PATHS=("$ROOT/app" "$ROOT/lib")
+RUNTIME_PATHS=()
+[[ -d "$ROOT/app" ]] && RUNTIME_PATHS+=("$ROOT/app")
+[[ -d "$ROOT/lib" ]] && RUNTIME_PATHS+=("$ROOT/lib")
+[[ -d "$ROOT/src" ]] && RUNTIME_PATHS+=("$ROOT/src")
+
+if [[ ${#RUNTIME_PATHS[@]} -eq 0 ]]; then
+  fail "No runtime paths found for canonical artifact guard (expected app/, lib/, or src/)."
+fi
 RUNTIME_GLOBS=(
   "--glob" "**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}"
   "--glob" "!**/*.test.*"
@@ -70,14 +77,14 @@ RUNTIME_GLOBS=(
 if rg -n --hidden "${RUNTIME_GLOBS[@]}" "one_page_summary" "${RUNTIME_PATHS[@]}" >/dev/null 2>&1; then
   echo "Detected forbidden runtime token references:" >&2
   rg -n --hidden "${RUNTIME_GLOBS[@]}" "one_page_summary" "${RUNTIME_PATHS[@]}" >&2 || true
-  fail "Runtime canonical drift: found one_page_summary in app/lib. Use evaluation_result_v1 only."
+  fail "Runtime canonical drift: found one_page_summary in runtime paths (${RUNTIME_PATHS[*]}). Use evaluation_result_v1 only."
 fi
 
 # 4b) Artifact-type assignment/query ban (operator-proof semantic check)
 if rg -n --hidden "${RUNTIME_GLOBS[@]}" "artifact_type[^\n]*one_page_summary|eq\(\s*[\"']artifact_type[\"']\s*,\s*[\"']one_page_summary[\"']\s*\)" "${RUNTIME_PATHS[@]}" >/dev/null 2>&1; then
   echo "Detected forbidden artifact_type canonical assignments/queries:" >&2
   rg -n --hidden "${RUNTIME_GLOBS[@]}" "artifact_type[^\n]*one_page_summary|eq\(\s*[\"']artifact_type[\"']\s*,\s*[\"']one_page_summary[\"']\s*\)" "${RUNTIME_PATHS[@]}" >&2 || true
-  fail "Runtime canonical drift: artifact_type must never use one_page_summary in app/lib."
+  fail "Runtime canonical drift: artifact_type must never use one_page_summary in runtime paths (${RUNTIME_PATHS[*]})."
 fi
 
 echo "✅ Canon Guard passed."

--- a/scripts/canon-guard.sh
+++ b/scripts/canon-guard.sh
@@ -67,6 +67,8 @@ RUNTIME_PATHS=()
 if [[ ${#RUNTIME_PATHS[@]} -eq 0 ]]; then
   fail "No runtime paths found for canonical artifact guard (expected app/, lib/, or src/)."
 fi
+
+echo "🔎 Canon Guard runtime roots: ${RUNTIME_PATHS[*]}"
 RUNTIME_GLOBS=(
   "--glob" "**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}"
   "--glob" "!**/*.test.*"

--- a/scripts/canon-guard.sh
+++ b/scripts/canon-guard.sh
@@ -55,4 +55,13 @@ fi
 # 3) Ensure contract doc exists (binding truth source)
 [[ -f "$ROOT/docs/JOB_CONTRACT_v1.md" ]] || fail "Missing docs/JOB_CONTRACT_v1.md (required CANON contract)."
 
+# 4) Enforce canonical artifact identity in runtime code paths.
+# Hard gate: legacy one_page_summary must not appear in active app/lib runtime tree.
+# Historical references in docs/tests/migrations are handled outside this scope.
+if rg -n --hidden --glob '!**/*.test.*' --glob '!**/__tests__/**' "one_page_summary" "$ROOT/app" "$ROOT/lib" >/dev/null 2>&1; then
+  echo "Detected forbidden runtime artifact type references:" >&2
+  rg -n --hidden --glob '!**/*.test.*' --glob '!**/__tests__/**' "one_page_summary" "$ROOT/app" "$ROOT/lib" >&2 || true
+  fail "Runtime canonical drift: found one_page_summary in app/lib. Use evaluation_result_v1 only."
+fi
+
 echo "✅ Canon Guard passed."

--- a/scripts/test-phase2-idempotency.sh
+++ b/scripts/test-phase2-idempotency.sh
@@ -76,7 +76,7 @@ echo ""
 
 # Step 6: Verify artifact exists
 echo "6. Verifying artifact exists..."
-ARTIFACT_RESPONSE=$(curl -s http://localhost:3000/api/jobs/$JOB_ID/artifacts?type=one_page_summary \
+ARTIFACT_RESPONSE=$(curl -s http://localhost:3000/api/jobs/$JOB_ID/artifacts?type=evaluation_result_v1 \
   -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY")
 
 ARTIFACT_FOUND=$(echo "$ARTIFACT_RESPONSE" | jq -r '.ok')

--- a/scripts/test-phase2-vertical-slice.sh
+++ b/scripts/test-phase2-vertical-slice.sh
@@ -180,7 +180,7 @@ echo ""
 
 # Step 6: Verify artifact exists via GET endpoint
 echo "[6/8] Verifying artifact via GET /api/jobs/:id/artifacts..."
-ARTIFACT_JSON=$(curl -s "$BASE_URL/api/jobs/$JOB_ID/artifacts?type=one_page_summary" \
+ARTIFACT_JSON=$(curl -s "$BASE_URL/api/jobs/$JOB_ID/artifacts?type=evaluation_result_v1" \
   -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY")
 
 ARTIFACT_OK=$(echo "$ARTIFACT_JSON" | jq -r '.ok // false')

--- a/supabase/migrations/20260222193000_align_report_shares_canonical_artifact_type.sql
+++ b/supabase/migrations/20260222193000_align_report_shares_canonical_artifact_type.sql
@@ -1,0 +1,146 @@
+-- Align report_shares + A7 RPCs with canonical artifact type: evaluation_result_v1
+
+begin;
+
+-- Canonical default for new share rows
+alter table public.report_shares
+	alter column artifact_type set default 'evaluation_result_v1';
+
+-- Backfill legacy rows created under previous default
+update public.report_shares
+set artifact_type = 'evaluation_result_v1'
+where artifact_type = 'one_page_summary';
+
+-- A7 create_report_share should revoke/create using canonical artifact type
+create or replace function public.create_report_share(
+	p_job_id uuid,
+	p_expires_hours int default 24
+)
+returns table (
+	token text,
+	expires_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+	v_uid uuid;
+	v_owner uuid;
+	v_token text;
+	v_token_hash text;
+	v_expires timestamptz;
+	v_hours int;
+begin
+	v_uid := auth.uid();
+	if v_uid is null then
+		raise exception 'unauthorized';
+	end if;
+
+	v_hours := greatest(1, least(coalesce(p_expires_hours, 24), 168)); -- 1h..168h
+	v_expires := now() + make_interval(hours => v_hours);
+
+	-- Fail-closed: check ownership
+	select m.user_id into v_owner
+	from public.evaluation_jobs j
+	join public.manuscripts m on m.id = j.manuscript_id
+	where j.id = p_job_id;
+
+	if v_owner is null then
+		raise exception 'job_not_found';
+	end if;
+	if v_owner <> v_uid then
+		raise exception 'job_not_found'; -- fail-closed (no leak)
+	end if;
+
+	-- Revoke any existing active share for this job (one active share per job invariant)
+	update public.report_shares
+	set revoked_at = coalesce(revoked_at, now())
+	where job_id = p_job_id
+		and artifact_type = 'evaluation_result_v1'
+		and revoked_at is null;
+
+	-- Generate token
+	v_token := public._rg_generate_share_token();
+
+	-- Hash token for storage (using PostgreSQL's digest function)
+	v_token_hash := encode(extensions.digest(v_token, 'sha256'), 'hex');
+
+	-- Insert share record with hash
+	insert into public.report_shares (token_hash, job_id, artifact_type, created_by, expires_at)
+	values (v_token_hash, p_job_id, 'evaluation_result_v1', v_uid, v_expires);
+
+	-- Return plaintext token (only time it's visible) and expiry
+	return query select v_token, v_expires;
+end;
+$$;
+
+-- A7 public share read should fetch canonical evaluation_result_v1 artifact
+create or replace function public.get_public_report_share(
+	p_token text
+)
+returns table (
+	job_id uuid,
+	artifact_type text,
+	artifact_version text,
+	content jsonb,
+	updated_at timestamptz,
+	source_hash text,
+	source_phase text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+	v_token_hash text;
+begin
+	-- Hash the provided token
+	v_token_hash := encode(extensions.digest(p_token, 'sha256'), 'hex');
+
+	-- Return artifact if share is valid
+	return query
+	with s as (
+		select rs.job_id
+		from public.report_shares rs
+		where rs.token_hash = v_token_hash
+			and rs.revoked_at is null
+			and (rs.expires_at is null or rs.expires_at > now())
+		limit 1
+	)
+	select
+		a.job_id,
+		a.artifact_type,
+		a.artifact_version,
+		a.content,
+		a.updated_at,
+		a.source_hash,
+		a.source_phase
+	from public.evaluation_artifacts a
+	join s on s.job_id = a.job_id
+	where a.artifact_type = 'evaluation_result_v1'
+	limit 1;
+
+	-- Best-effort view tracking (must not block on failure)
+	begin
+		update public.report_shares
+		set view_count = view_count + 1,
+				last_viewed_at = now()
+		where token_hash = v_token_hash
+			and revoked_at is null
+			and (expires_at is null or expires_at > now());
+	exception when others then
+		-- Fail-safe: metrics failure must not block
+		null;
+	end;
+end;
+$$;
+
+comment on function public.create_report_share(uuid, int) is
+	'A7 canonical: creates report share token bound to evaluation_result_v1 artifact type.';
+
+comment on function public.get_public_report_share(text) is
+	'A7 canonical: resolves public share token to evaluation_result_v1 artifact projection.';
+
+commit;
+

--- a/supabase/migrations/20260222201000_align_a8_canonical_artifact_type.sql
+++ b/supabase/migrations/20260222201000_align_a8_canonical_artifact_type.sql
@@ -1,0 +1,178 @@
+-- Align A8 artifact discovery functions with canonical artifact type: evaluation_result_v1
+-- Forward-only override of function bodies/comments (do not rewrite historical migrations)
+
+begin;
+
+create or replace function list_my_artifacts(
+  p_status text DEFAULT NULL,
+  p_since timestamptz DEFAULT NULL,
+  p_limit int DEFAULT 50,
+  p_policy_family text DEFAULT NULL,
+  p_voice_preservation_level text DEFAULT NULL,
+  p_english_variant text DEFAULT NULL
+)
+returns table (
+  job_id uuid,
+  manuscript_id bigint,
+  manuscript_title text,
+  job_type text,
+  status text,
+  created_at timestamptz,
+  updated_at timestamptz,
+
+  -- Job configuration
+  policy_family text,
+  voice_preservation_level text,
+  english_variant text,
+  work_type text,
+
+  -- Canonical artifact metadata
+  artifact_type text,
+  artifact_version text,
+  artifact_updated_at timestamptz,
+  source_phase text,
+  source_hash text,
+
+  -- Artifact payload
+  overall_score numeric,
+  credibility_valid boolean,
+  artifact_content jsonb
+)
+language plpgsql
+security invoker
+stable
+as $$
+begin
+  if p_limit < 1 or p_limit > 200 then
+    raise exception 'p_limit must be between 1 and 200';
+  end if;
+
+  return query
+  select
+    ej.id,
+    ej.manuscript_id,
+    m.title as manuscript_title,
+    ej.job_type,
+    ej.status,
+    ej.created_at,
+    ej.updated_at,
+
+    ej.policy_family,
+    ej.voice_preservation_level,
+    ej.english_variant,
+    ej.work_type,
+
+    ea.artifact_type,
+    ea.artifact_version,
+    ea.updated_at as artifact_updated_at,
+    ea.source_phase,
+    ea.source_hash,
+
+    (ea.content->>'overall_score')::numeric as overall_score,
+    (ea.content->'credibility_metrics'->>'valid')::boolean as credibility_valid,
+    ea.content as artifact_content
+  from evaluation_jobs ej
+  join manuscripts m on m.id = ej.manuscript_id
+  left join evaluation_artifacts ea
+    on ea.job_id = ej.id::text
+    and ea.artifact_type = 'evaluation_result_v1'
+  where
+    m.created_by = auth.uid()
+    and (p_status is null or ej.status = p_status)
+    and (p_since is null or ej.created_at >= p_since)
+    and (p_policy_family is null or ej.policy_family = p_policy_family)
+    and (p_voice_preservation_level is null or ej.voice_preservation_level = p_voice_preservation_level)
+    and (p_english_variant is null or ej.english_variant = p_english_variant)
+  order by ej.created_at desc
+  limit p_limit;
+end;
+$$;
+
+comment on function list_my_artifacts is
+  'A8 canonical: list owner artifacts with filters. SECURITY INVOKER (RLS-based). Ownership via manuscripts.created_by. Canonical artifact: evaluation_result_v1.';
+
+create or replace function get_public_artifact_collection(
+  p_token text
+)
+returns table (
+  collection_id uuid,
+  collection_name text,
+  collection_description text,
+  artifacts jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_token_hash bytea;
+  v_share_id uuid;
+  v_collection_id uuid;
+  v_collection_name text;
+  v_collection_description text;
+  v_artifacts jsonb;
+begin
+  v_token_hash := extensions.digest(p_token, 'sha256');
+
+  select
+    cs.id,
+    cs.collection_id,
+    ac.name,
+    ac.description
+  into
+    v_share_id,
+    v_collection_id,
+    v_collection_name,
+    v_collection_description
+  from collection_shares cs
+  join artifact_collections ac on ac.id = cs.collection_id
+  where cs.token_hash = v_token_hash
+    and cs.revoked_at is null
+    and (cs.expires_at is null or cs.expires_at > now());
+
+  if v_share_id is null then
+    return;
+  end if;
+
+  select jsonb_agg(
+    jsonb_build_object(
+      'job_id', ej.id,
+      'work_title', m.title,
+      'status', ej.status,
+      'created_at', ej.created_at,
+      'artifact', ea.content
+    )
+    order by ca.added_at desc
+  )
+  into v_artifacts
+  from collection_artifacts ca
+  join evaluation_jobs ej on ej.id = ca.job_id
+  join manuscripts m on m.id = ej.manuscript_id
+  left join evaluation_artifacts ea
+    on ea.job_id = ej.id::text
+    and ea.artifact_type = 'evaluation_result_v1'
+  where ca.collection_id = v_collection_id;
+
+  begin
+    update collection_shares
+    set
+      view_count = view_count + 1,
+      last_viewed_at = now()
+    where id = v_share_id;
+  exception
+    when others then null;
+  end;
+
+  return query
+  select
+    v_collection_id,
+    v_collection_name,
+    v_collection_description,
+    coalesce(v_artifacts, '[]'::jsonb);
+end;
+$$;
+
+comment on function get_public_artifact_collection is
+  'A8 canonical: public collection view via token (anon-callable). SECURITY DEFINER for RLS bypass. Canonical artifact projection: evaluation_result_v1. Fail-closed on invalid/revoked/expired.';
+
+commit;

--- a/tests/evaluation-artifacts-large-payload.test.ts
+++ b/tests/evaluation-artifacts-large-payload.test.ts
@@ -410,7 +410,7 @@ describeOrSkip("Evaluation Artifacts - Large Payload", () => {
         insertArtifact({
           jobId,
           manuscriptId: testManuscriptId,
-          artifactType: i === 0 ? "one_page_summary" : "detailed_evaluation",
+          artifactType: i === 0 ? "evaluation_result_v1" : "detailed_evaluation",
           artifactVersion: "v1",
           content: generateLargeArtifact(20),
           sourcePhase: "phase_2",


### PR DESCRIPTION
## Why
This PR closes canonical artifact identity drift by converging runtime reads/writes, share flows, and DB discovery functions on `evaluation_result_v1`.

## What changed
- Runtime/API/UI convergence to canonical `evaluation_result_v1`:
  - `app/api/evaluations/[jobId]/route.ts`
  - `app/api/jobs/[jobId]/artifacts/route.ts`
  - `app/evaluate/[jobId]/report/page.tsx`
  - `app/share/[token]/page.tsx`
  - `lib/artifacts/writeArtifact.ts`
  - `lib/jobs/phase2.ts`
- Report-share canonical alignment:
  - `app/api/report-shares/route.ts`
  - `supabase/migrations/20260222193000_align_report_shares_canonical_artifact_type.sql`
- A8 discovery function canonical alignment:
  - `supabase/migrations/20260222201000_align_a8_canonical_artifact_type.sql`
- Governance enforcement:
  - `scripts/canon-guard.sh` blocks runtime `one_page_summary` drift in `app/`, `lib/`, and `src/`.
  - `.github/workflows/ci.yml` runs `npm run canon:guard` as an early fast-fail step.

## Verification
- Branch-scoped proof is posted in PR comments (branch + SHA + runtime grep).
- `npm run canon:guard` passes on this branch.
- Prior suite/build evidence for convergence commits is included in PR comments.

## Canonical invariant
Canonical runtime artifact type is `evaluation_result_v1`; CI enforces no `one_page_summary` in `app/lib/src`.
