### PR TITLE
Audit-grade closure: provenance, canonical status enforcement, and worker hardening

### DIFF
--- a/AUDIT_GRADE_CLOSURE_PACKET_2026-02-22.md
+++ b/AUDIT_GRADE_CLOSURE_PACKET_2026-02-22.md
@@ -64,6 +64,15 @@ After remediation snapshot shows:
 - Static diagnostics: no errors in changed files.
 - Targeted regression test passed:
   - `__tests__/lib/evaluation/processor.short-text.test.ts`
+- Live operational verification (post-remediation):
+  - New retry job created for manuscript `4018`: `25b05913-acc9-4900-b9a1-6e72abbebf48`
+  - Job reached canonical terminal success: `status = complete`, `phase = phase_2`
+  - Canonical artifact persisted: `evaluation_artifacts.id = 7a79fe66-8403-48a6-afe0-1b736a48a4cc`, `artifact_type = evaluation_result_v1`
+
+## Additional Hardening (post-verification)
+- `app/api/workers/process-evaluations/route.ts`
+  - Hardened cron auth path: if `CRON_SECRET` is configured, Vercel-cron header path must also provide matching bearer token.
+  - Prevents spoof-only `x-vercel-cron` / `x-vercel-id` headers from being sufficient to trigger worker execution.
 
 ## Closure Verdict
 **AUDIT CLOSURE: PASS (governance + provenance + state canonicalization)**

--- a/AUDIT_GRADE_CLOSURE_PACKET_2026-02-22.md
+++ b/AUDIT_GRADE_CLOSURE_PACKET_2026-02-22.md
@@ -1,0 +1,77 @@
+# Audit-Grade Closure Packet — 2026-02-22
+
+## Scope
+Close the active incident with evidence-backed answers for:
+1. Input provenance correctness
+2. Job-state governance/canonical status compliance
+3. Stuck-job recovery and operational safety
+
+## Evidence Artifacts (captured this session)
+- `audit_closure_snapshot_before_2026-02-22T22-43-46-358Z.json`
+- `audit_closure_snapshot_after_2026-02-22T22-44-40-313Z.json`
+
+Note: Both snapshots are intentionally redacted. They include manuscript provenance hashes and a short preview only (no full manuscript payload).
+
+## Proven Facts
+
+### 1) Provenance for manuscript 4018
+- `manuscripts.id = 4018` exists.
+- Redacted evidence includes:
+  - `fileUrlSha256 = cbf7be7c4cd0b8fbc408245a158f5747e7382d948e50582ec3997d1b2b35c8ee`
+  - `decodedTextSha256 = 72a669223bd6ff70ee07a3144e99802fe0c2811e0fc0313f4e81e5e4f351973e`
+  - preview: `"29 February 2016 ... Commander Donaldson, I want him charged!..."`
+- This confirms the active manuscript row is not the old Meena-only seed mismatch.
+
+### 2) Job linkage for incident job
+- `evaluation_jobs.id = b3190658-4b3b-49b2-8992-28cb73d52977`
+- `manuscript_id = 4018`
+- Incident state observed: stuck `running` with no heartbeat/artifacts.
+- Recovery applied: job moved to canonical terminal state `failed` with explicit reason.
+
+### 3) Canonical status governance closure
+Before remediation, non-canonical values existed in `evaluation_jobs.status`:
+- `processing` (2 rows)
+- `completed` (1 row)
+- `cancelled` (2 rows)
+
+Remediation applied:
+- `completed -> complete`
+- `processing -> failed` (stale, non-heartbeating)
+- `cancelled -> failed` (non-canonical terminal)
+- `phase_status` aligned to canonical value for each remediated row
+- `last_error` set for traceability where status became `failed`
+
+After remediation snapshot shows:
+- Status counts: `{ "failed": 10, "complete": 44 }`
+- `non_canonical_status_count = 0`
+
+## Code Hardening Applied (workspace)
+
+### `app/api/evaluate/route.ts`
+- Accepts real manuscript payload (`manuscript_text`/`content`/`text`) and persists to `manuscripts.file_url`.
+- Uses canonical job type in this code path (`evaluate_full`).
+- Adds ownership checks when `manuscript_id` is provided:
+  - 404 if manuscript does not exist
+  - 403 if manuscript belongs to a different user
+
+### `lib/evaluation/processor.ts`
+- Adds OpenAI timeout guard (`EVAL_OPENAI_TIMEOUT_MS`, default 240000 ms).
+- Adds stale-running recovery (`EVAL_STALE_RUNNING_MINUTES`, default 10).
+- Adds stronger running/failed/complete writes with consistent `phase_status` and heartbeat updates.
+- Centralizes failure-state writes to reduce stuck `running` risk.
+
+## Validation Run
+- Static diagnostics: no errors in changed files.
+- Targeted regression test passed:
+  - `__tests__/lib/evaluation/processor.short-text.test.ts`
+
+## Closure Verdict
+**AUDIT CLOSURE: PASS (governance + provenance + state canonicalization)**
+
+- Input provenance for the active manuscript is proven.
+- Incident job is in an explicit canonical terminal state.
+- Non-canonical status drift has been eliminated from `evaluation_jobs`.
+- Hardening changes are present in workspace and validated by test/static checks.
+
+## Remaining Operational Step
+Deploy current workspace changes to production runtime so these safeguards are active in Vercel execution path as well.

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -30,27 +30,114 @@ export async function POST(req: Request) {
       );
     }
 
-    // Step 1: Create manuscript
-    const { data: manuscript, error: manuscriptError } = await supabase
-      .from("manuscripts")
-      .insert({ title: "Test Manuscript" })
-      .select()
-      .single();
+    const body = await req.json().catch(() => ({}));
+    const manuscriptIdInput = body?.manuscript_id;
+    const manuscriptTextInput =
+      typeof body?.manuscript_text === "string"
+        ? body.manuscript_text
+        : typeof body?.content === "string"
+        ? body.content
+        : typeof body?.text === "string"
+        ? body.text
+        : "";
+    const manuscriptTitleInput =
+      typeof body?.manuscript_title === "string"
+        ? body.manuscript_title
+        : typeof body?.title === "string"
+        ? body.title
+        : "Untitled Manuscript";
 
-    if (manuscriptError) {
-      console.error("Manuscript insert error:", manuscriptError);
+    let manuscriptId: number | null = null;
+
+    if (manuscriptIdInput !== undefined && manuscriptIdInput !== null) {
+      const parsed = Number.parseInt(String(manuscriptIdInput), 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return Response.json(
+          { ok: false, error: "Invalid manuscript_id" },
+          { status: 400 }
+        );
+      }
+      manuscriptId = parsed;
+
+      const { data: existingManuscript, error: manuscriptLookupError } = await supabase
+        .from("manuscripts")
+        .select("id,user_id")
+        .eq("id", manuscriptId)
+        .single();
+
+      if (manuscriptLookupError || !existingManuscript) {
+        return Response.json(
+          { ok: false, error: "manuscript_id not found" },
+          { status: 404 }
+        );
+      }
+
+      if (existingManuscript.user_id !== userId) {
+        return Response.json(
+          { ok: false, error: "Forbidden: manuscript does not belong to user" },
+          { status: 403 }
+        );
+      }
+    }
+
+    const trimmedText = manuscriptTextInput.trim();
+    if (!manuscriptId && trimmedText.length === 0) {
       return Response.json(
-        { ok: false, error: `Manuscript error: ${manuscriptError.message}` },
-        { status: 500 }
+        {
+          ok: false,
+          error:
+            "Missing manuscript input: provide manuscript_id or manuscript_text/content",
+        },
+        { status: 400 }
       );
+    }
+
+    // Step 1: Create manuscript
+    if (!manuscriptId) {
+      const encodedText = encodeURIComponent(trimmedText);
+      const fileUrl = `data:text/plain;charset=utf-8,${encodedText}`;
+      const fileSize = new TextEncoder().encode(trimmedText).length;
+      const wordCount = trimmedText.split(/\s+/).filter(Boolean).length;
+
+      const { data: manuscript, error: manuscriptError } = await supabase
+        .from("manuscripts")
+        .insert({
+          title: manuscriptTitleInput.trim() || "Untitled Manuscript",
+          user_id: userId,
+          created_by: userId,
+          file_url: fileUrl,
+          file_size: fileSize,
+          work_type: "novel",
+          tone_context: "neutral",
+          mood_context: "calm",
+          voice_mode: "balanced",
+          storygate_linked: false,
+          allow_industry_discovery: false,
+          is_final: false,
+          source: "paste",
+          english_variant: "us",
+          word_count: wordCount,
+        })
+        .select("id")
+        .single();
+
+      if (manuscriptError || !manuscript) {
+        console.error("Manuscript insert error:", manuscriptError);
+        return Response.json(
+          { ok: false, error: `Manuscript error: ${manuscriptError?.message}` },
+          { status: 500 }
+        );
+      }
+
+      manuscriptId = manuscript.id;
     }
 
     // Step 2: Create evaluation job
     const { data, error } = await supabase
       .from("evaluation_jobs")
       .insert({
-        manuscript_id: manuscript.id,
-        job_type: "full_evaluation",
+        manuscript_id: manuscriptId,
+        job_type: "evaluate_full",
         phase: PHASES.PHASE_1,
         policy_family: "standard",
         voice_preservation_level: "balanced",
@@ -74,7 +161,7 @@ export async function POST(req: Request) {
         message: "Evaluation job created",
         job: {
           id: data.id,
-          manuscript_id: manuscript.id,
+          manuscript_id: manuscriptId,
           status: data.status,
           phase: data.phase,
           phase_1_status: data.phase_1_status,

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -93,14 +93,31 @@ function isVercelCronInvocation(req: NextRequest): boolean {
  */
 function checkAuthorization(req: NextRequest): { authorized: boolean; method: string; secretTooLong: boolean } {
   const expectedSecret = process.env.CRON_SECRET || '';
+  const bearer = extractBearer(req.headers.get('authorization'));
   
   // Method 1: Vercel Cron invocation (highest trust)
   if (isVercelCronInvocation(req)) {
+    // Hardened: when CRON_SECRET is configured, cron path must also present matching bearer token.
+    // This prevents spoofed x-vercel-* headers from being sufficient on their own.
+    if (expectedSecret) {
+      if (!bearer) {
+        return { authorized: false, method: 'vercel_cron_missing_bearer', secretTooLong: false };
+      }
+
+      const result = timingSafeEqual(bearer, expectedSecret);
+      if (result.secretTooLong) {
+        return { authorized: false, method: 'vercel_cron_bearer_rejected', secretTooLong: true };
+      }
+
+      if (!result.equal) {
+        return { authorized: false, method: 'vercel_cron_bearer_mismatch', secretTooLong: false };
+      }
+    }
+
     return { authorized: true, method: 'vercel_cron', secretTooLong: false };
   }
   
   // Method 2: Bearer token (manual/admin trigger)
-  const bearer = extractBearer(req.headers.get('authorization'));
   if (expectedSecret && bearer) {
     const result = timingSafeEqual(bearer, expectedSecret);
     if (result.secretTooLong) {

--- a/audit_closure_snapshot_after_2026-02-22T22-44-40-313Z.json
+++ b/audit_closure_snapshot_after_2026-02-22T22-44-40-313Z.json
@@ -1,0 +1,49 @@
+{
+  "captured_at": "2026-02-22T22:44:40.313Z",
+  "redaction": {
+    "full_payload_removed": true,
+    "reason": "prevent repository storage of full manuscript content"
+  },
+  "canonical_statuses": [
+    "queued",
+    "running",
+    "complete",
+    "failed"
+  ],
+  "status_counts": {
+    "failed": 10,
+    "complete": 44
+  },
+  "non_canonical_status_count": 0,
+  "non_canonical_rows": [],
+  "job_4018": {
+    "id": "b3190658-4b3b-49b2-8992-28cb73d52977",
+    "manuscript_id": 4018,
+    "job_type": "full_evaluation",
+    "status": "failed",
+    "phase_status": "failed",
+    "last_error": "Manual recovery: stuck in running with no heartbeat/artifacts; likely worker timeout",
+    "progress": {
+      "phase": "phase_1",
+      "message": "Failed: worker timeout or crash before completion",
+      "failed_at": "2026-02-22T22:38:43.928Z",
+      "phase_status": "failed"
+    },
+    "created_at": "2026-02-22T22:11:21.332429+00:00",
+    "updated_at": "2026-02-22T22:38:44.088039+00:00"
+  },
+  "manuscript_4018": {
+    "id": 4018,
+    "title": "Untitled Manuscript",
+    "file_size": 27068,
+    "word_count": 4762,
+    "status": "uploaded",
+    "source": "paste",
+    "created_at": "2026-02-22T22:11:21.213591+00:00",
+    "updated_at": "2026-02-22T22:11:21.213591+00:00",
+    "fileUrlSha256": "cbf7be7c4cd0b8fbc408245a158f5747e7382d948e50582ec3997d1b2b35c8ee",
+    "decodedTextSha256": "72a669223bd6ff70ee07a3144e99802fe0c2811e0fc0313f4e81e5e4f351973e",
+    "decoded_preview": "29 February 2016\n\nBicycle by Mike Meraw\n\n\u201cCommander Donaldson, I want him charged! Not only was he drunk, but he was fighting.\u201d"
+  },
+  "artifacts_4018": []
+}

--- a/audit_closure_snapshot_before_2026-02-22T22-43-46-358Z.json
+++ b/audit_closure_snapshot_before_2026-02-22T22-43-46-358Z.json
@@ -1,0 +1,43 @@
+{
+  "captured_at": "2026-02-22T22:43:46.358Z",
+  "redaction": {
+    "full_payload_removed": true,
+    "reason": "prevent repository storage of full manuscript content"
+  },
+  "job_status_counts": {
+    "cancelled": 2,
+    "complete": 43,
+    "failed": 6,
+    "completed": 1,
+    "processing": 2
+  },
+  "non_canonical_statuses_detected": [
+    "cancelled",
+    "completed",
+    "processing"
+  ],
+  "manuscript_4018": {
+    "id": 4018,
+    "title": "Untitled Manuscript",
+    "file_size": 27068,
+    "word_count": 4762,
+    "status": "uploaded",
+    "source": "paste",
+    "created_at": "2026-02-22T22:11:21.213591+00:00",
+    "updated_at": "2026-02-22T22:11:21.213591+00:00",
+    "fileUrlSha256": "cbf7be7c4cd0b8fbc408245a158f5747e7382d948e50582ec3997d1b2b35c8ee",
+    "decodedTextSha256": "72a669223bd6ff70ee07a3144e99802fe0c2811e0fc0313f4e81e5e4f351973e",
+    "decoded_preview": "29 February 2016\n\nBicycle by Mike Meraw\n\n\u201cCommander Donaldson, I want him charged! Not only was he drunk, but he was fighting.\u201d"
+  },
+  "latest_job_4018": {
+    "id": "b3190658-4b3b-49b2-8992-28cb73d52977",
+    "manuscript_id": 4018,
+    "job_type": "full_evaluation",
+    "status": "failed",
+    "phase_status": "failed",
+    "last_error": "Manual recovery: stuck in running with no heartbeat/artifacts; likely worker timeout",
+    "created_at": "2026-02-22T22:11:21.332429+00:00",
+    "updated_at": "2026-02-22T22:38:44.088039+00:00"
+  },
+  "artifacts_for_latest_job_4018": []
+}

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -73,6 +73,15 @@ const evalMinManuscriptChars = (() => {
   const parsed = Number.parseInt(process.env.EVAL_MIN_MANUSCRIPT_CHARS || '200', 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 200;
 })();
+const openAiTimeoutMs = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || '240000', 10);
+  // Keep below Vercel maxDuration=300s so we can write failed status before platform kill.
+  return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 295000 ? parsed : 240000;
+})();
+const staleRunningMinutes = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_STALE_RUNNING_MINUTES || '10', 10);
+  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 240 ? parsed : 10;
+})();
 
 interface EvaluationJob {
   id: string;
@@ -702,7 +711,11 @@ async function generateAIEvaluation(manuscript: Manuscript, job: EvaluationJob):
     throw new Error('[Processor] OPENAI_API_KEY is not configured (fail-closed, no mock fallback)');
   }
 
-  const openai = new OpenAI({ apiKey: openaiApiKey });
+  const openai = new OpenAI({
+    apiKey: openaiApiKey,
+    timeout: openAiTimeoutMs,
+    maxRetries: 0,
+  });
   const now = new Date().toISOString();
   const startTime = Date.now();
   const calibration = getCalibrationProfile(manuscript.work_type);
@@ -886,6 +899,62 @@ Return ONLY valid JSON with this exact structure (no markdown, no code fences):
   }
 }
 
+export async function failStaleRunningJobs(): Promise<{
+  staleFound: number;
+  failed: number;
+  ids: string[];
+}> {
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const cutoff = new Date(Date.now() - staleRunningMinutes * 60_000).toISOString();
+
+  const { data: staleJobs, error: staleError } = await supabase
+    .from('evaluation_jobs')
+    .select('id, updated_at')
+    .eq('status', 'running')
+    .lt('updated_at', cutoff)
+    .order('updated_at', { ascending: true })
+    .limit(25);
+
+  if (staleError) {
+    console.warn('[Processor] Failed to check stale running jobs:', staleError.message);
+    return { staleFound: 0, failed: 0, ids: [] };
+  }
+
+  if (!staleJobs || staleJobs.length === 0) {
+    return { staleFound: 0, failed: 0, ids: [] };
+  }
+
+  const staleIds = staleJobs.map((row) => row.id);
+  const now = new Date().toISOString();
+  const { data: failedRows, error: failError } = await supabase
+    .from('evaluation_jobs')
+    .update({
+      status: 'failed',
+      last_error:
+        'Auto-failed stale running job: worker timed out or crashed before completion update',
+      updated_at: now,
+    })
+    .in('id', staleIds)
+    .eq('status', 'running')
+    .select('id');
+
+  if (failError) {
+    console.warn('[Processor] Failed to auto-fail stale jobs:', failError.message);
+    return { staleFound: staleIds.length, failed: 0, ids: staleIds };
+  }
+
+  const failedCount = failedRows?.length ?? 0;
+  if (failedCount > 0) {
+    console.log(`[Processor] Auto-failed ${failedCount} stale running job(s)`);
+  }
+
+  return {
+    staleFound: staleIds.length,
+    failed: failedCount,
+    ids: staleIds,
+  };
+}
+
 /**
  * Process a single evaluation job
  */
@@ -910,11 +979,66 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: `Job status is ${job.status}, not queued` };
     }
 
+    const progressState =
+      job.progress && typeof job.progress === 'object' ? { ...job.progress } : {};
+
+    const markRunning = async (message: string) => {
+      const now = new Date().toISOString();
+      const nextProgress = {
+        ...progressState,
+        phase: 'phase_1',
+        phase_status: 'running',
+        message,
+        last_heartbeat_at: now,
+      };
+
+      Object.assign(progressState, nextProgress);
+
+      await supabase
+        .from('evaluation_jobs')
+        .update({
+          status: 'running',
+          phase_status: 'running',
+          progress: nextProgress,
+          started_at: job.started_at ?? now,
+          last_heartbeat: now,
+          last_heartbeat_at: now,
+          heartbeat_at: now,
+          updated_at: now,
+        })
+        .eq('id', jobId);
+    };
+
+    const markFailed = async (errorMessage: string) => {
+      const now = new Date().toISOString();
+      const nextProgress = {
+        ...progressState,
+        phase: 'phase_1',
+        phase_status: 'failed',
+        message: 'Evaluation failed',
+        failed_at: now,
+      };
+
+      Object.assign(progressState, nextProgress);
+
+      try {
+        await supabase
+          .from('evaluation_jobs')
+          .update({
+            status: 'failed',
+            phase_status: 'failed',
+            progress: nextProgress,
+            last_error: errorMessage,
+            updated_at: now,
+          })
+          .eq('id', jobId);
+      } catch (writeError) {
+        console.error(`[Processor] Failed writing failure state for job ${jobId}:`, writeError);
+      }
+    };
+
     // 2. Update status to running
-    await supabase
-      .from('evaluation_jobs')
-      .update({ status: 'running', updated_at: new Date().toISOString() })
-      .eq('id', jobId);
+    await markRunning('Fetching manuscript');
 
     console.log(`[Processor] Job ${jobId} status updated to running`);
 
@@ -926,16 +1050,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       .single();
 
     if (manuscriptError || !manuscript) {
-      await supabase
-        .from('evaluation_jobs')
-        .update({ 
-          status: 'failed', 
-          last_error: `Manuscript not found: ${manuscriptError?.message}`,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', jobId);
-      
-      return { success: false, error: `Manuscript not found: ${manuscriptError?.message}` };
+      const message = `Manuscript not found: ${manuscriptError?.message}`;
+      await markFailed(message);
+      return { success: false, error: message };
     }
 
     console.log(`[Processor] Manuscript ${manuscript.id} fetched: "${manuscript.title}"`);
@@ -943,14 +1060,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     const resolvedManuscriptText = await resolveManuscriptText(supabase, manuscript as Manuscript);
     if (!resolvedManuscriptText || resolvedManuscriptText.trim().length === 0) {
       const contentError = 'Manuscript text unavailable: neither manuscripts.content nor manuscript_chunks.content found';
-      await supabase
-        .from('evaluation_jobs')
-        .update({
-          status: 'failed',
-          last_error: contentError,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', jobId);
+      await markFailed(contentError);
 
       return { success: false, error: contentError };
     }
@@ -959,14 +1069,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       const shortContentError =
         `Manuscript text too short for reliable evaluation: ${resolvedManuscriptText.trim().length} chars ` +
         `(minimum ${evalMinManuscriptChars})`;
-      await supabase
-        .from('evaluation_jobs')
-        .update({
-          status: 'failed',
-          last_error: shortContentError,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', jobId);
+      await markFailed(shortContentError);
 
       return { success: false, error: shortContentError };
     }
@@ -977,13 +1080,15 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     };
 
     // 4. Generate evaluation using AI (fail-closed; no mock fallback)
+    await markRunning('Generating evaluation with AI');
     const evaluationResult = await generateAIEvaluation(manuscriptWithContent, job);
 
     console.log(`[Processor] Evaluation generated for job ${jobId}`);
 
+    await markRunning('Persisting evaluation artifacts');
+
     const completionTime = new Date().toISOString();
-    const existingProgress =
-      job.progress && typeof job.progress === 'object' ? job.progress : {};
+    const existingProgress = { ...progressState };
 
     // 5. Persist canonical artifact with idempotent upsert (fail-closed)
     const manuscriptText = manuscriptWithContent.content || '(No content provided)';
@@ -1001,14 +1106,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     if (!Number.isFinite(job.manuscript_id) || job.manuscript_id <= 0) {
       const invalidManuscriptIdError = `Invalid job.manuscript_id for artifact persistence: ${job.manuscript_id}`;
-      await supabase
-        .from('evaluation_jobs')
-        .update({
-          status: 'failed',
-          last_error: invalidManuscriptIdError,
-          updated_at: completionTime,
-        })
-        .eq('id', jobId);
+      await markFailed(invalidManuscriptIdError);
 
       return { success: false, error: invalidManuscriptIdError };
     }
@@ -1027,14 +1125,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       console.log(`[Processor] Canonical artifact upserted: ${artifactId}`);
     } catch (artifactError) {
       const errorMsg = artifactError instanceof Error ? artifactError.message : String(artifactError);
-      await supabase
-        .from('evaluation_jobs')
-        .update({
-          status: 'failed',
-          last_error: `Artifact persistence failed: ${errorMsg}`,
-          updated_at: completionTime
-        })
-        .eq('id', jobId);
+      await markFailed(`Artifact persistence failed: ${errorMsg}`);
 
       return { success: false, error: `Artifact persistence failed: ${errorMsg}` };
     }
@@ -1045,29 +1136,26 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       .update({
         status: 'complete',
         phase: 'phase_2',
+        phase_status: 'complete',
         progress: {
           ...existingProgress,
           phase: 'phase_2',
           phase_status: 'complete',
           message: 'Evaluation completed',
-          finished_at: completionTime
+          finished_at: completionTime,
         },
         evaluation_result: evaluationResult,
         evaluation_result_version: 'evaluation_result_v1',
+        last_heartbeat: completionTime,
+        last_heartbeat_at: completionTime,
+        heartbeat_at: completionTime,
         last_error: null,
         updated_at: completionTime
       })
       .eq('id', jobId);
 
     if (updateError) {
-      await supabase
-        .from('evaluation_jobs')
-        .update({
-          status: 'failed',
-          last_error: `Completion update failed: ${updateError.message}`,
-          updated_at: completionTime
-        })
-        .eq('id', jobId);
+      await markFailed(`Completion update failed: ${updateError.message}`);
 
       console.error(`[Processor] Failed to update job ${jobId}:`, updateError);
       return { success: false, error: `Failed to store result: ${updateError.message}` };
@@ -1082,13 +1170,15 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     console.error(`[Processor] Error processing job ${jobId}:`, errorMessage);
 
     // Update job status to failed
+    const now = new Date().toISOString();
     try {
       await supabase
         .from('evaluation_jobs')
-        .update({ 
-          status: 'failed', 
+        .update({
+          status: 'failed',
+          phase_status: 'failed',
           last_error: errorMessage,
-          updated_at: new Date().toISOString()
+          updated_at: now,
         })
         .eq('id', jobId);
     } catch (updateError) {
@@ -1109,6 +1199,9 @@ export async function processQueuedJobs(): Promise<{
   errors: Array<{ jobId: string; error: string }>;
 }> {
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Safety net: recover jobs left in running due to platform hard timeout/crash.
+  await failStaleRunningJobs();
 
   // Fetch all queued jobs
   const { data: jobs, error } = await supabase


### PR DESCRIPTION
## Summary
- harden app/api/evaluate/route.ts to persist actual manuscript input, support manuscript payload variants, and enforce manuscript ownership checks
- harden lib/evaluation/processor.ts with bounded OpenAI timeout, stale-running auto-fail safety net, and stronger canonical status/heartbeat writes
- add redacted audit closure evidence packet and before/after snapshots with hash-based provenance proof (no raw manuscript payload)

## Why
This closes the incident with contract-safe canonical status governance (queued|running|complete|failed), provenance traceability, and reduced risk of jobs remaining stuck in running after worker timeout/crash conditions.

## Validation
- diagnostics: no errors in changed files
- targeted processor regression test passed earlier in this session (__tests__/lib/evaluation/processor.short-text.test.ts)

## Evidence
- AUDIT_GRADE_CLOSURE_PACKET_2026-02-22.md
- audit_closure_snapshot_before_2026-02-22T22-43-46-358Z.json
- audit_closure_snapshot_after_2026-02-22T22-44-40-313Z.json
