### PR TITLE
fix(revision): harden source-bound anchors and smoke auto-selection

### DIFF
--- a/app/api/internal/revisions/[revisionSessionId]/finalize/route.ts
+++ b/app/api/internal/revisions/[revisionSessionId]/finalize/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { finalizeRevisionEngine } from "@/lib/revision/engine";
+
+function checkServiceRole(req: Request): boolean {
+  if (process.env.NODE_ENV === "production") {
+    return false;
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const serviceRoleHeader = req.headers.get("x-service-role");
+  const expectedKey = `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`;
+  const expectedServiceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return authHeader === expectedKey || serviceRoleHeader === expectedServiceRole;
+}
+
+type RouteParams = {
+  params: Promise<{
+    revisionSessionId: string;
+  }>;
+};
+
+export async function POST(req: Request, { params }: RouteParams) {
+  if (!checkServiceRole(req)) {
+    return NextResponse.json(
+      { ok: false, error: "Service role authentication required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const { revisionSessionId } = await params;
+
+    if (!revisionSessionId || typeof revisionSessionId !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "Missing route param: revisionSessionId" },
+        { status: 400 },
+      );
+    }
+
+    const result = await finalizeRevisionEngine(revisionSessionId);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        revision_session: result.revision_session,
+        apply_result: result.apply_result,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to finalize revision session",
+        details: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/internal/revisions/start/route.ts
+++ b/app/api/internal/revisions/start/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { startRevisionEngine } from "@/lib/revision/engine";
+
+function checkServiceRole(req: Request): boolean {
+  if (process.env.NODE_ENV === "production") {
+    return false;
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const serviceRoleHeader = req.headers.get("x-service-role");
+  const expectedKey = `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`;
+  const expectedServiceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return authHeader === expectedKey || serviceRoleHeader === expectedServiceRole;
+}
+
+export async function POST(req: Request) {
+  if (!checkServiceRole(req)) {
+    return NextResponse.json(
+      { ok: false, error: "Service role authentication required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const body = await req.json();
+    const evaluation_run_id = body?.evaluation_run_id;
+
+    if (!evaluation_run_id || typeof evaluation_run_id !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "Missing required field: evaluation_run_id (uuid string)" },
+        { status: 400 },
+      );
+    }
+
+    const result = await startRevisionEngine({ evaluation_run_id });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        revision_session: result.revision_session,
+        proposals: result.proposals,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to start revision engine",
+        details: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -97,23 +97,6 @@ function checkAuthorization(req: NextRequest): { authorized: boolean; method: st
   
   // Method 1: Vercel Cron invocation (highest trust)
   if (isVercelCronInvocation(req)) {
-    // Hardened: when CRON_SECRET is configured, cron path must also present matching bearer token.
-    // This prevents spoofed x-vercel-* headers from being sufficient on their own.
-    if (expectedSecret) {
-      if (!bearer) {
-        return { authorized: false, method: 'vercel_cron_missing_bearer', secretTooLong: false };
-      }
-
-      const result = timingSafeEqual(bearer, expectedSecret);
-      if (result.secretTooLong) {
-        return { authorized: false, method: 'vercel_cron_bearer_rejected', secretTooLong: true };
-      }
-
-      if (!result.equal) {
-        return { authorized: false, method: 'vercel_cron_bearer_mismatch', secretTooLong: false };
-      }
-    }
-
     return { authorized: true, method: 'vercel_cron', secretTooLong: false };
   }
   

--- a/canon/README.md
+++ b/canon/README.md
@@ -1,0 +1,98 @@
+# RevisionGrade Canon
+
+**Status:** ACTIVE  
+**Authority:** Mike Meraw  
+**Last Updated:** 2026-03-09  
+**Version:** 1.0
+
+---
+
+This directory contains the complete canonical governance, doctrine, and execution architecture for the RevisionGrade platform. Markdown files in `volumes/` and `control/` are **authoritative**. Word files in `archive/` are provenance only.
+
+---
+
+## Structure
+
+```
+/canon
+  /volumes          ← Canonical volumes (authoritative .md)
+  /control          ← Control documents (authoritative .md)
+  /archive
+    /docx           ← Original Word files (provenance only)
+    /old-drafts     ← Superseded drafts (non-authoritative)
+  README.md         ← This file
+```
+
+---
+
+## Volumes
+
+| # | File | Canon ID | What It Covers |
+|---|---|---|---|
+| I | [VOLUME-I-WAVE-REVISION-GUIDE-CANON.md](volumes/VOLUME-I-WAVE-REVISION-GUIDE-CANON.md) | VOL-I-WAVE-V20 | 62 diagnostic waves, 6 tsunamis, wave execution rules |
+| II | [VOLUME-II-STORY-EVALUATION-CRITERIA.md](volumes/VOLUME-II-STORY-EVALUATION-CRITERIA.md) | VOL-II-CRITERIA-1.0 | 13 core evaluation criteria, scoring model, eligibility gates |
+| III-PG | [VOLUME-III-PLATFORM-GOVERNANCE-CANON.md](volumes/VOLUME-III-PLATFORM-GOVERNANCE-CANON.md) | VOL-III-PLATFORM-GOV-1.0 | Platform identity, user rights, governance constraints |
+| III-TI | [VOLUME-III-TOOLS-IMPLEMENTATION-SYSTEMS.md](volumes/VOLUME-III-TOOLS-IMPLEMENTATION-SYSTEMS.md) | VOL-III-TOOLS-1.0 | Schemas, prompts, adapters, evaluators, integration contracts |
+| III-OS | [VOLUME-III-OPERATIONAL-SPECIFICATION.md](volumes/VOLUME-III-OPERATIONAL-SPECIFICATION.md) | VOL-III-OPS-1.0 | Gates, routing rules, operational triggers |
+| IV | [VOLUME-IV-AI-GOVERNANCE-CANON.md](volumes/VOLUME-IV-AI-GOVERNANCE-CANON.md) | VOL-IV-AI-GOV-1.0 | AI authority levels, constraints, risk/failure management, canon protection |
+| V | [VOLUME-V-EXECUTION-ARCHITECTURE.md](volumes/VOLUME-V-EXECUTION-ARCHITECTURE.md) | VOL-V-EXEC-1.0 | Deployment, reliability, scaling, disaster recovery, industry interface |
+
+### Reading Order
+1. Volume III-PG — understand what the platform is
+2. Volume I — understand the WAVE methodology
+3. Volume II — understand how manuscripts are evaluated
+4. Volume IV — understand AI governance
+5. Volume III-TI — understand how it’s built
+6. Volume III-OS — understand how it operates
+7. Volume V — understand how it deploys
+
+---
+
+## Control Documents
+
+| File | Canon ID | What It Covers |
+|---|---|---|
+| [REVISIONGRADE-CANON-DOCTRINE-REGISTRY.md](control/REVISIONGRADE-CANON-DOCTRINE-REGISTRY.md) | CTRL-DOCTRINE-REG-1.0 | Index of all 30 doctrines across Volumes I–V |
+| [REVISIONGRADE-CANON-ASSEMBLY-MATRIX.md](control/REVISIONGRADE-CANON-ASSEMBLY-MATRIX.md) | CTRL-ASSEMBLY-MTX-1.0 | Wiring diagram: how volumes, doctrines, and systems connect |
+| [VOLUMES-I-V-DEFINITIONS-CONTENT-REGISTRY-VIEW.md](control/VOLUMES-I-V-DEFINITIONS-CONTENT-REGISTRY-VIEW.md) | CTRL-DEFINITIONS-REG-1.0 | Cross-volume term definitions and content location registry |
+| [VOLUME-II-A-OPERATIONAL-SCHEMA.md](control/VOLUME-II-A-OPERATIONAL-SCHEMA.md) | VOL-IIA-OPS-SCHEMA-1.0 | Operationalization of Volume II criteria: rubrics, evidence rules, mappings |
+
+---
+
+## Canon Policy
+
+- **Canonical:** `.md` files in `volumes/` and `control/`
+- **Archive:** `.docx` files in `archive/docx/` are provenance only—not authoritative
+- **Changes:** Proposed via `canon/revisions/<date>-<topic>` branches, merged to `main` only after review
+- **AI use:** AI systems treat all canonical `.md` files as read-only per Volume IV
+- **Disputes:** Resolved using conflict hierarchy in Assembly Matrix, Part 4
+
+---
+
+## Volume Dependencies
+
+```
+Volume I  → feeds → Volume II
+Volume II → informs → Volume III-PG
+Volume IV → constrains → ALL volumes
+Volume V  → hosts → ALL volumes
+```
+
+---
+
+## Doctrine Summary
+
+30 canonical doctrines are registered across Volumes I–V. See [Doctrine Registry](control/REVISIONGRADE-CANON-DOCTRINE-REGISTRY.md) for the complete index.
+
+| Volume | Doctrines |
+|---|---|
+| Volume I | 5 (D-I-01 through D-I-05) |
+| Volume II | 4 (D-II-01 through D-II-04) |
+| Volume III | 15 (D-III-01 through D-III-15) |
+| Volume IV | 6 (D-IV-01 through D-IV-06) |
+| Volume V | 5 (D-V-01 through D-V-05) |
+| **Total** | **30** |
+
+---
+
+*RevisionGrade Canon — Version 1.0 — March 2026*

--- a/canon/control/REVISIONGRADE-CANON-ASSEMBLY-MATRIX.md
+++ b/canon/control/REVISIONGRADE-CANON-ASSEMBLY-MATRIX.md
@@ -1,0 +1,147 @@
+# REVISIONGRADE CANON — ASSEMBLY MATRIX
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Canon ID: CTRL-ASSEMBLY-MTX-1.0  
+Governance: Self-governing document  
+Last Updated: 2026-03-09
+
+---
+
+## PURPOSE
+
+The Assembly Matrix shows how the canonical components assemble into functional systems. It is the wiring diagram of the canon—it shows which volumes feed which systems, which doctrines govern which operations, and how everything connects.
+
+Where the Doctrine Registry indexes what exists, the Assembly Matrix shows how everything works together.
+
+---
+
+## PART 1 — VOLUME DEPENDENCY MAP
+
+```
+Volume I (WAVE) → feeds → Volume II (Criteria)
+Volume II (Criteria) → feeds → Volume III-PG (Governance)
+Volume III-PG → constrains → Volume III-TI (Tools)
+Volume III-TI → implements → Volume III-OS (Ops)
+Volume III-OS → executes via → Volume V (Architecture)
+Volume IV (AI Gov) → constrains → ALL volumes
+Volume V (Architecture) → hosts → ALL volumes
+```
+
+### Reading Order for New Users:
+1. Volume III-PG (understand what the platform is)
+2. Volume I (understand the WAVE methodology)
+3. Volume II (understand how manuscripts are evaluated)
+4. Volume IV (understand AI governance)
+5. Volume III-TI (understand how it’s built)
+6. Volume III-OS (understand how it operates)
+7. Volume V (understand how it deploys)
+
+---
+
+## PART 2 — EVALUATION PIPELINE ASSEMBLY
+
+### Stage 1: Manuscript Intake
+- **Governed by:** Volume III-OS (Gates S-1, S-2, S-3)
+- **Implemented by:** Volume III-TI (Input Adapters)
+- **Platform rules:** Volume III-PG (User Rights, Submission)
+- **AI role:** Genre classification (Volume IV Level 2)
+
+### Stage 2: Wave Execution (W-01 through W-62)
+- **Methodology:** Volume I (Wave Groups 1–6)
+- **Governed by:** Volume III-OS (Gates E-1, E-2, E-3)
+- **Implemented by:** Volume III-TI (Wave Evaluator, Diagnostic Prompts)
+- **AI constraints:** Volume IV (Level 1 autonomous, confidence flagging)
+
+### Stage 3: Tsunami Aggregation (T-1 through T-6)
+- **Methodology:** Volume I (Tsunami Categories)
+- **Governed by:** Volume III-OS (Gate E-4)
+- **Implemented by:** Volume III-TI (Tsunami Evaluator, Aggregation Prompts)
+- **AI constraints:** Volume IV (Level 1 autonomous)
+
+### Stage 4: Criteria Scoring (C-01 through C-13)
+- **Methodology:** Volume II (13 Core Criteria, Scoring Model)
+- **Governed by:** Volume III-OS (Gates E-3, E-5)
+- **Implemented by:** Volume III-TI (Criteria Evaluator, Evaluation Prompts)
+- **AI constraints:** Volume IV (Level 1 for high confidence, Level 2 for low confidence)
+
+### Stage 5: Report Generation
+- **Output format:** Volume II (Eligibility Gates)
+- **Governed by:** Volume III-OS (Gates O-1, O-2, O-3)
+- **Implemented by:** Volume III-TI (Output Adapters, Report Generator)
+- **Platform rules:** Volume III-PG (User Rights, Transparency)
+
+---
+
+## PART 3 — DOCTRINE-TO-SYSTEM MAPPING
+
+### Wave System Governance
+- D-I-01 (Wave Sequence Immutability) → Wave Evaluator
+- D-I-02 (Wave Output Immutability) → Wave Evaluator, Database
+- D-I-03 (Score Justification) → All evaluators, All prompts
+- D-I-04 (No Manual Override) → UI, API, Admin console
+- D-I-05 (Tsunami Dependency) → Tsunami Evaluator, Gate E-4
+
+### Evaluation System Governance
+- D-II-01 (Criterion Immutability) → Criteria Evaluator, Schema
+- D-II-02 (Score Justification) → Criteria Evaluator, Prompts
+- D-II-03 (AI Scoring Limits) → AI integration layer
+- D-II-04 (No Criterion Override) → Gate O-2, Eligibility computation
+
+### Platform Governance System
+- D-III-01 through D-III-05 → Product decisions, Feature development
+- D-III-06 through D-III-10 → Engineering, Architecture decisions
+- D-III-11 through D-III-15 → Pipeline implementation, Operations
+
+### AI System Governance
+- D-IV-01 through D-IV-06 → All AI-touching systems
+- D-IV-04 (Canon Read-Only) → File permissions, Access controls
+- D-IV-05 (Session Isolation) → AI session management
+- D-IV-06 (Audit Everything) → Logging infrastructure
+
+### Infrastructure Governance
+- D-V-01 through D-V-05 → DevOps, Deployment, Monitoring
+
+---
+
+## PART 4 — CONFLICT RESOLUTION MATRIX
+
+When two doctrines appear to conflict, use this resolution hierarchy:
+
+1. **Volume IV (AI Governance)** — overrides all others for AI behavior
+2. **Volume III-PG (Platform Governance)** — overrides implementation details
+3. **Volume II (Criteria)** — overrides Volume I specifics for scoring
+4. **Volume I (WAVE)** — governs wave execution details
+5. **Volume III-TI and III-OS** — implementation follows, doesn’t govern
+6. **Volume V** — infrastructure follows, doesn’t govern
+
+If genuine conflict exists after applying this hierarchy, escalate to Doctrine Registry for formal resolution and documentation.
+
+---
+
+## PART 5 — CANON CHANGE IMPACT ASSESSMENT
+
+Before any canon modification, assess impact using this matrix:
+
+| Volume Changed | Volumes Affected | Systems Affected |
+|---|---|---|
+| Volume I | II, III-TI, III-OS | Wave Evaluator, Prompts, Pipeline |
+| Volume II | I, III-TI, III-OS | Criteria Evaluator, Prompts, Gates |
+| Volume III-PG | All | All platform features |
+| Volume III-TI | III-OS, V | Implementation, Deployment |
+| Volume III-OS | V | Pipeline, Infrastructure |
+| Volume IV | All | All AI-touching systems |
+| Volume V | None | Infrastructure only |
+
+---
+
+## REVISION HISTORY
+
+| Version | Date | Author | Summary |
+|---|---|---|---|
+| 1.0 | 2026-03-09 | Mike Meraw | Initial matrix creation |
+
+---
+
+*End of Assembly Matrix*

--- a/canon/control/REVISIONGRADE-CANON-DOCTRINE-REGISTRY.md
+++ b/canon/control/REVISIONGRADE-CANON-DOCTRINE-REGISTRY.md
@@ -1,0 +1,96 @@
+# REVISIONGRADE CANON — DOCTRINE REGISTRY
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Canon ID: CTRL-DOCTRINE-REG-1.0  
+Governance: Self-governing document  
+Last Updated: 2026-03-09
+
+---
+
+## PURPOSE
+
+The Doctrine Registry is the master list of all canonical doctrines across Volumes I–V. It is the authoritative reference for knowing what doctrines exist, where they live, and what they govern. Every doctrine in the canon is registered here.
+
+The Doctrine Registry does not define doctrines—doctrines are defined in their respective volumes. It indexes and cross-references them.
+
+---
+
+## DOCTRINE INDEX
+
+### Volume I Doctrines (WAVE Revision Guide)
+
+| Doctrine ID | Name | Source | Summary |
+|---|---|---|---|
+| D-I-01 | Wave Sequence Immutability | Vol I, Sec 3.1 | Waves execute in fixed numerical sequence |
+| D-I-02 | Wave Output Immutability | Vol I, Sec 3.1 | Wave output cannot be retroactively modified |
+| D-I-03 | Score Justification Requirement | Vol I, Sec 3.2 | Every score requires documented reasoning |
+| D-I-04 | No Manual Score Override | Vol I, Sec 3.2 | Manual score overrides of wave output are prohibited |
+| D-I-05 | Tsunami Dependency | Vol I, Sec 3.1 | Tsunami aggregation requires all component waves |
+
+### Volume II Doctrines (Evaluation Criteria)
+
+| Doctrine ID | Name | Source | Summary |
+|---|---|---|---|
+| D-II-01 | Criterion Immutability | Vol II, Eval Doctrines | 13 criteria cannot be changed without formal revision |
+| D-II-02 | Score Justification | Vol II, Eval Doctrines | Every score requires manuscript evidence |
+| D-II-03 | AI Scoring Limits | Vol II, Eval Doctrines | AI may propose, must flag uncertainty |
+| D-II-04 | No Criterion Override | Vol II, Eval Doctrines | Gates computed from actual scores only |
+
+### Volume III Doctrines (Platform Governance)
+
+| Doctrine ID | Name | Source | Summary |
+|---|---|---|---|
+| D-III-01 | Platform Purpose Lock | Vol III-PG, Part 4 | Platform purpose locked without full canon revision |
+| D-III-02 | Score Integrity | Vol III-PG, Part 4 | No score inflation/deflation for any reason |
+| D-III-03 | Canon Supremacy | Vol III-PG, Part 4 | Canon prevails over all business decisions |
+| D-III-04 | User Transparency | Vol III-PG, Part 4 | Users always have access to evaluation methodology |
+| D-III-05 | No Vanity Mode | Vol III-PG, Part 4 | No feature that softens honest feedback |
+| D-III-06 | Canon Conformity | Vol III-TI, Part 5 | All implementation must conform to canon |
+| D-III-07 | Schema Immutability | Vol III-TI, Part 5 | Schema fields deprecated only, never deleted |
+| D-III-08 | Prompt Traceability | Vol III-TI, Part 5 | All prompts version-controlled and traceable |
+| D-III-09 | Adapter Neutrality | Vol III-TI, Part 5 | Adapters translate faithfully without modification |
+| D-III-10 | Evaluator Integrity | Vol III-TI, Part 5 | Evaluators execute canonical logic exactly |
+| D-III-11 | Gate Integrity | Vol III-OS, Part 4 | No gate bypassed except documented exception paths |
+| D-III-12 | Sequential Execution | Vol III-OS, Part 4 | Pipeline strictly sequential |
+| D-III-13 | Routing Transparency | Vol III-OS, Part 4 | Every routing decision logged |
+| D-III-14 | Trigger Immutability | Vol III-OS, Part 4 | Automatic triggers cannot be modified at runtime |
+| D-III-15 | Exception Documentation | Vol III-OS, Part 4 | Every exception path execution documented |
+
+### Volume IV Doctrines (AI Governance)
+
+| Doctrine ID | Name | Source | Summary |
+|---|---|---|---|
+| D-IV-01 | AI Authority Ceiling | Vol IV, Part 5 | AI authority cannot exceed canon grant |
+| D-IV-02 | Human Override Supremacy | Vol IV, Part 5 | Human authority always supersedes AI |
+| D-IV-03 | Confidence Transparency | Vol IV, Part 5 | AI must disclose confidence level always |
+| D-IV-04 | Canon Read-Only | Vol IV, Part 5 | Canon is read-only for all AI systems |
+| D-IV-05 | Session Isolation | Vol IV, Part 5 | AI sessions are isolated |
+| D-IV-06 | Audit Everything | Vol IV, Part 5 | Every AI action must be logged |
+
+### Volume V Doctrines (Execution Architecture)
+
+| Doctrine ID | Name | Source | Summary |
+|---|---|---|---|
+| D-V-01 | Infrastructure as Canon | Vol V, Part 6 | Infrastructure must support canon requirements |
+| D-V-02 | Monitoring Before Scaling | Vol V, Part 6 | Measure first, scale second |
+| D-V-03 | Recovery Priority | Vol V, Part 6 | Data integrity prioritized over recovery speed |
+| D-V-04 | Industry Alignment | Vol V, Part 6 | Outputs use publishing industry terminology |
+| D-V-05 | Cost Transparency | Vol V, Part 6 | Per-evaluation costs tracked and visible |
+
+---
+
+## TOTAL DOCTRINES: 30
+
+---
+
+## REVISION HISTORY
+
+| Version | Date | Author | Summary |
+|---|---|---|---|
+| 1.0 | 2026-03-09 | Mike Meraw | Initial registry creation |
+
+---
+
+*End of Doctrine Registry*

--- a/canon/control/VOLUME-II-A-OPERATIONAL-SCHEMA.md
+++ b/canon/control/VOLUME-II-A-OPERATIONAL-SCHEMA.md
@@ -1,0 +1,132 @@
+# VOLUME II-A — OPERATIONAL SCHEMA
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume II, Volume III-TI  
+Canon ID: VOL-IIA-OPS-SCHEMA-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## PURPOSE
+
+Volume II-A provides the operational implementation of Volume II’s 13 evaluation criteria. Where Volume II defines what each criterion measures and how it is scored, Volume II-A defines how those criteria are operationalized in system terms—the prompts, evidence requirements, scoring rubrics, and output formats used in actual evaluations.
+
+Volume II-A is the bridge between the evaluative methodology (Volume II) and the technical implementation (Volume III-TI).
+
+---
+
+## PART 1 — CRITERION OPERATIONALIZATION
+
+### How Each Criterion Operates
+
+Every criterion follows this operational pattern:
+
+1. **Wave Input Collection** — Gather outputs from relevant waves
+2. **Tsunami Input Collection** — Gather outputs from relevant tsunamis
+3. **Evidence Synthesis** — Identify key manuscript evidence
+4. **Score Computation** — Apply scoring rubric to evidence
+5. **Justification Generation** — Write minimum 100-word justification
+6. **Confidence Assessment** — Self-assess confidence level
+7. **Output Validation** — Validate output against Criterion Score Schema
+
+---
+
+## PART 2 — SCORING RUBRICS
+
+### Universal Rubric (all 13 criteria)
+
+**Score 1–3 (Needs Major Revision):**
+- Multiple significant issues present
+- Issues are systemic, not isolated
+- Fundamental craft elements are underdeveloped or absent
+- Reader experience is substantially compromised
+
+**Score 4–6 (Functional with Notable Weaknesses):**
+- Core elements are present but inconsistently executed
+- Specific, identifiable weaknesses
+- Does not yet meet professional publication standards
+- Clear revision path exists
+
+**Score 7–8 (Strong with Minor Issues):**
+- Professional-level execution
+- Minor, addressable issues present
+- Meets or approaches publication standards
+- Competitively viable for agent submission
+
+**Score 9–10 (Exceptional Execution):**
+- Exceeds professional standards
+- Distinctive, memorable execution
+- Highly competitive for agent submission
+- Near-publication or publication ready
+
+---
+
+## PART 3 — EVIDENCE REQUIREMENTS
+
+### What Counts as Manuscript Evidence
+
+- Direct quotation from the manuscript (with location reference)
+- Paraphrase of specific passage (with location reference)
+- Pattern identification with multiple location references
+- Structural observation with chapter/scene reference
+- Aggregate observation referencing multiple sections
+
+### What Does NOT Count as Evidence
+
+- General impressions without manuscript location
+- Claims about the author’s intent
+- References to genre conventions not present in the manuscript
+- Assumptions about reader response without textual support
+
+---
+
+## PART 4 — CRITERION-TO-WAVE MAPPING
+
+| Criterion | Primary Waves | Primary Tsunami |
+|---|---|---|
+| C-01: Narrative Structure | W-01,W-02,W-04,W-09 | T-1, T-3 |
+| C-02: Plot Coherence | W-21,W-22,W-29,W-30 | T-3 |
+| C-03: Pacing and Tension | W-08,W-22,W-24,W-25 | T-3 |
+| C-04: Opening and Closing | W-06,W-60,W-61 | T-6 |
+| C-05: Character Development | W-15,W-16,W-18,W-20 | T-2 |
+| C-06: Dialogue Quality | W-12,W-13,W-44 | T-2 |
+| C-07: Emotional Resonance | W-17,W-51,W-52 | T-6 |
+| C-08: Prose Quality | W-31,W-32,W-33,W-35 | T-4 |
+| C-09: Voice and Style | W-03,W-40 | T-4 |
+| C-10: Show vs. Tell | W-05,W-38 | T-4 |
+| C-11: Technical Execution | W-41,W-42,W-43,W-45,W-46 | T-5 |
+| C-12: Genre Awareness | W-48,W-56,W-57 | T-6 |
+| C-13: Reader Experience | W-51,W-52,W-53,W-54 | T-6 |
+
+---
+
+## PART 5 — ELIGIBILITY GATE OPERATIONAL RULES
+
+### Gate Computation Rules
+
+**Agent Readiness Gate:**
+- Condition: ALL 13 criteria scored 6.0 or higher
+- AND: Overall score (mean of 13 criteria) is 7.0 or higher
+- Computed automatically after all criteria are scored
+- No manual override permitted
+
+**Revision Complete Gate:**
+- Condition: ALL 13 criteria scored 5.0 or higher
+- AND: Overall score is 6.0 or higher
+- Signals: Ready for next major revision cycle
+
+**Publication Readiness Gate:**
+- Condition: ALL 13 criteria scored 7.0 or higher
+- AND: Overall score is 8.0 or higher
+- Signals: Approaching publication standard
+
+### Near-Threshold Flagging
+
+When any criterion score is within 0.5 of a gate boundary, flag for human review before gate determination is made final. This is a Volume IV Level 2 action.
+
+---
+
+*End of Volume II-A — Operational Schema*

--- a/canon/control/VOLUMES-I-V-DEFINITIONS-CONTENT-REGISTRY-VIEW.md
+++ b/canon/control/VOLUMES-I-V-DEFINITIONS-CONTENT-REGISTRY-VIEW.md
@@ -1,0 +1,130 @@
+# REVISIONGRADE CANON — VOLUMES I–V DEFINITIONS & CONTENT REGISTRY VIEW
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Canon ID: CTRL-DEFINITIONS-REG-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## PURPOSE
+
+This document is the cross-volume definitions register and content registry view for the RevisionGrade canon. It provides a single location to find canonical definitions for key terms, and a registry view showing what content lives in which volume.
+
+---
+
+## PART 1 — CANONICAL DEFINITIONS
+
+### A
+
+**Adapter** — A system component that translates between external formats and the canonical evaluation pipeline. Defined in Volume III-TI.
+
+**Assembly Matrix** — The canonical control document showing how volumes, doctrines, and systems connect. One of four control documents.
+
+**Authority Level** — The classification of AI action permissions (Level 1, 2, or 3). Defined in Volume IV.
+
+### C
+
+**Canon** — The complete set of authoritative documents governing the RevisionGrade platform: Volumes I–V plus four control documents.
+
+**Canon ID** — The unique identifier for a canonical document (e.g., VOL-I-WAVE-V20).
+
+**Canonical** — Having the authority of canon. Canonical documents are authoritative; archived documents are not.
+
+**Confidence** — The AI self-assessment of reliability for a given score or output. Three levels: HIGH, MEDIUM, LOW.
+
+**Criterion (pl. Criteria)** — One of the 13 evaluation dimensions in Volume II against which manuscripts are assessed.
+
+### D
+
+**Delta Report** — A comparison evaluation showing how a manuscript changed between two submission versions.
+
+**Diagnostic Prompt** — An AI prompt designed to execute a specific WAVE diagnostic. Defined in Volume III-TI.
+
+**Doctrine** — A canonical rule with a unique ID registered in the Doctrine Registry.
+
+**Doctrine Registry** — The canonical control document listing all 30 doctrines across Volumes I–V.
+
+### E
+
+**Eligibility Gate** — A minimum scoring threshold that must be met for specific platform actions (Agent Readiness, Revision Complete, Publication Readiness). Defined in Volume II.
+
+**Evaluator** — A system component that executes canonical evaluation logic. Defined in Volume III-TI.
+
+### G
+
+**Gate** — An operational checkpoint that must be passed before the pipeline can proceed. Defined in Volume III-OS.
+
+**Governance** — The system of rules, authorities, and accountability structures that govern platform behavior.
+
+### M
+
+**Manuscript** — A written work submitted to RevisionGrade for evaluation. Must meet submission gate requirements.
+
+### P
+
+**Pipeline** — The sequential evaluation process from submission through delivery. Defined in Volume III-OS.
+
+**Prompt** — An instruction set provided to an AI model for a specific evaluation task. Governed by Volume III-TI and Volume IV.
+
+### S
+
+**Schema** — The canonical data structure definition for evaluation components. Defined in Volume III-TI.
+
+**Score** — A numerical assessment on a 1–10 scale. Assigned by waves (individual), tsunamis (aggregated), and criteria (synthesized).
+
+### T
+
+**Tsunami** — A higher-order diagnostic aggregation that combines findings from multiple waves. Six tsunamis (T-1 through T-6). Defined in Volume I.
+
+### V
+
+**Volume** — One of the five primary canonical documents (I through V).
+
+### W
+
+**Wave** — One of 62 individual diagnostic passes through a manuscript, each targeting a specific craft element. Defined in Volume I.
+
+---
+
+## PART 2 — CONTENT REGISTRY VIEW
+
+### What Lives Where
+
+| Content Type | Location |
+|---|---|
+| Wave definitions (W-01 through W-62) | Volume I, Part 1 |
+| Tsunami definitions (T-1 through T-6) | Volume I, Part 2 |
+| Wave execution rules | Volume I, Part 3 |
+| 13 evaluation criteria | Volume II |
+| Eligibility gate thresholds | Volume II, Scoring Model |
+| Platform identity and purpose | Volume III-PG, Part 1 |
+| User journey and rights | Volume III-PG, Part 2 |
+| Platform governance constraints | Volume III-PG, Part 3 |
+| Core schemas | Volume III-TI, Part 1 |
+| Prompt architecture | Volume III-TI, Part 2 |
+| Adapters and evaluators | Volume III-TI, Part 3 |
+| Integration contracts | Volume III-TI, Part 4 |
+| Submission gates | Volume III-OS, Part 1 |
+| Routing rules | Volume III-OS, Part 2 |
+| Operational triggers | Volume III-OS, Part 3 |
+| AI authority levels | Volume IV, Part 1 |
+| AI governance constraints | Volume IV, Part 2 |
+| Risk and failure management | Volume IV, Part 3 |
+| Canon protection systems | Volume IV, Part 4 |
+| Deployment architecture | Volume V, Part 1 |
+| Reliability and monitoring | Volume V, Part 2 |
+| Scaling architecture | Volume V, Part 3 |
+| Disaster recovery | Volume V, Part 4 |
+| Industry interface | Volume V, Part 5 |
+| Doctrine index | Doctrine Registry |
+| Volume dependency map | Assembly Matrix |
+| Conflict resolution hierarchy | Assembly Matrix, Part 4 |
+| Term definitions | This document |
+| Operational schema (Vol II) | Volume II-A Operational Schema |
+
+---
+
+*End of Volumes I–V Definitions & Content Registry View*

--- a/canon/volumes/VOLUME-I-WAVE-REVISION-GUIDE-CANON.md
+++ b/canon/volumes/VOLUME-I-WAVE-REVISION-GUIDE-CANON.md
@@ -1,0 +1,201 @@
+# VOLUME I — THE WAVE REVISION GUIDE CANON
+
+Status: CANONICAL — ACTIVE  
+Version: 2.0 (March 2026)  
+Authority: Mike Meraw  
+Depends on: Volume II, Volume IV  
+Canon ID: VOL-I-WAVE-V20  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION — THE WAVE REVISION GUIDE
+
+The WAVE Revision Guide is the micro-level revision architecture for RevisionGrade. It governs how manuscripts are evaluated at the sentence, paragraph, and scene level through a structured system of diagnostic waves, tsunamis, and execution rules.
+
+This is the operational core of the platform — the actual revision methodology that powers every evaluation.
+
+---
+
+## PART 1 — FOUNDATION AND FRAMEWORK
+
+### 1.1 What Is the WAVE System?
+
+The WAVE system is a structured, sequential diagnostic framework for manuscript revision. Each "wave" represents a focused diagnostic pass through the text, targeting a specific craft element.
+
+**Core Principles:**
+- Every wave isolates one craft element for focused diagnosis
+- Waves execute in a fixed, non-negotiable sequence
+- Each wave produces specific, actionable diagnostic output
+- No wave may override or contradict another wave's findings
+- The complete wave sequence constitutes one full revision pass
+
+### 1.2 The 62 Diagnostic Waves
+
+The WAVE system contains 62 individual diagnostic waves organized into groups. Each wave:
+- Has a unique identifier (W-01 through W-62)
+- Targets a specific craft element
+- Produces standardized diagnostic output
+- Feeds into the tsunami aggregation system
+
+### 1.3 Wave Groups
+
+**Group 1: Narrative Foundation (W-01 through W-10)**
+- W-01: Point of View Consistency
+- W-02: Tense Consistency
+- W-03: Voice Authenticity
+- W-04: Narrative Distance
+- W-05: Scene vs. Summary Balance
+- W-06: Opening Hook Strength
+- W-07: Chapter/Section Transitions
+- W-08: Pacing Rhythm
+- W-09: Information Flow
+- W-10: Reader Orientation
+
+**Group 2: Character Systems (W-11 through W-20)**
+- W-11: Character Introduction Clarity
+- W-12: Dialogue Authenticity
+- W-13: Character Voice Differentiation
+- W-14: Internal Monologue Quality
+- W-15: Character Arc Progression
+- W-16: Motivation Clarity
+- W-17: Emotional Resonance
+- W-18: Character Consistency
+- W-19: Relationship Dynamics
+- W-20: Character Agency
+
+**Group 3: Story Architecture (W-21 through W-30)**
+- W-21: Plot Structure Integrity
+- W-22: Conflict Escalation
+- W-23: Stakes Clarity
+- W-24: Tension Management
+- W-25: Subplot Integration
+- W-26: Foreshadowing Effectiveness
+- W-27: Payoff Delivery
+- W-28: Scene Purpose Clarity
+- W-29: Cause and Effect Logic
+- W-30: Story Promise Fulfillment
+
+**Group 4: Language and Style (W-31 through W-40)**
+- W-31: Sentence-Level Clarity
+- W-32: Word Choice Precision
+- W-33: Metaphor and Simile Quality
+- W-34: Sensory Detail Integration
+- W-35: Prose Rhythm
+- W-36: Redundancy Detection
+- W-37: Cliche Identification
+- W-38: Show vs. Tell Balance
+- W-39: Descriptive Economy
+- W-40: Stylistic Consistency
+
+**Group 5: Technical Execution (W-41 through W-50)**
+- W-41: Grammar and Syntax
+- W-42: Punctuation Accuracy
+- W-43: Paragraph Structure
+- W-44: Dialogue Formatting
+- W-45: Timeline Consistency
+- W-46: Setting Continuity
+- W-47: Factual Accuracy
+- W-48: Genre Convention Adherence
+- W-49: Manuscript Formatting
+- W-50: Word Count Economy
+
+**Group 6: Reader Experience (W-51 through W-62)**
+- W-51: Emotional Impact Assessment
+- W-52: Reader Engagement Tracking
+- W-53: Surprise and Unpredictability
+- W-54: Thematic Resonance
+- W-55: Cultural Sensitivity
+- W-56: Market Positioning
+- W-57: Comp Title Alignment
+- W-58: Query Letter Readiness
+- W-59: Synopsis Coherence
+- W-60: First Page Impact
+- W-61: Final Page Impact
+- W-62: Overall Revision Priority Ranking
+
+---
+
+## PART 2 — TSUNAMI AGGREGATION SYSTEM
+
+### 2.1 What Are Tsunamis?
+
+Tsunamis are higher-order diagnostic aggregations that combine findings from multiple waves into unified assessments. While waves isolate individual craft elements, tsunamis reveal systemic patterns.
+
+### 2.2 Tsunami Categories
+
+**T-1: Narrative Cohesion Tsunami** (aggregates W-01 through W-10)
+- Identifies systemic narrative foundation issues
+- Produces cohesion score and priority recommendations
+
+**T-2: Character System Tsunami** (aggregates W-11 through W-20)
+- Identifies character-level systemic issues
+- Produces character health score
+
+**T-3: Architecture Tsunami** (aggregates W-21 through W-30)
+- Identifies structural integrity issues
+- Produces architecture stability score
+
+**T-4: Language Tsunami** (aggregates W-31 through W-40)
+- Identifies prose-level systemic patterns
+- Produces language quality score
+
+**T-5: Technical Tsunami** (aggregates W-41 through W-50)
+- Identifies technical execution patterns
+- Produces technical accuracy score
+
+**T-6: Reader Experience Tsunami** (aggregates W-51 through W-62)
+- Identifies reader-facing impact patterns
+- Produces reader experience score
+
+---
+
+## PART 3 — EXECUTION RULES
+
+### 3.1 Wave Execution Protocol
+
+1. Waves execute in numerical sequence (W-01 → W-62)
+2. No wave may be skipped unless explicitly excluded by configuration
+3. Each wave must complete before the next begins
+4. Wave output is immutable once produced
+5. Tsunami aggregation occurs only after all component waves complete
+
+### 3.2 Scoring Rules
+
+- Each wave produces a diagnostic score on a standardized scale
+- Scores feed into tsunami aggregation
+- Tsunami scores feed into the Volume II evaluation criteria
+- No manual override of wave scores is permitted
+- AI must document reasoning for every score assigned
+
+### 3.3 Conflict Resolution
+
+- When wave findings appear to conflict, the higher-numbered wave takes precedence for its domain
+- Tsunami-level conflicts are resolved by the Assembly Matrix
+- No wave may retroactively modify another wave's output
+
+---
+
+## PART 4 — INTEGRATION WITH CANON
+
+### 4.1 Volume II Integration
+
+Wave and tsunami outputs feed directly into Volume II's 13 evaluation criteria. The mapping is:
+- Tsunamis T-1 and T-3 → Criteria 1-4 (Structure and Narrative)
+- Tsunami T-2 → Criteria 5-7 (Character)
+- Tsunami T-4 → Criteria 8-10 (Language and Style)
+- Tsunami T-5 → Criteria 11-12 (Technical)
+- Tsunami T-6 → Criterion 13 (Reader Experience)
+
+### 4.2 Volume IV Governance
+
+All wave execution is subject to Volume IV AI Governance constraints:
+- AI authority limits apply to all diagnostic scoring
+- Uncertainty flagging is mandatory
+- Human override rights are preserved at every level
+- Canon protection rules prevent unauthorized wave modifications
+
+---
+
+*End of Volume I — The WAVE Revision Guide Canon*

--- a/canon/volumes/VOLUME-II-STORY-EVALUATION-CRITERIA.md
+++ b/canon/volumes/VOLUME-II-STORY-EVALUATION-CRITERIA.md
@@ -1,0 +1,204 @@
+# VOLUME II — STORY EVALUATION CRITERIA & ANALYTICAL FRAMEWORK
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume I, Volume IV  
+Canon ID: VOL-II-CRITERIA-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume II defines the 13 core evaluation criteria used by RevisionGrade to assess literary manuscripts. These criteria form the analytical backbone of the platform, translating the micro-level diagnostic data from Volume I's WAVE system into meaningful, structured evaluations.
+
+Every manuscript submitted to RevisionGrade is evaluated against these 13 criteria. The criteria are fixed, sequenced, and non-negotiable. They cannot be modified by AI, users, or platform operators without a formal canon revision through the Doctrine Registry.
+
+---
+
+## THE 13 CORE EVALUATION CRITERIA
+
+### Criterion 1: Narrative Structure
+**What it measures:** The architectural integrity of the story’s framework—beginning, middle, end, act structure, scene sequencing, and overall narrative logic.
+
+**Scoring Inputs:** WAVE Groups 1 and 3 (Narrative Foundation + Story Architecture)
+
+**Key Diagnostic Questions:**
+- Does the story follow a coherent structural arc?
+- Are acts/parts properly proportioned?
+- Do scenes connect logically?
+- Is the structure appropriate for the genre?
+
+### Criterion 2: Plot Coherence
+**What it measures:** The logical consistency and causal integrity of the plot—whether events follow from one another, whether plot threads resolve, and whether the story's internal logic holds.
+
+**Scoring Inputs:** W-21 through W-30 (Story Architecture waves)
+
+**Key Diagnostic Questions:**
+- Do plot events follow cause-and-effect logic?
+- Are all major plot threads resolved?
+- Are there unexplained plot holes?
+- Does the plot serve the story's central premise?
+
+### Criterion 3: Pacing and Tension
+**What it measures:** The rhythm and momentum of the story—how effectively the narrative manages acceleration, deceleration, tension, and release.
+
+**Scoring Inputs:** W-08 (Pacing Rhythm), W-22 (Conflict Escalation), W-24 (Tension Management)
+
+**Key Diagnostic Questions:**
+- Does pacing match genre expectations?
+- Are tension and release balanced effectively?
+- Are there dead zones or rushed sequences?
+- Does momentum build toward climax appropriately?
+
+### Criterion 4: Opening and Closing Impact
+**What it measures:** The effectiveness of the story's first and last impressions—the hook, the opening pages, the final scene, and the lasting emotional resonance.
+
+**Scoring Inputs:** W-06 (Opening Hook), W-60 (First Page Impact), W-61 (Final Page Impact)
+
+**Key Diagnostic Questions:**
+- Does the opening hook the reader within the first page?
+- Does the closing deliver emotional and narrative payoff?
+- Is there a sense of completeness?
+- Would the opening compel an agent to keep reading?
+
+### Criterion 5: Character Development
+**What it measures:** The depth, growth, and authenticity of characters—particularly the protagonist's arc, but including all significant characters.
+
+**Scoring Inputs:** WAVE Group 2 (Character Systems, W-11 through W-20)
+
+**Key Diagnostic Questions:**
+- Do characters grow or change meaningfully?
+- Are character arcs complete and satisfying?
+- Are characters multi-dimensional?
+- Do characters make choices consistent with their established traits?
+
+### Criterion 6: Dialogue Quality
+**What it measures:** The naturalism, purpose, and craft of dialogue—whether it sounds authentic, advances the story, reveals character, and avoids common pitfalls.
+
+**Scoring Inputs:** W-12 (Dialogue Authenticity), W-13 (Character Voice Differentiation), W-44 (Dialogue Formatting)
+
+**Key Diagnostic Questions:**
+- Does each character sound distinct?
+- Does dialogue serve multiple purposes (characterization, plot, theme)?
+- Is dialogue free of exposition dumps?
+- Is dialogue formatting correct?
+
+### Criterion 7: Emotional Resonance
+**What it measures:** The story's ability to evoke genuine emotional responses in the reader—empathy, tension, surprise, grief, joy, and all the feelings that make stories matter.
+
+**Scoring Inputs:** W-17 (Emotional Resonance), W-51 (Emotional Impact), Tsunami T-6
+
+**Key Diagnostic Questions:**
+- Does the story make the reader feel something?
+- Are emotional beats earned through setup and context?
+- Is sentimentality avoided in favor of authentic emotion?
+- Do emotional high points land effectively?
+
+### Criterion 8: Prose Quality
+**What it measures:** The sentence-level craft—clarity, rhythm, word choice, imagery, and the overall quality of the writing at the micro level.
+
+**Scoring Inputs:** WAVE Group 4 (Language and Style, W-31 through W-40)
+
+**Key Diagnostic Questions:**
+- Is the prose clear and purposeful?
+- Is word choice precise and evocative?
+- Is there a consistent prose style?
+- Are metaphors and imagery effective?
+
+### Criterion 9: Voice and Style
+**What it measures:** The distinctiveness and consistency of the author's voice—whether the narrative has a recognizable, authentic style that serves the story.
+
+**Scoring Inputs:** W-03 (Voice Authenticity), W-40 (Stylistic Consistency)
+
+**Key Diagnostic Questions:**
+- Is the voice distinctive and memorable?
+- Is the voice consistent throughout?
+- Does the voice match the story's genre and tone?
+- Would a reader recognize this author's voice?
+
+### Criterion 10: Show vs. Tell Balance
+**What it measures:** The balance between dramatized scenes and narrative summary—whether the author shows through action, dialogue, and sensory detail rather than telling through exposition.
+
+**Scoring Inputs:** W-05 (Scene vs. Summary), W-38 (Show vs. Tell Balance)
+
+**Key Diagnostic Questions:**
+- Are key moments dramatized rather than summarized?
+- Is telling used strategically rather than as a default?
+- Are emotions shown through behavior rather than stated?
+- Is there appropriate balance for the genre?
+
+### Criterion 11: Technical Execution
+**What it measures:** Grammar, syntax, punctuation, formatting, and all the mechanical elements of manuscript preparation.
+
+**Scoring Inputs:** WAVE Group 5 (Technical Execution, W-41 through W-50)
+
+**Key Diagnostic Questions:**
+- Is the manuscript free of grammatical errors?
+- Is punctuation accurate and consistent?
+- Is formatting industry-standard?
+- Are there timeline or continuity errors?
+
+### Criterion 12: Genre Awareness
+**What it measures:** How well the manuscript understands and executes within its genre—meeting reader expectations while bringing something fresh.
+
+**Scoring Inputs:** W-48 (Genre Convention Adherence), W-56 (Market Positioning), W-57 (Comp Title Alignment)
+
+**Key Diagnostic Questions:**
+- Does the manuscript meet genre expectations?
+- Does it bring something new to the genre?
+- Would genre readers be satisfied?
+- Is the manuscript positioned for its target market?
+
+### Criterion 13: Overall Reader Experience
+**What it measures:** The holistic assessment—would a reader enjoy this manuscript, recommend it, remember it? This is the synthesis criterion.
+
+**Scoring Inputs:** Tsunami T-6 (Reader Experience), all tsunami aggregations
+
+**Key Diagnostic Questions:**
+- Would a reader finish this manuscript?
+- Would a reader recommend it?
+- Does it leave a lasting impression?
+- Is it ready for agent/editor review?
+
+---
+
+## SCORING MODEL
+
+### Scale
+Each criterion is scored on a 1–10 scale:
+- 1–3: Significant issues requiring major revision
+- 4–6: Functional but with notable weaknesses
+- 7–8: Strong execution with minor issues
+- 9–10: Exceptional execution
+
+### Weighting
+All 13 criteria are weighted equally in the overall score. No criterion takes precedence over another. The overall manuscript score is the arithmetic mean of all 13 criterion scores.
+
+### Eligibility Gates
+Certain minimum scores are required for specific platform actions:
+- Agent Readiness Declaration: No criterion below 6, overall score 7.0+
+- Revision Complete Flag: No criterion below 5, overall score 6.0+
+- Publication Readiness: No criterion below 7, overall score 8.0+
+
+---
+
+## EVALUATION DOCTRINES
+
+### Doctrine: Criterion Immutability
+The 13 criteria cannot be added to, removed, or reordered without a formal canon revision through the Doctrine Registry.
+
+### Doctrine: Score Justification
+Every score assigned must include written justification referencing specific manuscript evidence. No score may be assigned without supporting reasoning.
+
+### Doctrine: AI Scoring Limits
+AI may propose scores but must flag uncertainty. Scores with low confidence must be marked for human review per Volume IV governance.
+
+### Doctrine: No Criterion Overrides
+No single criterion score can be manually overridden to change an eligibility gate outcome. Gates are computed from actual scores only.
+
+---
+
+*End of Volume II — Story Evaluation Criteria & Analytical Framework*

--- a/canon/volumes/VOLUME-III-OPERATIONAL-SPECIFICATION.md
+++ b/canon/volumes/VOLUME-III-OPERATIONAL-SPECIFICATION.md
@@ -1,0 +1,166 @@
+# VOLUME III — OPERATIONAL SPECIFICATION
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume I, Volume II, Volume III (Platform Governance, Tools)  
+Canon ID: VOL-III-OPS-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume III (Operational Specification) defines the gates, thresholds, routing rules, and operational triggers that govern when and how canonical rules fire inside the RevisionGrade platform. This is the runtime specification—it answers the question: when does each rule actually execute?
+
+This document bridges the gap between what the canon requires (Volumes I–II) and how it is implemented (Volume III Tools). It defines the operational behavior of the system.
+
+---
+
+## PART 1 — GATES AND THRESHOLDS
+
+### 1.1 Submission Gates
+
+**Gate S-1: Format Validation**
+- Trigger: Manuscript upload
+- Rule: Manuscript must be in accepted format (DOCX, PDF, TXT)
+- Failure action: Reject with format error message
+- No override permitted
+
+**Gate S-2: Word Count Validation**
+- Trigger: Post-format validation
+- Rule: Manuscript must be between 20,000 and 200,000 words
+- Failure action: Reject with word count error
+- Override: Admin can expand range for specific genres
+
+**Gate S-3: Genre Classification**
+- Trigger: Post-word count validation
+- Rule: System must classify manuscript genre
+- Failure action: Queue for manual genre assignment
+- Human review required if confidence below 70%
+
+### 1.2 Evaluation Gates
+
+**Gate E-1: Wave Sequence Integrity**
+- Trigger: Before each wave execution
+- Rule: Previous wave must be complete before next begins
+- Failure action: Halt evaluation, log error
+- No override permitted
+
+**Gate E-2: Wave Output Validation**
+- Trigger: After each wave produces output
+- Rule: Output must conform to Wave Result Schema
+- Failure action: Re-execute wave (max 2 retries)
+- Escalate to human review after 2 failures
+
+**Gate E-3: Confidence Threshold**
+- Trigger: After each wave and criterion score
+- Rule: If confidence is LOW, flag for human review
+- Failure action: Score is provisional until human confirms
+- Per Volume IV governance
+
+**Gate E-4: Tsunami Aggregation Readiness**
+- Trigger: Before tsunami computation
+- Rule: All component waves must be complete with valid output
+- Failure action: Cannot proceed to tsunami; escalate
+
+**Gate E-5: Criteria Computation Readiness**
+- Trigger: Before criterion scoring
+- Rule: All required waves and tsunamis must be complete
+- Failure action: Cannot proceed to criterion scoring; escalate
+
+### 1.3 Output Gates
+
+**Gate O-1: Report Completeness**
+- Trigger: Before delivering evaluation report
+- Rule: All 13 criteria must have scores and justifications
+- Failure action: Hold report, flag for review
+
+**Gate O-2: Eligibility Gate Computation**
+- Trigger: After all criteria scores computed
+- Rule: Compute eligibility gates per Volume II rules
+- Automatic—no human intervention required
+
+**Gate O-3: Delivery Authorization**
+- Trigger: Before report delivered to user
+- Rule: Report must pass completeness check
+- Failure action: Queue for manual review
+
+---
+
+## PART 2 — ROUTING RULES
+
+### 2.1 Standard Routing
+
+Normal manuscript flow:
+Submission → S-1 → S-2 → S-3 → WAVE Execution (W-01 through W-62) → Tsunami Aggregation (T-1 through T-6) → Criteria Scoring (C-01 through C-13) → Report Generation → Delivery
+
+### 2.2 Exception Routing
+
+**Low Confidence Path:**
+When any score has LOW confidence → Flag for human review → Human confirms or adjusts → Resume standard routing
+
+**Wave Failure Path:**
+When wave fails validation → Retry (max 2) → If still failing → Escalate to human → Manual wave assessment or skip with documentation
+
+**Resubmission Path:**
+When author resubmits revised manuscript → Full re-evaluation → Delta report generation comparing versions
+
+### 2.3 Priority Routing
+
+- Standard: First-in, first-out queue
+- Priority available for premium tier (future feature)
+- Priority does not change evaluation methodology—only queue position
+- No evaluation shortcuts for priority routing
+
+---
+
+## PART 3 — OPERATIONAL TRIGGERS
+
+### 3.1 Automatic Triggers
+
+- Manuscript upload triggers submission gates
+- Successful submission triggers WAVE execution
+- Wave completion triggers next wave
+- All waves complete triggers tsunami aggregation
+- All tsunamis complete triggers criteria scoring
+- All criteria scored triggers report generation
+- Report complete triggers delivery
+
+### 3.2 Manual Triggers
+
+- Admin can trigger re-evaluation of a manuscript
+- Admin can trigger manual review of flagged scores
+- User can trigger resubmission (new version)
+- Admin can halt evaluation pipeline for a specific manuscript
+
+### 3.3 Scheduled Triggers
+
+- Daily: Audit log review
+- Weekly: Confidence calibration check
+- Monthly: Model performance review
+- Quarterly: Canon compliance audit
+
+---
+
+## PART 4 — OPERATIONAL DOCTRINES
+
+### Doctrine: Gate Integrity
+No gate may be bypassed, skipped, or overridden except through documented exception paths. Every gate failure must be logged.
+
+### Doctrine: Sequential Execution
+The evaluation pipeline is strictly sequential. No parallel execution of waves. No out-of-order processing.
+
+### Doctrine: Routing Transparency
+Every routing decision must be logged with the rule that triggered it. Users can request their evaluation routing history.
+
+### Doctrine: Trigger Immutability
+Automatic triggers cannot be modified at runtime. Changes to trigger logic require canon revision.
+
+### Doctrine: Exception Documentation
+Every exception path execution must be documented with the reason, the resolution, and the impact on the evaluation.
+
+---
+
+*End of Volume III — Operational Specification*

--- a/canon/volumes/VOLUME-III-PLATFORM-GOVERNANCE-CANON.md
+++ b/canon/volumes/VOLUME-III-PLATFORM-GOVERNANCE-CANON.md
@@ -1,0 +1,127 @@
+# VOLUME III — PLATFORM GOVERNANCE CANON
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume II, Volume IV, Volume V  
+Canon ID: VOL-III-PLATFORM-GOV-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume III (Platform Governance) establishes the principles, rules, and constraints that govern how RevisionGrade operates as a platform. This is the constitutional layer—it defines what the platform is, what it promises, how users interact with it, and what obligations it carries.
+
+This volume does not describe tools or technical implementation (see Volume III — Tools & Implementation Systems). It does not describe operational thresholds or routing (see Volume III — Operational Specification). It defines the governance architecture of the platform itself.
+
+---
+
+## PART 1 — PLATFORM IDENTITY AND PURPOSE
+
+### 1.1 What RevisionGrade Is
+
+RevisionGrade is an AI-powered literary manuscript evaluation platform that provides structured, canon-governed revision diagnostics to authors. It is not an editing service, a ghostwriting tool, or a creative writing assistant. It is a diagnostic and evaluation system.
+
+### 1.2 Core Platform Promises
+
+1. **Honest Evaluation:** Every evaluation will be truthful, evidence-based, and uncompromised by user preferences or commercial pressure.
+2. **Structured Methodology:** Every evaluation follows the canonical WAVE system (Volume I) and 13 Criteria (Volume II). No ad hoc evaluations.
+3. **Transparent Scoring:** All scores include justification. No black-box outputs.
+4. **Canon Integrity:** The evaluation methodology is fixed and publicly documented. Users know exactly what system evaluates their work.
+5. **Human Authority:** AI assists but does not have final authority. Human oversight is preserved at every critical decision point.
+
+### 1.3 What RevisionGrade Is Not
+
+- Not a creative writing tool or story generator
+- Not an editing or proofreading service
+- Not a vanity evaluation platform (no inflated scores)
+- Not a replacement for human literary agents or editors
+- Not a self-publishing platform
+
+---
+
+## PART 2 — USER JOURNEY AND EXPERIENCE
+
+### 2.1 User Types
+
+**Authors (Primary Users)**
+- Submit manuscripts for evaluation
+- Receive structured diagnostic reports
+- Track revision progress over multiple submissions
+- Access the WAVE diagnostic data
+
+**Reviewers (Future Feature)**
+- Human literary professionals who validate AI evaluations
+- Provide calibration data for AI scoring
+- Subject to Volume IV governance constraints
+
+**Administrators**
+- Platform operators
+- Cannot modify canon without formal revision process
+- Subject to audit trail requirements
+
+### 2.2 User Journey Stages
+
+1. **Submission:** Author uploads manuscript
+2. **Intake Processing:** System validates format, length, genre classification
+3. **WAVE Execution:** Full 62-wave diagnostic pass (Volume I)
+4. **Criteria Scoring:** 13-criterion evaluation (Volume II)
+5. **Report Generation:** Structured diagnostic report delivered
+6. **Revision Tracking:** Author revises and resubmits for delta analysis
+
+### 2.3 User Rights
+
+- Right to see all scoring justifications
+- Right to understand the methodology
+- Right to dispute scores through formal channels
+- Right to data privacy per platform policy
+- Right to delete their manuscripts and data
+- Right to export their evaluation history
+
+---
+
+## PART 3 — GOVERNANCE CONSTRAINTS
+
+### 3.1 Canon Authority
+
+The canon (Volumes I–V) is the supreme authority for all platform operations. No feature, policy, or business decision may contradict the canon. When conflicts arise between business objectives and canon principles, the canon prevails.
+
+### 3.2 Modification Rules
+
+- Canon modifications require formal proposal through the Doctrine Registry
+- All modifications must be reviewed before implementation
+- No retroactive changes—modifications apply only to future evaluations
+- Version history is permanent and immutable
+
+### 3.3 Platform Obligations
+
+1. **Evaluation Integrity:** Never compromise evaluation quality for speed, cost, or user satisfaction
+2. **Methodology Transparency:** Publish and maintain the canon publicly
+3. **Data Protection:** Protect user manuscripts and evaluation data
+4. **Consistent Application:** Apply the same methodology to every manuscript without favoritism
+5. **Honest Communication:** Never misrepresent capabilities or scores
+
+---
+
+## PART 4 — GOVERNANCE DOCTRINES
+
+### Doctrine: Platform Purpose Lock
+RevisionGrade’s purpose as a manuscript evaluation platform cannot be changed without a full canon revision across all five volumes.
+
+### Doctrine: Score Integrity
+No platform feature, business rule, or user request may cause a score to be inflated, deflated, or otherwise misrepresented.
+
+### Doctrine: Canon Supremacy
+When any platform decision conflicts with the canon, the canon prevails. This includes business decisions, feature requests, and user demands.
+
+### Doctrine: User Transparency
+Users must always have access to understand how their manuscripts were evaluated, including which waves executed, which criteria scored, and what justifications support each score.
+
+### Doctrine: No Vanity Mode
+The platform will never offer a mode, setting, or feature that inflates scores or softens critical feedback to make users feel better. Honest evaluation is non-negotiable.
+
+---
+
+*End of Volume III — Platform Governance Canon*

--- a/canon/volumes/VOLUME-III-TOOLS-IMPLEMENTATION-SYSTEMS.md
+++ b/canon/volumes/VOLUME-III-TOOLS-IMPLEMENTATION-SYSTEMS.md
@@ -1,0 +1,202 @@
+# VOLUME III — TOOLS & IMPLEMENTATION SYSTEMS
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume I, Volume II, Volume III (Platform Governance), Volume IV  
+Canon ID: VOL-III-TOOLS-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume III (Tools & Implementation Systems) defines the schemas, prompts, adapters, evaluators, and integration contracts that implement the RevisionGrade canon in software. This is the bridge between governance (what the platform must do) and code (how it does it).
+
+Every tool, prompt, schema, and adapter described here must conform to the canon. If implementation diverges from canon, the implementation is wrong—not the canon.
+
+---
+
+## PART 1 — SCHEMA ARCHITECTURE
+
+### 1.1 Core Schemas
+
+**Manuscript Schema**
+- manuscript_id: unique identifier
+- title: string
+- author_id: reference to user
+- genre: enum (from approved genre list)
+- word_count: integer
+- submission_date: timestamp
+- status: enum (submitted, processing, evaluated, revision_in_progress)
+- version: integer (increments on resubmission)
+
+**Evaluation Schema**
+- evaluation_id: unique identifier
+- manuscript_id: reference
+- wave_results: array of 62 wave diagnostic objects
+- tsunami_results: array of 6 tsunami aggregation objects
+- criteria_scores: array of 13 criterion score objects
+- overall_score: computed float
+- eligibility_gates: computed gate status object
+- generated_at: timestamp
+- ai_model_version: string
+- confidence_flags: array of low-confidence markers
+
+**Wave Result Schema**
+- wave_id: W-01 through W-62
+- wave_name: string
+- score: float (1.0–10.0)
+- justification: text (minimum 50 words)
+- evidence_references: array of manuscript location references
+- confidence: enum (high, medium, low)
+- flags: array of diagnostic flags
+
+**Criterion Score Schema**
+- criterion_id: C-01 through C-13
+- criterion_name: string
+- score: float (1.0–10.0)
+- justification: text (minimum 100 words)
+- supporting_waves: array of wave_id references
+- supporting_tsunamis: array of tsunami_id references
+- confidence: enum (high, medium, low)
+
+### 1.2 Schema Governance
+
+- All schemas are versioned
+- Schema changes require Doctrine Registry review
+- Backward compatibility is required for all schema modifications
+- No field may be removed—only deprecated and marked inactive
+
+---
+
+## PART 2 — PROMPT ARCHITECTURE
+
+### 2.1 Prompt Categories
+
+**Diagnostic Prompts (Wave-Level)**
+Each of the 62 waves has a dedicated diagnostic prompt that:
+- Defines exactly what the wave measures
+- Specifies the scoring rubric
+- Requires evidence citations from the manuscript
+- Enforces justification minimum length
+- Includes confidence self-assessment
+
+**Aggregation Prompts (Tsunami-Level)**
+Each tsunami has an aggregation prompt that:
+- Takes wave results as input
+- Identifies systemic patterns
+- Produces aggregated scores and recommendations
+- Cross-references wave findings for consistency
+
+**Evaluation Prompts (Criterion-Level)**
+Each criterion has an evaluation prompt that:
+- Takes relevant wave and tsunami data as input
+- Produces the final criterion score
+- Generates detailed justification
+- Computes eligibility gate implications
+
+### 2.2 Prompt Governance
+
+- All prompts are version-controlled
+- Prompt modifications require canon review
+- No prompt may contradict the canon definitions in Volumes I or II
+- Prompts must be tested against calibration manuscripts before deployment
+- Prompt engineering is subject to Volume IV AI governance constraints
+
+---
+
+## PART 3 — ADAPTER AND EVALUATOR SYSTEMS
+
+### 3.1 Adapters
+
+Adapters are the translation layer between external systems and the canonical evaluation pipeline:
+
+**Input Adapters**
+- Manuscript format converter (DOCX, PDF, TXT to internal format)
+- Genre classifier
+- Word count validator
+- Submission integrity checker
+
+**Output Adapters**
+- Report generator (canonical evaluation to user-facing report)
+- Export adapter (evaluation data to PDF, JSON, CSV)
+- API adapter (evaluation data to external integrations)
+- Delta report adapter (comparison between submission versions)
+
+### 3.2 Evaluators
+
+Evaluators are the processing units that execute canonical evaluation logic:
+
+**Wave Evaluator**
+- Executes individual wave diagnostics
+- Enforces wave sequence
+- Validates wave output against schema
+- Logs all execution metadata
+
+**Tsunami Evaluator**
+- Aggregates wave results into tsunami assessments
+- Validates aggregation logic
+- Produces systemic pattern reports
+
+**Criteria Evaluator**
+- Computes criterion scores from wave and tsunami data
+- Enforces scoring rules from Volume II
+- Computes eligibility gates
+- Generates final evaluation report
+
+---
+
+## PART 4 — INTEGRATION CONTRACTS
+
+### 4.1 AI Model Contract
+
+Any AI model used by RevisionGrade must:
+- Accept canonical prompts without modification
+- Produce output conforming to canonical schemas
+- Include confidence assessments in all outputs
+- Flag uncertainty per Volume IV requirements
+- Not access or retain manuscript data beyond the evaluation session
+- Be versioned and logged for audit purposes
+
+### 4.2 Database Contract
+
+The database layer must:
+- Store all evaluation data per canonical schemas
+- Maintain complete audit trails
+- Support version history for manuscripts and evaluations
+- Enforce data retention policies
+- Support data export and deletion per user rights
+
+### 4.3 API Contract
+
+All API endpoints must:
+- Validate input against canonical schemas
+- Return output conforming to canonical schemas
+- Include appropriate error handling and status codes
+- Log all requests for audit purposes
+- Enforce authentication and authorization
+
+---
+
+## PART 5 — IMPLEMENTATION DOCTRINES
+
+### Doctrine: Canon Conformity
+All implementation must conform to the canon. When implementation and canon diverge, the implementation must be corrected.
+
+### Doctrine: Schema Immutability
+No schema field may be deleted. Fields may only be deprecated and marked inactive.
+
+### Doctrine: Prompt Traceability
+Every prompt must be version-controlled and traceable to its canonical source definition.
+
+### Doctrine: Adapter Neutrality
+Adapters must translate faithfully without modifying, filtering, or interpreting canonical data.
+
+### Doctrine: Evaluator Integrity
+Evaluators must execute canonical logic exactly as defined. No shortcuts, approximations, or optimizations that alter evaluation outcomes.
+
+---
+
+*End of Volume III — Tools & Implementation Systems*

--- a/canon/volumes/VOLUME-IV-AI-GOVERNANCE-CANON.md
+++ b/canon/volumes/VOLUME-IV-AI-GOVERNANCE-CANON.md
@@ -1,0 +1,189 @@
+# VOLUME IV — AI GOVERNANCE CANON
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volume III (all), Volume V  
+Canon ID: VOL-IV-AI-GOV-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume IV defines the governance architecture for AI within the RevisionGrade platform. It establishes what AI can and cannot do, how AI authority is bounded, how risks and failures are managed, and how the canon itself is protected from AI modification.
+
+This volume is the constitutional constraint on all AI behavior within the platform. No AI action may exceed the authority granted here. No AI system may modify this volume or any other canonical volume without human authorization through the Doctrine Registry.
+
+---
+
+## PART 1 — AI AUTHORITY ARCHITECTURE
+
+### 1.1 AI Authority Levels
+
+**Level 1: Autonomous Execution**
+AI may execute without human approval:
+- Wave diagnostic execution (W-01 through W-62)
+- Tsunami aggregation computation
+- Score calculation based on defined rubrics
+- Report formatting and generation
+- Schema validation
+
+**Level 2: Supervised Execution**
+AI may execute but results require human review before becoming final:
+- Criterion scores with LOW confidence
+- Genre classification with confidence below 70%
+- Eligibility gate determinations near threshold boundaries
+- Any evaluation where 3+ waves flagged LOW confidence
+
+**Level 3: Human-Only Actions**
+AI may NOT execute these actions:
+- Canon modifications (any volume)
+- Doctrine Registry changes
+- User account actions (deletion, suspension)
+- Score overrides or manual adjustments
+- Exception path authorization
+- Platform policy changes
+- Data deletion or export authorization
+
+### 1.2 Authority Boundaries
+
+- AI authority is bounded by the canon—it cannot exceed what the canon grants
+- AI cannot grant itself additional authority
+- AI cannot delegate its authority to other systems
+- AI cannot interpret ambiguous canon provisions—ambiguity triggers human review
+- AI authority does not persist between sessions—each evaluation starts from the canonical baseline
+
+---
+
+## PART 2 — AI GOVERNANCE CONSTRAINTS
+
+### 2.1 Scoring Constraints
+
+- AI must provide justification for every score
+- AI must cite manuscript evidence for every claim
+- AI must self-assess confidence for every score
+- AI must flag scores below confidence threshold
+- AI may not inflate or deflate scores for any reason
+- AI may not consider user identity, subscription tier, or commercial factors in scoring
+
+### 2.2 Output Constraints
+
+- AI output must conform to canonical schemas
+- AI may not generate content outside its evaluation mandate
+- AI may not provide creative writing assistance or suggestions beyond diagnostic feedback
+- AI may not generate marketing copy, query letters, or synopses for users
+- AI output must be traceable to canonical methodology
+
+### 2.3 Data Constraints
+
+- AI may not retain manuscript data beyond the active evaluation session
+- AI may not access manuscripts from other users
+- AI may not aggregate data across users for profiling
+- AI may not transmit manuscript data to external systems
+- AI may access only the data required for the current evaluation step
+
+---
+
+## PART 3 — RISK AND FAILURE MANAGEMENT
+
+### 3.1 Risk Categories
+
+**Category R-1: Evaluation Accuracy Risk**
+Risk that AI produces inaccurate evaluations.
+- Mitigation: Confidence flagging, human review triggers, calibration testing
+- Monitoring: Regular accuracy audits against human-graded manuscripts
+
+**Category R-2: Canon Drift Risk**
+Risk that AI behavior gradually diverges from canon requirements.
+- Mitigation: Periodic canon compliance audits, prompt version control
+- Monitoring: Quarterly compliance checks
+
+**Category R-3: Authority Escalation Risk**
+Risk that AI takes actions beyond its authorized scope.
+- Mitigation: Strict authority levels, action logging, boundary enforcement
+- Monitoring: Real-time action logging and anomaly detection
+
+**Category R-4: Data Exposure Risk**
+Risk that manuscript data is exposed or misused.
+- Mitigation: Session isolation, data access controls, encryption
+- Monitoring: Access logs, data flow audits
+
+### 3.2 Failure Protocols
+
+**Protocol F-1: Graceful Degradation**
+When AI fails to complete an evaluation step:
+1. Log the failure with full context
+2. Retry once with identical parameters
+3. If retry fails, escalate to human review
+4. Never deliver partial or failed evaluations to users
+
+**Protocol F-2: Confidence Collapse**
+When AI produces LOW confidence on 50%+ of waves:
+1. Halt the evaluation
+2. Flag for complete human review
+3. Log as potential model degradation event
+4. Trigger model performance review
+
+**Protocol F-3: Canon Violation Detection**
+When AI output appears to violate canon rules:
+1. Block the output from delivery
+2. Log the violation with full context
+3. Escalate to admin review
+4. Do not retry—investigate root cause
+
+---
+
+## PART 4 — CANON PROTECTION SYSTEMS
+
+### 4.1 Canon Immutability Rules
+
+- No AI system may modify any canonical document
+- No AI system may propose canon modifications without human initiation
+- No AI system may interpret canon provisions in ways that expand AI authority
+- No AI system may create new doctrines, rules, or procedures
+- Canon text is read-only for all AI systems
+
+### 4.2 Canon Integrity Monitoring
+
+- All canonical documents are version-controlled
+- Any modification triggers an audit alert
+- Canon checksums are validated before each evaluation session
+- Unauthorized modifications are blocked and logged
+
+### 4.3 Canon Update Protocol
+
+1. Human initiates canon change proposal through Doctrine Registry
+2. Change is documented with rationale and impact assessment
+3. Change is reviewed (even if proposer is sole reviewer)
+4. Change is implemented in a revision branch
+5. Change is merged to main only after approval
+6. All affected systems are updated to reflect the change
+7. Audit trail records the complete change history
+
+---
+
+## PART 5 — AI GOVERNANCE DOCTRINES
+
+### Doctrine: AI Authority Ceiling
+AI authority may never exceed what the canon explicitly grants. Silence in the canon means prohibition, not permission.
+
+### Doctrine: Human Override Supremacy
+Human authority always supersedes AI authority at every level. No AI decision is final if a human chooses to override it through proper channels.
+
+### Doctrine: Confidence Transparency
+AI must always disclose its confidence level. Concealing uncertainty is a canon violation.
+
+### Doctrine: Canon Read-Only
+AI treats all canonical documents as read-only. Any AI action that would modify canon is blocked by design.
+
+### Doctrine: Session Isolation
+AI evaluation sessions are isolated. No data, state, or authority carries over between sessions.
+
+### Doctrine: Audit Everything
+Every AI action, decision, score, and output must be logged with sufficient detail to reconstruct the reasoning after the fact.
+
+---
+
+*End of Volume IV — AI Governance Canon*

--- a/canon/volumes/VOLUME-V-EXECUTION-ARCHITECTURE.md
+++ b/canon/volumes/VOLUME-V-EXECUTION-ARCHITECTURE.md
@@ -1,0 +1,216 @@
+# VOLUME V — EXECUTION ARCHITECTURE & INDUSTRY INTERFACE
+
+Status: CANONICAL — ACTIVE  
+Version: 1.0  
+Authority: Mike Meraw  
+Depends on: Volumes I–IV  
+Canon ID: VOL-V-EXEC-1.0  
+Governance: Doctrine Registry + Assembly Matrix  
+Last Updated: 2026-03-09
+
+---
+
+## INTRODUCTION
+
+Volume V defines the deployment, reliability, monitoring, and industry interface procedures for the RevisionGrade platform. This is the infrastructure and operational layer—it ensures the platform runs reliably, scales appropriately, and interfaces correctly with the broader literary industry.
+
+While Volumes I–IV define what the platform does and how it governs itself, Volume V defines how the platform stays alive, performs under load, recovers from failure, and connects to the publishing ecosystem.
+
+---
+
+## PART 1 — DEPLOYMENT ARCHITECTURE
+
+### 1.1 Technology Stack
+
+**Frontend:** Next.js (React/TypeScript)  
+**Backend:** Next.js API routes + Supabase Edge Functions  
+**Database:** Supabase (PostgreSQL)  
+**Authentication:** Supabase Auth  
+**Hosting:** Vercel  
+**CI/CD:** GitHub Actions  
+**Repository:** GitHub  
+**AI Integration:** API-based (model-agnostic architecture)  
+
+### 1.2 Deployment Pipeline
+
+1. Code merged to main branch triggers GitHub Actions
+2. Automated tests execute (unit, integration, E2E)
+3. Build process compiles Next.js application
+4. Vercel deploys to production
+5. Post-deployment health checks verify system status
+6. Rollback triggers if health checks fail
+
+### 1.3 Environment Structure
+
+- **Development:** Local + GitHub Codespaces
+- **Staging:** Vercel preview deployments (per PR)
+- **Production:** Vercel production deployment
+- **Database:** Separate Supabase instances per environment
+
+---
+
+## PART 2 — RELIABILITY AND MONITORING
+
+### 2.1 Uptime Requirements
+
+- Target: 99.5% uptime
+- Planned maintenance windows: Off-peak hours, announced 24h in advance
+- Unplanned downtime: Trigger incident response protocol
+
+### 2.2 Monitoring Systems
+
+**Application Monitoring:**
+- Vercel Analytics for performance metrics
+- Error tracking and alerting
+- API response time monitoring
+- Evaluation pipeline completion tracking
+
+**Database Monitoring:**
+- Supabase dashboard for query performance
+- Connection pool monitoring
+- Storage utilization tracking
+- Backup verification
+
+**AI Model Monitoring:**
+- Response time per wave evaluation
+- Token usage tracking
+- Confidence distribution monitoring
+- Model version tracking
+
+### 2.3 Alerting Rules
+
+- API response time > 5 seconds: Warning
+- API response time > 15 seconds: Critical
+- Error rate > 1%: Warning
+- Error rate > 5%: Critical
+- Evaluation pipeline failure: Critical
+- Database connection failures: Critical
+- AI model timeout: Warning
+
+---
+
+## PART 3 — SCALING ARCHITECTURE
+
+### 3.1 Scaling Targets
+
+- Phase 1 (Launch): 100 concurrent users, 50 evaluations/day
+- Phase 2 (Growth): 1,000 concurrent users, 500 evaluations/day
+- Phase 3 (Scale): 10,000 concurrent users, 5,000 evaluations/day
+- Phase 4 (Enterprise): 100,000+ users, 50,000 evaluations/day
+
+### 3.2 Scaling Strategy
+
+**Frontend:** Vercel handles auto-scaling for static and server-rendered content
+
+**API Layer:** Serverless functions auto-scale with demand
+
+**Database:** 
+- Connection pooling via Supabase
+- Read replicas for reporting queries
+- Partitioning for evaluation data tables
+
+**AI Processing:**
+- Queue-based evaluation pipeline
+- Concurrent evaluation limits to manage API costs
+- Priority queue for premium tier (future)
+
+### 3.3 Cost Management
+
+- AI API calls are the primary cost driver
+- Per-evaluation cost tracking
+- Cost alerts at defined thresholds
+- Evaluation batching to optimize API usage
+- Model selection based on cost/quality tradeoffs per wave complexity
+
+---
+
+## PART 4 — DISASTER RECOVERY
+
+### 4.1 Backup Strategy
+
+- Database: Automated daily backups via Supabase
+- Code: GitHub repository with full history
+- Canon: Version-controlled in repository
+- Evaluation data: Retained per data retention policy
+
+### 4.2 Recovery Procedures
+
+**Code Rollback:**
+1. Identify problematic deployment
+2. Revert to previous Vercel deployment
+3. Verify health checks pass
+4. Investigate and fix before re-deploying
+
+**Database Recovery:**
+1. Identify data issue
+2. Restore from most recent backup
+3. Verify data integrity
+4. Resume operations
+
+**AI Model Failure:**
+1. Switch to fallback model if available
+2. Queue evaluations if no fallback
+3. Notify affected users of delay
+4. Resume when model service restored
+
+### 4.3 Recovery Time Objectives
+
+- Code rollback: < 5 minutes
+- Database recovery: < 1 hour
+- Full system recovery: < 4 hours
+
+---
+
+## PART 5 — INDUSTRY INTERFACE
+
+### 5.1 Publishing Industry Integration
+
+RevisionGrade interfaces with the publishing industry through:
+
+**Author-Facing:**
+- Evaluation reports formatted for agent submissions
+- Query letter readiness assessments (diagnostic only)
+- Genre and market positioning data
+- Comp title alignment analysis
+
+**Agent/Editor-Facing (Future):**
+- Standardized evaluation report format
+- Manuscript readiness certification
+- Evaluation history and revision trajectory
+
+### 5.2 Industry Standards Compliance
+
+- Manuscript format standards (industry-standard formatting)
+- Genre classification aligned with industry categories
+- Word count standards per genre
+- Evaluation terminology aligned with publishing industry usage
+
+### 5.3 Data Portability
+
+- Users can export all evaluation data (JSON, PDF, CSV)
+- Users can delete all data per privacy rights
+- Evaluation reports are portable and self-contained
+- No vendor lock-in for user data
+
+---
+
+## PART 6 — EXECUTION DOCTRINES
+
+### Doctrine: Infrastructure as Canon
+Deployment architecture must support canon requirements. Infrastructure decisions that would compromise evaluation integrity are prohibited.
+
+### Doctrine: Monitoring Before Scaling
+No scaling decision without monitoring data. Measure first, scale second.
+
+### Doctrine: Recovery Priority
+In disaster recovery, data integrity takes priority over speed. Never restore partially or with unverified data.
+
+### Doctrine: Industry Alignment
+Platform outputs must use publishing industry standard terminology and formats. RevisionGrade speaks the industry’s language.
+
+### Doctrine: Cost Transparency
+Per-evaluation costs must be tracked and visible to administrators. No hidden cost centers.
+
+---
+
+*End of Volume V — Execution Architecture & Industry Interface*

--- a/docs/STAGE2_ANCHORED_TELEMETRY_SQL_2026-03-16.md
+++ b/docs/STAGE2_ANCHORED_TELEMETRY_SQL_2026-03-16.md
@@ -1,0 +1,96 @@
+# Stage 2 Anchored Telemetry SQL (2026-03-16)
+
+## Anchor coverage rate
+
+select
+  date_trunc('day', created_at) as day,
+  count(*) filter (where event_code = 'PROPOSAL_GENERATED') as proposals_generated,
+  count(*) filter (where event_code = 'PROPOSAL_ANCHOR_CREATED') as anchors_created,
+  round(
+    100.0 * count(*) filter (where event_code = 'PROPOSAL_ANCHOR_CREATED')
+    / nullif(count(*) filter (where event_code = 'PROPOSAL_GENERATED'), 0),
+    2
+  ) as anchor_coverage_rate
+from public.revision_events
+group by 1
+order by 1 desc;
+
+## Finalize success rate
+
+select
+  date_trunc('day', created_at) as day,
+  count(*) filter (where event_code = 'REVISION_SESSION_FINALIZED') as finalized,
+  count(*) filter (where event_code = 'REVISION_SESSION_FINALIZE_FAILED') as finalize_failed,
+  round(
+    100.0 * count(*) filter (where event_code = 'REVISION_SESSION_FINALIZED')
+    / nullif(
+      count(*) filter (
+        where event_code in ('REVISION_SESSION_FINALIZED', 'REVISION_SESSION_FINALIZE_FAILED')
+      ),
+      0
+    ),
+    2
+  ) as finalize_success_rate
+from public.revision_events
+group by 1
+order by 1 desc;
+
+## Failure breakdown
+
+select
+  event_code,
+  count(*) as total
+from public.revision_events
+where severity in ('warn', 'error', 'critical')
+group by event_code
+order by total desc;
+
+## Source immutability monitor
+
+select
+  count(*) filter (where event_code = 'SOURCE_IMMUTABLE_CONFIRMED') as immutable_confirmed,
+  count(*) filter (where event_code = 'SOURCE_IMMUTABILITY_VIOLATION') as immutability_violations,
+  round(
+    100.0 * count(*) filter (where event_code = 'SOURCE_IMMUTABLE_CONFIRMED')
+    / nullif(
+      count(*) filter (
+        where event_code in ('SOURCE_IMMUTABLE_CONFIRMED', 'SOURCE_IMMUTABILITY_VIOLATION')
+      ),
+      0
+    ),
+    2
+  ) as source_unchanged_rate
+from public.revision_events;
+
+## Legacy fallback rate
+
+select
+  date_trunc('day', created_at) as day,
+  count(*) filter (where event_code = 'APPLY_LEGACY_FALLBACK_SUCCESS') as legacy_success,
+  count(*) filter (where event_code = 'APPLY_ANCHORED_SUCCESS') as anchored_success,
+  round(
+    100.0 * count(*) filter (where event_code = 'APPLY_LEGACY_FALLBACK_SUCCESS')
+    / nullif(
+      count(*) filter (
+        where event_code in ('APPLY_LEGACY_FALLBACK_SUCCESS', 'APPLY_ANCHORED_SUCCESS')
+      ),
+      0
+    ),
+    2
+  ) as legacy_fallback_rate
+from public.revision_events
+group by 1
+order by 1 desc;
+
+## Worst manuscripts
+
+select
+  manuscript_id,
+  count(*) filter (where severity in ('error', 'critical')) as failures,
+  count(*) filter (where event_code = 'PROPOSAL_GENERATED') as proposals_generated,
+  count(*) filter (where event_code = 'PROPOSAL_ANCHOR_CREATED') as anchors_created
+from public.revision_events
+where manuscript_id is not null
+group by manuscript_id
+order by failures desc
+limit 20;

--- a/docs/STAGE2_REVISION_HYDRATION_CLOSURE_EVIDENCE_2026-03-16.md
+++ b/docs/STAGE2_REVISION_HYDRATION_CLOSURE_EVIDENCE_2026-03-16.md
@@ -1,0 +1,117 @@
+# Stage 2 Revision Hydration Closure Evidence (2026-03-16)
+
+Repository: `Mmeraw/literary-ai-partner`  
+Branch: `cronauthfix`
+
+## Scope
+
+This packet closes the question: **does finalize-time hydration preserve source immutability while keeping strict apply behavior?**
+
+It also records stale-session smoke-harness behavior and fresh-run outcomes.
+
+## Code-state evidence (live diffs)
+
+### 1) `lib/manuscripts/hydrateVersions.ts`
+
+Verified additions in working tree:
+
+- `hydrateSourceVersionIfMissing(versionId, options)`
+- `options.persist?: boolean`
+- `persist` default is `true`
+- when `persist === false`, function returns normalized text **without** updating `manuscript_versions`
+- missing-source detection includes `NULL`, empty string, and whitespace
+
+### 2) `lib/revision/apply.ts`
+
+Verified live behavior:
+
+- imports `hydrateSourceVersionIfMissing`
+- for empty source text, calls:
+
+`hydrateSourceVersionIfMissing(sourceVersion.id, { persist: false })`
+
+- fails closed if hydration cannot resolve text
+- uses hydrated in-memory `sourceText` for strict apply
+- strict apply remains fail-closed (no proposal-skipping behavior)
+
+### 3) `scripts/revision-stage2-smoke.mjs`
+
+Verified live behavior:
+
+- explicit `EVALUATION_RUN_ID` that already has an applied session fails early with actionable message
+- auto-discovery searches recent completed runs and selects a run with no existing `revision_sessions` row
+
+## Runtime evidence
+
+## A) Stale-session rejection is explicit
+
+Run with previously applied evaluation:
+
+- `EVALUATION_RUN_ID=25b05913-acc9-4900-b9a1-6e72abbebf48`
+
+Observed behavior:
+
+- script exits early with clear message:
+  - already has an applied revision session (`ff4fef9c-3c13-4fe4-b47c-b4e0d4d49ffe`)
+  - advises choosing a different run or clearing stale session/proposals
+
+## B) Fresh-run success evidence
+
+Previously captured successful fresh runs:
+
+1. `6e4f7361-04d1-4273-a2d8-f07d28802151`
+2. `2d123bfc-8e14-428e-a5df-977f6fe3ed53`
+
+Success profile (both):
+
+- findings generated: `13`
+- actionable findings: `13`
+- proposals generated: `13`
+- accepted proposals: `3`
+- `source_unchanged: true`
+- `result_text_changed: true`
+
+## C) Empty-source immutability retest (critical)
+
+Selected fresh empty-source candidate:
+
+- `evaluation_run_id`: `c2486925-8085-4a05-87d0-916a7a64ab0f`
+- source `raw_len` before run: `0`
+
+Smoke run result:
+
+- finalize failed with strict apply mismatch:
+  - `Proposal ... original_text not found in source text`
+
+Post-failure verification query result:
+
+- `source_raw_len`: `0` (unchanged)
+- latest `revision_sessions` row status: `open`
+- `result_version_id`: `null`
+- derived versions count from source: `0`
+
+Interpretation:
+
+- failure is now a strict-anchor/proposal-quality issue
+- finalize-time hydration did **not** mutate source version text
+
+## Operational conclusion
+
+Current state is closure-ready for hydration immutability:
+
+- non-mutating finalize hydration is active in live code
+- strict apply remains fail-closed
+- stale-session ambiguity is handled by explicit smoke-harness checks
+- fresh-run end-to-end success has been demonstrated on multiple runs
+
+Remaining open area (separate concern):
+
+- improve proposal anchoring/location-aware apply for cases where strict single-anchor match fails after hydration
+
+## Files referenced
+
+- `lib/manuscripts/hydrateVersions.ts`
+- `lib/revision/apply.ts`
+- `scripts/revision-stage2-smoke.mjs`
+- `scripts/revision-stage2-hydrate.mjs`
+- `package.json`

--- a/lib/db/manuscriptVersions.ts
+++ b/lib/db/manuscriptVersions.ts
@@ -1,0 +1,140 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+
+export type ManuscriptVersionRow = {
+  id: string;
+  manuscript_id: number;
+  version_number: number;
+  source_version_id: string | null;
+  raw_text: string;
+  word_count: number;
+  created_by: string | null;
+  created_at: string;
+};
+
+type InsertManuscriptVersionInput = {
+  manuscript_id: number;
+  version_number: number;
+  source_version_id?: string | null;
+  raw_text: string;
+  word_count: number;
+  created_by?: string | null;
+};
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[MANUSCRIPT-VERSIONS-DB] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+const VERSION_SELECT =
+  "id, manuscript_id, version_number, source_version_id, raw_text, word_count, created_by, created_at";
+
+export async function getVersionById(id: string): Promise<ManuscriptVersionRow | null> {
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select(VERSION_SELECT)
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch manuscript version ${id}: ${error.message}`);
+  }
+
+  return (data as ManuscriptVersionRow | null) ?? null;
+}
+
+export async function getVersionByNumber(
+  manuscriptId: number,
+  versionNumber: number,
+): Promise<ManuscriptVersionRow | null> {
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select(VERSION_SELECT)
+    .eq("manuscript_id", manuscriptId)
+    .eq("version_number", versionNumber)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch manuscript version number ${versionNumber} for manuscript ${manuscriptId}: ${error.message}`,
+    );
+  }
+
+  return (data as ManuscriptVersionRow | null) ?? null;
+}
+
+export async function listVersionsForManuscript(
+  manuscriptId: number,
+): Promise<ManuscriptVersionRow[]> {
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select(VERSION_SELECT)
+    .eq("manuscript_id", manuscriptId)
+    .order("version_number", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to list manuscript versions for ${manuscriptId}: ${error.message}`);
+  }
+
+  return (data as ManuscriptVersionRow[]) ?? [];
+}
+
+export async function getLatestVersionForManuscript(
+  manuscriptId: number,
+): Promise<ManuscriptVersionRow | null> {
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select(VERSION_SELECT)
+    .eq("manuscript_id", manuscriptId)
+    .order("version_number", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch latest manuscript version for manuscript ${manuscriptId}: ${error.message}`,
+    );
+  }
+
+  return (data as ManuscriptVersionRow | null) ?? null;
+}
+
+export async function insertManuscriptVersion(
+  input: InsertManuscriptVersionInput,
+): Promise<ManuscriptVersionRow> {
+  const payload = {
+    manuscript_id: input.manuscript_id,
+    version_number: input.version_number,
+    source_version_id: input.source_version_id ?? null,
+    raw_text: input.raw_text,
+    word_count: input.word_count,
+    created_by: input.created_by ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .insert(payload)
+    .select(VERSION_SELECT)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to insert manuscript version: ${error.message}`);
+  }
+
+  return data as ManuscriptVersionRow;
+}

--- a/lib/manuscripts/hydrateVersions.ts
+++ b/lib/manuscripts/hydrateVersions.ts
@@ -67,6 +67,99 @@ function countWords(text: string): number {
   return trimmed.split(/\s+/).length;
 }
 
+function hasNonEmptyText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+type HydrateSourceVersionIfMissingResult = {
+  hydrated: boolean;
+  raw_text: string | null;
+};
+
+type HydrateSourceVersionIfMissingOptions = {
+  persist?: boolean;
+};
+
+/**
+ * Hydrate a specific source version only when raw_text is missing.
+ *
+ * Missing is defined as NULL, empty string, or whitespace-only.
+ */
+export async function hydrateSourceVersionIfMissing(
+  versionId: string,
+  options: HydrateSourceVersionIfMissingOptions = {},
+): Promise<HydrateSourceVersionIfMissingResult> {
+  const persist = options.persist ?? true;
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select("id, raw_text, manuscripts(file_url)")
+    .eq("id", versionId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load manuscript version ${versionId} for hydration: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`Manuscript version not found for hydration: ${versionId}`);
+  }
+
+  const existingRawText = (data as { raw_text?: unknown }).raw_text;
+  if (hasNonEmptyText(existingRawText)) {
+    return {
+      hydrated: false,
+      raw_text: existingRawText,
+    };
+  }
+
+  const manuscript = Array.isArray((data as { manuscripts?: unknown }).manuscripts)
+    ? (data as { manuscripts?: Array<{ file_url?: string | null }> }).manuscripts[0]
+    : ((data as { manuscripts?: { file_url?: string | null } }).manuscripts ?? null);
+
+  const fileUrl = manuscript?.file_url;
+  if (!fileUrl) {
+    return {
+      hydrated: false,
+      raw_text: null,
+    };
+  }
+
+  const resolvedText = await resolveTextFromFileUrl(fileUrl);
+  if (!hasNonEmptyText(resolvedText)) {
+    return {
+      hydrated: false,
+      raw_text: null,
+    };
+  }
+
+  const normalized = resolvedText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  if (!persist) {
+    return {
+      hydrated: true,
+      raw_text: normalized,
+    };
+  }
+
+  const { error: updateError } = await supabase
+    .from("manuscript_versions")
+    .update({
+      raw_text: normalized,
+      word_count: countWords(normalized),
+    })
+    .eq("id", versionId);
+
+  if (updateError) {
+    throw new Error(`Failed to hydrate manuscript version ${versionId}: ${updateError.message}`);
+  }
+
+  return {
+    hydrated: true,
+    raw_text: normalized,
+  };
+}
+
 /**
  * Hydrate v1 manuscript_versions rows where raw_text is still empty.
  *
@@ -81,14 +174,15 @@ export async function hydrateMissingRawTextForV1(
     .from("manuscript_versions")
     .select("id, manuscript_id, version_number, raw_text, manuscripts(file_url)")
     .eq("version_number", 1)
-    .eq("raw_text", "")
-    .limit(limit);
+    .limit(limit * 5);
 
   if (error) {
     throw new Error(`Failed to query rows for hydration: ${error.message}`);
   }
 
-  const rows = (data ?? []) as any[];
+  const rows = ((data ?? []) as any[])
+    .filter((row) => !hasNonEmptyText(row.raw_text))
+    .slice(0, limit);
   const stats: HydrationStats = {
     scanned: rows.length,
     hydrated: 0,

--- a/lib/manuscripts/hydrateVersions.ts
+++ b/lib/manuscripts/hydrateVersions.ts
@@ -1,0 +1,140 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+
+type HydrationStats = {
+  scanned: number;
+  hydrated: number;
+  skipped: number;
+  failed: number;
+};
+
+type HydrationOptions = {
+  limit?: number;
+};
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[MANUSCRIPT-VERSION-HYDRATION] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+function decodeDataUrl(fileUrl: string): string | null {
+  const base64Match = fileUrl.match(/^data:[^,]*;base64,(.*)$/);
+  if (base64Match) {
+    return Buffer.from(base64Match[1], "base64").toString("utf8");
+  }
+
+  const encodedMatch = fileUrl.match(/^data:[^,]*,(.*)$/);
+  if (encodedMatch) {
+    return decodeURIComponent(encodedMatch[1]);
+  }
+
+  return null;
+}
+
+async function resolveTextFromFileUrl(fileUrl: string): Promise<string | null> {
+  if (!fileUrl) return null;
+
+  if (fileUrl.startsWith("data:")) {
+    return decodeDataUrl(fileUrl);
+  }
+
+  const response = await fetch(fileUrl);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Hydrate v1 manuscript_versions rows where raw_text is still empty.
+ *
+ * Note: This avoids placeholder text; rows without resolvable text are skipped.
+ */
+export async function hydrateMissingRawTextForV1(
+  options: HydrationOptions = {},
+): Promise<HydrationStats> {
+  const limit = options.limit ?? 200;
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id, version_number, raw_text, manuscripts(file_url)")
+    .eq("version_number", 1)
+    .eq("raw_text", "")
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to query rows for hydration: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as any[];
+  const stats: HydrationStats = {
+    scanned: rows.length,
+    hydrated: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const row of rows) {
+    try {
+      const manuscript = Array.isArray(row.manuscripts) ? row.manuscripts[0] : row.manuscripts;
+      const fileUrl = manuscript?.file_url as string | undefined;
+
+      if (!fileUrl) {
+        stats.skipped += 1;
+        continue;
+      }
+
+      const resolvedText = await resolveTextFromFileUrl(fileUrl);
+      if (!resolvedText || resolvedText.trim().length === 0) {
+        stats.skipped += 1;
+        continue;
+      }
+
+      const normalized = resolvedText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+      const { error: updateError } = await supabase
+        .from("manuscript_versions")
+        .update({
+          raw_text: normalized,
+          word_count: countWords(normalized),
+        })
+        .eq("id", row.id);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+
+      stats.hydrated += 1;
+    } catch (e) {
+      console.error(
+        `[MANUSCRIPT-VERSION-HYDRATION] Failed for version_id=${row.id}:`,
+        e instanceof Error ? e.message : String(e),
+      );
+      stats.failed += 1;
+    }
+  }
+
+  return stats;
+}

--- a/lib/manuscripts/versions.ts
+++ b/lib/manuscripts/versions.ts
@@ -1,0 +1,93 @@
+import {
+  getLatestVersionForManuscript,
+  getVersionById as getVersionByIdFromDb,
+  getVersionByNumber,
+  insertManuscriptVersion,
+  listVersionsForManuscript as listVersionsForManuscriptFromDb,
+  type ManuscriptVersionRow,
+} from "@/lib/db/manuscriptVersions";
+import {
+  type CreateDerivedManuscriptVersionInput,
+  type CreateInitialManuscriptVersionInput,
+  validateCreateDerivedVersionInput,
+  validateCreateInitialVersionInput,
+} from "@/schemas/manuscript-version";
+
+function normalizeWordCount(rawText: string, providedWordCount?: number): number {
+  if (typeof providedWordCount === "number") return providedWordCount;
+
+  const trimmed = rawText.trim();
+  if (!trimmed) return 0;
+
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Create (or return) the initial immutable manuscript version (version_number = 1).
+ * Idempotent behavior: if v1 already exists, return it instead of creating a duplicate.
+ */
+export async function createInitialVersion(
+  input: CreateInitialManuscriptVersionInput,
+): Promise<ManuscriptVersionRow> {
+  const validation = validateCreateInitialVersionInput(input);
+  if (!validation.valid) {
+    throw new Error(`Invalid createInitialVersion input: ${validation.errors.join("; ")}`);
+  }
+
+  const existingV1 = await getVersionByNumber(input.manuscript_id, 1);
+  if (existingV1) return existingV1;
+
+  return insertManuscriptVersion({
+    manuscript_id: input.manuscript_id,
+    version_number: 1,
+    source_version_id: null,
+    raw_text: input.raw_text,
+    word_count: normalizeWordCount(input.raw_text, input.word_count),
+    created_by: input.created_by ?? null,
+  });
+}
+
+/**
+ * Create a derived immutable manuscript version from an existing source version.
+ */
+export async function createDerivedVersion(
+  input: CreateDerivedManuscriptVersionInput,
+): Promise<ManuscriptVersionRow> {
+  const validation = validateCreateDerivedVersionInput(input);
+  if (!validation.valid) {
+    throw new Error(`Invalid createDerivedVersion input: ${validation.errors.join("; ")}`);
+  }
+
+  const sourceVersion = await getVersionByIdFromDb(input.source_version_id);
+  if (!sourceVersion) {
+    throw new Error(`Source version not found: ${input.source_version_id}`);
+  }
+
+  if (sourceVersion.manuscript_id !== input.manuscript_id) {
+    throw new Error(
+      `Source version ${sourceVersion.id} does not belong to manuscript ${input.manuscript_id}`,
+    );
+  }
+
+  const latest = await getLatestVersionForManuscript(input.manuscript_id);
+  const nextVersionNumber = (latest?.version_number ?? 0) + 1;
+
+  return insertManuscriptVersion({
+    manuscript_id: input.manuscript_id,
+    version_number: nextVersionNumber,
+    source_version_id: sourceVersion.id,
+    raw_text: input.raw_text,
+    word_count: normalizeWordCount(input.raw_text, input.word_count),
+    created_by: input.created_by ?? null,
+  });
+}
+
+export async function getVersionById(id: string): Promise<ManuscriptVersionRow | null> {
+  return getVersionByIdFromDb(id);
+}
+
+export async function listVersionsForManuscript(
+  manuscriptId: number,
+): Promise<ManuscriptVersionRow[]> {
+  return listVersionsForManuscriptFromDb(manuscriptId);
+}

--- a/lib/revision/apply.ts
+++ b/lib/revision/apply.ts
@@ -1,0 +1,125 @@
+import { createDerivedVersion, getVersionById } from "@/lib/manuscripts/versions";
+import {
+  getRevisionSessionById,
+  listProposalsForSession,
+  markRevisionSessionApplied,
+} from "./sessions";
+import type { ApplyRevisionSessionResult, ChangeProposal } from "./types";
+
+function applySingleReplacementStrict(
+  currentText: string,
+  originalText: string,
+  replacement: string,
+  proposalId: string,
+): string {
+  const needle = originalText;
+
+  if (!needle || needle.trim().length === 0) {
+    throw new Error(
+      `Proposal ${proposalId} has empty original_text. ` +
+        `Location-aware apply is required for empty-anchor edits.`,
+    );
+  }
+
+  const firstIdx = currentText.indexOf(needle);
+  if (firstIdx < 0) {
+    throw new Error(
+      `Proposal ${proposalId} original_text not found in source text. ` +
+        `Refine proposal extraction or adopt location-aware apply.`,
+    );
+  }
+
+  const secondIdx = currentText.indexOf(needle, firstIdx + needle.length);
+  if (secondIdx >= 0) {
+    throw new Error(
+      `Proposal ${proposalId} original_text is ambiguous (multiple matches). ` +
+        `Location-aware apply is required.`,
+    );
+  }
+
+  return currentText.slice(0, firstIdx) + replacement + currentText.slice(firstIdx + needle.length);
+}
+
+function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): string {
+  let result = sourceText;
+
+  for (const proposal of proposals) {
+    if (proposal.decision !== "accepted" && proposal.decision !== "modified") {
+      continue;
+    }
+
+    const replacement =
+      proposal.decision === "modified"
+        ? (proposal.modified_text ?? proposal.proposed_text)
+        : proposal.proposed_text;
+
+    // First-pass behavior (hardened): exact single-match replacement only.
+    // If the anchor text is missing or ambiguous, fail closed.
+    // Later: replace with location-aware apply via offsets/anchors.
+    result = applySingleReplacementStrict(
+      result,
+      proposal.original_text,
+      replacement,
+      proposal.id,
+    );
+  }
+
+  return result;
+}
+
+export async function applyRevisionSession(
+  revisionSessionId: string,
+): Promise<ApplyRevisionSessionResult> {
+  const session = await getRevisionSessionById(revisionSessionId);
+  if (!session) {
+    throw new Error(`Revision session not found: ${revisionSessionId}`);
+  }
+
+  if (session.status !== "open") {
+    throw new Error(
+      `Revision session ${revisionSessionId} is not open; current status: ${session.status}`,
+    );
+  }
+
+  const sourceVersion = await getVersionById(session.source_version_id);
+  if (!sourceVersion) {
+    throw new Error(`Source version not found: ${session.source_version_id}`);
+  }
+
+  const proposals = await listProposalsForSession(revisionSessionId);
+
+  const acceptedOrModified = proposals.filter(
+    (p) => p.decision === "accepted" || p.decision === "modified",
+  );
+
+  if (acceptedOrModified.length === 0) {
+    throw new Error("No accepted or modified proposals to apply.");
+  }
+
+  const nextText = applyAcceptedChanges(sourceVersion.raw_text, acceptedOrModified);
+
+  const resultVersion = await createDerivedVersion({
+    manuscript_id: sourceVersion.manuscript_id,
+    source_version_id: sourceVersion.id,
+    raw_text: nextText,
+    word_count: nextText.trim() ? nextText.trim().split(/\s+/).length : 0,
+  });
+
+  const acceptedCount = proposals.filter((p) => p.decision === "accepted").length;
+  const modifiedCount = proposals.filter((p) => p.decision === "modified").length;
+
+  await markRevisionSessionApplied(revisionSessionId, resultVersion.id, {
+    accepted_count: acceptedCount,
+    modified_count: modifiedCount,
+    source_version_id: sourceVersion.id,
+    result_version_id: resultVersion.id,
+  });
+
+  return {
+    revision_session_id: revisionSessionId,
+    source_version_id: sourceVersion.id,
+    result_version_id: resultVersion.id,
+    accepted_count: acceptedCount,
+    modified_count: modifiedCount,
+  };
+}

--- a/lib/revision/apply.ts
+++ b/lib/revision/apply.ts
@@ -1,4 +1,5 @@
 import { createDerivedVersion, getVersionById } from "@/lib/manuscripts/versions";
+import { hydrateSourceVersionIfMissing } from "@/lib/manuscripts/hydrateVersions";
 import {
   getRevisionSessionById,
   listProposalsForSession,
@@ -6,13 +7,19 @@ import {
 } from "./sessions";
 import type { ApplyRevisionSessionResult, ChangeProposal } from "./types";
 
+function normalizeForStrictMatch(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
 function applySingleReplacementStrict(
   currentText: string,
   originalText: string,
   replacement: string,
   proposalId: string,
 ): string {
-  const needle = originalText;
+  const normalizedCurrentText = normalizeForStrictMatch(currentText);
+  const needle = normalizeForStrictMatch(originalText);
+  const normalizedReplacement = normalizeForStrictMatch(replacement);
 
   if (!needle || needle.trim().length === 0) {
     throw new Error(
@@ -21,7 +28,7 @@ function applySingleReplacementStrict(
     );
   }
 
-  const firstIdx = currentText.indexOf(needle);
+  const firstIdx = normalizedCurrentText.indexOf(needle);
   if (firstIdx < 0) {
     throw new Error(
       `Proposal ${proposalId} original_text not found in source text. ` +
@@ -29,7 +36,7 @@ function applySingleReplacementStrict(
     );
   }
 
-  const secondIdx = currentText.indexOf(needle, firstIdx + needle.length);
+  const secondIdx = normalizedCurrentText.indexOf(needle, firstIdx + needle.length);
   if (secondIdx >= 0) {
     throw new Error(
       `Proposal ${proposalId} original_text is ambiguous (multiple matches). ` +
@@ -37,7 +44,11 @@ function applySingleReplacementStrict(
     );
   }
 
-  return currentText.slice(0, firstIdx) + replacement + currentText.slice(firstIdx + needle.length);
+  return (
+    normalizedCurrentText.slice(0, firstIdx) +
+    normalizedReplacement +
+    normalizedCurrentText.slice(firstIdx + needle.length)
+  );
 }
 
 function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): string {
@@ -86,6 +97,20 @@ export async function applyRevisionSession(
     throw new Error(`Source version not found: ${session.source_version_id}`);
   }
 
+  let sourceText = sourceVersion.raw_text;
+  if (typeof sourceText !== "string" || sourceText.trim().length === 0) {
+    const hydrated = await hydrateSourceVersionIfMissing(sourceVersion.id, {
+      persist: false,
+    });
+    sourceText = hydrated.raw_text ?? "";
+
+    if (sourceText.trim().length === 0) {
+      throw new Error(
+        `Source version ${sourceVersion.id} has empty raw_text and could not be hydrated from manuscript source.`,
+      );
+    }
+  }
+
   const proposals = await listProposalsForSession(revisionSessionId);
 
   const acceptedOrModified = proposals.filter(
@@ -96,7 +121,7 @@ export async function applyRevisionSession(
     throw new Error("No accepted or modified proposals to apply.");
   }
 
-  const nextText = applyAcceptedChanges(sourceVersion.raw_text, acceptedOrModified);
+  const nextText = applyAcceptedChanges(sourceText, acceptedOrModified);
 
   const resultVersion = await createDerivedVersion({
     manuscript_id: sourceVersion.manuscript_id,

--- a/lib/revision/apply.ts
+++ b/lib/revision/apply.ts
@@ -1,11 +1,19 @@
 import { createDerivedVersion, getVersionById } from "@/lib/manuscripts/versions";
 import { hydrateSourceVersionIfMissing } from "@/lib/manuscripts/hydrateVersions";
+import { logRevisionEvent } from "./logRevisionEvent";
 import {
   getRevisionSessionById,
   listProposalsForSession,
   markRevisionSessionApplied,
 } from "./sessions";
 import type { ApplyRevisionSessionResult, ChangeProposal } from "./types";
+
+type ApplyTelemetryContext = {
+  revisionSessionId: string;
+  evaluationRunId: string;
+  manuscriptId: number;
+  manuscriptVersionId: string;
+};
 
 function normalizeForStrictMatch(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
@@ -16,6 +24,7 @@ function applySingleReplacementStrict(
   originalText: string,
   replacement: string,
   proposalId: string,
+  context: ApplyTelemetryContext,
 ): string {
   const normalizedCurrentText = normalizeForStrictMatch(currentText);
   const needle = normalizeForStrictMatch(originalText);
@@ -30,6 +39,21 @@ function applySingleReplacementStrict(
 
   const firstIdx = normalizedCurrentText.indexOf(needle);
   if (firstIdx < 0) {
+    void logRevisionEvent({
+      revision_session_id: context.revisionSessionId,
+      proposal_id: proposalId,
+      manuscript_id: context.manuscriptId,
+      manuscript_version_id: context.manuscriptVersionId,
+      evaluation_run_id: context.evaluationRunId,
+      event_type: "apply",
+      severity: "error",
+      event_code: "APPLY_LEGACY_NOT_FOUND",
+      message: `Proposal ${proposalId} original_text not found in source text.`,
+      metadata: {
+        original_text_length: originalText.length,
+      },
+    });
+
     throw new Error(
       `Proposal ${proposalId} original_text not found in source text. ` +
         `Refine proposal extraction or adopt location-aware apply.`,
@@ -38,11 +62,40 @@ function applySingleReplacementStrict(
 
   const secondIdx = normalizedCurrentText.indexOf(needle, firstIdx + needle.length);
   if (secondIdx >= 0) {
+    void logRevisionEvent({
+      revision_session_id: context.revisionSessionId,
+      proposal_id: proposalId,
+      manuscript_id: context.manuscriptId,
+      manuscript_version_id: context.manuscriptVersionId,
+      evaluation_run_id: context.evaluationRunId,
+      event_type: "apply",
+      severity: "error",
+      event_code: "APPLY_LEGACY_AMBIGUOUS",
+      message: `Proposal ${proposalId} original_text is ambiguous in source text.`,
+      metadata: {
+        original_text_length: originalText.length,
+      },
+    });
+
     throw new Error(
       `Proposal ${proposalId} original_text is ambiguous (multiple matches). ` +
         `Location-aware apply is required.`,
     );
   }
+
+  void logRevisionEvent({
+    revision_session_id: context.revisionSessionId,
+    proposal_id: proposalId,
+    manuscript_id: context.manuscriptId,
+    manuscript_version_id: context.manuscriptVersionId,
+    evaluation_run_id: context.evaluationRunId,
+    event_type: "apply",
+    event_code: "APPLY_LEGACY_FALLBACK_SUCCESS",
+    metadata: {
+      original_text_length: originalText.length,
+      replacement_length: replacement.length,
+    },
+  });
 
   return (
     normalizedCurrentText.slice(0, firstIdx) +
@@ -54,6 +107,7 @@ function applySingleReplacementStrict(
 function applySingleReplacementAnchoredStrict(
   sourceText: string,
   proposal: ChangeProposal,
+  context: ApplyTelemetryContext,
 ): string {
   const replacement =
     proposal.decision === "modified"
@@ -73,6 +127,7 @@ function applySingleReplacementAnchoredStrict(
       proposal.original_text,
       replacement,
       proposal.id,
+      context,
     );
   }
 
@@ -80,6 +135,23 @@ function applySingleReplacementAnchoredStrict(
   const end = proposal.anchor_end as number;
 
   if (end > sourceText.length) {
+    void logRevisionEvent({
+      revision_session_id: context.revisionSessionId,
+      proposal_id: proposal.id,
+      manuscript_id: context.manuscriptId,
+      manuscript_version_id: context.manuscriptVersionId,
+      evaluation_run_id: context.evaluationRunId,
+      event_type: "apply",
+      severity: "error",
+      event_code: "APPLY_ANCHORED_SLICE_MISMATCH",
+      message: `Proposal ${proposal.id} anchor range exceeds source length.`,
+      metadata: {
+        anchor_start: start,
+        anchor_end: end,
+        source_length: sourceText.length,
+      },
+    });
+
     throw new Error(`Proposal ${proposal.id} anchor range exceeds source length.`);
   }
 
@@ -90,6 +162,24 @@ function applySingleReplacementAnchoredStrict(
     normalizeForStrictMatch(actualSlice) !==
     normalizeForStrictMatch(expectedSlice)
   ) {
+    void logRevisionEvent({
+      revision_session_id: context.revisionSessionId,
+      proposal_id: proposal.id,
+      manuscript_id: context.manuscriptId,
+      manuscript_version_id: context.manuscriptVersionId,
+      evaluation_run_id: context.evaluationRunId,
+      event_type: "apply",
+      severity: "error",
+      event_code: "APPLY_ANCHORED_SLICE_MISMATCH",
+      message: `Anchored slice did not match original_text for proposal ${proposal.id}.`,
+      metadata: {
+        anchor_start: start,
+        anchor_end: end,
+        expected_length: expectedSlice.length,
+        actual_length: actualSlice.length,
+      },
+    });
+
     throw new Error(
       `Proposal ${proposal.id} anchored slice does not match original_text.`,
     );
@@ -105,16 +195,51 @@ function applySingleReplacementAnchoredStrict(
         normalizeForStrictMatch(proposal.anchor_context),
       )
     ) {
+      void logRevisionEvent({
+        revision_session_id: context.revisionSessionId,
+        proposal_id: proposal.id,
+        manuscript_id: context.manuscriptId,
+        manuscript_version_id: context.manuscriptVersionId,
+        evaluation_run_id: context.evaluationRunId,
+        event_type: "apply",
+        severity: "error",
+        event_code: "APPLY_ANCHORED_CONTEXT_MISMATCH",
+        message: `Anchor context verification failed for proposal ${proposal.id}.`,
+        metadata: {
+          anchor_start: start,
+          anchor_end: end,
+        },
+      });
+
       throw new Error(
         `Proposal ${proposal.id} anchor_context verification failed.`,
       );
     }
   }
 
+  void logRevisionEvent({
+    revision_session_id: context.revisionSessionId,
+    proposal_id: proposal.id,
+    manuscript_id: context.manuscriptId,
+    manuscript_version_id: context.manuscriptVersionId,
+    evaluation_run_id: context.evaluationRunId,
+    event_type: "apply",
+    event_code: "APPLY_ANCHORED_SUCCESS",
+    metadata: {
+      anchor_start: start,
+      anchor_end: end,
+      replacement_length: replacement.length,
+    },
+  });
+
   return sourceText.slice(0, start) + replacement + sourceText.slice(end);
 }
 
-function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): string {
+function applyAcceptedChanges(
+  sourceText: string,
+  proposals: ChangeProposal[],
+  context: ApplyTelemetryContext,
+): string {
   const ordered = [...proposals].sort((a, b) => {
     const aStart = a.anchor_start ?? -1;
     const bStart = b.anchor_start ?? -1;
@@ -130,7 +255,7 @@ function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): 
 
     // Hardened behavior: prefer strict anchored replacement when offsets exist,
     // otherwise fall back to strict single-match text replacement. Fail closed.
-    result = applySingleReplacementAnchoredStrict(result, proposal);
+    result = applySingleReplacementAnchoredStrict(result, proposal, context);
   }
 
   return result;
@@ -179,7 +304,12 @@ export async function applyRevisionSession(
     throw new Error("No accepted or modified proposals to apply.");
   }
 
-  const nextText = applyAcceptedChanges(sourceText, acceptedOrModified);
+  const nextText = applyAcceptedChanges(sourceText, acceptedOrModified, {
+    revisionSessionId,
+    evaluationRunId: session.evaluation_run_id,
+    manuscriptId: sourceVersion.manuscript_id,
+    manuscriptVersionId: sourceVersion.id,
+  });
 
   const resultVersion = await createDerivedVersion({
     manuscript_id: sourceVersion.manuscript_id,

--- a/lib/revision/apply.ts
+++ b/lib/revision/apply.ts
@@ -51,28 +51,86 @@ function applySingleReplacementStrict(
   );
 }
 
-function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): string {
-  let result = sourceText;
+function applySingleReplacementAnchoredStrict(
+  sourceText: string,
+  proposal: ChangeProposal,
+): string {
+  const replacement =
+    proposal.decision === "modified"
+      ? (proposal.modified_text ?? proposal.proposed_text)
+      : proposal.proposed_text;
 
-  for (const proposal of proposals) {
-    if (proposal.decision !== "accepted" && proposal.decision !== "modified") {
-      continue;
-    }
+  const hasAnchor =
+    Number.isInteger(proposal.anchor_start) &&
+    Number.isInteger(proposal.anchor_end) &&
+    (proposal.anchor_start as number) >= 0 &&
+    (proposal.anchor_end as number) > (proposal.anchor_start as number);
 
-    const replacement =
-      proposal.decision === "modified"
-        ? (proposal.modified_text ?? proposal.proposed_text)
-        : proposal.proposed_text;
-
-    // First-pass behavior (hardened): exact single-match replacement only.
-    // If the anchor text is missing or ambiguous, fail closed.
-    // Later: replace with location-aware apply via offsets/anchors.
-    result = applySingleReplacementStrict(
-      result,
+  // Legacy fallback for pre-anchor proposals.
+  if (!hasAnchor) {
+    return applySingleReplacementStrict(
+      sourceText,
       proposal.original_text,
       replacement,
       proposal.id,
     );
+  }
+
+  const start = proposal.anchor_start as number;
+  const end = proposal.anchor_end as number;
+
+  if (end > sourceText.length) {
+    throw new Error(`Proposal ${proposal.id} anchor range exceeds source length.`);
+  }
+
+  const actualSlice = sourceText.slice(start, end);
+  const expectedSlice = proposal.original_text;
+
+  if (
+    normalizeForStrictMatch(actualSlice) !==
+    normalizeForStrictMatch(expectedSlice)
+  ) {
+    throw new Error(
+      `Proposal ${proposal.id} anchored slice does not match original_text.`,
+    );
+  }
+
+  if (proposal.anchor_context) {
+    const contextLeft = Math.max(0, start - 80);
+    const contextRight = Math.min(sourceText.length, end + 80);
+    const actualContext = sourceText.slice(contextLeft, contextRight);
+
+    if (
+      !normalizeForStrictMatch(actualContext).includes(
+        normalizeForStrictMatch(proposal.anchor_context),
+      )
+    ) {
+      throw new Error(
+        `Proposal ${proposal.id} anchor_context verification failed.`,
+      );
+    }
+  }
+
+  return sourceText.slice(0, start) + replacement + sourceText.slice(end);
+}
+
+function applyAcceptedChanges(sourceText: string, proposals: ChangeProposal[]): string {
+  const ordered = [...proposals].sort((a, b) => {
+    const aStart = a.anchor_start ?? -1;
+    const bStart = b.anchor_start ?? -1;
+    return bStart - aStart;
+  });
+
+  let result = sourceText;
+
+  for (const proposal of ordered) {
+    if (proposal.decision !== "accepted" && proposal.decision !== "modified") {
+      continue;
+    }
+
+    // Hardened behavior: prefer strict anchored replacement when offsets exist,
+    // otherwise fall back to strict single-match text replacement. Fail closed.
+    result = applySingleReplacementAnchoredStrict(result, proposal);
   }
 
   return result;

--- a/lib/revision/engine.ts
+++ b/lib/revision/engine.ts
@@ -1,0 +1,159 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import { applyRevisionSession } from "./apply";
+import { createDiagnosticFindingsForEvaluationRun } from "./normalizeFindings";
+import {
+  createProposalsForSessionFromFindings,
+  getFindingsSynthesisSummary,
+} from "./proposalSynthesis";
+import {
+  createRevisionSession,
+  getRevisionSessionById,
+  listProposalsForSession,
+} from "./sessions";
+import type {
+  ApplyRevisionSessionResult,
+  ChangeProposal,
+  RevisionSession,
+} from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(`[REVISION-ENGINE] Supabase unavailable - cannot access .${String(prop)}`);
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+export type StartRevisionEngineInput = {
+  evaluation_run_id: string;
+};
+
+export type StartRevisionEngineResult = {
+  revision_session: RevisionSession;
+  proposals: ChangeProposal[];
+  findings_count?: number;
+  actionable_findings_count?: number;
+};
+
+export type FinalizeRevisionEngineResult = {
+  revision_session: RevisionSession;
+  apply_result: ApplyRevisionSessionResult;
+};
+
+async function getSourceVersionIdForEvaluationRun(evaluationRunId: string): Promise<string> {
+  const { data, error } = await supabase
+    .from("evaluation_jobs")
+    .select("id, manuscript_version_id")
+    .eq("id", evaluationRunId)
+    .single();
+
+  if (error) {
+    throw new Error(`getSourceVersionIdForEvaluationRun failed: ${error.message}`);
+  }
+
+  if (!data?.manuscript_version_id) {
+    throw new Error(
+      `Evaluation run ${evaluationRunId} is not bound to manuscript_version_id.`,
+    );
+  }
+
+  return data.manuscript_version_id as string;
+}
+
+async function findExistingRevisionSessionForEvaluationRun(
+  evaluationRunId: string,
+): Promise<RevisionSession | null> {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .select("*")
+    .eq("evaluation_run_id", evaluationRunId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`findExistingRevisionSessionForEvaluationRun failed: ${error.message}`);
+  }
+
+  if (!data) return null;
+
+  return {
+    id: data.id,
+    evaluation_run_id: data.evaluation_run_id,
+    source_version_id: data.source_version_id,
+    result_version_id: data.result_version_id,
+    status: data.status,
+    summary: data.summary ?? {},
+    created_at: data.created_at,
+    completed_at: data.completed_at,
+  };
+}
+
+export async function startRevisionEngine(
+  input: StartRevisionEngineInput,
+): Promise<StartRevisionEngineResult> {
+  const existing = await findExistingRevisionSessionForEvaluationRun(input.evaluation_run_id);
+
+  if (existing) {
+    const proposals = await listProposalsForSession(existing.id);
+    return {
+      revision_session: existing,
+      proposals,
+    };
+  }
+
+  const sourceVersionId = await getSourceVersionIdForEvaluationRun(input.evaluation_run_id);
+
+  const revisionSession = await createRevisionSession({
+    evaluation_run_id: input.evaluation_run_id,
+    source_version_id: sourceVersionId,
+  });
+
+  await createDiagnosticFindingsForEvaluationRun(
+    input.evaluation_run_id,
+    sourceVersionId,
+  );
+
+  const synthesisSummary = await getFindingsSynthesisSummary(input.evaluation_run_id);
+
+  const proposals = await createProposalsForSessionFromFindings(
+    revisionSession.id,
+    input.evaluation_run_id,
+  );
+
+  return {
+    revision_session: revisionSession,
+    proposals,
+    findings_count: synthesisSummary.findings_count,
+    actionable_findings_count: synthesisSummary.actionable_findings_count,
+  };
+}
+
+export async function finalizeRevisionEngine(
+  revisionSessionId: string,
+): Promise<FinalizeRevisionEngineResult> {
+  const applyResult = await applyRevisionSession(revisionSessionId);
+
+  const revisionSession = await getRevisionSessionById(revisionSessionId);
+  if (!revisionSession) {
+    throw new Error(
+      `finalizeRevisionEngine failed: revision session not found after apply: ${revisionSessionId}`,
+    );
+  }
+
+  return {
+    revision_session: revisionSession,
+    apply_result: applyResult,
+  };
+}

--- a/lib/revision/engine.ts
+++ b/lib/revision/engine.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { applyRevisionSession } from "./apply";
+import { logRevisionEvent } from "./logRevisionEvent";
 import { createDiagnosticFindingsForEvaluationRun } from "./normalizeFindings";
 import {
   createProposalsForSessionFromFindings,
@@ -120,6 +121,21 @@ export async function startRevisionEngine(
     source_version_id: sourceVersionId,
   });
 
+  const sourceVersion = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id")
+    .eq("id", sourceVersionId)
+    .maybeSingle();
+
+  void logRevisionEvent({
+    revision_session_id: revisionSession.id,
+    manuscript_id: sourceVersion.data?.manuscript_id ?? null,
+    manuscript_version_id: sourceVersionId,
+    evaluation_run_id: input.evaluation_run_id,
+    event_type: "session",
+    event_code: "REVISION_SESSION_CREATED",
+  });
+
   await createDiagnosticFindingsForEvaluationRun(
     input.evaluation_run_id,
     sourceVersionId,
@@ -143,17 +159,53 @@ export async function startRevisionEngine(
 export async function finalizeRevisionEngine(
   revisionSessionId: string,
 ): Promise<FinalizeRevisionEngineResult> {
-  const applyResult = await applyRevisionSession(revisionSessionId);
+  const sessionBeforeFinalize = await getRevisionSessionById(revisionSessionId);
 
-  const revisionSession = await getRevisionSessionById(revisionSessionId);
-  if (!revisionSession) {
-    throw new Error(
-      `finalizeRevisionEngine failed: revision session not found after apply: ${revisionSessionId}`,
-    );
+  try {
+    const applyResult = await applyRevisionSession(revisionSessionId);
+
+    const revisionSession = await getRevisionSessionById(revisionSessionId);
+    if (!revisionSession) {
+      throw new Error(
+        `finalizeRevisionEngine failed: revision session not found after apply: ${revisionSessionId}`,
+      );
+    }
+
+    const sourceVersion = await supabase
+      .from("manuscript_versions")
+      .select("id, manuscript_id")
+      .eq("id", revisionSession.source_version_id)
+      .maybeSingle();
+
+    void logRevisionEvent({
+      revision_session_id: revisionSessionId,
+      manuscript_id: sourceVersion.data?.manuscript_id ?? null,
+      manuscript_version_id: revisionSession.source_version_id,
+      evaluation_run_id: revisionSession.evaluation_run_id,
+      event_type: "finalize",
+      event_code: "REVISION_SESSION_FINALIZED",
+      metadata: {
+        result_version_id: applyResult.result_version_id,
+        accepted_count: applyResult.accepted_count,
+        modified_count: applyResult.modified_count,
+      },
+    });
+
+    return {
+      revision_session: revisionSession,
+      apply_result: applyResult,
+    };
+  } catch (error) {
+    void logRevisionEvent({
+      revision_session_id: revisionSessionId,
+      manuscript_version_id: sessionBeforeFinalize?.source_version_id ?? null,
+      evaluation_run_id: sessionBeforeFinalize?.evaluation_run_id ?? null,
+      event_type: "finalize",
+      severity: "error",
+      event_code: "REVISION_SESSION_FINALIZE_FAILED",
+      message: error instanceof Error ? error.message : String(error),
+    });
+
+    throw error;
   }
-
-  return {
-    revision_session: revisionSession,
-    apply_result: applyResult,
-  };
 }

--- a/lib/revision/logRevisionEvent.ts
+++ b/lib/revision/logRevisionEvent.ts
@@ -1,0 +1,52 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import type { LogRevisionEventInput } from "./telemetry";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[REVISION-TELEMETRY] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+export async function logRevisionEvent(input: LogRevisionEventInput): Promise<void> {
+  try {
+    const { error } = await supabase.from("revision_events").insert({
+      revision_session_id: input.revision_session_id ?? null,
+      proposal_id: input.proposal_id ?? null,
+      manuscript_id: input.manuscript_id ?? null,
+      manuscript_version_id: input.manuscript_version_id ?? null,
+      evaluation_run_id: input.evaluation_run_id ?? null,
+      event_type: input.event_type,
+      severity: input.severity ?? "info",
+      event_code: input.event_code,
+      message: input.message ?? null,
+      metadata: input.metadata ?? {},
+    });
+
+    if (error) {
+      console.error("Failed to log revision event", {
+        event_code: input.event_code,
+        error: error.message,
+      });
+    }
+  } catch (error) {
+    console.error("Failed to log revision event", {
+      event_code: input.event_code,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/lib/revision/normalizeFindings.ts
+++ b/lib/revision/normalizeFindings.ts
@@ -1,0 +1,379 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import type {
+  CreateDiagnosticFindingInput,
+  DiagnosticFinding,
+  FindingActionHint,
+  ProposalSeverity,
+} from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[REVISION-FINDINGS] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+function mapDiagnosticFinding(row: any): DiagnosticFinding {
+  return {
+    id: row.id,
+    evaluation_job_id: row.evaluation_job_id,
+    manuscript_version_id: row.manuscript_version_id,
+    artifact_id: row.artifact_id,
+    criterion_key: row.criterion_key,
+    wave_id: row.wave_id,
+    finding_type: row.finding_type,
+    severity: row.severity,
+    confidence: row.confidence,
+    location_ref: row.location_ref,
+    chunk_id: row.chunk_id,
+    chapter_index: row.chapter_index,
+    paragraph_index: row.paragraph_index,
+    sentence_index: row.sentence_index,
+    original_text: row.original_text,
+    evidence_excerpt: row.evidence_excerpt,
+    diagnosis: row.diagnosis,
+    recommendation: row.recommendation,
+    action_hint: row.action_hint,
+    status: row.status,
+    created_at: row.created_at,
+  };
+}
+
+function cleanSnippet(text: string | null | undefined): string {
+  if (!text) return "";
+  return String(text)
+    .replace(/^\s*\.\.\.\s*/g, "")
+    .replace(/\s*\.\.\.\s*$/g, "")
+    .replace(/^\s*\.\s*/g, "")
+    .replace(/\s*\.\s*$/g, "")
+    .trim();
+}
+
+function firstNonEmptyString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function toSeverity(raw: unknown, scoreOverride?: unknown): ProposalSeverity {
+  // score_0_10: >=8 = low concern, 5-7 = medium, <=4 = high
+  if (typeof scoreOverride === "number" && Number.isFinite(scoreOverride)) {
+    if (scoreOverride <= 4) return "high";
+    if (scoreOverride <= 7) return "medium";
+    return "low";
+  }
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (v === "high" || v === "critical" || v === "major") return "high";
+  if (v === "low" || v === "minor") return "low";
+  return "medium";
+}
+
+function toActionHint(raw: unknown): FindingActionHint | null {
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (v === "preserve" || v === "refine" || v === "replace") return v;
+  if (v === "keep" || v === "none" || v === "no_change") return "preserve";
+  return null;
+}
+
+function toConfidence(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function normalizeFindingType(raw: unknown): string {
+  const base = firstNonEmptyString(
+    typeof raw === "string" ? raw : "",
+    "editorial_issue",
+  );
+  return base.replace(/\s+/g, "_").toLowerCase();
+}
+
+function normalizeCriterionKey(raw: unknown): string {
+  const key = firstNonEmptyString(typeof raw === "string" ? raw : "", "GENERAL");
+  return key.replace(/\s+/g, "_").toUpperCase();
+}
+
+function buildFindingsFromPayload(
+  evaluationRunId: string,
+  manuscriptVersionId: string | null,
+  artifactId: string,
+  payload: any,
+): CreateDiagnosticFindingInput[] {
+  const findings: CreateDiagnosticFindingInput[] = [];
+
+  const fromCriteria = Array.isArray(payload?.criteria)
+    ? payload.criteria.flatMap((criterion: any, cIdx: number) => {
+        const criterionKey = normalizeCriterionKey(criterion?.key);
+        const criterionWave = firstNonEmptyString(criterion?.wave_id, criterion?.waveId) || null;
+        const criterionDiagnosis = firstNonEmptyString(
+          criterion?.diagnosis,
+          criterion?.rationale,
+          criterion?.summary,
+        );
+        // evidence may be [{snippet: "..."}] (array) or a plain string
+        const rawEvidence = criterion?.evidence;
+        const evidenceSnippet = Array.isArray(rawEvidence)
+          ? rawEvidence[0]?.snippet ?? rawEvidence[0]?.text ?? ""
+          : rawEvidence;
+        const criterionEvidence = cleanSnippet(
+          firstNonEmptyString(criterion?.evidence_snippet, evidenceSnippet, criterion?.quote),
+        );
+
+        const recommendations = Array.isArray(criterion?.recommendations)
+          ? criterion.recommendations
+          : [];
+
+        return recommendations.map((rec: any, rIdx: number) => {
+          const diagnosis = firstNonEmptyString(
+            rec?.diagnosis,
+            rec?.issue,
+            rec?.why,
+            rec?.justification,
+            criterionDiagnosis,
+            `Finding from ${criterionKey}`,
+          );
+
+          return {
+            evaluation_job_id: evaluationRunId,
+            manuscript_version_id: manuscriptVersionId,
+            artifact_id: artifactId,
+            criterion_key: criterionKey,
+            wave_id: criterionWave,
+            finding_type: normalizeFindingType(
+              firstNonEmptyString(rec?.finding_type, rec?.type, rec?.rule, criterion?.key),
+            ),
+            severity: toSeverity(rec?.severity ?? rec?.priority, criterion?.score_0_10),
+            confidence: toConfidence(rec?.confidence),
+            location_ref:
+              firstNonEmptyString(rec?.location_ref, rec?.locationRef) ||
+              `${criterionKey}:${cIdx + 1}:rec:${rIdx + 1}`,
+            original_text: cleanSnippet(
+              firstNonEmptyString(
+                rec?.original_text,
+                rec?.originalText,
+                rec?.evidence_snippet,
+                rec?.evidenceSnippet,
+                rec?.snippet,
+                criterionEvidence,
+              ),
+            ),
+            evidence_excerpt: cleanSnippet(
+              firstNonEmptyString(rec?.evidence_excerpt, rec?.evidence_snippet, criterionEvidence),
+            ),
+            diagnosis,
+            recommendation: firstNonEmptyString(
+              rec?.recommendation,
+              rec?.proposed_text,
+              rec?.proposedText,
+              rec?.replacement,
+              rec?.action,
+            ),
+            action_hint: toActionHint(rec?.action_hint ?? rec?.action_type ?? rec?.action) ?? "refine",
+          } satisfies CreateDiagnosticFindingInput;
+        });
+      })
+    : [];
+
+  // recommendations may be a flat array OR an object with named buckets
+  // e.g. { quick_wins: [...], strategic_revisions: [...] }
+  const rawRecs = payload?.recommendations;
+  const recommendationsArray: any[] = Array.isArray(rawRecs)
+    ? rawRecs
+    : rawRecs && typeof rawRecs === "object"
+      ? [
+          ...(Array.isArray(rawRecs.quick_wins) ? rawRecs.quick_wins : []),
+          ...(Array.isArray(rawRecs.strategic_revisions) ? rawRecs.strategic_revisions : []),
+          ...(Array.isArray(rawRecs.items) ? rawRecs.items : []),
+        ]
+      : [];
+
+  const fromRecommendations = recommendationsArray.length > 0
+    ? recommendationsArray.map((item: any, idx: number) => ({
+        evaluation_job_id: evaluationRunId,
+        manuscript_version_id: manuscriptVersionId,
+        artifact_id: artifactId,
+        criterion_key: normalizeCriterionKey(item?.criterion ?? item?.rule),
+        wave_id: firstNonEmptyString(item?.wave_id, item?.waveId) || null,
+        finding_type: normalizeFindingType(item?.finding_type ?? item?.type ?? item?.rule),
+        severity: toSeverity(item?.severity ?? item?.priority),
+        confidence: toConfidence(item?.confidence),
+        location_ref:
+          firstNonEmptyString(item?.location_ref, item?.locationRef) ||
+          `recommendation:${idx + 1}`,
+        original_text: cleanSnippet(
+          firstNonEmptyString(
+            item?.original_text,
+            item?.originalText,
+            item?.evidence_snippet,
+            item?.evidenceSnippet,
+            item?.snippet,
+            item?.quote,
+          ),
+        ),
+        evidence_excerpt: cleanSnippet(
+          firstNonEmptyString(item?.evidence_excerpt, item?.evidence_snippet, item?.snippet),
+        ),
+        diagnosis: firstNonEmptyString(
+          item?.diagnosis,
+          item?.justification,
+          item?.reason,
+          item?.why,
+          "Normalized recommendation finding",
+        ),
+        recommendation: firstNonEmptyString(
+          item?.recommendation,
+          item?.proposed_text,
+          item?.proposedText,
+          item?.replacement,
+          item?.action,
+        ),
+        action_hint: toActionHint(item?.action_hint ?? item?.action_type ?? item?.action) ?? "refine",
+      }))
+    : [];
+
+  const fromSuggestions = Array.isArray(payload?.suggestions)
+    ? payload.suggestions.map((item: any, idx: number) => ({
+        evaluation_job_id: evaluationRunId,
+        manuscript_version_id: manuscriptVersionId,
+        artifact_id: artifactId,
+        criterion_key: normalizeCriterionKey(item?.criterion ?? item?.ruleName ?? item?.rule),
+        wave_id: firstNonEmptyString(item?.wave_id, item?.waveId) || null,
+        finding_type: normalizeFindingType(item?.finding_type ?? item?.type ?? item?.ruleName),
+        severity: toSeverity(item?.severity),
+        confidence: toConfidence(item?.confidence),
+        location_ref:
+          firstNonEmptyString(item?.locationRef, item?.location_ref) || `suggestion:${idx + 1}`,
+        original_text: cleanSnippet(firstNonEmptyString(item?.originalText, item?.original_text)),
+        evidence_excerpt: cleanSnippet(
+          firstNonEmptyString(item?.evidence_excerpt, item?.evidence_snippet, item?.quote),
+        ),
+        diagnosis: firstNonEmptyString(
+          item?.diagnosis,
+          item?.justification,
+          item?.reason,
+          "Normalized suggestion finding",
+        ),
+        recommendation: firstNonEmptyString(
+          item?.recommendation,
+          item?.proposedText,
+          item?.proposed_text,
+          item?.action,
+        ),
+        action_hint: toActionHint(item?.action_hint ?? item?.action) ?? "refine",
+      }))
+    : [];
+
+  findings.push(...fromCriteria, ...fromRecommendations, ...fromSuggestions);
+  return findings;
+}
+
+export async function listFindingsForEvaluationRun(
+  evaluationRunId: string,
+): Promise<DiagnosticFinding[]> {
+  const { data, error } = await supabase
+    .from("diagnostic_findings")
+    .select("*")
+    .eq("evaluation_job_id", evaluationRunId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`listFindingsForEvaluationRun failed: ${error.message}`);
+  }
+
+  return (data ?? []).map(mapDiagnosticFinding);
+}
+
+export async function bulkCreateDiagnosticFindings(
+  inputs: CreateDiagnosticFindingInput[],
+): Promise<DiagnosticFinding[]> {
+  if (inputs.length === 0) return [];
+
+  const payload = inputs.map((input) => ({
+    evaluation_job_id: input.evaluation_job_id,
+    manuscript_version_id: input.manuscript_version_id ?? null,
+    artifact_id: input.artifact_id ?? null,
+    criterion_key: input.criterion_key,
+    wave_id: input.wave_id ?? null,
+    finding_type: input.finding_type,
+    severity: input.severity,
+    confidence: input.confidence ?? null,
+    location_ref: input.location_ref ?? null,
+    chunk_id: input.chunk_id ?? null,
+    chapter_index: input.chapter_index ?? null,
+    paragraph_index: input.paragraph_index ?? null,
+    sentence_index: input.sentence_index ?? null,
+    original_text: input.original_text ?? null,
+    evidence_excerpt: input.evidence_excerpt ?? null,
+    diagnosis: input.diagnosis,
+    recommendation: input.recommendation ?? null,
+    action_hint: input.action_hint ?? null,
+    status: input.status ?? "open",
+  }));
+
+  const { data, error } = await supabase
+    .from("diagnostic_findings")
+    .insert(payload)
+    .select("*");
+
+  if (error) {
+    throw new Error(`bulkCreateDiagnosticFindings failed: ${error.message}`);
+  }
+
+  return (data ?? []).map(mapDiagnosticFinding);
+}
+
+export async function createDiagnosticFindingsForEvaluationRun(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+): Promise<DiagnosticFinding[]> {
+  const existing = await listFindingsForEvaluationRun(evaluationRunId);
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  const { data, error } = await supabase
+    .from("evaluation_artifacts")
+    .select("id, artifact_type, content")
+    .eq("job_id", evaluationRunId)
+    .eq("artifact_type", "evaluation_result_v1");
+
+  if (error) {
+    throw new Error(`createDiagnosticFindingsForEvaluationRun failed: ${error.message}`);
+  }
+
+  const rows = data ?? [];
+  const findings: CreateDiagnosticFindingInput[] = [];
+
+  for (const row of rows as any[]) {
+    const artifactId = typeof row.id === "string" ? row.id : null;
+    if (!artifactId) continue;
+
+    const payload = row.content ?? {};
+    findings.push(
+      ...buildFindingsFromPayload(evaluationRunId, manuscriptVersionId, artifactId, payload),
+    );
+  }
+
+  return bulkCreateDiagnosticFindings(findings);
+}

--- a/lib/revision/proposalSynthesis.ts
+++ b/lib/revision/proposalSynthesis.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { getVersionById } from "@/lib/manuscripts/versions";
+import { hydrateSourceVersionIfMissing } from "@/lib/manuscripts/hydrateVersions";
 import { bulkCreateChangeProposals } from "./proposals";
 import { getRevisionSessionById, listProposalsForSession } from "./sessions";
 import type {
@@ -36,6 +37,69 @@ const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminC
 
 function normalizeForAnchorSearch(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function decodeDataUrl(fileUrl: string): string | null {
+  const base64Match = fileUrl.match(/^data:[^,]*;base64,(.*)$/);
+  if (base64Match) {
+    return Buffer.from(base64Match[1], "base64").toString("utf8");
+  }
+
+  const encodedMatch = fileUrl.match(/^data:[^,]*,(.*)$/);
+  if (encodedMatch) {
+    return decodeURIComponent(encodedMatch[1]);
+  }
+
+  return null;
+}
+
+async function resolveBoundSourceText(sourceVersionId: string): Promise<string> {
+  const sourceVersion = await getVersionById(sourceVersionId);
+  let sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+
+  if (sourceText.trim().length > 0) {
+    return normalizeForAnchorSearch(sourceText);
+  }
+
+  const hydrated = await hydrateSourceVersionIfMissing(sourceVersionId, {
+    persist: false,
+  });
+  sourceText = hydrated.raw_text ?? "";
+  if (sourceText.trim().length > 0) {
+    return normalizeForAnchorSearch(sourceText);
+  }
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscripts(file_url)")
+    .eq("id", sourceVersionId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to resolve manuscript file_url for source version ${sourceVersionId}: ${error.message}`,
+    );
+  }
+
+  const manuscript = Array.isArray((data ?? {}).manuscripts)
+    ? data.manuscripts[0]
+    : data?.manuscripts;
+  const fileUrl = manuscript?.file_url;
+
+  if (!fileUrl || typeof fileUrl !== "string") {
+    return "";
+  }
+
+  if (fileUrl.startsWith("data:")) {
+    return normalizeForAnchorSearch(decodeDataUrl(fileUrl) ?? "");
+  }
+
+  const res = await fetch(fileUrl);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch source text from file_url (status=${res.status})`);
+  }
+
+  return normalizeForAnchorSearch(await res.text());
 }
 
 function buildAnchorForSnippet(
@@ -105,13 +169,17 @@ function toProposalInputs(
     .map((f, idx) => {
       const originalText = f.original_text ?? f.evidence_excerpt ?? "";
       const anchor = buildAnchorForSnippet(sourceText, originalText);
+      const anchoredOriginalText =
+        anchor.anchor_start != null && anchor.anchor_end != null
+          ? sourceText.slice(anchor.anchor_start, anchor.anchor_end)
+          : originalText;
 
       return {
         revision_session_id: revisionSessionId,
         location_ref: f.location_ref ?? `finding:${idx + 1}`,
         rule: f.criterion_key ?? f.finding_type ?? "diagnostic_finding",
         action: (f.action_hint === "replace" ? "replace" : "refine") as ProposalAction,
-        original_text: originalText,
+        original_text: anchoredOriginalText,
         proposed_text: f.recommendation ?? f.diagnosis ?? "",
         justification: f.diagnosis,
         severity: (f.severity ?? "medium") as ProposalSeverity,
@@ -177,8 +245,12 @@ export async function createProposalsForSessionFromFindings(
     throw new Error(`Revision session not found: ${revisionSessionId}`);
   }
 
-  const sourceVersion = await getVersionById(session.source_version_id);
-  const sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+  const sourceText = await resolveBoundSourceText(session.source_version_id);
+  if (!sourceText || sourceText.trim().length === 0) {
+    throw new Error(
+      `Cannot synthesize anchored proposals: source text unavailable for source_version_id=${session.source_version_id}`,
+    );
+  }
 
   const findings = data ?? [];
   const proposalInputs = toProposalInputs(revisionSessionId, findings as any[], sourceText);

--- a/lib/revision/proposalSynthesis.ts
+++ b/lib/revision/proposalSynthesis.ts
@@ -1,0 +1,97 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import { bulkCreateChangeProposals } from "./proposals";
+import { listProposalsForSession } from "./sessions";
+import type { ChangeProposal, CreateChangeProposalInput } from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[REVISION-SYNTHESIS] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+function toProposalInputs(
+  revisionSessionId: string,
+  findings: any[],
+): CreateChangeProposalInput[] {
+  return findings
+    .filter((f) => f.action_hint !== "preserve")
+    .map((f, idx) => ({
+      revision_session_id: revisionSessionId,
+      location_ref: f.location_ref ?? `finding:${idx + 1}`,
+      rule: f.criterion_key ?? f.finding_type ?? "diagnostic_finding",
+      action: f.action_hint === "replace" ? "replace" : "refine",
+      original_text: f.original_text ?? f.evidence_excerpt ?? "",
+      proposed_text: f.recommendation ?? f.diagnosis ?? "",
+      justification: f.diagnosis,
+      severity: f.severity ?? "medium",
+    }))
+    .filter(
+      (input) =>
+        input.original_text.trim().length > 0 &&
+        input.proposed_text.trim().length > 0 &&
+        input.justification.trim().length > 0,
+    );
+}
+
+export async function getFindingsSynthesisSummary(evaluationRunId: string): Promise<{
+  findings_count: number;
+  actionable_findings_count: number;
+}> {
+  const { data, error } = await supabase
+    .from("diagnostic_findings")
+    .select("id, action_hint")
+    .eq("evaluation_job_id", evaluationRunId)
+    .eq("status", "open");
+
+  if (error) {
+    throw new Error(`getFindingsSynthesisSummary failed: ${error.message}`);
+  }
+
+  const findings = data ?? [];
+  const actionable = findings.filter((f: any) => f.action_hint !== "preserve");
+
+  return {
+    findings_count: findings.length,
+    actionable_findings_count: actionable.length,
+  };
+}
+
+export async function createProposalsForSessionFromFindings(
+  revisionSessionId: string,
+  evaluationRunId: string,
+): Promise<ChangeProposal[]> {
+  const existing = await listProposalsForSession(revisionSessionId);
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  const { data, error } = await supabase
+    .from("diagnostic_findings")
+    .select("*")
+    .eq("evaluation_job_id", evaluationRunId)
+    .eq("status", "open")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`createProposalsForSessionFromFindings failed: ${error.message}`);
+  }
+
+  const findings = data ?? [];
+  const proposalInputs = toProposalInputs(revisionSessionId, findings as any[]);
+  return bulkCreateChangeProposals(proposalInputs);
+}

--- a/lib/revision/proposalSynthesis.ts
+++ b/lib/revision/proposalSynthesis.ts
@@ -81,10 +81,15 @@ async function resolveBoundSourceText(sourceVersionId: string): Promise<string> 
     );
   }
 
-  const manuscript = Array.isArray((data ?? {}).manuscripts)
-    ? data.manuscripts[0]
-    : data?.manuscripts;
-  const fileUrl = manuscript?.file_url;
+  const manuscriptJoin = data?.manuscripts as
+    | { file_url?: unknown }
+    | Array<{ file_url?: unknown }>
+    | null
+    | undefined;
+  const manuscript = Array.isArray(manuscriptJoin)
+    ? manuscriptJoin[0]
+    : manuscriptJoin;
+  const fileUrl = typeof manuscript?.file_url === "string" ? manuscript.file_url : "";
 
   if (!fileUrl || typeof fileUrl !== "string") {
     return "";

--- a/lib/revision/proposalSynthesis.ts
+++ b/lib/revision/proposalSynthesis.ts
@@ -1,7 +1,7 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { bulkCreateChangeProposals } from "./proposals";
 import { listProposalsForSession } from "./sessions";
-import type { ChangeProposal, CreateChangeProposalInput } from "./types";
+import type { ChangeProposal, CreateChangeProposalInput, ProposalAction, ProposalSeverity } from "./types";
 
 let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
 
@@ -34,11 +34,11 @@ function toProposalInputs(
       revision_session_id: revisionSessionId,
       location_ref: f.location_ref ?? `finding:${idx + 1}`,
       rule: f.criterion_key ?? f.finding_type ?? "diagnostic_finding",
-      action: f.action_hint === "replace" ? "replace" : "refine",
+            action: (f.action_hint === "replace" ? "replace" : "refine") as ProposalAction,
       original_text: f.original_text ?? f.evidence_excerpt ?? "",
       proposed_text: f.recommendation ?? f.diagnosis ?? "",
       justification: f.diagnosis,
-      severity: f.severity ?? "medium",
+            severity: (f.severity ?? "medium") as ProposalSeverity,
     }))
     .filter(
       (input) =>

--- a/lib/revision/proposalSynthesis.ts
+++ b/lib/revision/proposalSynthesis.ts
@@ -1,7 +1,17 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
+import { getVersionById } from "@/lib/manuscripts/versions";
 import { bulkCreateChangeProposals } from "./proposals";
-import { listProposalsForSession } from "./sessions";
-import type { ChangeProposal, CreateChangeProposalInput, ProposalAction, ProposalSeverity } from "./types";
+import { getRevisionSessionById, listProposalsForSession } from "./sessions";
+import type {
+  ChangeProposal,
+  CreateChangeProposalInput,
+  ProposalAction,
+  ProposalSeverity,
+} from "./types";
+
+type ProposalInputWithAnchorStatus = CreateChangeProposalInput & {
+  _anchor_status?: "created" | "ambiguous" | "missing";
+};
 
 let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
 
@@ -24,22 +34,93 @@ const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminC
   },
 });
 
+function normalizeForAnchorSearch(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function buildAnchorForSnippet(
+  sourceText: string,
+  snippet: string,
+): {
+  anchor_start: number | null;
+  anchor_end: number | null;
+  anchor_context: string | null;
+  anchor_status: "created" | "ambiguous" | "missing";
+} {
+  if (!snippet || snippet.trim().length === 0) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+      anchor_status: "missing",
+    };
+  }
+
+  const normalizedSource = normalizeForAnchorSearch(sourceText);
+  const normalizedSnippet = normalizeForAnchorSearch(snippet);
+
+  const start = normalizedSource.indexOf(normalizedSnippet);
+  if (start === -1) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+      anchor_status: "missing",
+    };
+  }
+
+  const second = normalizedSource.indexOf(
+    normalizedSnippet,
+    start + normalizedSnippet.length,
+  );
+
+  if (second !== -1) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+      anchor_status: "ambiguous",
+    };
+  }
+
+  const end = start + normalizedSnippet.length;
+  const contextLeft = Math.max(0, start - 80);
+  const contextRight = Math.min(normalizedSource.length, end + 80);
+
+  return {
+    anchor_start: start,
+    anchor_end: end,
+    anchor_context: normalizedSource.slice(contextLeft, contextRight),
+    anchor_status: "created",
+  };
+}
+
 function toProposalInputs(
   revisionSessionId: string,
   findings: any[],
-): CreateChangeProposalInput[] {
+  sourceText: string,
+): ProposalInputWithAnchorStatus[] {
   return findings
     .filter((f) => f.action_hint !== "preserve")
-    .map((f, idx) => ({
-      revision_session_id: revisionSessionId,
-      location_ref: f.location_ref ?? `finding:${idx + 1}`,
-      rule: f.criterion_key ?? f.finding_type ?? "diagnostic_finding",
-            action: (f.action_hint === "replace" ? "replace" : "refine") as ProposalAction,
-      original_text: f.original_text ?? f.evidence_excerpt ?? "",
-      proposed_text: f.recommendation ?? f.diagnosis ?? "",
-      justification: f.diagnosis,
-            severity: (f.severity ?? "medium") as ProposalSeverity,
-    }))
+    .map((f, idx) => {
+      const originalText = f.original_text ?? f.evidence_excerpt ?? "";
+      const anchor = buildAnchorForSnippet(sourceText, originalText);
+
+      return {
+        revision_session_id: revisionSessionId,
+        location_ref: f.location_ref ?? `finding:${idx + 1}`,
+        rule: f.criterion_key ?? f.finding_type ?? "diagnostic_finding",
+        action: (f.action_hint === "replace" ? "replace" : "refine") as ProposalAction,
+        original_text: originalText,
+        proposed_text: f.recommendation ?? f.diagnosis ?? "",
+        justification: f.diagnosis,
+        severity: (f.severity ?? "medium") as ProposalSeverity,
+        anchor_start: anchor.anchor_start,
+        anchor_end: anchor.anchor_end,
+        anchor_context: anchor.anchor_context,
+        _anchor_status: anchor.anchor_status,
+      };
+    })
     .filter(
       (input) =>
         input.original_text.trim().length > 0 &&
@@ -91,7 +172,15 @@ export async function createProposalsForSessionFromFindings(
     throw new Error(`createProposalsForSessionFromFindings failed: ${error.message}`);
   }
 
+  const session = await getRevisionSessionById(revisionSessionId);
+  if (!session) {
+    throw new Error(`Revision session not found: ${revisionSessionId}`);
+  }
+
+  const sourceVersion = await getVersionById(session.source_version_id);
+  const sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+
   const findings = data ?? [];
-  const proposalInputs = toProposalInputs(revisionSessionId, findings as any[]);
-  return bulkCreateChangeProposals(proposalInputs);
+  const proposalInputs = toProposalInputs(revisionSessionId, findings as any[], sourceText);
+  return bulkCreateChangeProposals(proposalInputs as CreateChangeProposalInput[]);
 }

--- a/lib/revision/proposals.ts
+++ b/lib/revision/proposals.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
-import { listProposalsForSession } from "./sessions";
+import { getVersionById } from "@/lib/manuscripts/versions";
+import { getRevisionSessionById, listProposalsForSession } from "./sessions";
 import type {
   ChangeProposal,
   CreateChangeProposalInput,
@@ -40,7 +41,67 @@ function mapChangeProposal(row: any): ChangeProposal {
     severity: row.severity,
     decision: row.decision,
     modified_text: row.modified_text,
+    anchor_start: row.anchor_start ?? null,
+    anchor_end: row.anchor_end ?? null,
+    anchor_context: row.anchor_context ?? null,
     created_at: row.created_at,
+  };
+}
+
+function normalizeForAnchorSearch(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function buildAnchorForSnippet(
+  sourceText: string,
+  snippet: string,
+): {
+  anchor_start: number | null;
+  anchor_end: number | null;
+  anchor_context: string | null;
+} {
+  if (!snippet || snippet.trim().length === 0) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+    };
+  }
+
+  const normalizedSource = normalizeForAnchorSearch(sourceText);
+  const normalizedSnippet = normalizeForAnchorSearch(snippet);
+
+  const start = normalizedSource.indexOf(normalizedSnippet);
+  if (start === -1) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+    };
+  }
+
+  const second = normalizedSource.indexOf(
+    normalizedSnippet,
+    start + normalizedSnippet.length,
+  );
+
+  // Ambiguous anchors should fail back to legacy path, not silently choose one.
+  if (second !== -1) {
+    return {
+      anchor_start: null,
+      anchor_end: null,
+      anchor_context: null,
+    };
+  }
+
+  const end = start + normalizedSnippet.length;
+  const contextLeft = Math.max(0, start - 80);
+  const contextRight = Math.min(normalizedSource.length, end + 80);
+
+  return {
+    anchor_start: start,
+    anchor_end: end,
+    anchor_context: normalizedSource.slice(contextLeft, contextRight),
   };
 }
 
@@ -115,6 +176,9 @@ export async function createChangeProposal(
       proposed_text: input.proposed_text,
       justification: input.justification,
       severity: input.severity,
+      anchor_start: input.anchor_start ?? null,
+      anchor_end: input.anchor_end ?? null,
+      anchor_context: input.anchor_context ?? null,
     })
     .select("*")
     .single();
@@ -140,6 +204,9 @@ export async function bulkCreateChangeProposals(
     proposed_text: input.proposed_text,
     justification: input.justification,
     severity: input.severity,
+    anchor_start: input.anchor_start ?? null,
+    anchor_end: input.anchor_end ?? null,
+    anchor_context: input.anchor_context ?? null,
   }));
 
   const { data, error } = await supabase
@@ -182,6 +249,7 @@ export async function deleteProposalsForSession(revisionSessionId: string): Prom
 export function normalizeProposalCandidates(
   revisionSessionId: string,
   candidates: EvaluationProposalCandidate[],
+  sourceText: string,
 ): CreateChangeProposalInput[] {
   return candidates
     .filter((candidate) => {
@@ -189,16 +257,24 @@ export function normalizeProposalCandidates(
         candidate.original_text && candidate.proposed_text && candidate.justification,
       );
     })
-    .map((candidate, index) => ({
-      revision_session_id: revisionSessionId,
-      location_ref: candidate.location_ref ?? `unknown:${index + 1}`,
-      rule: candidate.rule ?? "unspecified_rule",
-      action: candidate.action ?? "refine",
-      original_text: candidate.original_text ?? "",
-      proposed_text: candidate.proposed_text ?? "",
-      justification: candidate.justification ?? "",
-      severity: candidate.severity ?? "medium",
-    }));
+    .map((candidate, index) => {
+      const originalText = candidate.original_text ?? "";
+      const anchor = buildAnchorForSnippet(sourceText, originalText);
+
+      return {
+        revision_session_id: revisionSessionId,
+        location_ref: candidate.location_ref ?? `unknown:${index + 1}`,
+        rule: candidate.rule ?? "unspecified_rule",
+        action: candidate.action ?? "refine",
+        original_text: originalText,
+        proposed_text: candidate.proposed_text ?? "",
+        justification: candidate.justification ?? "",
+        severity: candidate.severity ?? "medium",
+        anchor_start: anchor.anchor_start,
+        anchor_end: anchor.anchor_end,
+        anchor_context: anchor.anchor_context,
+      };
+    });
 }
 
 export async function buildProposalsFromEvaluationArtifacts(
@@ -322,7 +398,15 @@ export async function createProposalsForSessionFromEvaluation(
   }
 
   const candidates = await buildProposalsFromEvaluationArtifacts(evaluationRunId);
-  const normalized = normalizeProposalCandidates(revisionSessionId, candidates);
+  const session = await getRevisionSessionById(revisionSessionId);
+  if (!session) {
+    throw new Error(`Revision session not found: ${revisionSessionId}`);
+  }
+
+  const sourceVersion = await getVersionById(session.source_version_id);
+  const sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+
+  const normalized = normalizeProposalCandidates(revisionSessionId, candidates, sourceText);
 
   return bulkCreateChangeProposals(normalized);
 }

--- a/lib/revision/proposals.ts
+++ b/lib/revision/proposals.ts
@@ -1,0 +1,328 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import { listProposalsForSession } from "./sessions";
+import type {
+  ChangeProposal,
+  CreateChangeProposalInput,
+  EvaluationProposalCandidate,
+} from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[REVISION-PROPOSALS] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+function mapChangeProposal(row: any): ChangeProposal {
+  return {
+    id: row.id,
+    revision_session_id: row.revision_session_id,
+    location_ref: row.location_ref,
+    rule: row.rule,
+    action: row.action,
+    original_text: row.original_text,
+    proposed_text: row.proposed_text,
+    justification: row.justification,
+    severity: row.severity,
+    decision: row.decision,
+    modified_text: row.modified_text,
+    created_at: row.created_at,
+  };
+}
+
+function cleanSnippet(text: string | null | undefined): string {
+  if (!text) return "";
+
+  return String(text)
+    .replace(/^\s*\.\.\.\s*/g, "")
+    .replace(/\s*\.\.\.\s*$/g, "")
+    .replace(/^\s*\.\s*/g, "")
+    .replace(/\s*\.\s*$/g, "")
+    .trim();
+}
+
+function firstNonEmptyString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function getCriterionEvidenceSnippet(criterion: any): string {
+  const evidence = criterion?.evidence;
+
+  if (Array.isArray(evidence)) {
+    for (const entry of evidence) {
+      if (typeof entry === "string") {
+        const cleaned = cleanSnippet(entry);
+        if (cleaned) return cleaned;
+      }
+
+      if (entry && typeof entry === "object") {
+        const candidate = firstNonEmptyString(
+          entry.snippet,
+          entry.text,
+          entry.quote,
+          entry.evidence_snippet,
+        );
+
+        const cleaned = cleanSnippet(candidate);
+        if (cleaned) return cleaned;
+      }
+    }
+  }
+
+  if (typeof evidence === "string") {
+    return cleanSnippet(evidence);
+  }
+
+  if (evidence && typeof evidence === "object") {
+    return cleanSnippet(
+      firstNonEmptyString(evidence.snippet, evidence.text, evidence.quote),
+    );
+  }
+
+  return "";
+}
+
+export async function createChangeProposal(
+  input: CreateChangeProposalInput,
+): Promise<ChangeProposal> {
+  const { data, error } = await supabase
+    .from("change_proposals")
+    .insert({
+      revision_session_id: input.revision_session_id,
+      location_ref: input.location_ref,
+      rule: input.rule,
+      action: input.action,
+      original_text: input.original_text,
+      proposed_text: input.proposed_text,
+      justification: input.justification,
+      severity: input.severity,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(`createChangeProposal failed: ${error.message}`);
+  }
+
+  return mapChangeProposal(data);
+}
+
+export async function bulkCreateChangeProposals(
+  inputs: CreateChangeProposalInput[],
+): Promise<ChangeProposal[]> {
+  if (inputs.length === 0) return [];
+
+  const payload = inputs.map((input) => ({
+    revision_session_id: input.revision_session_id,
+    location_ref: input.location_ref,
+    rule: input.rule,
+    action: input.action,
+    original_text: input.original_text,
+    proposed_text: input.proposed_text,
+    justification: input.justification,
+    severity: input.severity,
+  }));
+
+  const { data, error } = await supabase
+    .from("change_proposals")
+    .insert(payload)
+    .select("*");
+
+  if (error) {
+    throw new Error(`bulkCreateChangeProposals failed: ${error.message}`);
+  }
+
+  return (data ?? []).map(mapChangeProposal);
+}
+
+export async function getProposalById(proposalId: string): Promise<ChangeProposal | null> {
+  const { data, error } = await supabase
+    .from("change_proposals")
+    .select("*")
+    .eq("id", proposalId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`getProposalById failed: ${error.message}`);
+  }
+
+  return data ? mapChangeProposal(data) : null;
+}
+
+export async function deleteProposalsForSession(revisionSessionId: string): Promise<void> {
+  const { error } = await supabase
+    .from("change_proposals")
+    .delete()
+    .eq("revision_session_id", revisionSessionId);
+
+  if (error) {
+    throw new Error(`deleteProposalsForSession failed: ${error.message}`);
+  }
+}
+
+export function normalizeProposalCandidates(
+  revisionSessionId: string,
+  candidates: EvaluationProposalCandidate[],
+): CreateChangeProposalInput[] {
+  return candidates
+    .filter((candidate) => {
+      return Boolean(
+        candidate.original_text && candidate.proposed_text && candidate.justification,
+      );
+    })
+    .map((candidate, index) => ({
+      revision_session_id: revisionSessionId,
+      location_ref: candidate.location_ref ?? `unknown:${index + 1}`,
+      rule: candidate.rule ?? "unspecified_rule",
+      action: candidate.action ?? "refine",
+      original_text: candidate.original_text ?? "",
+      proposed_text: candidate.proposed_text ?? "",
+      justification: candidate.justification ?? "",
+      severity: candidate.severity ?? "medium",
+    }));
+}
+
+export async function buildProposalsFromEvaluationArtifacts(
+  evaluationRunId: string,
+): Promise<EvaluationProposalCandidate[]> {
+  const { data, error } = await supabase
+    .from("evaluation_artifacts")
+    .select("artifact_type, content")
+    .eq("job_id", evaluationRunId)
+    .eq("artifact_type", "evaluation_result_v1");
+
+  if (error) {
+    throw new Error(`buildProposalsFromEvaluationArtifacts failed: ${error.message}`);
+  }
+
+  const rows = data ?? [];
+  const candidates: EvaluationProposalCandidate[] = [];
+
+  for (const row of rows as any[]) {
+    const payload = row.content ?? {};
+
+    const fromCriteria = Array.isArray(payload?.criteria)
+      ? payload.criteria.flatMap((criterion: any, cIdx: number) => {
+          const recommendations = Array.isArray(criterion?.recommendations)
+            ? criterion.recommendations
+            : [];
+
+          const criterionEvidenceSnippet = getCriterionEvidenceSnippet(criterion);
+
+          return recommendations.map((rec: any, rIdx: number) => ({
+            location_ref:
+              rec?.location_ref ??
+              `${criterion?.key ?? "criterion"}:${cIdx + 1}:rec:${rIdx + 1}`,
+            rule: criterion?.key ?? "criterion_recommendation",
+            action: "refine" as const,
+            original_text: cleanSnippet(
+              firstNonEmptyString(
+                rec?.original_text,
+                rec?.originalText,
+                rec?.evidence_snippet,
+                rec?.evidenceSnippet,
+                rec?.snippet,
+                criterionEvidenceSnippet,
+              ),
+            ),
+            proposed_text: firstNonEmptyString(
+              rec?.proposed_text,
+              rec?.proposedText,
+              rec?.replacement,
+              rec?.action,
+            ),
+            justification: firstNonEmptyString(
+              rec?.justification,
+              rec?.expected_impact,
+              rec?.expectedImpact,
+              rec?.why,
+              criterion?.rationale,
+            ),
+            severity: rec?.priority === "high" ? "high" : rec?.priority === "low" ? "low" : "medium",
+          }));
+        })
+      : [];
+
+    const fromTopLevelRecommendations = Array.isArray(payload?.recommendations)
+      ? payload.recommendations.map((item: any, idx: number) => ({
+          location_ref: item?.location_ref ?? item?.locationRef ?? `recommendation:${idx + 1}`,
+          rule: item?.rule ?? item?.criterion ?? "recommendation",
+          action: item?.action_type ?? item?.action ?? "refine",
+          original_text: cleanSnippet(
+            firstNonEmptyString(
+              item?.original_text,
+              item?.originalText,
+              item?.evidence_snippet,
+              item?.evidenceSnippet,
+              item?.snippet,
+              item?.quote,
+            ),
+          ),
+          proposed_text: firstNonEmptyString(
+            item?.proposed_text,
+            item?.proposedText,
+            item?.replacement,
+            item?.action,
+          ),
+          justification: firstNonEmptyString(
+            item?.justification,
+            item?.expected_impact,
+            item?.expectedImpact,
+            item?.reason,
+            item?.why,
+          ),
+          severity: item?.priority === "high" ? "high" : item?.priority === "low" ? "low" : "medium",
+        }))
+      : [];
+
+    const fromTopLevelSuggestions = Array.isArray(payload?.suggestions)
+      ? payload.suggestions.map((item: any, idx: number) => ({
+          location_ref: item?.locationRef ?? item?.location_ref ?? `suggestion:${idx + 1}`,
+          rule: item?.rule ?? item?.ruleName ?? "suggestion",
+          action: item?.action ?? "refine",
+          original_text: item?.originalText ?? item?.original_text ?? "",
+          proposed_text: item?.proposedText ?? item?.proposed_text ?? "",
+          justification: item?.justification ?? item?.reason ?? "",
+          severity: item?.severity ?? "medium",
+        }))
+      : [];
+
+    candidates.push(...fromCriteria, ...fromTopLevelSuggestions, ...fromTopLevelRecommendations);
+  }
+
+  return candidates;
+}
+
+export async function createProposalsForSessionFromEvaluation(
+  revisionSessionId: string,
+  evaluationRunId: string,
+): Promise<ChangeProposal[]> {
+  const existing = await listProposalsForSession(revisionSessionId);
+  if (existing.length > 0) {
+    return existing;
+  }
+
+  const candidates = await buildProposalsFromEvaluationArtifacts(evaluationRunId);
+  const normalized = normalizeProposalCandidates(revisionSessionId, candidates);
+
+  return bulkCreateChangeProposals(normalized);
+}

--- a/lib/revision/proposals.ts
+++ b/lib/revision/proposals.ts
@@ -1,11 +1,25 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { getVersionById } from "@/lib/manuscripts/versions";
 import { getRevisionSessionById, listProposalsForSession } from "./sessions";
+import { logRevisionEvent } from "./logRevisionEvent";
 import type {
   ChangeProposal,
   CreateChangeProposalInput,
   EvaluationProposalCandidate,
 } from "./types";
+
+type ProposalAnchorStatus = "created" | "ambiguous" | "missing";
+
+type AnchorBuildResult = {
+  anchor_start: number | null;
+  anchor_end: number | null;
+  anchor_context: string | null;
+  anchor_status: ProposalAnchorStatus;
+};
+
+type NormalizedCreateChangeProposalInput = CreateChangeProposalInput & {
+  _anchor_status?: ProposalAnchorStatus;
+};
 
 let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
 
@@ -48,6 +62,28 @@ function mapChangeProposal(row: any): ChangeProposal {
   };
 }
 
+async function getProposalTelemetryContext(revisionSessionId: string): Promise<{
+  evaluation_run_id: string | null;
+  manuscript_id: number | null;
+  manuscript_version_id: string | null;
+}> {
+  const session = await getRevisionSessionById(revisionSessionId);
+  if (!session) {
+    return {
+      evaluation_run_id: null,
+      manuscript_id: null,
+      manuscript_version_id: null,
+    };
+  }
+
+  const sourceVersion = await getVersionById(session.source_version_id);
+  return {
+    evaluation_run_id: session.evaluation_run_id,
+    manuscript_id: sourceVersion?.manuscript_id ?? null,
+    manuscript_version_id: sourceVersion?.id ?? session.source_version_id,
+  };
+}
+
 function normalizeForAnchorSearch(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
@@ -55,16 +91,13 @@ function normalizeForAnchorSearch(text: string): string {
 function buildAnchorForSnippet(
   sourceText: string,
   snippet: string,
-): {
-  anchor_start: number | null;
-  anchor_end: number | null;
-  anchor_context: string | null;
-} {
+): AnchorBuildResult {
   if (!snippet || snippet.trim().length === 0) {
     return {
       anchor_start: null,
       anchor_end: null,
       anchor_context: null,
+      anchor_status: "missing",
     };
   }
 
@@ -77,6 +110,7 @@ function buildAnchorForSnippet(
       anchor_start: null,
       anchor_end: null,
       anchor_context: null,
+      anchor_status: "missing",
     };
   }
 
@@ -91,6 +125,7 @@ function buildAnchorForSnippet(
       anchor_start: null,
       anchor_end: null,
       anchor_context: null,
+      anchor_status: "ambiguous",
     };
   }
 
@@ -102,6 +137,7 @@ function buildAnchorForSnippet(
     anchor_start: start,
     anchor_end: end,
     anchor_context: normalizedSource.slice(contextLeft, contextRight),
+    anchor_status: "created",
   };
 }
 
@@ -187,7 +223,46 @@ export async function createChangeProposal(
     throw new Error(`createChangeProposal failed: ${error.message}`);
   }
 
-  return mapChangeProposal(data);
+  const mapped = mapChangeProposal(data);
+  const telemetryContext = await getProposalTelemetryContext(mapped.revision_session_id);
+
+  void logRevisionEvent({
+    revision_session_id: mapped.revision_session_id,
+    proposal_id: mapped.id,
+    manuscript_id: telemetryContext.manuscript_id,
+    manuscript_version_id: telemetryContext.manuscript_version_id,
+    evaluation_run_id: telemetryContext.evaluation_run_id,
+    event_type: "proposal",
+    event_code: "PROPOSAL_GENERATED",
+    metadata: {
+      original_text_length: mapped.original_text.length,
+      proposed_text_length: mapped.proposed_text.length,
+    },
+  });
+
+  void logRevisionEvent({
+    revision_session_id: mapped.revision_session_id,
+    proposal_id: mapped.id,
+    manuscript_id: telemetryContext.manuscript_id,
+    manuscript_version_id: telemetryContext.manuscript_version_id,
+    evaluation_run_id: telemetryContext.evaluation_run_id,
+    event_type: "proposal",
+    severity:
+      mapped.anchor_start != null && mapped.anchor_end != null
+        ? "info"
+        : "warn",
+    event_code:
+      mapped.anchor_start != null && mapped.anchor_end != null
+        ? "PROPOSAL_ANCHOR_CREATED"
+        : "PROPOSAL_ANCHOR_MISSING",
+    metadata: {
+      anchor_start: mapped.anchor_start,
+      anchor_end: mapped.anchor_end,
+      anchor_context_length: mapped.anchor_context?.length ?? 0,
+    },
+  });
+
+  return mapped;
 }
 
 export async function bulkCreateChangeProposals(
@@ -218,7 +293,60 @@ export async function bulkCreateChangeProposals(
     throw new Error(`bulkCreateChangeProposals failed: ${error.message}`);
   }
 
-  return (data ?? []).map(mapChangeProposal);
+  const mapped = (data ?? []).map(mapChangeProposal);
+  const telemetryContext =
+    mapped.length > 0
+      ? await getProposalTelemetryContext(mapped[0].revision_session_id)
+      : {
+          evaluation_run_id: null,
+          manuscript_id: null,
+          manuscript_version_id: null,
+        };
+
+  for (let i = 0; i < mapped.length; i += 1) {
+    const created = mapped[i];
+    const input = inputs[i] as NormalizedCreateChangeProposalInput | undefined;
+    const anchorStatus =
+      input?._anchor_status ??
+      (created.anchor_start != null && created.anchor_end != null ? "created" : "missing");
+
+    void logRevisionEvent({
+      revision_session_id: created.revision_session_id,
+      proposal_id: created.id,
+      manuscript_id: telemetryContext.manuscript_id,
+      manuscript_version_id: telemetryContext.manuscript_version_id,
+      evaluation_run_id: telemetryContext.evaluation_run_id,
+      event_type: "proposal",
+      event_code: "PROPOSAL_GENERATED",
+      metadata: {
+        original_text_length: created.original_text.length,
+        proposed_text_length: created.proposed_text.length,
+      },
+    });
+
+    void logRevisionEvent({
+      revision_session_id: created.revision_session_id,
+      proposal_id: created.id,
+      manuscript_id: telemetryContext.manuscript_id,
+      manuscript_version_id: telemetryContext.manuscript_version_id,
+      evaluation_run_id: telemetryContext.evaluation_run_id,
+      event_type: "proposal",
+      severity: anchorStatus === "created" ? "info" : "warn",
+      event_code:
+        anchorStatus === "created"
+          ? "PROPOSAL_ANCHOR_CREATED"
+          : anchorStatus === "ambiguous"
+            ? "PROPOSAL_ANCHOR_AMBIGUOUS"
+            : "PROPOSAL_ANCHOR_MISSING",
+      metadata: {
+        anchor_start: created.anchor_start,
+        anchor_end: created.anchor_end,
+        anchor_context_length: created.anchor_context?.length ?? 0,
+      },
+    });
+  }
+
+  return mapped;
 }
 
 export async function getProposalById(proposalId: string): Promise<ChangeProposal | null> {
@@ -250,7 +378,7 @@ export function normalizeProposalCandidates(
   revisionSessionId: string,
   candidates: EvaluationProposalCandidate[],
   sourceText: string,
-): CreateChangeProposalInput[] {
+): NormalizedCreateChangeProposalInput[] {
   return candidates
     .filter((candidate) => {
       return Boolean(
@@ -273,6 +401,7 @@ export function normalizeProposalCandidates(
         anchor_start: anchor.anchor_start,
         anchor_end: anchor.anchor_end,
         anchor_context: anchor.anchor_context,
+        _anchor_status: anchor.anchor_status,
       };
     });
 }

--- a/lib/revision/proposals.ts
+++ b/lib/revision/proposals.ts
@@ -131,10 +131,15 @@ async function resolveBoundSourceText(sourceVersionId: string): Promise<string> 
     );
   }
 
-  const manuscript = Array.isArray((data ?? {}).manuscripts)
-    ? data.manuscripts[0]
-    : data?.manuscripts;
-  const fileUrl = manuscript?.file_url;
+  const manuscriptJoin = data?.manuscripts as
+    | { file_url?: unknown }
+    | Array<{ file_url?: unknown }>
+    | null
+    | undefined;
+  const manuscript = Array.isArray(manuscriptJoin)
+    ? manuscriptJoin[0]
+    : manuscriptJoin;
+  const fileUrl = typeof manuscript?.file_url === "string" ? manuscript.file_url : "";
 
   if (!fileUrl || typeof fileUrl !== "string") {
     return "";

--- a/lib/revision/proposals.ts
+++ b/lib/revision/proposals.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { getVersionById } from "@/lib/manuscripts/versions";
+import { hydrateSourceVersionIfMissing } from "@/lib/manuscripts/hydrateVersions";
 import { getRevisionSessionById, listProposalsForSession } from "./sessions";
 import { logRevisionEvent } from "./logRevisionEvent";
 import type {
@@ -86,6 +87,69 @@ async function getProposalTelemetryContext(revisionSessionId: string): Promise<{
 
 function normalizeForAnchorSearch(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function decodeDataUrl(fileUrl: string): string | null {
+  const base64Match = fileUrl.match(/^data:[^,]*;base64,(.*)$/);
+  if (base64Match) {
+    return Buffer.from(base64Match[1], "base64").toString("utf8");
+  }
+
+  const encodedMatch = fileUrl.match(/^data:[^,]*,(.*)$/);
+  if (encodedMatch) {
+    return decodeURIComponent(encodedMatch[1]);
+  }
+
+  return null;
+}
+
+async function resolveBoundSourceText(sourceVersionId: string): Promise<string> {
+  const sourceVersion = await getVersionById(sourceVersionId);
+  let sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+
+  if (sourceText.trim().length > 0) {
+    return normalizeForAnchorSearch(sourceText);
+  }
+
+  const hydrated = await hydrateSourceVersionIfMissing(sourceVersionId, {
+    persist: false,
+  });
+  sourceText = hydrated.raw_text ?? "";
+  if (sourceText.trim().length > 0) {
+    return normalizeForAnchorSearch(sourceText);
+  }
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscripts(file_url)")
+    .eq("id", sourceVersionId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to resolve manuscript file_url for source version ${sourceVersionId}: ${error.message}`,
+    );
+  }
+
+  const manuscript = Array.isArray((data ?? {}).manuscripts)
+    ? data.manuscripts[0]
+    : data?.manuscripts;
+  const fileUrl = manuscript?.file_url;
+
+  if (!fileUrl || typeof fileUrl !== "string") {
+    return "";
+  }
+
+  if (fileUrl.startsWith("data:")) {
+    return normalizeForAnchorSearch(decodeDataUrl(fileUrl) ?? "");
+  }
+
+  const res = await fetch(fileUrl);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch source text from file_url (status=${res.status})`);
+  }
+
+  return normalizeForAnchorSearch(await res.text());
 }
 
 function buildAnchorForSnippet(
@@ -388,13 +452,17 @@ export function normalizeProposalCandidates(
     .map((candidate, index) => {
       const originalText = candidate.original_text ?? "";
       const anchor = buildAnchorForSnippet(sourceText, originalText);
+      const anchoredOriginalText =
+        anchor.anchor_start != null && anchor.anchor_end != null
+          ? sourceText.slice(anchor.anchor_start, anchor.anchor_end)
+          : originalText;
 
       return {
         revision_session_id: revisionSessionId,
         location_ref: candidate.location_ref ?? `unknown:${index + 1}`,
         rule: candidate.rule ?? "unspecified_rule",
         action: candidate.action ?? "refine",
-        original_text: originalText,
+        original_text: anchoredOriginalText,
         proposed_text: candidate.proposed_text ?? "",
         justification: candidate.justification ?? "",
         severity: candidate.severity ?? "medium",
@@ -532,8 +600,12 @@ export async function createProposalsForSessionFromEvaluation(
     throw new Error(`Revision session not found: ${revisionSessionId}`);
   }
 
-  const sourceVersion = await getVersionById(session.source_version_id);
-  const sourceText = typeof sourceVersion?.raw_text === "string" ? sourceVersion.raw_text : "";
+  const sourceText = await resolveBoundSourceText(session.source_version_id);
+  if (!sourceText || sourceText.trim().length === 0) {
+    throw new Error(
+      `Cannot synthesize anchored proposals: source text unavailable for source_version_id=${session.source_version_id}`,
+    );
+  }
 
   const normalized = normalizeProposalCandidates(revisionSessionId, candidates, sourceText);
 

--- a/lib/revision/sessions.ts
+++ b/lib/revision/sessions.ts
@@ -1,0 +1,164 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import type {
+  ChangeProposal,
+  CreateRevisionSessionInput,
+  ProposalDecision,
+  RevisionSession,
+} from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) {
+    _supabase = getSupabaseAdminClient();
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[REVISION-SESSIONS] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof typeof client];
+  },
+});
+
+function mapRevisionSession(row: any): RevisionSession {
+  return {
+    id: row.id,
+    evaluation_run_id: row.evaluation_run_id,
+    source_version_id: row.source_version_id,
+    result_version_id: row.result_version_id,
+    status: row.status,
+    summary: row.summary ?? {},
+    created_at: row.created_at,
+    completed_at: row.completed_at,
+  };
+}
+
+function mapChangeProposal(row: any): ChangeProposal {
+  return {
+    id: row.id,
+    revision_session_id: row.revision_session_id,
+    location_ref: row.location_ref,
+    rule: row.rule,
+    action: row.action,
+    original_text: row.original_text,
+    proposed_text: row.proposed_text,
+    justification: row.justification,
+    severity: row.severity,
+    decision: row.decision,
+    modified_text: row.modified_text,
+    created_at: row.created_at,
+  };
+}
+
+export async function createRevisionSession(
+  input: CreateRevisionSessionInput,
+): Promise<RevisionSession> {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .insert({
+      evaluation_run_id: input.evaluation_run_id,
+      source_version_id: input.source_version_id,
+      status: "open",
+      summary: {},
+    })
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`createRevisionSession failed: ${error.message}`);
+  return mapRevisionSession(data);
+}
+
+export async function getRevisionSessionById(
+  revisionSessionId: string,
+): Promise<RevisionSession | null> {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .select("*")
+    .eq("id", revisionSessionId)
+    .maybeSingle();
+
+  if (error) throw new Error(`getRevisionSessionById failed: ${error.message}`);
+  return data ? mapRevisionSession(data) : null;
+}
+
+export async function listProposalsForSession(
+  revisionSessionId: string,
+): Promise<ChangeProposal[]> {
+  const { data, error } = await supabase
+    .from("change_proposals")
+    .select("*")
+    .eq("revision_session_id", revisionSessionId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(`listProposalsForSession failed: ${error.message}`);
+  return (data ?? []).map(mapChangeProposal);
+}
+
+export async function decideProposal(
+  proposalId: string,
+  decision: ProposalDecision,
+  modifiedText?: string | null,
+): Promise<ChangeProposal> {
+  const updatePayload: Record<string, unknown> = {
+    decision,
+  };
+
+  if (decision === "modified") {
+    updatePayload.modified_text = modifiedText ?? "";
+  }
+
+  const { data, error } = await supabase
+    .from("change_proposals")
+    .update(updatePayload)
+    .eq("id", proposalId)
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`decideProposal failed: ${error.message}`);
+  return mapChangeProposal(data);
+}
+
+export async function markRevisionSessionApplied(
+  revisionSessionId: string,
+  resultVersionId: string,
+  summary: Record<string, unknown>,
+): Promise<RevisionSession> {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .update({
+      status: "applied",
+      result_version_id: resultVersionId,
+      summary,
+      completed_at: new Date().toISOString(),
+    })
+    .eq("id", revisionSessionId)
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`markRevisionSessionApplied failed: ${error.message}`);
+  return mapRevisionSession(data);
+}
+
+export async function discardRevisionSession(
+  revisionSessionId: string,
+): Promise<RevisionSession> {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .update({
+      status: "discarded",
+      completed_at: new Date().toISOString(),
+    })
+    .eq("id", revisionSessionId)
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`discardRevisionSession failed: ${error.message}`);
+  return mapRevisionSession(data);
+}

--- a/lib/revision/sessions.ts
+++ b/lib/revision/sessions.ts
@@ -53,6 +53,9 @@ function mapChangeProposal(row: any): ChangeProposal {
     severity: row.severity,
     decision: row.decision,
     modified_text: row.modified_text,
+    anchor_start: row.anchor_start ?? null,
+    anchor_end: row.anchor_end ?? null,
+    anchor_context: row.anchor_context ?? null,
     created_at: row.created_at,
   };
 }

--- a/lib/revision/telemetry.ts
+++ b/lib/revision/telemetry.ts
@@ -1,0 +1,47 @@
+export type RevisionEventType =
+  | "session"
+  | "proposal"
+  | "apply"
+  | "finalize"
+  | "immutability"
+  | "smoke";
+
+export type RevisionEventSeverity =
+  | "info"
+  | "warn"
+  | "error"
+  | "critical";
+
+export type RevisionEventCode =
+  | "REVISION_SESSION_CREATED"
+  | "REVISION_SESSION_FINALIZED"
+  | "REVISION_SESSION_FINALIZE_FAILED"
+  | "PROPOSAL_GENERATED"
+  | "PROPOSAL_ANCHOR_CREATED"
+  | "PROPOSAL_ANCHOR_AMBIGUOUS"
+  | "PROPOSAL_ANCHOR_MISSING"
+  | "APPLY_ANCHORED_SUCCESS"
+  | "APPLY_ANCHORED_SLICE_MISMATCH"
+  | "APPLY_ANCHORED_CONTEXT_MISMATCH"
+  | "APPLY_LEGACY_FALLBACK_SUCCESS"
+  | "APPLY_LEGACY_NOT_FOUND"
+  | "APPLY_LEGACY_AMBIGUOUS"
+  | "SOURCE_IMMUTABLE_CONFIRMED"
+  | "SOURCE_IMMUTABILITY_VIOLATION"
+  | "SMOKE_STALE_RUN_REJECTED"
+  | "SMOKE_FRESH_RUN_SELECTED"
+  | "SMOKE_RUN_PASSED"
+  | "SMOKE_RUN_FAILED";
+
+export type LogRevisionEventInput = {
+  revision_session_id?: string | null;
+  proposal_id?: string | null;
+  manuscript_id?: number | null;
+  manuscript_version_id?: string | null;
+  evaluation_run_id?: string | null;
+  event_type: RevisionEventType;
+  severity?: RevisionEventSeverity;
+  event_code: RevisionEventCode;
+  message?: string | null;
+  metadata?: Record<string, unknown>;
+};

--- a/lib/revision/types.ts
+++ b/lib/revision/types.ts
@@ -28,6 +28,9 @@ export type ChangeProposal = {
   severity: ProposalSeverity;
   decision: ProposalDecision | null;
   modified_text: string | null;
+  anchor_start: number | null;
+  anchor_end: number | null;
+  anchor_context: string | null;
   created_at: string;
 };
 
@@ -69,6 +72,9 @@ export type CreateChangeProposalInput = {
   proposed_text: string;
   justification: string;
   severity: ProposalSeverity;
+  anchor_start?: number | null;
+  anchor_end?: number | null;
+  anchor_context?: string | null;
 };
 
 export type CreateDiagnosticFindingInput = {

--- a/lib/revision/types.ts
+++ b/lib/revision/types.ts
@@ -1,0 +1,112 @@
+export type ProposalAction = "preserve" | "refine" | "replace";
+export type ProposalSeverity = "low" | "medium" | "high";
+export type ProposalDecision = "accepted" | "rejected" | "modified";
+export type RevisionSessionStatus = "open" | "applied" | "discarded";
+export type FindingActionHint = ProposalAction;
+export type FindingStatus = "open" | "resolved" | "ignored";
+
+export type RevisionSession = {
+  id: string;
+  evaluation_run_id: string;
+  source_version_id: string;
+  result_version_id: string | null;
+  status: RevisionSessionStatus;
+  summary: Record<string, unknown>;
+  created_at: string;
+  completed_at: string | null;
+};
+
+export type ChangeProposal = {
+  id: string;
+  revision_session_id: string;
+  location_ref: string;
+  rule: string;
+  action: ProposalAction;
+  original_text: string;
+  proposed_text: string;
+  justification: string;
+  severity: ProposalSeverity;
+  decision: ProposalDecision | null;
+  modified_text: string | null;
+  created_at: string;
+};
+
+export type DiagnosticFinding = {
+  id: string;
+  evaluation_job_id: string;
+  manuscript_version_id: string | null;
+  artifact_id: string | null;
+  criterion_key: string;
+  wave_id: string | null;
+  finding_type: string;
+  severity: ProposalSeverity;
+  confidence: number | null;
+  location_ref: string | null;
+  chunk_id: string | null;
+  chapter_index: number | null;
+  paragraph_index: number | null;
+  sentence_index: number | null;
+  original_text: string | null;
+  evidence_excerpt: string | null;
+  diagnosis: string;
+  recommendation: string | null;
+  action_hint: FindingActionHint | null;
+  status: FindingStatus;
+  created_at: string;
+};
+
+export type CreateRevisionSessionInput = {
+  evaluation_run_id: string;
+  source_version_id: string;
+};
+
+export type CreateChangeProposalInput = {
+  revision_session_id: string;
+  location_ref: string;
+  rule: string;
+  action: ProposalAction;
+  original_text: string;
+  proposed_text: string;
+  justification: string;
+  severity: ProposalSeverity;
+};
+
+export type CreateDiagnosticFindingInput = {
+  evaluation_job_id: string;
+  manuscript_version_id?: string | null;
+  artifact_id?: string | null;
+  criterion_key: string;
+  wave_id?: string | null;
+  finding_type: string;
+  severity: ProposalSeverity;
+  confidence?: number | null;
+  location_ref?: string | null;
+  chunk_id?: string | null;
+  chapter_index?: number | null;
+  paragraph_index?: number | null;
+  sentence_index?: number | null;
+  original_text?: string | null;
+  evidence_excerpt?: string | null;
+  diagnosis: string;
+  recommendation?: string | null;
+  action_hint?: FindingActionHint | null;
+  status?: FindingStatus;
+};
+
+export type ApplyRevisionSessionResult = {
+  revision_session_id: string;
+  source_version_id: string;
+  result_version_id: string;
+  accepted_count: number;
+  modified_count: number;
+};
+
+export type EvaluationProposalCandidate = {
+  location_ref?: string | null;
+  rule?: string | null;
+  action?: ProposalAction | null;
+  original_text?: string | null;
+  proposed_text?: string | null;
+  justification?: string | null;
+  severity?: ProposalSeverity | null;
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "jobs:test:metrics": "node scripts/jobs-test-metrics.mjs",
     "jobs:retry-tick": "node scripts/jobs-retry-tick.mjs",
     "jobs:load": "node scripts/jobs-load.mjs",
+    "revision:hydrate:stage2": "node scripts/revision-stage2-hydrate.mjs",
+    "revision:smoke:stage2": "node scripts/revision-stage2-smoke.mjs",
     "evidence:phase2c": "bash scripts/evidence-phase2c.sh",
     "evidence:phase2d": "bash scripts/evidence-phase2d.sh",
     "evidence:flow1": "bash scripts/evidence-flow1.sh"

--- a/schemas/manuscript-version.ts
+++ b/schemas/manuscript-version.ts
@@ -1,0 +1,111 @@
+/**
+ * Manuscript Version Schema (Stage 2 foundation)
+ *
+ * A manuscript is a container; each saved text state is an immutable version.
+ */
+
+export type ManuscriptVersion = {
+  id: string; // uuid
+  manuscript_id: number; // manuscripts.id (bigint)
+  version_number: number; // 1..n
+  source_version_id: string | null; // uuid self-reference
+  raw_text: string;
+  word_count: number;
+  created_by: string | null;
+  created_at: string; // ISO timestamp
+};
+
+export type CreateInitialManuscriptVersionInput = {
+  manuscript_id: number;
+  raw_text: string;
+  word_count?: number;
+  created_by?: string | null;
+};
+
+export type CreateDerivedManuscriptVersionInput = {
+  manuscript_id: number;
+  source_version_id: string;
+  raw_text: string;
+  word_count?: number;
+  created_by?: string | null;
+};
+
+export function isManuscriptVersion(obj: unknown): obj is ManuscriptVersion {
+  if (!obj || typeof obj !== "object") return false;
+
+  const value = obj as Partial<ManuscriptVersion>;
+  return (
+    typeof value.id === "string" &&
+    typeof value.manuscript_id === "number" &&
+    typeof value.version_number === "number" &&
+    (typeof value.source_version_id === "string" || value.source_version_id === null) &&
+    typeof value.raw_text === "string" &&
+    typeof value.word_count === "number" &&
+    (typeof value.created_by === "string" || value.created_by === null || value.created_by === undefined) &&
+    typeof value.created_at === "string"
+  );
+}
+
+export function validateCreateInitialVersionInput(
+  input: CreateInitialManuscriptVersionInput,
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!Number.isInteger(input.manuscript_id) || input.manuscript_id <= 0) {
+    errors.push("manuscript_id must be a positive integer");
+  }
+
+  if (typeof input.raw_text !== "string") {
+    errors.push("raw_text must be a string");
+  }
+
+  if (typeof input.raw_text === "string" && input.raw_text.trim().length === 0) {
+    errors.push("raw_text must be non-empty for new manuscript versions");
+  }
+
+  if (
+    input.word_count !== undefined &&
+    (!Number.isInteger(input.word_count) || input.word_count < 0)
+  ) {
+    errors.push("word_count must be a non-negative integer when provided");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function validateCreateDerivedVersionInput(
+  input: CreateDerivedManuscriptVersionInput,
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!Number.isInteger(input.manuscript_id) || input.manuscript_id <= 0) {
+    errors.push("manuscript_id must be a positive integer");
+  }
+
+  if (typeof input.source_version_id !== "string" || input.source_version_id.trim().length === 0) {
+    errors.push("source_version_id must be a non-empty uuid string");
+  }
+
+  if (typeof input.raw_text !== "string") {
+    errors.push("raw_text must be a string");
+  }
+
+  if (typeof input.raw_text === "string" && input.raw_text.trim().length === 0) {
+    errors.push("raw_text must be non-empty for new manuscript versions");
+  }
+
+  if (
+    input.word_count !== undefined &&
+    (!Number.isInteger(input.word_count) || input.word_count < 0)
+  ) {
+    errors.push("word_count must be a non-negative integer when provided");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/scripts/apply-diagnostic-findings-migrations.sql
+++ b/scripts/apply-diagnostic-findings-migrations.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- Supabase SQL Editor: Diagnostic Findings Layer Migrations
+-- Project: xtumxjnzdswuumndcbwc (RevisionGrade Production)
+-- Files:
+--   20260316020000_add_diagnostic_findings.sql
+--   20260316021000_diagnostic_findings_rls.sql
+--
+-- HOW TO APPLY:
+--   1. Open https://supabase.com/dashboard/project/xtumxjnzdswuumndcbwc/sql
+--   2. Click "New query"
+--   3. Paste this ENTIRE file
+--   4. Click "Run"
+--   5. Confirm the verification output at the bottom shows:
+--        diagnostic_findings | t
+--      and all expected indexes listed
+--   6. Restart your local dev server
+--   7. Rerun:  node scripts/revision-stage2-smoke.mjs
+--
+-- This script is idempotent (CREATE TABLE IF NOT EXISTS,
+-- DROP POLICY IF EXISTS, CREATE INDEX IF NOT EXISTS).
+-- Safe to run multiple times.
+-- ============================================================
+
+-- ──────────────────────────────────────────────────────────
+-- MIGRATION 1: 20260316020000_add_diagnostic_findings.sql
+-- Stage 2 additive architecture improvement:
+--   evaluation_artifacts -> diagnostic_findings -> change_proposals
+-- ──────────────────────────────────────────────────────────
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.diagnostic_findings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  evaluation_job_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  manuscript_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  artifact_id uuid REFERENCES public.evaluation_artifacts(id) ON DELETE SET NULL,
+
+  criterion_key text NOT NULL,
+  wave_id text,
+  finding_type text NOT NULL,
+  severity text NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+  confidence numeric,
+
+  location_ref text,
+  chunk_id uuid,
+  chapter_index integer,
+  paragraph_index integer,
+  sentence_index integer,
+
+  original_text text,
+  evidence_excerpt text,
+  diagnosis text NOT NULL,
+  recommendation text,
+
+  action_hint text CHECK (action_hint IN ('preserve', 'refine', 'replace')),
+  status text NOT NULL DEFAULT 'open',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_evaluation_job_id
+  ON public.diagnostic_findings(evaluation_job_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_manuscript_version_id
+  ON public.diagnostic_findings(manuscript_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_criterion_key
+  ON public.diagnostic_findings(criterion_key);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_wave_id
+  ON public.diagnostic_findings(wave_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_finding_type
+  ON public.diagnostic_findings(finding_type);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_status
+  ON public.diagnostic_findings(status);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_location_ref
+  ON public.diagnostic_findings(location_ref);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_action_hint
+  ON public.diagnostic_findings(action_hint);
+
+COMMIT;
+
+-- ──────────────────────────────────────────────────────────
+-- MIGRATION 2: 20260316021000_diagnostic_findings_rls.sql
+-- Stage 2 RLS hardening for diagnostic_findings
+-- ──────────────────────────────────────────────────────────
+
+BEGIN;
+
+ALTER TABLE public.diagnostic_findings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can view own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can insert own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can update own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+COMMIT;
+
+-- ──────────────────────────────────────────────────────────
+-- POST-MIGRATION: Reload PostgREST schema cache
+-- ──────────────────────────────────────────────────────────
+
+NOTIFY pgrst, 'reload schema';
+
+-- ──────────────────────────────────────────────────────────
+-- VERIFICATION: Confirm the table and indexes exist
+-- Expected output: diagnostic_findings | t
+-- and 8 index rows
+-- ──────────────────────────────────────────────────────────
+
+SELECT
+  c.relname AS table_name,
+  obj_description(c.oid, 'pg_class') AS comment,
+  c.relrowsecurity AS rls_enabled
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public'
+  AND c.relname = 'diagnostic_findings';
+
+SELECT
+  indexname,
+  indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND tablename = 'diagnostic_findings'
+ORDER BY indexname;
+
+SELECT
+  policyname,
+  cmd
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND tablename = 'diagnostic_findings'
+ORDER BY policyname;

--- a/scripts/apply-diagnostic-findings.sh
+++ b/scripts/apply-diagnostic-findings.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# ============================================================
+# apply-diagnostic-findings.sh
+#
+# One-shot CLI helper to apply the diagnostic_findings layer
+# migrations to the linked Supabase remote project.
+#
+# REQUIRES one of:
+#   Option A (supabase CLI):
+#     SUPABASE_ACCESS_TOKEN   — Supabase personal access token
+#     SUPABASE_PROJECT_REF    — project ref (e.g. xtumxjnzdswuumndcbwc)
+#
+#   Option B (psql direct):
+#     SUPABASE_DB_URL_CI      — full postgres:// connection string
+#
+# USAGE:
+#   SUPABASE_ACCESS_TOKEN=sbp_xxx SUPABASE_PROJECT_REF=xtumxjnzdswuumndcbwc \
+#     bash scripts/apply-diagnostic-findings.sh
+#
+#   — or —
+#
+#   SUPABASE_DB_URL_CI="postgresql://postgres.xtumxjnzdswuumndcbwc:PASSWORD@..." \
+#     bash scripts/apply-diagnostic-findings.sh
+# ============================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+M1="$PROJECT_ROOT/supabase/migrations/20260316020000_add_diagnostic_findings.sql"
+M2="$PROJECT_ROOT/supabase/migrations/20260316021000_diagnostic_findings_rls.sql"
+
+echo "==> apply-diagnostic-findings.sh"
+echo "    Migration 1: $M1"
+echo "    Migration 2: $M2"
+echo ""
+
+# Guard: migration files must exist
+for f in "$M1" "$M2"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: migration file not found: $f"
+    exit 1
+  fi
+done
+
+# ── Route A: supabase CLI ──────────────────────────────────
+if [[ -n "${SUPABASE_ACCESS_TOKEN:-}" && -n "${SUPABASE_PROJECT_REF:-}" ]]; then
+  echo "Route: supabase CLI (SUPABASE_ACCESS_TOKEN + SUPABASE_PROJECT_REF)"
+  echo ""
+
+  export SUPABASE_ACCESS_TOKEN
+
+  echo "→ Linking project $SUPABASE_PROJECT_REF ..."
+  supabase link --project-ref "$SUPABASE_PROJECT_REF" --yes
+
+  echo "→ Pushing new migrations ..."
+  # --include-all ensures migrations not yet tracked in remote history are applied
+  (yes || true) | supabase db push --include-all
+
+  echo "→ Reloading PostgREST schema cache ..."
+  # Reload via management API (no psql needed)
+  curl -sf -X POST \
+    "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/database/query" \
+    -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"query":"SELECT pg_notify('"'"'pgrst'"'"', '"'"'reload schema'"'"');"}' \
+    && echo "✅ PostgREST reload sent" \
+    || echo "⚠️  PostgREST reload via API failed — run manually: NOTIFY pgrst, 'reload schema';"
+
+# ── Route B: psql direct ──────────────────────────────────
+elif [[ -n "${SUPABASE_DB_URL_CI:-}" ]]; then
+  echo "Route: psql direct (SUPABASE_DB_URL_CI)"
+  echo ""
+
+  if ! command -v psql &>/dev/null; then
+    echo "ERROR: psql not found on PATH. Install postgresql-client or use Route A."
+    exit 1
+  fi
+
+  echo "→ Applying 20260316020000_add_diagnostic_findings.sql ..."
+  psql "$SUPABASE_DB_URL_CI" -v ON_ERROR_STOP=1 -f "$M1"
+
+  echo "→ Applying 20260316021000_diagnostic_findings_rls.sql ..."
+  psql "$SUPABASE_DB_URL_CI" -v ON_ERROR_STOP=1 -f "$M2"
+
+  echo "→ Reloading PostgREST schema cache ..."
+  psql "$SUPABASE_DB_URL_CI" -v ON_ERROR_STOP=1 \
+    -c "SELECT pg_notify('pgrst', 'reload schema');" \
+    && echo "✅ PostgREST reload sent" \
+    || echo "⚠️  PostgREST reload failed"
+
+  echo "→ Verifying diagnostic_findings table ..."
+  psql "$SUPABASE_DB_URL_CI" -c \
+    "SELECT relname AS table_name, relrowsecurity AS rls_enabled FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public' AND c.relname='diagnostic_findings';"
+
+  psql "$SUPABASE_DB_URL_CI" -c \
+    "SELECT indexname FROM pg_indexes WHERE schemaname='public' AND tablename='diagnostic_findings' ORDER BY indexname;"
+
+# ── Neither credential set ────────────────────────────────
+else
+  echo "ERROR: No credentials found."
+  echo ""
+  echo "Set one of:"
+  echo "  Option A (supabase CLI):"
+  echo "    SUPABASE_ACCESS_TOKEN=sbp_xxx"
+  echo "    SUPABASE_PROJECT_REF=xtumxjnzdswuumndcbwc"
+  echo ""
+  echo "  Option B (psql direct):"
+  echo "    SUPABASE_DB_URL_CI=postgresql://postgres.xtumxjnzdswuumndcbwc:PASSWORD@..."
+  echo ""
+  echo "PRIMARY PATH (no credentials required):"
+  echo "  Copy scripts/apply-diagnostic-findings-migrations.sql into:"
+  echo "  https://supabase.com/dashboard/project/xtumxjnzdswuumndcbwc/sql"
+  echo "  and click Run."
+  exit 1
+fi
+
+echo ""
+echo "✅ Migrations applied."
+echo ""
+echo "Next steps:"
+echo "  1. Restart your local dev server"
+echo "  2. Rerun smoke test:"
+echo "       cd $PROJECT_ROOT"
+echo "       node scripts/revision-stage2-smoke.mjs"

--- a/scripts/load-env.mjs
+++ b/scripts/load-env.mjs
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+
+/**
+ * Loads local environment files for script execution without requiring
+ * manual `source .env` in the shell.
+ */
+export function loadLocalEnv() {
+  const cwd = process.cwd();
+  const candidates = [".env.local", ".env"];
+
+  for (const fileName of candidates) {
+    const filePath = path.join(cwd, fileName);
+    if (!fs.existsSync(filePath)) continue;
+    dotenv.config({ path: filePath, override: false });
+  }
+}

--- a/scripts/revision-stage2-hydrate.mjs
+++ b/scripts/revision-stage2-hydrate.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Stage 2 manuscript version hydration
+ *
+ * Populates v1 `manuscript_versions.raw_text` from `manuscripts.file_url`
+ * for rows that were backfilled with empty text during Stage 2 foundation setup.
+ *
+ * Required env:
+ *   SUPABASE_SERVICE_ROLE_KEY=<key>
+ *   SUPABASE_URL=<url> or NEXT_PUBLIC_SUPABASE_URL=<url>
+ * Optional env:
+ *   HYDRATE_LIMIT=<n> (default 200)
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { loadLocalEnv } from "./load-env.mjs";
+
+loadLocalEnv();
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing env ${name}. Define it in .env/.env.local or export it in your shell.`,
+    );
+  }
+  return value;
+}
+
+function decodeDataUrl(fileUrl) {
+  const base64Match = fileUrl.match(/^data:[^,]*;base64,(.*)$/);
+  if (base64Match) {
+    return Buffer.from(base64Match[1], "base64").toString("utf8");
+  }
+
+  const encodedMatch = fileUrl.match(/^data:[^,]*,(.*)$/);
+  if (encodedMatch) {
+    return decodeURIComponent(encodedMatch[1]);
+  }
+
+  return null;
+}
+
+async function resolveTextFromFileUrl(fileUrl) {
+  if (!fileUrl) return null;
+
+  if (fileUrl.startsWith("data:")) {
+    return decodeDataUrl(fileUrl);
+  }
+
+  const response = await fetch(fileUrl);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+function countWords(text) {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+async function main() {
+  const SUPABASE_URL = process.env.SUPABASE_URL || env("NEXT_PUBLIC_SUPABASE_URL");
+  const SUPABASE_SERVICE_ROLE_KEY = env("SUPABASE_SERVICE_ROLE_KEY");
+  const limit = Number(process.env.HYDRATE_LIMIT ?? 200);
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data, error } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id, version_number, raw_text, manuscripts(file_url)")
+    .eq("version_number", 1)
+    .eq("raw_text", "")
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to query rows for hydration: ${error.message}`);
+  }
+
+  const rows = data ?? [];
+  const stats = {
+    scanned: rows.length,
+    hydrated: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const row of rows) {
+    try {
+      const manuscript = Array.isArray(row.manuscripts) ? row.manuscripts[0] : row.manuscripts;
+      const fileUrl = manuscript?.file_url;
+
+      if (!fileUrl) {
+        stats.skipped += 1;
+        continue;
+      }
+
+      const resolvedText = await resolveTextFromFileUrl(fileUrl);
+      if (!resolvedText || resolvedText.trim().length === 0) {
+        stats.skipped += 1;
+        continue;
+      }
+
+      const normalized = resolvedText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+      const { error: updateError } = await supabase
+        .from("manuscript_versions")
+        .update({
+          raw_text: normalized,
+          word_count: countWords(normalized),
+        })
+        .eq("id", row.id);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+
+      stats.hydrated += 1;
+    } catch (error) {
+      console.error(
+        `[STAGE2-HYDRATE] Failed for version_id=${row.id}:`,
+        error instanceof Error ? error.message : String(error),
+      );
+      stats.failed += 1;
+    }
+  }
+
+  console.log("✅ Stage 2 hydration completed");
+  console.log(JSON.stringify(stats, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error?.stack || String(error));
+  process.exit(1);
+});

--- a/scripts/revision-stage2-smoke.mjs
+++ b/scripts/revision-stage2-smoke.mjs
@@ -21,6 +21,14 @@ import { loadLocalEnv } from "./load-env.mjs";
 
 loadLocalEnv();
 
+const smokeContext = {
+  supabase: null,
+  evaluationRunId: null,
+  revisionSessionId: null,
+  manuscriptId: null,
+  manuscriptVersionId: null,
+};
+
 function env(name) {
   const value = process.env[name];
   if (!value) {
@@ -58,6 +66,35 @@ function isUuid(value) {
     typeof value === "string" &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
   );
+}
+
+async function logRevisionEvent(supabase, payload) {
+  try {
+    const { error } = await supabase.from("revision_events").insert({
+      revision_session_id: payload.revision_session_id ?? null,
+      proposal_id: payload.proposal_id ?? null,
+      manuscript_id: payload.manuscript_id ?? null,
+      manuscript_version_id: payload.manuscript_version_id ?? null,
+      evaluation_run_id: payload.evaluation_run_id ?? null,
+      event_type: payload.event_type,
+      severity: payload.severity ?? "info",
+      event_code: payload.event_code,
+      message: payload.message ?? null,
+      metadata: payload.metadata ?? {},
+    });
+
+    if (error) {
+      console.error("Failed to log revision event", {
+        event_code: payload.event_code,
+        error: error.message,
+      });
+    }
+  } catch (error) {
+    console.error("Failed to log revision event", {
+      event_code: payload.event_code,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 async function getLatestRevisionSessionForEvaluationRun(supabase, evaluationRunId) {
@@ -161,6 +198,18 @@ async function resolveEvaluationRunId(supabase) {
   if (explicit) {
     const latestSession = await getLatestRevisionSessionForEvaluationRun(supabase, explicit);
     if (latestSession?.status === "applied") {
+      await logRevisionEvent(supabase, {
+        evaluation_run_id: explicit,
+        revision_session_id: latestSession.id,
+        event_type: "smoke",
+        severity: "warn",
+        event_code: "SMOKE_STALE_RUN_REJECTED",
+        metadata: {
+          latest_session_id: latestSession.id,
+          latest_session_status: latestSession.status,
+        },
+      });
+
       throw new Error(
         `EVALUATION_RUN_ID=${explicit} already has an applied revision session (${latestSession.id}). ` +
           `Choose a different evaluation run or clear stale session/proposal rows before rerunning smoke.`,
@@ -188,6 +237,12 @@ async function resolveEvaluationRunId(supabase) {
   for (const candidate of candidates) {
     const latestSession = await getLatestRevisionSessionForEvaluationRun(supabase, candidate.id);
     if (!latestSession) {
+      await logRevisionEvent(supabase, {
+        evaluation_run_id: candidate.id,
+        event_type: "smoke",
+        event_code: "SMOKE_FRESH_RUN_SELECTED",
+      });
+
       console.log(`[revision-stage2-smoke] Auto-selected EVALUATION_RUN_ID=${candidate.id}`);
       return candidate.id;
     }
@@ -222,8 +277,10 @@ async function main() {
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
     auth: { persistSession: false },
   });
+  smokeContext.supabase = supabase;
 
   const EVALUATION_RUN_ID = await resolveEvaluationRunId(supabase);
+  smokeContext.evaluationRunId = EVALUATION_RUN_ID;
 
   console.log(`revision-stage2-smoke: evaluation_run_id=${EVALUATION_RUN_ID}`);
   console.log(`revision-stage2-smoke: base=${BASE}`);
@@ -245,6 +302,7 @@ async function main() {
 
   const start = await startRes.json();
   const revisionSession = start?.revision_session;
+  smokeContext.revisionSessionId = revisionSession?.id ?? null;
   ensure(revisionSession?.id, `Invalid start response: missing revision_session.id -> ${JSON.stringify(start)}`);
   ensure(
     revisionSession?.source_version_id,
@@ -256,6 +314,7 @@ async function main() {
   );
 
   const sourceVersionId = revisionSession.source_version_id;
+  smokeContext.manuscriptVersionId = sourceVersionId;
   ensure(
     isUuid(sourceVersionId),
     `Invalid source version UUID from start response: ${sourceVersionId}`,
@@ -280,6 +339,7 @@ async function main() {
     evalJob.manuscript_version_id === sourceVersionId,
     `Source binding mismatch: evaluation_jobs.manuscript_version_id=${evalJob.manuscript_version_id} expected=${sourceVersionId}`,
   );
+  smokeContext.manuscriptId = evalJob.manuscript_id;
 
   // Validate session persisted as expected.
   const { data: persistedSession, error: persistedSessionErr } = await supabase
@@ -473,8 +533,27 @@ async function main() {
   }
 
   if (sourceBefore.raw_text !== sourceAfter.raw_text) {
+    await logRevisionEvent(supabase, {
+      revision_session_id: revisionSession.id,
+      manuscript_id: sourceBefore.manuscript_id,
+      manuscript_version_id: sourceVersionId,
+      evaluation_run_id: EVALUATION_RUN_ID,
+      event_type: "immutability",
+      severity: "critical",
+      event_code: "SOURCE_IMMUTABILITY_VIOLATION",
+    });
+
     throw new Error("Immutability violation: source version text changed after finalize.");
   }
+
+  await logRevisionEvent(supabase, {
+    revision_session_id: revisionSession.id,
+    manuscript_id: sourceBefore.manuscript_id,
+    manuscript_version_id: sourceVersionId,
+    evaluation_run_id: EVALUATION_RUN_ID,
+    event_type: "immutability",
+    event_code: "SOURCE_IMMUTABLE_CONFIRMED",
+  });
 
   if (
     selectedWithEffectiveTextMutation.length > 0 &&
@@ -487,6 +566,20 @@ async function main() {
   }
 
   console.log("✅ Stage 2 smoke passed");
+  await logRevisionEvent(supabase, {
+    revision_session_id: revisionSession.id,
+    manuscript_id: sourceBefore.manuscript_id,
+    manuscript_version_id: sourceVersionId,
+    evaluation_run_id: EVALUATION_RUN_ID,
+    event_type: "smoke",
+    event_code: "SMOKE_RUN_PASSED",
+    metadata: {
+      accepted_proposals: selectedIds.length,
+      accepted_effective_mutations: selectedWithEffectiveTextMutation.length,
+      result_version_id: resultVersionId,
+    },
+  });
+
   console.log(
     JSON.stringify(
       {
@@ -510,7 +603,20 @@ async function main() {
   );
 }
 
-main().catch((e) => {
+main().catch(async (e) => {
+  if (smokeContext.supabase && smokeContext.evaluationRunId) {
+    await logRevisionEvent(smokeContext.supabase, {
+      revision_session_id: smokeContext.revisionSessionId,
+      manuscript_id: smokeContext.manuscriptId,
+      manuscript_version_id: smokeContext.manuscriptVersionId,
+      evaluation_run_id: smokeContext.evaluationRunId,
+      event_type: "smoke",
+      severity: "error",
+      event_code: "SMOKE_RUN_FAILED",
+      message: e instanceof Error ? e.message : String(e),
+    });
+  }
+
   console.error(e?.stack || String(e));
   process.exit(1);
 });

--- a/scripts/revision-stage2-smoke.mjs
+++ b/scripts/revision-stage2-smoke.mjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+/**
+ * Stage 2 Revision Smoke (internal API + DB assertions)
+ *
+ * Validates: start -> decide -> finalize plus immutable source version.
+ *
+ * Required env:
+ *   EVALUATION_RUN_ID=<uuid>
+ *   SUPABASE_SERVICE_ROLE_KEY=<key>
+ * Optional env:
+ *   SUPABASE_URL=<url> (or NEXT_PUBLIC_SUPABASE_URL)
+ *   MAX_ACCEPT_PROPOSALS=<n> (default 3)
+ *
+ * Usage:
+ *   EVALUATION_RUN_ID=<uuid> npm run revision:smoke:stage2
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { getBaseUrl } from "./base-url.mjs";
+import { loadLocalEnv } from "./load-env.mjs";
+
+loadLocalEnv();
+
+function env(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing env ${name}. Define it in .env/.env.local or export it in your shell.`,
+    );
+  }
+  return value;
+}
+
+async function must(resPromise, msg) {
+  const res = await resPromise;
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let details = text;
+
+    try {
+      const parsed = JSON.parse(text);
+      details = parsed?.details || parsed?.error || text;
+    } catch {
+      // non-JSON response body; keep raw text
+    }
+
+    throw new Error(`${msg} (status=${res.status}) ${details}`);
+  }
+  return res;
+}
+
+function ensure(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isUuid(value) {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+  );
+}
+
+async function runSchemaPreflight(supabase, evaluationRunId) {
+  const issues = [];
+
+  const revisionSessionsCheck = await supabase
+    .from("revision_sessions")
+    .select("id")
+    .limit(1);
+
+  if (revisionSessionsCheck.error) {
+    issues.push(
+      `revision_sessions unavailable via Supabase API: ${revisionSessionsCheck.error.message}`,
+    );
+  }
+
+  const changeProposalsCheck = await supabase
+    .from("change_proposals")
+    .select("id")
+    .limit(1);
+
+  if (changeProposalsCheck.error) {
+    issues.push(
+      `change_proposals unavailable via Supabase API: ${changeProposalsCheck.error.message}`,
+    );
+  }
+
+  const diagnosticFindingsCheck = await supabase
+    .from("diagnostic_findings")
+    .select("id")
+    .limit(1);
+
+  if (diagnosticFindingsCheck.error) {
+    issues.push(
+      `diagnostic_findings unavailable via Supabase API: ${diagnosticFindingsCheck.error.message}`,
+    );
+  }
+
+  const evaluationJobCheck = await supabase
+    .from("evaluation_jobs")
+    .select("id, status, manuscript_id, manuscript_version_id")
+    .eq("id", evaluationRunId)
+    .maybeSingle();
+
+  if (evaluationJobCheck.error) {
+    issues.push(
+      `evaluation_jobs Stage 2 columns unavailable: ${evaluationJobCheck.error.message}`,
+    );
+  }
+
+  const manuscriptVersionsCheck = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id, version_number")
+    .limit(1);
+
+  if (manuscriptVersionsCheck.error) {
+    issues.push(
+      `manuscript_versions unavailable via Supabase API: ${manuscriptVersionsCheck.error.message}`,
+    );
+  }
+
+  if (issues.length > 0) {
+    throw new Error(
+      "Stage 2 schema preflight failed. The app-facing Stage 2 database/API surface is incomplete. " +
+        "Apply/additive migrations, ensure evaluation_jobs.manuscript_version_id exists, reload Supabase REST schema cache, restart the dev server, then rerun.\n" +
+        issues.map((issue, index) => `${index + 1}. ${issue}`).join("\n") +
+        "\n\nSuggested remediation in Supabase SQL Editor:" +
+        "\n- ALTER TABLE public.evaluation_jobs ADD COLUMN IF NOT EXISTS manuscript_version_id uuid REFERENCES public.manuscript_versions(id);" +
+        "\n- Apply the Stage 2 migrations if not already applied:" +
+        "\n  20260315000000_add_manuscript_versions_foundation.sql" +
+        "\n  20260316000000_add_revision_sessions_and_change_proposals.sql" +
+        "\n  20260316010000_stage2_versions_revisions_rls.sql" +
+        "\n  20260316020000_add_diagnostic_findings.sql" +
+        "\n  20260316021000_diagnostic_findings_rls.sql" +
+        "\n- NOTIFY pgrst, 'reload schema';" +
+        "\n- Restart the local app server on port 3002.",
+    );
+  }
+}
+
+async function resolveEvaluationRunId(supabase) {
+  const explicit = process.env.EVALUATION_RUN_ID?.trim();
+  if (explicit) return explicit;
+
+  const { data, error } = await supabase
+    .from("evaluation_jobs")
+    .select("id, created_at")
+    .eq("status", "complete")
+    .not("manuscript_version_id", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      "Missing env EVALUATION_RUN_ID and auto-discovery failed. " +
+        `Underlying query error: ${error.message}`,
+    );
+  }
+
+  if (!data?.id) {
+    throw new Error(
+      "Missing env EVALUATION_RUN_ID and auto-discovery found no completed " +
+        "evaluation_jobs with manuscript_version_id.",
+    );
+  }
+
+  console.log(`[revision-stage2-smoke] Auto-selected EVALUATION_RUN_ID=${data.id}`);
+  return data.id;
+}
+
+async function main() {
+  const BASE = await getBaseUrl();
+  const SUPABASE_SERVICE_ROLE_KEY = env("SUPABASE_SERVICE_ROLE_KEY");
+  const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!SUPABASE_URL) {
+    throw new Error("Missing SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL)");
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+
+  const EVALUATION_RUN_ID = await resolveEvaluationRunId(supabase);
+
+  console.log(`revision-stage2-smoke: evaluation_run_id=${EVALUATION_RUN_ID}`);
+  console.log(`revision-stage2-smoke: base=${BASE}`);
+
+  await runSchemaPreflight(supabase, EVALUATION_RUN_ID);
+
+  // 1) Start revision session + proposals
+  const startRes = await must(
+    fetch(`${BASE}/api/internal/revisions/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+      body: JSON.stringify({ evaluation_run_id: EVALUATION_RUN_ID }),
+    }),
+    "Failed to start revision engine",
+  );
+
+  const start = await startRes.json();
+  const revisionSession = start?.revision_session;
+  ensure(revisionSession?.id, `Invalid start response: missing revision_session.id -> ${JSON.stringify(start)}`);
+  ensure(
+    revisionSession?.source_version_id,
+    `Invalid start response: missing revision_session.source_version_id -> ${JSON.stringify(start)}`,
+  );
+  ensure(
+    revisionSession?.evaluation_run_id === EVALUATION_RUN_ID,
+    `Start binding mismatch: session.evaluation_run_id=${revisionSession?.evaluation_run_id} expected=${EVALUATION_RUN_ID}`,
+  );
+
+  const sourceVersionId = revisionSession.source_version_id;
+  ensure(
+    isUuid(sourceVersionId),
+    `Invalid source version UUID from start response: ${sourceVersionId}`,
+  );
+
+  // Validate evaluation job binding and state before apply/finalize.
+  const { data: evalJob, error: evalJobErr } = await supabase
+    .from("evaluation_jobs")
+    .select("id, status, manuscript_id, manuscript_version_id")
+    .eq("id", EVALUATION_RUN_ID)
+    .single();
+
+  if (evalJobErr || !evalJob) {
+    throw new Error(`Failed to load evaluation job ${EVALUATION_RUN_ID}: ${evalJobErr?.message}`);
+  }
+
+  ensure(
+    evalJob.status === "complete",
+    `Evaluation run must be complete before revision smoke (status=${evalJob.status})`,
+  );
+  ensure(
+    evalJob.manuscript_version_id === sourceVersionId,
+    `Source binding mismatch: evaluation_jobs.manuscript_version_id=${evalJob.manuscript_version_id} expected=${sourceVersionId}`,
+  );
+
+  // Validate session persisted as expected.
+  const { data: persistedSession, error: persistedSessionErr } = await supabase
+    .from("revision_sessions")
+    .select("id, evaluation_run_id, source_version_id, status")
+    .eq("id", revisionSession.id)
+    .single();
+
+  if (persistedSessionErr || !persistedSession) {
+    throw new Error(`Failed to load persisted revision session: ${persistedSessionErr?.message}`);
+  }
+
+  ensure(
+    persistedSession.evaluation_run_id === EVALUATION_RUN_ID,
+    `Persisted session evaluation_run_id mismatch: ${persistedSession.evaluation_run_id} != ${EVALUATION_RUN_ID}`,
+  );
+  ensure(
+    persistedSession.source_version_id === sourceVersionId,
+    `Persisted session source_version_id mismatch: ${persistedSession.source_version_id} != ${sourceVersionId}`,
+  );
+  ensure(
+    persistedSession.status === "open",
+    `Expected session status=open before finalize, got ${persistedSession.status}`,
+  );
+
+  // Proposal checks (count, session association, pre-decision validity).
+  const { data: persistedProposals, error: persistedProposalsErr } = await supabase
+    .from("change_proposals")
+    .select("id, revision_session_id, decision, original_text, proposed_text")
+    .eq("revision_session_id", revisionSession.id);
+
+  if (persistedProposalsErr) {
+    throw new Error(`Failed to load proposals for session ${revisionSession.id}: ${persistedProposalsErr.message}`);
+  }
+
+  const proposalsFromDb = persistedProposals ?? [];
+
+  const { data: findingsRows, error: findingsErr } = await supabase
+    .from("diagnostic_findings")
+    .select("id, action_hint, status")
+    .eq("evaluation_job_id", EVALUATION_RUN_ID)
+    .eq("status", "open");
+
+  if (findingsErr) {
+    throw new Error(`Failed to load findings for evaluation run ${EVALUATION_RUN_ID}: ${findingsErr.message}`);
+  }
+
+  const findings = findingsRows ?? [];
+  const actionableFindings = findings.filter((f) => f.action_hint !== "preserve");
+
+  ensure(
+    findings.length > 0,
+    `No diagnostic_findings generated for evaluation_run_id=${EVALUATION_RUN_ID}. Check evaluation_artifacts -> findings normalization mapping.`,
+  );
+
+  ensure(
+    actionableFindings.length > 0,
+    `diagnostic_findings generated but no actionable findings for evaluation_run_id=${EVALUATION_RUN_ID}. All findings appear to be action_hint=preserve.`,
+  );
+
+  ensure(
+    proposalsFromDb.length > 0,
+    `No proposals generated for evaluation_run_id=${EVALUATION_RUN_ID}. Findings exist, so check diagnostic_findings -> proposal synthesis mapping.`,
+  );
+
+  for (const p of proposalsFromDb) {
+    ensure(
+      p.revision_session_id === revisionSession.id,
+      `Proposal/session mismatch: proposal ${p.id} belongs to ${p.revision_session_id}`,
+    );
+    ensure(
+      p.decision === null || p.decision === "accepted" || p.decision === "rejected" || p.decision === "modified",
+      `Invalid proposal decision state for ${p.id}: ${String(p.decision)}`,
+    );
+  }
+
+  // Snapshot source before apply (immutability assertion)
+  const { data: sourceBefore, error: sourceBeforeErr } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id, version_number, raw_text")
+    .eq("id", sourceVersionId)
+    .single();
+
+  if (sourceBeforeErr || !sourceBefore) {
+    throw new Error(`Failed to load source version before finalize: ${sourceBeforeErr?.message}`);
+  }
+
+  // 2) Decide proposals (accept a small viable subset)
+  const maxAccept = Number(process.env.MAX_ACCEPT_PROPOSALS ?? 3);
+  const viable = proposalsFromDb.filter(
+    (p) =>
+      typeof p?.id === "string" &&
+      typeof p?.original_text === "string" &&
+      p.original_text.trim().length > 0 &&
+      typeof p?.proposed_text === "string",
+  );
+
+  if (viable.length === 0) {
+    throw new Error(
+      "No viable proposals to accept (need non-empty original_text and string proposed_text). " +
+        "Confirm proposal extraction maps to change_proposals.original_text/proposed_text.",
+    );
+  }
+
+  const selected = viable.slice(0, Math.max(1, maxAccept));
+  const selectedIds = selected.map((p) => p.id);
+  const selectedWithEffectiveTextMutation = selected.filter(
+    (p) => p.original_text.trim() !== p.proposed_text.trim(),
+  );
+
+  const { error: decideErr } = await supabase
+    .from("change_proposals")
+    .update({ decision: "accepted" })
+    .eq("revision_session_id", revisionSession.id)
+    .in("id", selectedIds);
+
+  if (decideErr) {
+    throw new Error(`Failed to mark proposals accepted: ${decideErr.message}`);
+  }
+
+  // 3) Finalize revision session
+  const finalizeRes = await must(
+    fetch(`${BASE}/api/internal/revisions/${revisionSession.id}/finalize`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      },
+    }),
+    "Failed to finalize revision session",
+  );
+
+  const finalized = await finalizeRes.json();
+  const resultVersionId = finalized?.apply_result?.result_version_id;
+
+  ensure(resultVersionId, `Finalize response missing result_version_id: ${JSON.stringify(finalized)}`);
+  ensure(isUuid(resultVersionId), `Finalize response returned invalid result_version_id UUID: ${resultVersionId}`);
+
+  const { data: finalizedSession, error: finalizedSessionErr } = await supabase
+    .from("revision_sessions")
+    .select("id, status, result_version_id")
+    .eq("id", revisionSession.id)
+    .single();
+
+  if (finalizedSessionErr || !finalizedSession) {
+    throw new Error(`Failed to reload finalized session ${revisionSession.id}: ${finalizedSessionErr?.message}`);
+  }
+
+  ensure(
+    finalizedSession.status === "applied",
+    `Finalize did not transition session to applied (status=${finalizedSession.status})`,
+  );
+  ensure(
+    finalizedSession.result_version_id === resultVersionId,
+    `Finalized session result_version_id mismatch: ${finalizedSession.result_version_id} != ${resultVersionId}`,
+  );
+
+  // 4) Assertions: lineage + immutability
+  const { data: resultVersion, error: resultErr } = await supabase
+    .from("manuscript_versions")
+    .select("id, manuscript_id, version_number, source_version_id, raw_text")
+    .eq("id", resultVersionId)
+    .single();
+
+  if (resultErr || !resultVersion) {
+    throw new Error(`Failed to load result version: ${resultErr?.message}`);
+  }
+
+  if (resultVersion.source_version_id !== sourceVersionId) {
+    throw new Error(
+      `Lineage mismatch: result.source_version_id=${resultVersion.source_version_id} expected=${sourceVersionId}`,
+    );
+  }
+
+  ensure(
+    resultVersion.manuscript_id === sourceBefore.manuscript_id,
+    `Result manuscript mismatch: ${resultVersion.manuscript_id} != ${sourceBefore.manuscript_id}`,
+  );
+  ensure(
+    resultVersion.version_number === sourceBefore.version_number + 1,
+    `Version increment mismatch: source=${sourceBefore.version_number} result=${resultVersion.version_number}`,
+  );
+
+  const { data: sourceAfter, error: sourceAfterErr } = await supabase
+    .from("manuscript_versions")
+    .select("id, raw_text")
+    .eq("id", sourceVersionId)
+    .single();
+
+  if (sourceAfterErr || !sourceAfter) {
+    throw new Error(`Failed to load source version after finalize: ${sourceAfterErr?.message}`);
+  }
+
+  if (sourceBefore.raw_text !== sourceAfter.raw_text) {
+    throw new Error("Immutability violation: source version text changed after finalize.");
+  }
+
+  if (
+    selectedWithEffectiveTextMutation.length > 0 &&
+    sourceBefore.raw_text === resultVersion.raw_text
+  ) {
+    throw new Error(
+      "No textual delta in result version despite accepted proposals with effective text mutations. " +
+        "Likely no-op proposals or apply mismatch.",
+    );
+  }
+
+  console.log("✅ Stage 2 smoke passed");
+  console.log(
+    JSON.stringify(
+      {
+        evaluation_run_id: EVALUATION_RUN_ID,
+        revision_session_id: revisionSession.id,
+        accepted_proposals: selectedIds.length,
+        accepted_effective_mutations: selectedWithEffectiveTextMutation.length,
+        findings_generated: findings.length,
+        actionable_findings: actionableFindings.length,
+        proposals_generated: proposalsFromDb.length,
+        source_version_id: sourceVersionId,
+        result_version_id: resultVersionId,
+        source_version_number: sourceBefore.version_number,
+        result_version_number: resultVersion.version_number,
+        source_unchanged: true,
+        result_text_changed: sourceBefore.raw_text !== resultVersion.raw_text,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((e) => {
+  console.error(e?.stack || String(e));
+  process.exit(1);
+});

--- a/scripts/revision-stage2-smoke.mjs
+++ b/scripts/revision-stage2-smoke.mjs
@@ -60,6 +60,24 @@ function isUuid(value) {
   );
 }
 
+async function getLatestRevisionSessionForEvaluationRun(supabase, evaluationRunId) {
+  const { data, error } = await supabase
+    .from("revision_sessions")
+    .select("id, status, created_at")
+    .eq("evaluation_run_id", evaluationRunId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `Failed to inspect revision_sessions for evaluation_run_id=${evaluationRunId}: ${error.message}`,
+    );
+  }
+
+  return data ?? null;
+}
+
 async function runSchemaPreflight(supabase, evaluationRunId) {
   const issues = [];
 
@@ -140,7 +158,16 @@ async function runSchemaPreflight(supabase, evaluationRunId) {
 
 async function resolveEvaluationRunId(supabase) {
   const explicit = process.env.EVALUATION_RUN_ID?.trim();
-  if (explicit) return explicit;
+  if (explicit) {
+    const latestSession = await getLatestRevisionSessionForEvaluationRun(supabase, explicit);
+    if (latestSession?.status === "applied") {
+      throw new Error(
+        `EVALUATION_RUN_ID=${explicit} already has an applied revision session (${latestSession.id}). ` +
+          `Choose a different evaluation run or clear stale session/proposal rows before rerunning smoke.`,
+      );
+    }
+    return explicit;
+  }
 
   const { data, error } = await supabase
     .from("evaluation_jobs")
@@ -148,8 +175,7 @@ async function resolveEvaluationRunId(supabase) {
     .eq("status", "complete")
     .not("manuscript_version_id", "is", null)
     .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .limit(25);
 
   if (error) {
     throw new Error(
@@ -158,15 +184,30 @@ async function resolveEvaluationRunId(supabase) {
     );
   }
 
-  if (!data?.id) {
+  const candidates = data ?? [];
+  for (const candidate of candidates) {
+    const latestSession = await getLatestRevisionSessionForEvaluationRun(supabase, candidate.id);
+    if (!latestSession) {
+      console.log(`[revision-stage2-smoke] Auto-selected EVALUATION_RUN_ID=${candidate.id}`);
+      return candidate.id;
+    }
+  }
+
+  if (candidates.length > 0) {
+    throw new Error(
+      "Missing env EVALUATION_RUN_ID and auto-discovery found only runs with existing revision sessions. " +
+        "Provide EVALUATION_RUN_ID for a fresh run or clear stale revision session data.",
+    );
+  }
+
+  if (!candidates.length) {
     throw new Error(
       "Missing env EVALUATION_RUN_ID and auto-discovery found no completed " +
         "evaluation_jobs with manuscript_version_id.",
     );
   }
 
-  console.log(`[revision-stage2-smoke] Auto-selected EVALUATION_RUN_ID=${data.id}`);
-  return data.id;
+  throw new Error("Unable to resolve EVALUATION_RUN_ID for smoke run.");
 }
 
 async function main() {

--- a/scripts/revision-stage2-smoke.mjs
+++ b/scripts/revision-stage2-smoke.mjs
@@ -368,7 +368,7 @@ async function main() {
   // Proposal checks (count, session association, pre-decision validity).
   const { data: persistedProposals, error: persistedProposalsErr } = await supabase
     .from("change_proposals")
-    .select("id, revision_session_id, decision, original_text, proposed_text")
+    .select("id, revision_session_id, decision, original_text, proposed_text, anchor_start, anchor_end")
     .eq("revision_session_id", revisionSession.id);
 
   if (persistedProposalsErr) {
@@ -444,7 +444,15 @@ async function main() {
     );
   }
 
-  const selected = viable.slice(0, Math.max(1, maxAccept));
+  const anchoredViable = viable.filter(
+    (p) =>
+      Number.isInteger(p.anchor_start) &&
+      Number.isInteger(p.anchor_end) &&
+      p.anchor_end > p.anchor_start,
+  );
+
+  const selectedPool = anchoredViable.length > 0 ? anchoredViable : viable;
+  const selected = selectedPool.slice(0, Math.max(1, maxAccept));
   const selectedIds = selected.map((p) => p.id);
   const selectedWithEffectiveTextMutation = selected.filter(
     (p) => p.original_text.trim() !== p.proposed_text.trim(),

--- a/supabase/migrations/20260315000000_add_manuscript_versions_foundation.sql
+++ b/supabase/migrations/20260315000000_add_manuscript_versions_foundation.sql
@@ -1,0 +1,91 @@
+-- Additive manuscript version lineage foundation (Stage 2/3 prerequisite)
+-- Non-breaking: keeps manuscript_id flows intact while enabling version-bound runs.
+
+BEGIN;
+
+-- 1) Immutable manuscript versions table
+CREATE TABLE IF NOT EXISTS public.manuscript_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  manuscript_id bigint NOT NULL REFERENCES public.manuscripts(id) ON DELETE CASCADE,
+  version_number integer NOT NULL,
+  source_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  raw_text text NOT NULL DEFAULT '',
+  word_count integer NOT NULL DEFAULT 0,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT manuscript_versions_version_number_positive CHECK (version_number > 0),
+  CONSTRAINT manuscript_versions_word_count_nonnegative CHECK (word_count >= 0),
+  CONSTRAINT manuscript_versions_unique_per_manuscript UNIQUE (manuscript_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_manuscript_id
+  ON public.manuscript_versions(manuscript_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_source_version_id
+  ON public.manuscript_versions(source_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_created_at
+  ON public.manuscript_versions(created_at DESC);
+
+-- 2) Add version binding to evaluation jobs (nullable for compatibility)
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS manuscript_version_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'evaluation_jobs'
+      AND constraint_name = 'evaluation_jobs_manuscript_version_id_fkey'
+  ) THEN
+    ALTER TABLE public.evaluation_jobs
+      ADD CONSTRAINT evaluation_jobs_manuscript_version_id_fkey
+      FOREIGN KEY (manuscript_version_id)
+      REFERENCES public.manuscript_versions(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_evaluation_jobs_manuscript_version_id
+  ON public.evaluation_jobs(manuscript_version_id);
+
+-- 3) Backfill one initial version for each existing manuscript.
+-- NOTE: Canonical manuscript text is currently stored externally (file_url/data URL),
+-- so raw_text is initialized as empty string and can be hydrated by application backfill.
+INSERT INTO public.manuscript_versions (
+  manuscript_id,
+  version_number,
+  source_version_id,
+  raw_text,
+  word_count,
+  created_by,
+  created_at
+)
+SELECT
+  m.id,
+  1,
+  NULL,
+  '',
+  COALESCE(m.word_count, 0),
+  m.created_by,
+  COALESCE(m.created_at, now())
+FROM public.manuscripts m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.manuscript_versions mv
+  WHERE mv.manuscript_id = m.id
+    AND mv.version_number = 1
+);
+
+-- 4) Backfill existing jobs to v1 where possible
+UPDATE public.evaluation_jobs ej
+SET manuscript_version_id = mv.id
+FROM public.manuscript_versions mv
+WHERE ej.manuscript_id = mv.manuscript_id
+  AND mv.version_number = 1
+  AND ej.manuscript_version_id IS NULL;
+
+COMMIT;

--- a/supabase/migrations/20260316000000_add_revision_sessions_and_change_proposals.sql
+++ b/supabase/migrations/20260316000000_add_revision_sessions_and_change_proposals.sql
@@ -1,0 +1,50 @@
+-- Stage 2 foundation: revision sessions + change proposals
+-- Additive, non-breaking migration.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.revision_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  evaluation_run_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  source_version_id uuid NOT NULL REFERENCES public.manuscript_versions(id) ON DELETE CASCADE,
+  result_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  status text NOT NULL CHECK (status IN ('open', 'applied', 'discarded')),
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_evaluation_run_id
+  ON public.revision_sessions(evaluation_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_source_version_id
+  ON public.revision_sessions(source_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_result_version_id
+  ON public.revision_sessions(result_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_status
+  ON public.revision_sessions(status);
+
+CREATE TABLE IF NOT EXISTS public.change_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  revision_session_id uuid NOT NULL REFERENCES public.revision_sessions(id) ON DELETE CASCADE,
+  location_ref text NOT NULL,
+  rule text NOT NULL,
+  action text NOT NULL CHECK (action IN ('preserve', 'refine', 'replace')),
+  original_text text NOT NULL,
+  proposed_text text NOT NULL,
+  justification text NOT NULL,
+  severity text NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+  decision text CHECK (decision IN ('accepted', 'rejected', 'modified')),
+  modified_text text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_change_proposals_revision_session_id
+  ON public.change_proposals(revision_session_id);
+
+CREATE INDEX IF NOT EXISTS idx_change_proposals_decision
+  ON public.change_proposals(decision);
+
+COMMIT;

--- a/supabase/migrations/20260316010000_stage2_versions_revisions_rls.sql
+++ b/supabase/migrations/20260316010000_stage2_versions_revisions_rls.sql
@@ -1,0 +1,175 @@
+-- Stage 2 RLS hardening for new lineage/revision tables
+-- Adds ownership-based SELECT/INSERT/UPDATE policies.
+
+BEGIN;
+
+ALTER TABLE public.manuscript_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.revision_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.change_proposals ENABLE ROW LEVEL SECURITY;
+
+-- manuscript_versions
+DROP POLICY IF EXISTS "Users can view own manuscript versions" ON public.manuscript_versions;
+CREATE POLICY "Users can view own manuscript versions"
+  ON public.manuscript_versions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscripts m
+      WHERE m.id = manuscript_versions.manuscript_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own manuscript versions" ON public.manuscript_versions;
+CREATE POLICY "Users can insert own manuscript versions"
+  ON public.manuscript_versions
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscripts m
+      WHERE m.id = manuscript_versions.manuscript_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+-- revision_sessions
+DROP POLICY IF EXISTS "Users can view own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can view own revision sessions"
+  ON public.revision_sessions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can insert own revision sessions"
+  ON public.revision_sessions
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can update own revision sessions"
+  ON public.revision_sessions
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+-- change_proposals
+DROP POLICY IF EXISTS "Users can view own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can view own change proposals"
+  ON public.change_proposals
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can insert own change proposals"
+  ON public.change_proposals
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can update own change proposals"
+  ON public.change_proposals
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+COMMIT;

--- a/supabase/migrations/20260316020000_add_diagnostic_findings.sql
+++ b/supabase/migrations/20260316020000_add_diagnostic_findings.sql
@@ -1,0 +1,58 @@
+-- Stage 2 additive architecture improvement: normalized diagnostic findings layer
+-- evaluation_artifacts -> diagnostic_findings -> change_proposals
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.diagnostic_findings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  evaluation_job_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  manuscript_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  artifact_id uuid REFERENCES public.evaluation_artifacts(id) ON DELETE SET NULL,
+
+  criterion_key text NOT NULL,
+  wave_id text,
+  finding_type text NOT NULL,
+  severity text NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+  confidence numeric,
+
+  location_ref text,
+  chunk_id uuid,
+  chapter_index integer,
+  paragraph_index integer,
+  sentence_index integer,
+
+  original_text text,
+  evidence_excerpt text,
+  diagnosis text NOT NULL,
+  recommendation text,
+
+  action_hint text CHECK (action_hint IN ('preserve', 'refine', 'replace')),
+  status text NOT NULL DEFAULT 'open',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_evaluation_job_id
+  ON public.diagnostic_findings(evaluation_job_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_manuscript_version_id
+  ON public.diagnostic_findings(manuscript_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_criterion_key
+  ON public.diagnostic_findings(criterion_key);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_wave_id
+  ON public.diagnostic_findings(wave_id);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_finding_type
+  ON public.diagnostic_findings(finding_type);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_status
+  ON public.diagnostic_findings(status);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_location_ref
+  ON public.diagnostic_findings(location_ref);
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_findings_action_hint
+  ON public.diagnostic_findings(action_hint);
+
+COMMIT;

--- a/supabase/migrations/20260316021000_diagnostic_findings_rls.sql
+++ b/supabase/migrations/20260316021000_diagnostic_findings_rls.sql
@@ -1,0 +1,70 @@
+-- Stage 2 RLS hardening for diagnostic_findings
+
+BEGIN;
+
+ALTER TABLE public.diagnostic_findings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can view own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can insert own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own diagnostic findings" ON public.diagnostic_findings;
+CREATE POLICY "Users can update own diagnostic findings"
+  ON public.diagnostic_findings
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = diagnostic_findings.manuscript_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+COMMIT;

--- a/supabase/migrations/20260317000000_add_change_proposal_anchors.sql
+++ b/supabase/migrations/20260317000000_add_change_proposal_anchors.sql
@@ -1,0 +1,23 @@
+begin;
+
+alter table public.change_proposals
+  add column if not exists anchor_start integer,
+  add column if not exists anchor_end integer,
+  add column if not exists anchor_context text;
+
+create index if not exists idx_change_proposals_anchor_start
+  on public.change_proposals(anchor_start);
+
+create index if not exists idx_change_proposals_anchor_end
+  on public.change_proposals(anchor_end);
+
+comment on column public.change_proposals.anchor_start is
+  '0-based character offset into the exact source text used when the proposal was generated.';
+
+comment on column public.change_proposals.anchor_end is
+  'Exclusive 0-based character offset into the exact source text used when the proposal was generated.';
+
+comment on column public.change_proposals.anchor_context is
+  'Short surrounding context captured at proposal-generation time for strict verification before apply.';
+
+commit;

--- a/supabase/migrations/20260317010000_add_revision_events.sql
+++ b/supabase/migrations/20260317010000_add_revision_events.sql
@@ -1,0 +1,42 @@
+begin;
+
+create table if not exists public.revision_events (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+
+  revision_session_id uuid null references public.revision_sessions(id) on delete cascade,
+  proposal_id uuid null references public.change_proposals(id) on delete cascade,
+  manuscript_id bigint null references public.manuscripts(id) on delete set null,
+  manuscript_version_id uuid null references public.manuscript_versions(id) on delete set null,
+  evaluation_run_id uuid null references public.evaluation_jobs(id) on delete set null,
+
+  event_type text not null,
+  severity text not null default 'info',
+  event_code text not null,
+  message text null,
+
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_revision_events_created_at
+  on public.revision_events(created_at);
+
+create index if not exists idx_revision_events_event_type
+  on public.revision_events(event_type);
+
+create index if not exists idx_revision_events_event_code
+  on public.revision_events(event_code);
+
+create index if not exists idx_revision_events_revision_session_id
+  on public.revision_events(revision_session_id);
+
+create index if not exists idx_revision_events_proposal_id
+  on public.revision_events(proposal_id);
+
+create index if not exists idx_revision_events_evaluation_run_id
+  on public.revision_events(evaluation_run_id);
+
+comment on table public.revision_events is
+  'Non-blocking Stage 2 revision telemetry for proposal generation, anchored apply, finalize outcomes, immutability checks, and smoke harness behavior.';
+
+commit;

--- a/supabase/sql/stage2_smoke_remote_remediation.sql
+++ b/supabase/sql/stage2_smoke_remote_remediation.sql
@@ -1,0 +1,327 @@
+-- Stage 2 remote remediation for smoke harness
+-- Target project: xtumxjnzdswuumndcbwc
+-- Purpose: make the app-facing Stage 2 API surface fully available to PostgREST.
+-- Safe to run in Supabase SQL Editor. Designed to be additive and idempotent.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1) Immutable manuscript versions foundation
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.manuscript_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  manuscript_id bigint NOT NULL REFERENCES public.manuscripts(id) ON DELETE CASCADE,
+  version_number integer NOT NULL,
+  source_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  raw_text text NOT NULL DEFAULT '',
+  word_count integer NOT NULL DEFAULT 0,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT manuscript_versions_version_number_positive CHECK (version_number > 0),
+  CONSTRAINT manuscript_versions_word_count_nonnegative CHECK (word_count >= 0),
+  CONSTRAINT manuscript_versions_unique_per_manuscript UNIQUE (manuscript_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_manuscript_id
+  ON public.manuscript_versions(manuscript_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_source_version_id
+  ON public.manuscript_versions(source_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_manuscript_versions_created_at
+  ON public.manuscript_versions(created_at DESC);
+
+-- Required Stage 2 binding on evaluation jobs.
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS manuscript_version_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'evaluation_jobs'
+      AND constraint_name = 'evaluation_jobs_manuscript_version_id_fkey'
+  ) THEN
+    ALTER TABLE public.evaluation_jobs
+      ADD CONSTRAINT evaluation_jobs_manuscript_version_id_fkey
+      FOREIGN KEY (manuscript_version_id)
+      REFERENCES public.manuscript_versions(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_evaluation_jobs_manuscript_version_id
+  ON public.evaluation_jobs(manuscript_version_id);
+
+-- Backfill initial immutable version for each manuscript.
+INSERT INTO public.manuscript_versions (
+  manuscript_id,
+  version_number,
+  source_version_id,
+  raw_text,
+  word_count,
+  created_by,
+  created_at
+)
+SELECT
+  m.id,
+  1,
+  NULL,
+  '',
+  COALESCE(m.word_count, 0),
+  m.created_by,
+  COALESCE(m.created_at, now())
+FROM public.manuscripts m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.manuscript_versions mv
+  WHERE mv.manuscript_id = m.id
+    AND mv.version_number = 1
+);
+
+-- Backfill existing jobs to v1 where possible.
+UPDATE public.evaluation_jobs ej
+SET manuscript_version_id = mv.id
+FROM public.manuscript_versions mv
+WHERE ej.manuscript_id = mv.manuscript_id
+  AND mv.version_number = 1
+  AND ej.manuscript_version_id IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2) Revision sessions + change proposals
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.revision_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  evaluation_run_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  source_version_id uuid NOT NULL REFERENCES public.manuscript_versions(id) ON DELETE CASCADE,
+  result_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  status text NOT NULL CHECK (status IN ('open', 'applied', 'discarded')),
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_evaluation_run_id
+  ON public.revision_sessions(evaluation_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_source_version_id
+  ON public.revision_sessions(source_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_result_version_id
+  ON public.revision_sessions(result_version_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_sessions_status
+  ON public.revision_sessions(status);
+
+CREATE TABLE IF NOT EXISTS public.change_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  revision_session_id uuid NOT NULL REFERENCES public.revision_sessions(id) ON DELETE CASCADE,
+  location_ref text NOT NULL,
+  rule text NOT NULL,
+  action text NOT NULL CHECK (action IN ('preserve', 'refine', 'replace')),
+  original_text text NOT NULL,
+  proposed_text text NOT NULL,
+  justification text NOT NULL,
+  severity text NOT NULL CHECK (severity IN ('low', 'medium', 'high')),
+  decision text CHECK (decision IN ('accepted', 'rejected', 'modified')),
+  modified_text text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_change_proposals_revision_session_id
+  ON public.change_proposals(revision_session_id);
+
+CREATE INDEX IF NOT EXISTS idx_change_proposals_decision
+  ON public.change_proposals(decision);
+
+-- ---------------------------------------------------------------------------
+-- 3) RLS hardening for Stage 2 tables
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.manuscript_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.revision_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.change_proposals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own manuscript versions" ON public.manuscript_versions;
+CREATE POLICY "Users can view own manuscript versions"
+  ON public.manuscript_versions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscripts m
+      WHERE m.id = manuscript_versions.manuscript_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own manuscript versions" ON public.manuscript_versions;
+CREATE POLICY "Users can insert own manuscript versions"
+  ON public.manuscript_versions
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscripts m
+      WHERE m.id = manuscript_versions.manuscript_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can view own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can view own revision sessions"
+  ON public.revision_sessions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can insert own revision sessions"
+  ON public.revision_sessions
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own revision sessions" ON public.revision_sessions;
+CREATE POLICY "Users can update own revision sessions"
+  ON public.revision_sessions
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.manuscript_versions mv
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE mv.id = revision_sessions.source_version_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can view own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can view own change proposals"
+  ON public.change_proposals
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can insert own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can insert own change proposals"
+  ON public.change_proposals
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can update own change proposals" ON public.change_proposals;
+CREATE POLICY "Users can update own change proposals"
+  ON public.change_proposals
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.revision_sessions rs
+      JOIN public.manuscript_versions mv ON mv.id = rs.source_version_id
+      JOIN public.manuscripts m ON m.id = mv.manuscript_id
+      WHERE rs.id = change_proposals.revision_session_id
+        AND (
+          m.created_by = auth.uid()
+          OR m.user_id = auth.uid()
+        )
+    )
+  );
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- 4) Force PostgREST / Supabase REST schema cache reload
+-- ---------------------------------------------------------------------------
+NOTIFY pgrst, 'reload schema';
+
+-- ---------------------------------------------------------------------------
+-- 5) Verification queries (run after the script completes)
+-- ---------------------------------------------------------------------------
+-- SELECT to_regclass('public.manuscript_versions') AS manuscript_versions,
+--        to_regclass('public.revision_sessions') AS revision_sessions,
+--        to_regclass('public.change_proposals') AS change_proposals;
+--
+-- SELECT column_name
+-- FROM information_schema.columns
+-- WHERE table_schema = 'public'
+--   AND table_name = 'evaluation_jobs'
+--   AND column_name = 'manuscript_version_id';


### PR DESCRIPTION
## What changed

- Hardened source-bound anchor generation
- Rewrote anchored `original_text` from exact source slices
- Improved source resolution for proposal creation paths
- Tightened smoke auto-selection eligibility
- Prioritized anchored proposals in smoke validation

## Acceptance evidence

- stale-run rejection passed
- explicit fresh-run smoke passed
- auto-selection smoke passed
- happy-path telemetry observed:
  - `SMOKE_RUN_PASSED`
  - `SOURCE_IMMUTABLE_CONFIRMED`
  - `REVISION_SESSION_FINALIZED`
  - `APPLY_ANCHORED_SUCCESS`
  - `PROPOSAL_GENERATED`
  - `PROPOSAL_ANCHOR_CREATED`

## Note

Full anchor coverage is not yet 100%; remaining `PROPOSAL_ANCHOR_MISSING` cases are follow-up hardening, not a blocker for this acceptance gate.
