### PR TITLE
Phase 0.3: Governance Injection Map (runtime-bound, fail-closed)

### DIFF
--- a/PHASE_0_3_GOVERNANCE_INJECTION_MAP.md
+++ b/PHASE_0_3_GOVERNANCE_INJECTION_MAP.md
@@ -1,0 +1,77 @@
+# Phase 0.3 — Governance Injection Map
+
+## Status
+
+**IMPLEMENTED (runtime-bound, fail-closed)**
+
+## Purpose
+
+Phase 0.3 defines and validates the canonical governance injection map for the evaluation pipeline.
+
+This map makes control points explicit and auditable by answering:
+
+- where governance checks fire,
+- what enters each checkpoint,
+- what exits each checkpoint,
+- what action can be taken (ALLOW/WARN/BLOCK/AUDIT),
+- which authority governs that checkpoint,
+- which downstream stages are affected.
+
+## Runtime Binding
+
+The runtime map is implemented in:
+
+- `lib/governance/injectionMap.ts`
+
+The pipeline binds and validates it at startup:
+
+- `lib/evaluation/pipeline/runPipeline.ts`
+
+If the map is invalid or incomplete, pipeline execution fails closed with:
+
+- `GOVERNANCE_INJECTION_MAP_INVALID`
+
+## Stage Matrix
+
+| Checkpoint ID | Stage | Primary Action | Authority | Block Code (if BLOCK) | Downstream Impact |
+|---|---|---|---|---|---|
+| `CANON_REGISTRY_BINDING` | `pipeline_boot` | `BLOCK` | `docs/NOMENCLATURE_CANON_v1.md` | `CANON_REGISTRY_BIND_FAILED` | blocks pass1-pass4 |
+| `CANON_GATE` | `pipeline_boot` | `BLOCK` | `AI_GOVERNANCE.md` | `CANON_REGISTRY_EMPTY` | blocks pass1-pass4 |
+| `LLR_POST_STRUCTURAL` | `post_pass1` | `BLOCK` | `Phase 0.2 Lessons Learned` | `LLR_POST_STRUCTURAL_BLOCK` | blocks pass2-pass4 |
+| `LLR_POST_DIAGNOSTIC` | `post_pass2` | `BLOCK` | `Phase 0.2 Lessons Learned` | `LLR_POST_DIAGNOSTIC_BLOCK` | blocks pass3-pass4 |
+| `LLR_POST_CONVERGENCE` | `post_pass3` | `BLOCK` | `Phase 0.2 Lessons Learned` | `LLR_POST_CONVERGENCE_BLOCK` | blocks pass4 |
+| `LLR_PRE_ARTIFACT_GENERATION` | `pre_pass4` | `BLOCK` | `Phase 0.2 Lessons Learned` | `LLR_PRE_ARTIFACT_GENERATION_BLOCK` | blocks pass4 |
+| `ELIGIBILITY_GATE` | `post_evaluation_envelope` | `BLOCK` | `Volume II-A Eligibility Gate` | `REFINEMENT_BLOCKED_BY_GATE` | blocks downstream refinement path |
+| `QUALITY_GATE` | `pass4` | `BLOCK` | `Phase 2.7 Quality Gate` | `QG_UNKNOWN` | blocks artifact certification |
+| `HUMAN_REVIEW_BOUNDARY` | `post_pass4` | `AUDIT` | `Operations Runbook` | n/a | manual intervention boundary |
+| `ARTIFACT_CERTIFICATION_BOUNDARY` | `artifact_certification` | `AUDIT` | `docs/JOB_CONTRACT_v1.md` | n/a | governs publishability |
+| `FAILURE_ESCALATION_DEAD_LETTER` | `failure_path` | `WARN` | `Operations Runbook` | n/a | dead-letter escalation |
+
+## Validation Rules
+
+The map validator enforces:
+
+1. Map is non-empty.
+2. Checkpoint IDs are unique.
+3. Every required checkpoint exists.
+4. Any `BLOCK` checkpoint must define `blockErrorCode`.
+5. `llrStage` may only appear on `LLR_*` checkpoints.
+
+## Test Coverage
+
+- `lib/governance/__tests__/injectionMap.test.ts`
+  - required checkpoint completeness
+  - duplicate ID rejection
+  - missing checkpoint rejection
+  - LLR stage mapping correctness
+  - canonical checkpoint metadata access
+
+- `tests/evaluation/pipeline/pipeline-e2e.test.ts`
+  - fail-closed on invalid injection map
+  - checkpoint metadata present in block errors
+
+## Notes
+
+- Observability remains passive; no control-flow alteration outside explicit action semantics.
+- No changes to canonical job status values.
+- No changes to Phase 2.8 or Phase 3.0 scope.

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -28,6 +28,12 @@ import type { RunPass3Options } from "./runPass3Synthesis";
 import { loadCanonicalRegistry } from "@/lib/governance/canonRegistry";
 import type { CanonRegistry } from "@/lib/governance/canonRegistry";
 import {
+  loadGovernanceInjectionMap,
+  getGovernanceCheckpointById,
+  getLlrCheckpointForStage,
+} from "@/lib/governance/injectionMap";
+import type { GovernanceCheckpoint, GovernanceInjectionMap } from "@/lib/governance/injectionMap";
+import {
   evaluateLessonsLearnedRules as defaultEvaluateLessonsLearnedRules,
   deriveLessonsLearnedEnforcementDecision as defaultDeriveLessonsLearnedEnforcementDecision,
 } from "@/lib/governance/lessonsLearned";
@@ -60,6 +66,8 @@ export interface RunPipelineOptions {
   };
   /** Dependency injection for registry loader (testing only). */
   _registryLoader?: () => CanonRegistry;
+  /** Dependency injection for governance injection map loader (testing only). */
+  _governanceInjectionMapLoader?: () => GovernanceInjectionMap;
   manuscriptId?: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   /** Dependency injection for lessons-learned engine (testing only). */
@@ -137,9 +145,26 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   const _runPass3 = opts._runners?.runPass3Synthesis ?? defaultRunPass3;
   const _runQualityGate = opts._runners?.runQualityGate ?? defaultRunQualityGate;
   const _loadRegistry = opts._registryLoader ?? loadCanonicalRegistry;
+  const _loadGovernanceInjectionMap = opts._governanceInjectionMapLoader ?? loadGovernanceInjectionMap;
   const _evaluateLessonsLearned = opts._lessonsLearned?.evaluateRules ?? defaultEvaluateLessonsLearnedRules;
   const _deriveLessonsLearnedDecision =
     opts._lessonsLearned?.deriveDecision ?? defaultDeriveLessonsLearnedEnforcementDecision;
+
+  let governanceInjectionMap: GovernanceInjectionMap;
+  try {
+    governanceInjectionMap = _loadGovernanceInjectionMap();
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Governance injection map invalid: ${String(err instanceof Error ? err.message : err)}`,
+      error_code: "GOVERNANCE_INJECTION_MAP_INVALID",
+      failed_at: "pass1",
+    };
+  }
+
+  const checkpointContext = (checkpoint: GovernanceCheckpoint): string => {
+    return ` [checkpoint=${checkpoint.id} authority=${checkpoint.authority}]`;
+  };
 
   const llrContextBase = {
     manuscript_id: opts.manuscriptId ?? `pipeline:${opts.title}`,
@@ -163,6 +188,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       stage,
     );
     const decision = _deriveLessonsLearnedDecision(report);
+    const checkpoint = getLlrCheckpointForStage(stage, governanceInjectionMap);
 
     if (decision.action === "BLOCK") {
       const failedRules = report.results
@@ -172,8 +198,8 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
 
       return {
         ok: false,
-        error: `Lessons-learned enforcement blocked at ${stage}: ${decision.reason}${failedRules ? ` (rules: ${failedRules})` : ""}`,
-        error_code: `LLR_${stage.toUpperCase()}_BLOCK`,
+        error: `Lessons-learned enforcement blocked at ${stage}: ${decision.reason}${failedRules ? ` (rules: ${failedRules})` : ""}${checkpointContext(checkpoint)}`,
+        error_code: checkpoint.blockErrorCode ?? `LLR_${stage.toUpperCase()}_BLOCK`,
         failed_at: failedAt,
       };
     }
@@ -182,13 +208,15 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   };
 
   let registry: CanonRegistry;
+  const registryBindingCheckpoint = getGovernanceCheckpointById("CANON_REGISTRY_BINDING", governanceInjectionMap);
+  const canonGateCheckpoint = getGovernanceCheckpointById("CANON_GATE", governanceInjectionMap);
   try {
     registry = _loadRegistry();
   } catch (err) {
     return {
       ok: false,
-      error: `Canonical registry binding failed: ${String(err instanceof Error ? err.message : err)}`,
-      error_code: "CANON_REGISTRY_BIND_FAILED",
+      error: `Canonical registry binding failed: ${String(err instanceof Error ? err.message : err)}${checkpointContext(registryBindingCheckpoint)}`,
+      error_code: registryBindingCheckpoint.blockErrorCode ?? "CANON_REGISTRY_BIND_FAILED",
       failed_at: "pass1",
     };
   }
@@ -196,8 +224,8 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   if (registry.size === 0) {
     return {
       ok: false,
-      error: "Canonical registry binding failed: registry empty",
-      error_code: "CANON_REGISTRY_EMPTY",
+      error: `Canonical registry binding failed: registry empty${checkpointContext(canonGateCheckpoint)}`,
+      error_code: canonGateCheckpoint.blockErrorCode ?? "CANON_REGISTRY_EMPTY",
       failed_at: "pass1",
     };
   }
@@ -319,12 +347,13 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   // ── Pass 4: Quality Gate (deterministic) ───────────────────────────────
   const qualityGate = _runQualityGate(pass3Output, pass1Output, pass2Output);
   if (!qualityGate.pass) {
+    const qualityGateCheckpoint = getGovernanceCheckpointById("QUALITY_GATE", governanceInjectionMap);
     const failedChecks = qualityGate.checks.filter((c) => !c.passed);
     const errorCode = failedChecks[0]?.error_code ?? "QG_UNKNOWN";
     const details = failedChecks.map((c) => c.details ?? c.error_code).join("; ");
     return {
       ok: false,
-      error: `Quality gate failed: ${details}`,
+      error: `Quality gate failed: ${details}${checkpointContext(qualityGateCheckpoint)}`,
       error_code: errorCode,
       failed_at: "pass4",
     };

--- a/lib/governance/__tests__/injectionMap.test.ts
+++ b/lib/governance/__tests__/injectionMap.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  DEFAULT_GOVERNANCE_INJECTION_MAP,
+  REQUIRED_GOVERNANCE_CHECKPOINT_IDS,
+  getGovernanceCheckpointById,
+  getLlrCheckpointForStage,
+  loadGovernanceInjectionMap,
+  validateGovernanceInjectionMap,
+} from "@/lib/governance/injectionMap";
+
+describe("governance injection map", () => {
+  it("loads the default map and includes all required checkpoints", () => {
+    const map = loadGovernanceInjectionMap();
+    const ids = new Set(map.map((entry) => entry.id));
+
+    for (const requiredId of REQUIRED_GOVERNANCE_CHECKPOINT_IDS) {
+      expect(ids.has(requiredId)).toBe(true);
+    }
+  });
+
+  it("rejects duplicate checkpoint ids", () => {
+    const duplicate = [
+      ...DEFAULT_GOVERNANCE_INJECTION_MAP,
+      { ...DEFAULT_GOVERNANCE_INJECTION_MAP[0] },
+    ] as const;
+
+    expect(() => validateGovernanceInjectionMap(duplicate)).toThrow(
+      "duplicate checkpoint id",
+    );
+  });
+
+  it("rejects missing required checkpoints", () => {
+    const withoutQualityGate = DEFAULT_GOVERNANCE_INJECTION_MAP.filter(
+      (entry) => entry.id !== "QUALITY_GATE",
+    );
+
+    expect(() => validateGovernanceInjectionMap(withoutQualityGate)).toThrow(
+      "missing required checkpoint: QUALITY_GATE",
+    );
+  });
+
+  it("maps each LLR stage to the correct checkpoint", () => {
+    expect(getLlrCheckpointForStage("post_structural").id).toBe("LLR_POST_STRUCTURAL");
+    expect(getLlrCheckpointForStage("post_diagnostic").id).toBe("LLR_POST_DIAGNOSTIC");
+    expect(getLlrCheckpointForStage("post_convergence").id).toBe("LLR_POST_CONVERGENCE");
+    expect(getLlrCheckpointForStage("pre_artifact_generation").id).toBe("LLR_PRE_ARTIFACT_GENERATION");
+  });
+
+  it("exposes canonical checkpoint metadata for pipeline binding", () => {
+    const checkpoint = getGovernanceCheckpointById("CANON_REGISTRY_BINDING");
+
+    expect(checkpoint.primaryAction).toBe("BLOCK");
+    expect(checkpoint.blockErrorCode).toBe("CANON_REGISTRY_BIND_FAILED");
+    expect(checkpoint.authority).toBeDefined();
+  });
+});

--- a/lib/governance/injectionMap.ts
+++ b/lib/governance/injectionMap.ts
@@ -1,0 +1,303 @@
+import type { RuleStage } from "@/lib/governance/lessonsLearned";
+
+export type ExecutionMode = "TRUSTED_PATH" | "STUDIO";
+
+export type GovernanceCheckpointId =
+  | "CANON_REGISTRY_BINDING"
+  | "CANON_GATE"
+  | "LLR_POST_STRUCTURAL"
+  | "LLR_POST_DIAGNOSTIC"
+  | "LLR_POST_CONVERGENCE"
+  | "LLR_PRE_ARTIFACT_GENERATION"
+  | "ELIGIBILITY_GATE"
+  | "QUALITY_GATE"
+  | "HUMAN_REVIEW_BOUNDARY"
+  | "ARTIFACT_CERTIFICATION_BOUNDARY"
+  | "FAILURE_ESCALATION_DEAD_LETTER";
+
+export type GovernanceAuthority =
+  | "AI_GOVERNANCE.md"
+  | "docs/JOB_CONTRACT_v1.md"
+  | "docs/NOMENCLATURE_CANON_v1.md"
+  | "Volume II-A Eligibility Gate"
+  | "Phase 0.2 Lessons Learned"
+  | "Phase 2.7 Quality Gate"
+  | "Operations Runbook";
+
+export type GovernanceAction = "ALLOW" | "WARN" | "BLOCK" | "AUDIT";
+
+export type DownstreamImpact = {
+  blocksStages?: Array<"pass1" | "pass2" | "pass3" | "pass4">;
+  warnsStages?: Array<"pass1" | "pass2" | "pass3" | "pass4">;
+  affectsArtifacts?: boolean;
+};
+
+export type GovernanceCheckpoint = {
+  id: GovernanceCheckpointId;
+  stage: string;
+  description: string;
+  appliesToExecutionModes: ExecutionMode[];
+  authority: GovernanceAuthority;
+  primaryAction: GovernanceAction;
+  auditEvent: string;
+  inputShape: string[];
+  outputShape: string[];
+  downstreamImpact: DownstreamImpact;
+  blockErrorCode?: string;
+  llrStage?: RuleStage;
+};
+
+export type GovernanceInjectionMap = readonly GovernanceCheckpoint[];
+
+export const REQUIRED_GOVERNANCE_CHECKPOINT_IDS: readonly GovernanceCheckpointId[] = [
+  "CANON_REGISTRY_BINDING",
+  "CANON_GATE",
+  "LLR_POST_STRUCTURAL",
+  "LLR_POST_DIAGNOSTIC",
+  "LLR_POST_CONVERGENCE",
+  "LLR_PRE_ARTIFACT_GENERATION",
+  "ELIGIBILITY_GATE",
+  "QUALITY_GATE",
+  "HUMAN_REVIEW_BOUNDARY",
+  "ARTIFACT_CERTIFICATION_BOUNDARY",
+  "FAILURE_ESCALATION_DEAD_LETTER",
+] as const;
+
+export const DEFAULT_GOVERNANCE_INJECTION_MAP: GovernanceInjectionMap = [
+  {
+    id: "CANON_REGISTRY_BINDING",
+    stage: "pipeline_boot",
+    description: "Binds canonical registry before any pass execution.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "docs/NOMENCLATURE_CANON_v1.md",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.canon_registry.bound",
+    inputShape: ["registry_loader"],
+    outputShape: ["registry"],
+    downstreamImpact: {
+      blocksStages: ["pass1", "pass2", "pass3", "pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "CANON_REGISTRY_BIND_FAILED",
+  },
+  {
+    id: "CANON_GATE",
+    stage: "pipeline_boot",
+    description: "Validates canon registry is non-empty before pass execution.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "AI_GOVERNANCE.md",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.canon_gate.checked",
+    inputShape: ["registry"],
+    outputShape: ["canon_gate_decision"],
+    downstreamImpact: {
+      blocksStages: ["pass1", "pass2", "pass3", "pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "CANON_REGISTRY_EMPTY",
+  },
+  {
+    id: "LLR_POST_STRUCTURAL",
+    stage: "post_pass1",
+    description: "Lessons-learned enforcement after structural pass.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Phase 0.2 Lessons Learned",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.llr.post_structural",
+    inputShape: ["structural_result", "registry", "trace_metadata"],
+    outputShape: ["lessons_learned_report", "enforcement_decision"],
+    downstreamImpact: {
+      blocksStages: ["pass2", "pass3", "pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "LLR_POST_STRUCTURAL_BLOCK",
+    llrStage: "post_structural",
+  },
+  {
+    id: "LLR_POST_DIAGNOSTIC",
+    stage: "post_pass2",
+    description: "Lessons-learned enforcement after diagnostic pass.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Phase 0.2 Lessons Learned",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.llr.post_diagnostic",
+    inputShape: ["structural_result", "diagnostic_result", "registry", "trace_metadata"],
+    outputShape: ["lessons_learned_report", "enforcement_decision"],
+    downstreamImpact: {
+      blocksStages: ["pass3", "pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "LLR_POST_DIAGNOSTIC_BLOCK",
+    llrStage: "post_diagnostic",
+  },
+  {
+    id: "LLR_POST_CONVERGENCE",
+    stage: "post_pass3",
+    description: "Lessons-learned enforcement after convergence output.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Phase 0.2 Lessons Learned",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.llr.post_convergence",
+    inputShape: ["structural_result", "diagnostic_result", "convergence_result", "registry", "trace_metadata"],
+    outputShape: ["lessons_learned_report", "enforcement_decision"],
+    downstreamImpact: {
+      blocksStages: ["pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "LLR_POST_CONVERGENCE_BLOCK",
+    llrStage: "post_convergence",
+  },
+  {
+    id: "LLR_PRE_ARTIFACT_GENERATION",
+    stage: "pre_pass4",
+    description: "Final lessons-learned enforcement before quality gate/artifact boundary.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Phase 0.2 Lessons Learned",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.llr.pre_artifact_generation",
+    inputShape: ["structural_result", "diagnostic_result", "convergence_result", "registry", "trace_metadata"],
+    outputShape: ["lessons_learned_report", "enforcement_decision"],
+    downstreamImpact: {
+      blocksStages: ["pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "LLR_PRE_ARTIFACT_GENERATION_BLOCK",
+    llrStage: "pre_artifact_generation",
+  },
+  {
+    id: "ELIGIBILITY_GATE",
+    stage: "post_evaluation_envelope",
+    description: "Eligibility gate controlling refinement path entry.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Volume II-A Eligibility Gate",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.eligibility_gate.checked",
+    inputShape: ["evaluation_envelope"],
+    outputShape: ["eligibility_gate", "readiness_state"],
+    downstreamImpact: {
+      blocksStages: ["pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "REFINEMENT_BLOCKED_BY_GATE",
+  },
+  {
+    id: "QUALITY_GATE",
+    stage: "pass4",
+    description: "Deterministic quality gate over synthesized output.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Phase 2.7 Quality Gate",
+    primaryAction: "BLOCK",
+    auditEvent: "governance.quality_gate.checked",
+    inputShape: ["synthesis", "pass1", "pass2"],
+    outputShape: ["quality_gate_result"],
+    downstreamImpact: {
+      blocksStages: ["pass4"],
+      affectsArtifacts: true,
+    },
+    blockErrorCode: "QG_UNKNOWN",
+  },
+  {
+    id: "HUMAN_REVIEW_BOUNDARY",
+    stage: "post_pass4",
+    description: "Boundary where human review may intervene before certification.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Operations Runbook",
+    primaryAction: "AUDIT",
+    auditEvent: "governance.human_review_boundary.reached",
+    inputShape: ["pipeline_result", "quality_gate_result"],
+    outputShape: ["review_decision"],
+    downstreamImpact: {
+      warnsStages: ["pass4"],
+      affectsArtifacts: true,
+    },
+  },
+  {
+    id: "ARTIFACT_CERTIFICATION_BOUNDARY",
+    stage: "artifact_certification",
+    description: "Final boundary for artifact certification and publication eligibility.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "docs/JOB_CONTRACT_v1.md",
+    primaryAction: "AUDIT",
+    auditEvent: "governance.artifact_certification_boundary.reached",
+    inputShape: ["pipeline_result", "audit_summary"],
+    outputShape: ["certified_artifact"],
+    downstreamImpact: {
+      affectsArtifacts: true,
+    },
+  },
+  {
+    id: "FAILURE_ESCALATION_DEAD_LETTER",
+    stage: "failure_path",
+    description: "Escalates blocked/failed executions into dead-letter operational handling.",
+    appliesToExecutionModes: ["TRUSTED_PATH", "STUDIO"],
+    authority: "Operations Runbook",
+    primaryAction: "WARN",
+    auditEvent: "governance.failure_escalation.dead_letter",
+    inputShape: ["error_code", "failed_at", "trace_metadata"],
+    outputShape: ["dead_letter_event"],
+    downstreamImpact: {
+      affectsArtifacts: false,
+    },
+  },
+] as const;
+
+function checkpointToString(checkpoint: GovernanceCheckpoint): string {
+  return `${checkpoint.id} @ ${checkpoint.stage}`;
+}
+
+export function validateGovernanceInjectionMap(map: GovernanceInjectionMap): void {
+  if (!Array.isArray(map) || map.length === 0) {
+    throw new Error("Governance injection map is empty");
+  }
+
+  const seen = new Set<GovernanceCheckpointId>();
+  for (const checkpoint of map) {
+    if (seen.has(checkpoint.id)) {
+      throw new Error(`Governance injection map contains duplicate checkpoint id: ${checkpoint.id}`);
+    }
+    seen.add(checkpoint.id);
+
+    if (checkpoint.primaryAction === "BLOCK" && !checkpoint.blockErrorCode) {
+      throw new Error(`Governance injection map BLOCK checkpoint missing blockErrorCode: ${checkpointToString(checkpoint)}`);
+    }
+
+    if (checkpoint.llrStage && !checkpoint.id.startsWith("LLR_")) {
+      throw new Error(`Governance injection map llrStage attached to non-LLR checkpoint: ${checkpointToString(checkpoint)}`);
+    }
+  }
+
+  for (const requiredId of REQUIRED_GOVERNANCE_CHECKPOINT_IDS) {
+    if (!seen.has(requiredId)) {
+      throw new Error(`Governance injection map missing required checkpoint: ${requiredId}`);
+    }
+  }
+}
+
+export function loadGovernanceInjectionMap(
+  map: GovernanceInjectionMap = DEFAULT_GOVERNANCE_INJECTION_MAP,
+): GovernanceInjectionMap {
+  validateGovernanceInjectionMap(map);
+  return map;
+}
+
+export function getGovernanceCheckpointById(
+  id: GovernanceCheckpointId,
+  map: GovernanceInjectionMap = DEFAULT_GOVERNANCE_INJECTION_MAP,
+): GovernanceCheckpoint {
+  const checkpoint = map.find((entry) => entry.id === id);
+  if (!checkpoint) {
+    throw new Error(`Governance checkpoint not found: ${id}`);
+  }
+  return checkpoint;
+}
+
+export function getLlrCheckpointForStage(
+  stage: RuleStage,
+  map: GovernanceInjectionMap = DEFAULT_GOVERNANCE_INJECTION_MAP,
+): GovernanceCheckpoint {
+  const checkpoint = map.find((entry) => entry.llrStage === stage);
+  if (!checkpoint) {
+    throw new Error(`Governance LLR checkpoint not found for stage: ${stage}`);
+  }
+  return checkpoint;
+}

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -295,6 +295,7 @@ describe("runPipeline (e2e with injected runners)", () => {
     if (!result.ok) {
       expect(result.error_code).toBe("CANON_REGISTRY_BIND_FAILED");
       expect(result.failed_at).toBe("pass1");
+      expect(result.error).toContain("checkpoint=CANON_REGISTRY_BINDING");
     }
 
     expect(mockRunPass1).not.toHaveBeenCalled();
@@ -393,6 +394,7 @@ describe("runPipeline (e2e with injected runners)", () => {
     if (!result.ok) {
       expect(result.error_code).toBe("LLR_POST_STRUCTURAL_BLOCK");
       expect(result.failed_at).toBe("pass1");
+      expect(result.error).toContain("checkpoint=LLR_POST_STRUCTURAL");
     }
 
     expect(mockRunPass2).not.toHaveBeenCalled();
@@ -438,11 +440,39 @@ describe("runPipeline (e2e with injected runners)", () => {
     if (!result.ok) {
       expect(result.error_code).toBe("LLR_PRE_ARTIFACT_GENERATION_BLOCK");
       expect(result.failed_at).toBe("pass4");
+      expect(result.error).toContain("checkpoint=LLR_PRE_ARTIFACT_GENERATION");
     }
 
     expect(mockRunPass1).toHaveBeenCalledTimes(1);
     expect(mockRunPass2).toHaveBeenCalledTimes(1);
     expect(mockRunPass3).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when governance injection map validation fails", async () => {
+    const result = await runPipeline({
+      manuscriptText: "test",
+      workType: "literary_fiction",
+      title: "Test",
+      openaiApiKey: "sk-test",
+      _governanceInjectionMapLoader: () => {
+        throw new Error("missing required checkpoint: QUALITY_GATE");
+      },
+      _runners: {
+        runPass1: mockRunPass1,
+        runPass2: mockRunPass2,
+        runPass3Synthesis: mockRunPass3,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error_code).toBe("GOVERNANCE_INJECTION_MAP_INVALID");
+      expect(result.failed_at).toBe("pass1");
+    }
+
+    expect(mockRunPass1).not.toHaveBeenCalled();
+    expect(mockRunPass2).not.toHaveBeenCalled();
+    expect(mockRunPass3).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- implement canonical governance injection map (`lib/governance/injectionMap.ts`)
- define required checkpoints, authorities, actions, and downstream impact contracts
- add fail-closed injection map validation at pipeline startup
- bind checkpoint metadata into runtime errors for canon registry, lessons-learned, and quality gate enforcement
- add Phase 0.3 governance mapping artifact (`PHASE_0_3_GOVERNANCE_INJECTION_MAP.md`)

## Scope Boundaries
- no changes to Phase 2.8 multi-chunk logic
- no changes to Phase 3.0 scope
- no changes to canonical job status values

## Verification
### Focused
- `npm test -- lib/governance/__tests__/injectionMap.test.ts tests/evaluation/pipeline/pipeline-e2e.test.ts` ✅

### Broader targeted regression
- `npm test -- tests/evaluation/pipeline lib/governance/__tests__` ✅
- Result: 13 passed / 13 total suites
- Result: 156 passed / 156 total tests

## Files Changed
- `lib/governance/injectionMap.ts`
- `lib/governance/__tests__/injectionMap.test.ts`
- `lib/evaluation/pipeline/runPipeline.ts`
- `tests/evaluation/pipeline/pipeline-e2e.test.ts`
- `PHASE_0_3_GOVERNANCE_INJECTION_MAP.md`
