### PR TITLE
Docs: update Sprint 0 status after live RLS verification

### DIFF
--- a/docs/ROADMAP_2026-04-01.md
+++ b/docs/ROADMAP_2026-04-01.md
@@ -1,0 +1,77 @@
+# RevisionGrade Project Roadmap
+## Updated: 2026-04-02 | Branch: feat/repo-rebuild
+
+---
+
+## COMPLETED
+
+### Repo Rebuild (feat/repo-rebuild)
+- [x] Root cleanup: 210 files relocated to archive/root-clutter/
+- [x] Docs spine established: canon/architecture/operations/support
+- [x] Safe-slice: 143 files relocated from functions/scripts
+- [x] Forensic tranche: 7/7 complete
+- [x] Six-state audit classification applied to all files
+
+### Supabase Audit
+- [x] Live table inventory: 24 public tables catalogued
+- [x] Ghost table verification: job_costs, worker_lifecycle_events confirmed non-existent
+- [x] RLS audit: all 24 tables inspected for policy state
+- [x] Policy-target defect family identified: 4 internal tables with {public} instead of {service_role}
+- [x] RLS-disabled tables identified: evaluation_provider_calls, revision_events
+- [x] Consolidated RLS migration drafted (20250614000000_rls_fixes.sql, 128 lines, 7 tables)
+- [x] Migration verified against live Supabase state via SQL Editor
+- [x] Review-only draft SQL created (2026-04-01_rls_canonicalization_draft.sql)
+- [x] Reconciliation plan updated (SUPABASE_AUDIT_RECONCILIATION_PLAN_2026-04-01.md)
+
+### RLS Correction Tranche
+- [x] Consolidated RLS hardening applied to production across all 7 internal/system tables
+- [x] Post-apply verification completed against live policy state
+- [x] Final posture confirmed: service-role-only for all covered internal/system tables
+- [x] Row 51 updated from In Progress to Completed with live-application verification notes
+- [x] Migration reconciliation remains pending because production was corrected via partial manual apply, not by executing the tracked migration as a single unit
+
+### Sprint 0 Closeout
+- [x] #45 Repo Rebuild & Normalization — Completed
+- [x] #46 Supabase RLS Audit & Defect Discovery — Completed
+- [x] #47 Consolidated RLS Hardening (7 tables) — Completed (live state), migration reconciliation pending
+- [x] #48 PR/CI Governance & Repo Governance — Completed
+- [x] #49 Project Roadmap Update — Completed
+
+---
+
+## NEXT UP
+
+### Phase 3 (#42–44)
+- [ ] Remain at Next status
+
+### Branch Merge
+- [ ] PR: feat/repo-rebuild -> main
+- [ ] Split commits for review if needed (repo structure vs Supabase)
+- [ ] CI validation pass
+
+### Remaining Supabase Work
+- [ ] Decide user-scoped read policies (if needed) using join-based ownership chain
+- [ ] protected_spans: add canonical migration to repo (currently live-only)
+- [ ] Auto-enable RLS trigger for new tables
+
+### Pipeline & Runtime
+- [ ] Wave pipeline end-to-end validation
+- [ ] Governance enforcement wiring (governance_logs integration)
+- [ ] Edge function deployment verification
+
+---
+
+## FUTURE
+
+### Phase 5 (#39–41)
+- [ ] Remain at Future status
+
+---
+
+## REFERENCE FILES
+| File | Purpose |
+|------|--------|
+| supabase/migrations/20250614000000_rls_fixes.sql | Consolidated RLS migration (review-only) |
+| 2026-04-01_rls_canonicalization_draft.sql | Clean preflight artifact |
+| docs/operations/runbooks/SUPABASE_AUDIT_RECONCILIATION_PLAN_2026-04-01.md | Audit plan with live findings |
+| docs/RevisionGrade_Roadmap_UPDATED.xlsx | Original project roadmap (Excel) |

--- a/schemas/criteria-keys.ts
+++ b/schemas/criteria-keys.ts
@@ -22,7 +22,7 @@
  *    • MDM responsibility:
  *      Work Type × Matrix Version → applicability status (R / O / NA / C)
  *
- *    • Registry responsibility:
+ *  • Registry responsibility:
  *      Criterion identity, stability, and semantic meaning
  *
  * 3. Any MDM matrix referencing a key NOT present in CRITERIA_KEYS


### PR DESCRIPTION
Updates Sprint 0 status wording to reflect verified live RLS completion while explicitly noting migration-lineage reconciliation remains pending. Includes a small non-functional formatting cleanup in schemas/criteria-keys.ts.