### PR TITLE
fix(ci): Flow1 auth mode and Supabase DB password gate

### DIFF
--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -370,6 +370,21 @@ jobs:
           echo "  Applying Repo Migrations to CI Supabase"
           echo "════════════════════════════════════════════════════════"
 
+          # Supabase CLI requires SUPABASE_DB_PASSWORD for temp-role login.
+          # Prefer explicit CI secret; otherwise derive from DB URL when available.
+          if [[ -z "${SUPABASE_DB_PASSWORD:-}" ]]; then
+            DERIVED_DB_PASSWORD="$(python3 -c 'import os, urllib.parse; u=os.environ.get("SUPABASE_DB_URL_CI", ""); print(urllib.parse.unquote(urllib.parse.urlparse(u).password or "") if u else "")')"
+            if [[ -n "${DERIVED_DB_PASSWORD}" ]]; then
+              export SUPABASE_DB_PASSWORD="${DERIVED_DB_PASSWORD}"
+              echo "✅ Derived SUPABASE_DB_PASSWORD from SUPABASE_DB_URL_CI"
+            else
+              echo "❌ Missing SUPABASE_DB_PASSWORD and could not derive from SUPABASE_DB_URL_CI"
+              exit 1
+            fi
+          else
+            echo "✅ Using SUPABASE_DB_PASSWORD from CI secret"
+          fi
+
           # Link to CI project
           supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF_CI }}" --yes
 
@@ -444,6 +459,7 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN_CI }}
           SUPABASE_DB_URL_CI: ${{ secrets.SUPABASE_DB_URL_CI }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_CI }}
 
       - name: Check CI DB migrations (proof gate)
         run: |

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -57,6 +57,12 @@ jobs:
             missing=1
           fi
 
+          # Required for Supabase CLI auth during migration operations
+          if [[ -z "${{ secrets.SUPABASE_DB_PASSWORD_CI }}" ]]; then
+            echo "❌ Missing SUPABASE_DB_PASSWORD_CI"
+            missing=1
+          fi
+
           if [ "$missing" -eq 1 ]; then
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             echo "⚠️  Supabase proof gates cannot run (secrets missing)"
@@ -96,6 +102,7 @@ jobs:
           echo "  • SUPABASE_PROJECT_REF_CI"
           echo "  • SUPABASE_ACCESS_TOKEN_CI"
           echo "  • SUPABASE_DB_URL_CI"
+          echo "  • SUPABASE_DB_PASSWORD_CI"
           echo ""
           echo "Resolution:"
           echo "  Configure these secrets in repository settings to enable"

--- a/.github/workflows/phase1-evidence.yml
+++ b/.github/workflows/phase1-evidence.yml
@@ -76,6 +76,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           FLOW1_BASE_URL: http://127.0.0.1:3002
           FLOW1_SERVER_MODE: prod
+          TEST_MODE: 'true'
           USE_SUPABASE_JOBS: 'true'
           ALLOW_HEADER_USER_ID: 'true'
           NEXT_TELEMETRY_DISABLED: '1'

--- a/app/api/jobs/[jobId]/route.ts
+++ b/app/api/jobs/[jobId]/route.ts
@@ -23,6 +23,7 @@ type Params = Promise<{ jobId: string }>;
  */
 type CanonicalJobResponse = {
   id: string;
+  user_id: string;
   status: "queued" | "running" | "complete" | "failed";
   progress: number; // 0-100
   created_at: string;
@@ -89,6 +90,7 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
       ok: true,
       job: {
         id: job.id,
+        user_id: job.user_id,
         status: job.status as "queued" | "running" | "complete" | "failed",
         progress: calculateProgressPercentage(job),
         created_at: job.created_at,


### PR DESCRIPTION
## What

Two targeted CI fixes for the job system workflows:

### 1. Flow 1 Evidence Gate — auth mode
- Added `TEST_MODE: 'true'` to `phase1-evidence.yml` evidence step env
- `app/api/jobs/[jobId]/route.ts` requires **both** `TEST_MODE` and `ALLOW_HEADER_USER_ID=true` to accept `x-user-id` header identity; only the latter was set
- Added `user_id` to `CanonicalJobResponse` type and GET response so the Flow 1 evidence script owner assertion passes

### 2. Supabase-Backed Job Tests — DB password gate
- Added `SUPABASE_DB_PASSWORD_CI` to the `proof-availability` secret check
- If the secret is absent, Supabase-backed tests become `neutral` (skipped) rather than hard-failing on SASL auth

## Evidence
Flow 1 Evidence Gate: `success` on run `23987875261`
Supabase-Backed Job Tests: `neutral` (correctly gated) on run `23987875278`

## Extracted from
Originally part of `feat/rg-ops-finalizer-spec` (PR #76). Cherry-picked to this clean branch for isolated review.