### PR TITLE
fix(db): restore failure_envelope column dropped by remote_schema sync

### DIFF
--- a/supabase/migrations/20260404000000_restore_failure_envelope.sql
+++ b/supabase/migrations/20260404000000_restore_failure_envelope.sql
@@ -1,0 +1,8 @@
+-- Restore failure_envelope column dropped by 20260205175822_remote_schema.sql
+-- Required by: lib/db/schema.ts, lib/reliability/deadLetter.ts, jobs API
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS failure_envelope JSONB NULL;
+
+-- Restore index for failure_envelope queries
+CREATE INDEX IF NOT EXISTS idx_evaluation_jobs_failure_envelope
+  ON public.evaluation_jobs USING gin (failure_envelope);


### PR DESCRIPTION
## What

Restores the `failure_envelope JSONB` column on `public.evaluation_jobs` that was dropped by `20260205175822_remote_schema.sql`.

## Why

This column is required by:
- `lib/db/schema.ts`
- `lib/reliability/deadLetter.ts`
- Jobs API failure persistence

## Changes

Single migration file: `supabase/migrations/20260404000000_restore_failure_envelope.sql`
- `ALTER TABLE public.evaluation_jobs ADD COLUMN IF NOT EXISTS failure_envelope JSONB NULL`
- Restores GIN index for failure_envelope queries

## Scope
Isolated migration fix. Cherry-picked from `feat/rg-ops-finalizer-spec` (PR #76) to stand alone for clean review.