### PR TITLE
feat(finalizer): Finalizer scaffold — contracts, invariants, failure taxonomy

### DIFF
--- a/lib/jobs/failures.ts
+++ b/lib/jobs/failures.ts
@@ -1,0 +1,57 @@
+/**
+ * Failure Code Taxonomy — RevisionGrade Phase 1
+ * 
+ * Classified failure codes for structured error handling.
+ * Retry is ONLY allowed for transient codes.
+ */
+
+export type FailureCode =
+  // Transient (retry allowed)
+  | "TRANSIENT_NETWORK"
+  | "TRANSIENT_UPSTREAM"
+  | "RATE_LIMITED"
+  // Non-transient (fail closed, no retry)
+  | "VALIDATION_ERROR"
+  | "SCHEMA_ERROR"
+  | "GOVERNANCE_BLOCK"
+  | "ANCHOR_CONTRACT_VIOLATION"
+  | "MISSING_PASS_ARTIFACT"
+  | "PASS_CONVERGENCE_FAILURE"
+  | "CANONICAL_ARTIFACT_WRITE_FAILED"
+  | "SUMMARY_PROJECTION_FAILED"
+  | "LEASE_EXPIRED"
+  | "STATE_TRANSITION_INVALID"
+  | "RLS_BLOCKED"
+  | "MANUAL_REVIEW_REQUIRED";
+
+const TRANSIENT_CODES: ReadonlySet<FailureCode> = new Set([
+  "TRANSIENT_NETWORK",
+  "TRANSIENT_UPSTREAM",
+  "RATE_LIMITED",
+]);
+
+export function isTransientFailure(code: FailureCode): boolean {
+  return TRANSIENT_CODES.has(code);
+}
+
+export function isNonTransientFailure(code: FailureCode): boolean {
+  return !TRANSIENT_CODES.has(code);
+}
+
+/**
+ * Assert that a failure code is valid.
+ * Throws if the code is not in the taxonomy.
+ */
+export function assertValidFailureCode(code: string): asserts code is FailureCode {
+  const ALL_CODES: string[] = [
+    "TRANSIENT_NETWORK", "TRANSIENT_UPSTREAM", "RATE_LIMITED",
+    "VALIDATION_ERROR", "SCHEMA_ERROR", "GOVERNANCE_BLOCK",
+    "ANCHOR_CONTRACT_VIOLATION", "MISSING_PASS_ARTIFACT",
+    "PASS_CONVERGENCE_FAILURE", "CANONICAL_ARTIFACT_WRITE_FAILED",
+    "SUMMARY_PROJECTION_FAILED", "LEASE_EXPIRED",
+    "STATE_TRANSITION_INVALID", "RLS_BLOCKED", "MANUAL_REVIEW_REQUIRED",
+  ];
+  if (!ALL_CODES.includes(code)) {
+    throw new Error(`Invalid failure code: ${code}`);
+  }
+}

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -25,7 +25,6 @@ import type {
   FinalizeJobResult,
 } from "./finalize.types";
 import type { FailureCode } from "./failures";
-import { isTransientFailure } from "./failures";
 import {
   InvariantViolation,
   assertFinalizerAuthority,

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -1,0 +1,290 @@
+/**
+ * Finalizer — RevisionGrade Phase 1
+ * 
+ * The sole truth gate between execution and canonical artifact publication.
+ * 
+ * Rules:
+ * - No code path sets job.status = "complete" outside this module
+ * - No report renders without Finalizer-approved canonical artifact
+ * - No missing pass artifact tolerated
+ * - No partial-complete states
+ * - All decisions reconstructable from logs and persisted state
+ * 
+ * Architecture:
+ * Layer 1 — Pure domain logic (validate, enforce, build)
+ * Layer 2 — Side effects (fetch, persist, update)
+ */
+
+import type {
+  EvaluationJob,
+  PassArtifact,
+  ConvergenceArtifact,
+  CanonicalEvaluationArtifact,
+  ReportSummaryProjection,
+  FinalizeJobInput,
+  FinalizeJobResult,
+} from "./finalize.types";
+import type { FailureCode } from "./failures";
+import { isTransientFailure } from "./failures";
+import {
+  InvariantViolation,
+  assertFinalizerAuthority,
+  assertRequiredArtifactsPresent,
+  enforcePassSeparation,
+  enforceAnchorIntegrity,
+  enforceA6Credibility,
+  assertPreCompletionInvariants,
+} from "./invariants";
+
+// === Finalizer Version ===
+export const FINALIZER_VERSION = "1.0.0";
+
+// === Storage Interface (injected) ===
+
+export interface FinalizerStorage {
+  getJob(jobId: string): Promise<EvaluationJob | null>;
+  getPassArtifact(artifactId: string): Promise<PassArtifact | null>;
+  getConvergenceArtifact(artifactId: string): Promise<ConvergenceArtifact | null>;
+  persistCanonicalArtifact(artifact: CanonicalEvaluationArtifact): Promise<string>;
+  persistSummaryProjection(summary: ReportSummaryProjection): Promise<string>;
+  markJobComplete(args: {
+    job_id: string;
+    canonical_artifact_id: string;
+    summary_artifact_id: string;
+  }): Promise<void>;
+  markJobFailed(args: {
+    job_id: string;
+    failure_code: FailureCode;
+    last_error: string;
+  }): Promise<void>;
+}
+
+// === Layer 1: Pure Domain Logic ===
+
+export function buildCanonicalArtifact(args: {
+  job: EvaluationJob;
+  pass1: PassArtifact;
+  pass2: PassArtifact;
+  pass3: PassArtifact;
+  convergence: ConvergenceArtifact;
+}): CanonicalEvaluationArtifact {
+  const { job, pass1, pass2, pass3, convergence } = args;
+
+  // Compute overall score from convergence merged criteria
+  const scores = convergence.merged_criteria.map((c) => c.score_0_10);
+  const avgScore = scores.length > 0
+    ? Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 10)
+    : 0;
+
+  // Compute confidence from pass artifacts
+  const confidences = [
+    ...pass1.criteria.map((c) => c.confidence_0_1),
+    ...pass2.criteria.map((c) => c.confidence_0_1),
+    ...pass3.criteria.map((c) => c.confidence_0_1),
+  ];
+  const avgConfidence = confidences.length > 0
+    ? confidences.reduce((a, b) => a + b, 0) / confidences.length
+    : 0;
+
+  const allWarnings = [
+    ...pass1.criteria.flatMap((c) => c.warnings),
+    ...pass2.criteria.flatMap((c) => c.warnings),
+    ...pass3.criteria.flatMap((c) => c.warnings),
+  ];
+
+  return {
+    id: "", // Set by persistence layer
+    job_id: job.id,
+    schema_version: "1.0.0",
+    generated_at: new Date().toISOString(),
+    source: {
+      pass1_artifact_id: pass1.id,
+      pass2_artifact_id: pass2.id,
+      pass3_artifact_id: pass3.id,
+      convergence_artifact_id: convergence.id,
+    },
+    overview: {
+      overall_score_0_100: avgScore,
+      verdict: avgScore >= 70 ? "Pass" : "Needs Revision",
+      one_paragraph_summary: convergence.overview_summary,
+      top_strengths: [],
+      top_risks: [],
+    },
+    criteria: convergence.merged_criteria,
+    governance: {
+      confidence_0_1: Math.round(avgConfidence * 100) / 100,
+      warnings: allWarnings,
+      limitations: [],
+      transparency_passed: true,
+      anchor_contract_passed: convergence.validations.anchor_contract_valid,
+      canonical_ready: convergence.validations.schema_valid
+        && convergence.validations.pass_separation_preserved
+        && convergence.validations.all_required_passes_present
+        && convergence.validations.anchor_contract_valid,
+    },
+    eligibility: {
+      structural_pass: avgScore >= 50,
+      refinement_unlocked: avgScore >= 40,
+      wave_unlocked: avgScore >= 70,
+      submission_packaging_unlocked: avgScore >= 80,
+      reason: null,
+    },
+    provenance: {
+      evaluator_version: pass1.provenance.evaluator_version,
+      prompt_pack_version: pass1.provenance.prompt_pack_version,
+      run_id: pass1.provenance.run_id,
+      finalizer_version: FINALIZER_VERSION,
+    },
+  };
+}
+
+export function buildReportSummaryProjection(
+  job: EvaluationJob,
+  canonical: CanonicalEvaluationArtifact,
+  canonicalArtifactId: string,
+): ReportSummaryProjection {
+  return {
+    id: "", // Set by persistence layer
+    job_id: job.id,
+    user_id: job.user_id,
+    canonical_artifact_id: canonicalArtifactId,
+    generated_at: new Date().toISOString(),
+    overall_score_0_100: canonical.overview.overall_score_0_100,
+    verdict: canonical.overview.verdict,
+    one_paragraph_summary: canonical.overview.one_paragraph_summary,
+    top_3_strengths: canonical.overview.top_strengths.slice(0, 3),
+    top_3_risks: canonical.overview.top_risks.slice(0, 3),
+    confidence_0_1: canonical.governance.confidence_0_1,
+    warnings_count: canonical.governance.warnings.length,
+    structural_pass: canonical.eligibility.structural_pass,
+    refinement_unlocked: canonical.eligibility.refinement_unlocked,
+    wave_unlocked: canonical.eligibility.wave_unlocked,
+    submission_packaging_unlocked: canonical.eligibility.submission_packaging_unlocked,
+  };
+}
+
+function validateCanonicalArtifact(canonical: CanonicalEvaluationArtifact): void {
+  if (!canonical.governance.canonical_ready) {
+    throw new InvariantViolation(
+      "SCHEMA_ERROR",
+      `Canonical artifact not marked as ready`,
+    );
+  }
+  if (!canonical.schema_version) {
+    throw new InvariantViolation(
+      "SCHEMA_ERROR",
+      `Canonical artifact missing schema_version`,
+    );
+  }
+}
+
+// === Layer 2: Side Effects (Finalizer Entry Point) ===
+
+export async function finalizeJob(
+  input: FinalizeJobInput,
+  storage: FinalizerStorage,
+): Promise<FinalizeJobResult> {
+  try {
+    // Step 1: Acquire and verify authority
+    const job = await storage.getJob(input.job_id);
+    if (!job) {
+      return failResult(input.job_id, "VALIDATION_ERROR", `Job ${input.job_id} not found`);
+    }
+    assertFinalizerAuthority(job, input.worker_id);
+
+    // Step 2: Verify pass artifact presence
+    const refs = assertRequiredArtifactsPresent(job);
+
+    // Step 3: Load all artifacts
+    const pass1 = await storage.getPassArtifact(refs.pass1_artifact_id);
+    const pass2 = await storage.getPassArtifact(refs.pass2_artifact_id);
+    const pass3 = await storage.getPassArtifact(refs.pass3_artifact_id);
+    const convergence = await storage.getConvergenceArtifact(refs.convergence_artifact_id);
+
+    if (!pass1 || !pass2 || !pass3) {
+      const missing = [!pass1 && "pass1", !pass2 && "pass2", !pass3 && "pass3"].filter(Boolean);
+      return failResult(input.job_id, "MISSING_PASS_ARTIFACT", `Missing artifacts: ${missing.join(", ")}`);
+    }
+    if (!convergence) {
+      return failResult(input.job_id, "PASS_CONVERGENCE_FAILURE", "Convergence artifact not found");
+    }
+
+    // Step 5: Pass separation enforcement
+    enforcePassSeparation(pass1, pass2, pass3, convergence);
+
+    // Step 6: Anchor integrity
+    enforceAnchorIntegrity(pass1, pass2, pass3, convergence);
+
+    // Step 7: A6 credibility
+    enforceA6Credibility(pass1, pass2, pass3, convergence);
+
+    // Step 8: Build canonical artifact
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+
+    // Step 9: Validate canonical artifact
+    validateCanonicalArtifact(canonical);
+
+    // Step 10: Persist canonical artifact
+    const canonicalArtifactId = await storage.persistCanonicalArtifact(canonical);
+
+    // Step 11: Build summary projection
+    const summary = buildReportSummaryProjection(job, canonical, canonicalArtifactId);
+
+    // Step 12: Persist summary
+    const summaryArtifactId = await storage.persistSummaryProjection(summary);
+
+    // Step 13: Pre-completion invariants
+    assertPreCompletionInvariants({
+      job_id: job.id,
+      canonical_artifact_id: canonicalArtifactId,
+      summary_artifact_id: summaryArtifactId,
+      worker_id: input.worker_id,
+    });
+
+    // Step 14: Terminal completion
+    await storage.markJobComplete({
+      job_id: job.id,
+      canonical_artifact_id: canonicalArtifactId,
+      summary_artifact_id: summaryArtifactId,
+    });
+
+    return {
+      ok: true,
+      job_id: job.id,
+      canonical_artifact_id: canonicalArtifactId,
+      summary_artifact_id: summaryArtifactId,
+      final_status: "complete",
+    };
+  } catch (error) {
+    if (error instanceof InvariantViolation) {
+      await storage.markJobFailed({
+        job_id: input.job_id,
+        failure_code: error.failureCode,
+        last_error: error.message,
+      });
+      return failResult(input.job_id, error.failureCode, error.message);
+    }
+    // Unknown error — classify as validation error, do not retry
+    const message = error instanceof Error ? error.message : String(error);
+    await storage.markJobFailed({
+      job_id: input.job_id,
+      failure_code: "VALIDATION_ERROR",
+      last_error: message,
+    });
+    return failResult(input.job_id, "VALIDATION_ERROR", message);
+  }
+}
+
+function failResult(
+  jobId: string,
+  failureCode: FailureCode,
+  reason: string,
+): FinalizeJobResult {
+  return {
+    ok: false,
+    job_id: jobId,
+    failure_code: failureCode,
+    final_status: "failed",
+    reason,
+  };
+}

--- a/lib/jobs/finalize.types.ts
+++ b/lib/jobs/finalize.types.ts
@@ -1,0 +1,233 @@
+/**
+ * Finalizer Types — RevisionGrade Phase 1
+ * 
+ * The Finalizer is the sole truth gate between execution and canonical
+ * artifact publication. No code path may set job.status = "complete"
+ * outside the Finalizer.
+ */
+
+import { type JobStatus } from "./types";
+import { type FailureCode } from "./failures";
+
+// === Pass & Phase Enums ===
+
+export type PassId = "pass1" | "pass2" | "pass3";
+
+export type JobPhase =
+  | "submit"
+  | "pass1"
+  | "pass2"
+  | "pass3"
+  | "convergence"
+  | "finalizer"
+  | "report"
+  | "done";
+
+// === Evidence & Assessment ===
+
+export interface EvidenceAnchor {
+  anchor_id: string;
+  source_type: "manuscript_chunk" | "manuscript_span" | "criterion_note";
+  source_ref: string;
+  start_offset: number | null;
+  end_offset: number | null;
+  excerpt: string | null;
+}
+
+export interface CriterionAssessment {
+  criterion_id: string;
+  score_0_10: number;
+  rationale: string;
+  confidence_0_1: number;
+  evidence: EvidenceAnchor[];
+  warnings: string[];
+}
+
+// === Pass Artifact ===
+
+export interface PassArtifact {
+  id: string;
+  job_id: string;
+  pass_id: PassId;
+  schema_version: string;
+  manuscript_revision_id: string;
+  generated_at: string;
+  summary: string;
+  criteria: CriterionAssessment[];
+  provenance: {
+    evaluator_version: string;
+    prompt_pack_version: string | null;
+    run_id: string;
+  };
+  validations: {
+    schema_valid: boolean;
+    anchor_contract_valid: boolean;
+    evidence_nonempty: boolean;
+    orphan_reasoning_absent: boolean;
+  };
+}
+
+// === Convergence Artifact ===
+
+export interface ConvergenceArtifact {
+  id: string;
+  job_id: string;
+  schema_version: string;
+  generated_at: string;
+  inputs: {
+    pass1_artifact_id: string;
+    pass2_artifact_id: string;
+    pass3_artifact_id: string;
+  };
+  merged_criteria: CriterionAssessment[];
+  overview_summary: string;
+  convergence_notes: string[];
+  conflicts_detected: string[];
+  conflicts_resolved: string[];
+  validations: {
+    schema_valid: boolean;
+    pass_separation_preserved: boolean;
+    all_required_passes_present: boolean;
+    anchor_contract_valid: boolean;
+  };
+}
+
+// === Canonical Evaluation Artifact ===
+
+export interface EligibilityBlock {
+  structural_pass: boolean;
+  refinement_unlocked: boolean;
+  wave_unlocked: boolean;
+  submission_packaging_unlocked: boolean;
+  reason: string | null;
+}
+
+export interface CanonicalEvaluationArtifact {
+  id: string;
+  job_id: string;
+  schema_version: string;
+  generated_at: string;
+  source: {
+    pass1_artifact_id: string;
+    pass2_artifact_id: string;
+    pass3_artifact_id: string;
+    convergence_artifact_id: string;
+  };
+  overview: {
+    overall_score_0_100: number;
+    verdict: string;
+    one_paragraph_summary: string;
+    top_strengths: string[];
+    top_risks: string[];
+  };
+  criteria: CriterionAssessment[];
+  governance: {
+    confidence_0_1: number;
+    warnings: string[];
+    limitations: string[];
+    transparency_passed: boolean;
+    anchor_contract_passed: boolean;
+    canonical_ready: boolean;
+  };
+  eligibility: EligibilityBlock;
+  provenance: {
+    evaluator_version: string;
+    prompt_pack_version: string | null;
+    run_id: string;
+    finalizer_version: string;
+  };
+}
+
+// === Report Summary Projection ===
+
+export interface ReportSummaryProjection {
+  id: string;
+  job_id: string;
+  user_id: string;
+  canonical_artifact_id: string;
+  generated_at: string;
+  overall_score_0_100: number;
+  verdict: string;
+  one_paragraph_summary: string;
+  top_3_strengths: string[];
+  top_3_risks: string[];
+  confidence_0_1: number;
+  warnings_count: number;
+  structural_pass: boolean;
+  refinement_unlocked: boolean;
+  wave_unlocked: boolean;
+  submission_packaging_unlocked: boolean;
+}
+
+// === Finalizer I/O Contracts ===
+
+export interface FinalizeJobInput {
+  job_id: string;
+  worker_id: string;
+  expected_status: "running";
+  expected_phase: "finalizer";
+}
+
+export type FinalizeJobResult =
+  | {
+      ok: true;
+      job_id: string;
+      canonical_artifact_id: string;
+      summary_artifact_id: string;
+      final_status: "complete";
+    }
+  | {
+      ok: false;
+      job_id: string;
+      failure_code: FailureCode;
+      final_status: "failed";
+      reason: string;
+    };
+
+// === Evaluation Job (extended with Finalizer fields) ===
+
+export interface EvaluationJob {
+  id: string;
+  user_id: string;
+  status: JobStatus;
+  phase: JobPhase;
+  progress_percent: number;
+  submission_idempotency_key: string | null;
+  claimed_by: string | null;
+  lease_expires_at: string | null;
+  attempt_count: number;
+  next_retry_at: string | null;
+  failure_code: FailureCode | null;
+  last_error: string | null;
+  pass1_artifact_id: string | null;
+  pass2_artifact_id: string | null;
+  pass3_artifact_id: string | null;
+  convergence_artifact_id: string | null;
+  canonical_artifact_id: string | null;
+  summary_artifact_id: string | null;
+  created_at: string;
+  updated_at: string;
+  terminal_at: string | null;
+}
+
+// === Audit Events ===
+
+export interface JobAuditEvent {
+  id: string;
+  job_id: string;
+  event_type:
+    | "job_created"
+    | "lease_acquired"
+    | "pass_completed"
+    | "convergence_completed"
+    | "finalizer_started"
+    | "finalizer_failed"
+    | "canonical_artifact_persisted"
+    | "summary_persisted"
+    | "job_completed";
+  actor_id: string | null;
+  failure_code: FailureCode | null;
+  message: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}

--- a/lib/jobs/invariants.ts
+++ b/lib/jobs/invariants.ts
@@ -1,0 +1,189 @@
+/**
+ * Runtime Invariant Checks — RevisionGrade Phase 1
+ * 
+ * These invariants MUST block execution. They are not warnings.
+ * Violation = immediate failure with classified error.
+ */
+
+import type {
+  EvaluationJob,
+  PassArtifact,
+  ConvergenceArtifact,
+  CanonicalEvaluationArtifact,
+} from "./finalize.types";
+import type { FailureCode } from "./failures";
+
+export class InvariantViolation extends Error {
+  constructor(
+    public readonly failureCode: FailureCode,
+    message: string,
+  ) {
+    super(`[INVARIANT:${failureCode}] ${message}`);
+    this.name = "InvariantViolation";
+  }
+}
+
+// === Finalizer Authority ===
+
+export function assertFinalizerAuthority(
+  job: EvaluationJob,
+  workerId: string,
+): void {
+  if (job.status !== "running") {
+    throw new InvariantViolation(
+      "STATE_TRANSITION_INVALID",
+      `Job ${job.id} status is '${job.status}', expected 'running'`,
+    );
+  }
+  if (job.phase !== "finalizer") {
+    throw new InvariantViolation(
+      "STATE_TRANSITION_INVALID",
+      `Job ${job.id} phase is '${job.phase}', expected 'finalizer'`,
+    );
+  }
+  if (job.claimed_by !== workerId) {
+    throw new InvariantViolation(
+      "LEASE_EXPIRED",
+      `Job ${job.id} claimed by '${job.claimed_by}', worker is '${workerId}'`,
+    );
+  }
+  if (job.lease_expires_at && new Date(job.lease_expires_at) < new Date()) {
+    throw new InvariantViolation(
+      "LEASE_EXPIRED",
+      `Job ${job.id} lease expired at ${job.lease_expires_at}`,
+    );
+  }
+}
+
+// === Pass Artifact Presence ===
+
+export function assertRequiredArtifactsPresent(job: EvaluationJob): {
+  pass1_artifact_id: string;
+  pass2_artifact_id: string;
+  pass3_artifact_id: string;
+  convergence_artifact_id: string;
+} {
+  if (!job.pass1_artifact_id) {
+    throw new InvariantViolation("MISSING_PASS_ARTIFACT", `Job ${job.id}: pass1 artifact missing`);
+  }
+  if (!job.pass2_artifact_id) {
+    throw new InvariantViolation("MISSING_PASS_ARTIFACT", `Job ${job.id}: pass2 artifact missing`);
+  }
+  if (!job.pass3_artifact_id) {
+    throw new InvariantViolation("MISSING_PASS_ARTIFACT", `Job ${job.id}: pass3 artifact missing`);
+  }
+  if (!job.convergence_artifact_id) {
+    throw new InvariantViolation("PASS_CONVERGENCE_FAILURE", `Job ${job.id}: convergence artifact missing`);
+  }
+  return {
+    pass1_artifact_id: job.pass1_artifact_id,
+    pass2_artifact_id: job.pass2_artifact_id,
+    pass3_artifact_id: job.pass3_artifact_id,
+    convergence_artifact_id: job.convergence_artifact_id,
+  };
+}
+
+// === Pass Separation ===
+
+export function enforcePassSeparation(
+  pass1: PassArtifact,
+  pass2: PassArtifact,
+  pass3: PassArtifact,
+  convergence: ConvergenceArtifact,
+): void {
+  const ids = [pass1.id, pass2.id, pass3.id];
+  const uniqueIds = new Set(ids);
+  if (uniqueIds.size !== 3) {
+    throw new InvariantViolation(
+      "PASS_CONVERGENCE_FAILURE",
+      `Pass artifact IDs are not distinct: ${ids.join(", ")}`,
+    );
+  }
+  // Verify convergence references correct pass artifacts
+  if (
+    convergence.inputs.pass1_artifact_id !== pass1.id ||
+    convergence.inputs.pass2_artifact_id !== pass2.id ||
+    convergence.inputs.pass3_artifact_id !== pass3.id
+  ) {
+    throw new InvariantViolation(
+      "PASS_CONVERGENCE_FAILURE",
+      `Convergence inputs do not match loaded pass artifacts`,
+    );
+  }
+}
+
+// === Anchor Integrity ===
+
+export function enforceAnchorIntegrity(
+  pass1: PassArtifact,
+  pass2: PassArtifact,
+  pass3: PassArtifact,
+  convergence: ConvergenceArtifact,
+): void {
+  const allArtifacts = [pass1, pass2, pass3];
+  for (const artifact of allArtifacts) {
+    for (const criterion of artifact.criteria) {
+      if (criterion.evidence.length === 0 && criterion.rationale.length > 0) {
+        throw new InvariantViolation(
+          "ANCHOR_CONTRACT_VIOLATION",
+          `Pass ${artifact.pass_id} criterion ${criterion.criterion_id}: rationale without evidence`,
+        );
+      }
+      for (const anchor of criterion.evidence) {
+        if (!anchor.anchor_id || !anchor.source_ref) {
+          throw new InvariantViolation(
+            "ANCHOR_CONTRACT_VIOLATION",
+            `Pass ${artifact.pass_id} criterion ${criterion.criterion_id}: phantom anchor`,
+          );
+        }
+      }
+    }
+  }
+}
+
+// === A6 Credibility ===
+
+export function enforceA6Credibility(
+  pass1: PassArtifact,
+  pass2: PassArtifact,
+  pass3: PassArtifact,
+  convergence: ConvergenceArtifact,
+): void {
+  const allArtifacts = [pass1, pass2, pass3];
+  for (const artifact of allArtifacts) {
+    if (!artifact.validations.orphan_reasoning_absent) {
+      throw new InvariantViolation(
+        "GOVERNANCE_BLOCK",
+        `Pass ${artifact.pass_id}: orphan reasoning detected`,
+      );
+    }
+    if (!artifact.provenance.evaluator_version || !artifact.provenance.run_id) {
+      throw new InvariantViolation(
+        "GOVERNANCE_BLOCK",
+        `Pass ${artifact.pass_id}: missing provenance trace`,
+      );
+    }
+  }
+}
+
+// === Pre-Completion Invariants ===
+
+export function assertPreCompletionInvariants(args: {
+  job_id: string;
+  canonical_artifact_id: string;
+  summary_artifact_id: string;
+  worker_id: string;
+}): void {
+  if (!args.canonical_artifact_id) {
+    throw new InvariantViolation(
+      "CANONICAL_ARTIFACT_WRITE_FAILED",
+      `Job ${args.job_id}: canonical artifact ID is empty`,
+    );
+  }
+  if (!args.summary_artifact_id) {
+    throw new InvariantViolation(
+      "SUMMARY_PROJECTION_FAILED",
+      `Job ${args.job_id}: summary artifact ID is empty`,
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds the Finalizer module — the sole truth gate between job execution and canonical artifact persistence.

**This is a scaffold PR (Draft).** It is reviewable as a design artifact but is not merge-ready until validators and tests land.

## Files

| File | Purpose |
|---|---|
| `lib/jobs/finalize.types.ts` | All Finalizer I/O contracts and artifact types |
| `lib/jobs/failures.ts` | Failure code taxonomy + transient/non-transient classification |
| `lib/jobs/invariants.ts` | Pure domain invariant functions (authority, artifact presence, pass separation, anchor integrity, A6 credibility) |
| `lib/jobs/finalize.ts` | Finalizer entry point — orchestrates invariant checks and storage side effects |

## Architecture

Two-layer design:
- **Layer 1 (pure):** invariant functions in `invariants.ts` — throw `InvariantViolation` on contract breach
- **Layer 2 (side effects):** `finalizeJob()` in `finalize.ts` — calls invariants, then writes to storage via `FinalizerStorage` interface (DI)

## Truth-gate blockers for merge (not yet present)

- [ ] Schema validator files (`schemas/pass-artifact-v1.ts`, `schemas/convergence-artifact-v1.ts`, etc.)
- [ ] Finalizer unit tests (authority/lease checks, artifact classification, pass separation, A6 credibility, catch-path classification)
- [ ] Integration tests proving fail-closed behavior

## Scope
Cherry-picked from `feat/rg-ops-finalizer-spec` (PR #76, now superseded). Isolated to the four Finalizer files only.