### PR TITLE
test(finalizer): add validator contracts and fail-closed unit tests

### DIFF
--- a/schemas/canonical-evaluation-artifact-v1.ts
+++ b/schemas/canonical-evaluation-artifact-v1.ts
@@ -179,5 +179,5 @@ export function validateCanonicalEvaluationArtifact(raw: unknown): CanonicalEval
     throw new CanonicalEvaluationArtifactValidationError("provenance.prompt_pack_version", "must be a string or null");
   }
 
-  return raw as CanonicalEvaluationArtifact;
+  return raw as unknown as CanonicalEvaluationArtifact;
 }

--- a/schemas/canonical-evaluation-artifact-v1.ts
+++ b/schemas/canonical-evaluation-artifact-v1.ts
@@ -1,0 +1,183 @@
+/**
+ * CanonicalEvaluationArtifact v1 — Runtime Validator
+ */
+
+import type {
+  CanonicalEvaluationArtifact,
+  CriterionAssessment,
+  EvidenceAnchor,
+} from "../lib/jobs/finalize.types";
+
+export class CanonicalEvaluationArtifactValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    message: string,
+  ) {
+    super(`[CanonicalArtifact:${field}] ${message}`);
+    this.name = "CanonicalEvaluationArtifactValidationError";
+  }
+}
+
+function assertObject(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    throw new CanonicalEvaluationArtifactValidationError(path, "must be an object");
+  }
+}
+
+function validateEvidenceAnchor(anchor: unknown, path: string): asserts anchor is EvidenceAnchor {
+  assertObject(anchor, path);
+
+  if (typeof anchor.anchor_id !== "string" || anchor.anchor_id.length === 0) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.anchor_id`, "must be a non-empty string");
+  }
+
+  if (!["manuscript_chunk", "manuscript_span", "criterion_note"].includes(String(anchor.source_type))) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.source_type`, `invalid value: ${anchor.source_type}`);
+  }
+
+  if (typeof anchor.source_ref !== "string" || anchor.source_ref.length === 0) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.source_ref`, "must be a non-empty string");
+  }
+}
+
+function validateCriterionAssessment(criterion: unknown, path: string): asserts criterion is CriterionAssessment {
+  assertObject(criterion, path);
+
+  if (typeof criterion.criterion_id !== "string" || criterion.criterion_id.length === 0) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.criterion_id`, "must be a non-empty string");
+  }
+
+  if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.score_0_10`, "must be a number in [0, 10]");
+  }
+
+  if (typeof criterion.rationale !== "string") {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.rationale`, "must be a string");
+  }
+
+  if (typeof criterion.confidence_0_1 !== "number" || criterion.confidence_0_1 < 0 || criterion.confidence_0_1 > 1) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.confidence_0_1`, "must be a number in [0, 1]");
+  }
+
+  if (!Array.isArray(criterion.evidence)) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.evidence`, "must be an array");
+  }
+
+  criterion.evidence.forEach((anchor, index) => {
+    validateEvidenceAnchor(anchor, `${path}.evidence[${index}]`);
+  });
+
+  if (!Array.isArray(criterion.warnings)) {
+    throw new CanonicalEvaluationArtifactValidationError(`${path}.warnings`, "must be an array");
+  }
+}
+
+export function validateCanonicalEvaluationArtifact(raw: unknown): CanonicalEvaluationArtifact {
+  assertObject(raw, "root");
+
+  for (const requiredString of ["id", "job_id", "schema_version", "generated_at"] as const) {
+    if (typeof raw[requiredString] !== "string" || raw[requiredString].length === 0) {
+      throw new CanonicalEvaluationArtifactValidationError(requiredString, "must be a non-empty string");
+    }
+  }
+
+  assertObject(raw.source, "source");
+  for (const sourceField of [
+    "pass1_artifact_id",
+    "pass2_artifact_id",
+    "pass3_artifact_id",
+    "convergence_artifact_id",
+  ] as const) {
+    if (typeof raw.source[sourceField] !== "string" || raw.source[sourceField].length === 0) {
+      throw new CanonicalEvaluationArtifactValidationError(`source.${sourceField}`, "must be a non-empty string");
+    }
+  }
+
+  assertObject(raw.overview, "overview");
+  if (
+    typeof raw.overview.overall_score_0_100 !== "number"
+    || raw.overview.overall_score_0_100 < 0
+    || raw.overview.overall_score_0_100 > 100
+  ) {
+    throw new CanonicalEvaluationArtifactValidationError("overview.overall_score_0_100", "must be a number in [0, 100]");
+  }
+
+  if (typeof raw.overview.verdict !== "string" || raw.overview.verdict.length === 0) {
+    throw new CanonicalEvaluationArtifactValidationError("overview.verdict", "must be a non-empty string");
+  }
+
+  if (typeof raw.overview.one_paragraph_summary !== "string") {
+    throw new CanonicalEvaluationArtifactValidationError("overview.one_paragraph_summary", "must be a string");
+  }
+
+  if (!Array.isArray(raw.overview.top_strengths)) {
+    throw new CanonicalEvaluationArtifactValidationError("overview.top_strengths", "must be an array");
+  }
+
+  if (!Array.isArray(raw.overview.top_risks)) {
+    throw new CanonicalEvaluationArtifactValidationError("overview.top_risks", "must be an array");
+  }
+
+  if (!Array.isArray(raw.criteria)) {
+    throw new CanonicalEvaluationArtifactValidationError("criteria", "must be an array");
+  }
+
+  raw.criteria.forEach((criterion, index) => {
+    validateCriterionAssessment(criterion, `criteria[${index}]`);
+  });
+
+  assertObject(raw.governance, "governance");
+  if (
+    typeof raw.governance.confidence_0_1 !== "number"
+    || raw.governance.confidence_0_1 < 0
+    || raw.governance.confidence_0_1 > 1
+  ) {
+    throw new CanonicalEvaluationArtifactValidationError("governance.confidence_0_1", "must be a number in [0, 1]");
+  }
+
+  for (const governanceArrayField of ["warnings", "limitations"] as const) {
+    if (!Array.isArray(raw.governance[governanceArrayField])) {
+      throw new CanonicalEvaluationArtifactValidationError(`governance.${governanceArrayField}`, "must be an array");
+    }
+  }
+
+  for (const governanceBooleanField of [
+    "transparency_passed",
+    "anchor_contract_passed",
+    "canonical_ready",
+  ] as const) {
+    if (typeof raw.governance[governanceBooleanField] !== "boolean") {
+      throw new CanonicalEvaluationArtifactValidationError(`governance.${governanceBooleanField}`, "must be a boolean");
+    }
+  }
+
+  assertObject(raw.eligibility, "eligibility");
+
+  for (const eligibilityFlag of [
+    "structural_pass",
+    "refinement_unlocked",
+    "wave_unlocked",
+    "submission_packaging_unlocked",
+  ] as const) {
+    if (typeof raw.eligibility[eligibilityFlag] !== "boolean") {
+      throw new CanonicalEvaluationArtifactValidationError(`eligibility.${eligibilityFlag}`, "must be a boolean");
+    }
+  }
+
+  if (raw.eligibility.reason !== null && typeof raw.eligibility.reason !== "string") {
+    throw new CanonicalEvaluationArtifactValidationError("eligibility.reason", "must be a string or null");
+  }
+
+  assertObject(raw.provenance, "provenance");
+  for (const provenanceField of ["evaluator_version", "run_id", "finalizer_version"] as const) {
+    if (typeof raw.provenance[provenanceField] !== "string" || raw.provenance[provenanceField].length === 0) {
+      throw new CanonicalEvaluationArtifactValidationError(`provenance.${provenanceField}`, "must be a non-empty string");
+    }
+  }
+
+  if (raw.provenance.prompt_pack_version !== null && typeof raw.provenance.prompt_pack_version !== "string") {
+    throw new CanonicalEvaluationArtifactValidationError("provenance.prompt_pack_version", "must be a string or null");
+  }
+
+  return raw as CanonicalEvaluationArtifact;
+}

--- a/schemas/convergence-artifact-v1.ts
+++ b/schemas/convergence-artifact-v1.ts
@@ -136,5 +136,5 @@ export function validateConvergenceArtifact(raw: unknown): ConvergenceArtifact {
     }
   }
 
-  return raw as ConvergenceArtifact;
+  return raw as unknown as ConvergenceArtifact;
 }

--- a/schemas/convergence-artifact-v1.ts
+++ b/schemas/convergence-artifact-v1.ts
@@ -1,0 +1,140 @@
+/**
+ * ConvergenceArtifact v1 — Runtime Validator
+ */
+
+import type {
+  ConvergenceArtifact,
+  CriterionAssessment,
+  EvidenceAnchor,
+} from "../lib/jobs/finalize.types";
+
+export class ConvergenceArtifactValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    message: string,
+  ) {
+    super(`[ConvergenceArtifact:${field}] ${message}`);
+    this.name = "ConvergenceArtifactValidationError";
+  }
+}
+
+function assertObject(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) {
+    throw new ConvergenceArtifactValidationError(path, "must be an object");
+  }
+}
+
+function validateEvidenceAnchor(anchor: unknown, path: string): asserts anchor is EvidenceAnchor {
+  assertObject(anchor, path);
+
+  if (typeof anchor.anchor_id !== "string" || anchor.anchor_id.length === 0) {
+    throw new ConvergenceArtifactValidationError(`${path}.anchor_id`, "must be a non-empty string");
+  }
+
+  if (!["manuscript_chunk", "manuscript_span", "criterion_note"].includes(String(anchor.source_type))) {
+    throw new ConvergenceArtifactValidationError(`${path}.source_type`, `invalid value: ${anchor.source_type}`);
+  }
+
+  if (typeof anchor.source_ref !== "string" || anchor.source_ref.length === 0) {
+    throw new ConvergenceArtifactValidationError(`${path}.source_ref`, "must be a non-empty string");
+  }
+}
+
+function validateCriterionAssessment(criterion: unknown, path: string): asserts criterion is CriterionAssessment {
+  assertObject(criterion, path);
+
+  if (typeof criterion.criterion_id !== "string" || criterion.criterion_id.length === 0) {
+    throw new ConvergenceArtifactValidationError(`${path}.criterion_id`, "must be a non-empty string");
+  }
+
+  if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+    throw new ConvergenceArtifactValidationError(`${path}.score_0_10`, "must be a number in [0, 10]");
+  }
+
+  if (typeof criterion.rationale !== "string") {
+    throw new ConvergenceArtifactValidationError(`${path}.rationale`, "must be a string");
+  }
+
+  if (typeof criterion.confidence_0_1 !== "number" || criterion.confidence_0_1 < 0 || criterion.confidence_0_1 > 1) {
+    throw new ConvergenceArtifactValidationError(`${path}.confidence_0_1`, "must be a number in [0, 1]");
+  }
+
+  if (!Array.isArray(criterion.evidence)) {
+    throw new ConvergenceArtifactValidationError(`${path}.evidence`, "must be an array");
+  }
+
+  criterion.evidence.forEach((anchor, index) => {
+    validateEvidenceAnchor(anchor, `${path}.evidence[${index}]`);
+  });
+
+  if (!Array.isArray(criterion.warnings)) {
+    throw new ConvergenceArtifactValidationError(`${path}.warnings`, "must be an array");
+  }
+}
+
+export function validateConvergenceArtifact(raw: unknown): ConvergenceArtifact {
+  assertObject(raw, "root");
+
+  if (typeof raw.id !== "string" || raw.id.length === 0) {
+    throw new ConvergenceArtifactValidationError("id", "must be a non-empty string");
+  }
+
+  if (typeof raw.job_id !== "string" || raw.job_id.length === 0) {
+    throw new ConvergenceArtifactValidationError("job_id", "must be a non-empty string");
+  }
+
+  if (typeof raw.schema_version !== "string" || raw.schema_version.length === 0) {
+    throw new ConvergenceArtifactValidationError("schema_version", "must be a non-empty string");
+  }
+
+  if (typeof raw.generated_at !== "string" || raw.generated_at.length === 0) {
+    throw new ConvergenceArtifactValidationError("generated_at", "must be a non-empty string");
+  }
+
+  assertObject(raw.inputs, "inputs");
+
+  if (typeof raw.inputs.pass1_artifact_id !== "string" || raw.inputs.pass1_artifact_id.length === 0) {
+    throw new ConvergenceArtifactValidationError("inputs.pass1_artifact_id", "must be a non-empty string");
+  }
+
+  if (typeof raw.inputs.pass2_artifact_id !== "string" || raw.inputs.pass2_artifact_id.length === 0) {
+    throw new ConvergenceArtifactValidationError("inputs.pass2_artifact_id", "must be a non-empty string");
+  }
+
+  if (typeof raw.inputs.pass3_artifact_id !== "string" || raw.inputs.pass3_artifact_id.length === 0) {
+    throw new ConvergenceArtifactValidationError("inputs.pass3_artifact_id", "must be a non-empty string");
+  }
+
+  if (!Array.isArray(raw.merged_criteria)) {
+    throw new ConvergenceArtifactValidationError("merged_criteria", "must be an array");
+  }
+
+  raw.merged_criteria.forEach((criterion, index) => {
+    validateCriterionAssessment(criterion, `merged_criteria[${index}]`);
+  });
+
+  if (typeof raw.overview_summary !== "string") {
+    throw new ConvergenceArtifactValidationError("overview_summary", "must be a string");
+  }
+
+  for (const listField of ["convergence_notes", "conflicts_detected", "conflicts_resolved"] as const) {
+    if (!Array.isArray(raw[listField])) {
+      throw new ConvergenceArtifactValidationError(listField, "must be an array");
+    }
+  }
+
+  assertObject(raw.validations, "validations");
+
+  for (const validationFlag of [
+    "schema_valid",
+    "pass_separation_preserved",
+    "all_required_passes_present",
+    "anchor_contract_valid",
+  ] as const) {
+    if (typeof raw.validations[validationFlag] !== "boolean") {
+      throw new ConvergenceArtifactValidationError(`validations.${validationFlag}`, "must be a boolean");
+    }
+  }
+
+  return raw as ConvergenceArtifact;
+}

--- a/schemas/pass-artifact-v1.ts
+++ b/schemas/pass-artifact-v1.ts
@@ -114,5 +114,5 @@ export function validatePassArtifact(raw: unknown): PassArtifact {
     }
   }
 
-  return raw as PassArtifact;
+  return raw as unknown as PassArtifact;
 }

--- a/schemas/pass-artifact-v1.ts
+++ b/schemas/pass-artifact-v1.ts
@@ -1,0 +1,118 @@
+/**
+ * PassArtifact v1 — Runtime Validator
+ *
+ * Validates that a raw object conforms to the PassArtifact contract.
+ * Throws a descriptive error for any violation; returns typed value on success.
+ */
+
+import type { PassArtifact, EvidenceAnchor, CriterionAssessment } from "../lib/jobs/finalize.types";
+
+export class PassArtifactValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    message: string,
+  ) {
+    super(`[PassArtifact:${field}] ${message}`);
+    this.name = "PassArtifactValidationError";
+  }
+}
+
+function validateEvidenceAnchor(anchor: unknown, path: string): asserts anchor is EvidenceAnchor {
+  if (typeof anchor !== "object" || anchor === null) {
+    throw new PassArtifactValidationError(path, "must be an object");
+  }
+  const a = anchor as Record<string, unknown>;
+  if (typeof a.anchor_id !== "string" || !a.anchor_id) {
+    throw new PassArtifactValidationError(`${path}.anchor_id`, "must be a non-empty string");
+  }
+  if (!["manuscript_chunk", "manuscript_span", "criterion_note"].includes(a.source_type as string)) {
+    throw new PassArtifactValidationError(`${path}.source_type`, `invalid value: ${a.source_type}`);
+  }
+  if (typeof a.source_ref !== "string" || !a.source_ref) {
+    throw new PassArtifactValidationError(`${path}.source_ref`, "must be a non-empty string");
+  }
+}
+
+function validateCriterionAssessment(criterion: unknown, path: string): asserts criterion is CriterionAssessment {
+  if (typeof criterion !== "object" || criterion === null) {
+    throw new PassArtifactValidationError(path, "must be an object");
+  }
+  const c = criterion as Record<string, unknown>;
+  if (typeof c.criterion_id !== "string" || !c.criterion_id) {
+    throw new PassArtifactValidationError(`${path}.criterion_id`, "must be a non-empty string");
+  }
+  if (typeof c.score_0_10 !== "number" || c.score_0_10 < 0 || c.score_0_10 > 10) {
+    throw new PassArtifactValidationError(`${path}.score_0_10`, "must be a number in [0, 10]");
+  }
+  if (typeof c.rationale !== "string") {
+    throw new PassArtifactValidationError(`${path}.rationale`, "must be a string");
+  }
+  if (typeof c.confidence_0_1 !== "number" || c.confidence_0_1 < 0 || c.confidence_0_1 > 1) {
+    throw new PassArtifactValidationError(`${path}.confidence_0_1`, "must be a number in [0, 1]");
+  }
+  if (!Array.isArray(c.evidence)) {
+    throw new PassArtifactValidationError(`${path}.evidence`, "must be an array");
+  }
+  (c.evidence as unknown[]).forEach((anchor, i) => validateEvidenceAnchor(anchor, `${path}.evidence[${i}]`));
+  if (!Array.isArray(c.warnings)) {
+    throw new PassArtifactValidationError(`${path}.warnings`, "must be an array");
+  }
+}
+
+export function validatePassArtifact(raw: unknown): PassArtifact {
+  if (typeof raw !== "object" || raw === null) {
+    throw new PassArtifactValidationError("root", "must be an object");
+  }
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.id !== "string" || !r.id) {
+    throw new PassArtifactValidationError("id", "must be a non-empty string");
+  }
+  if (typeof r.job_id !== "string" || !r.job_id) {
+    throw new PassArtifactValidationError("job_id", "must be a non-empty string");
+  }
+  if (!["pass1", "pass2", "pass3"].includes(r.pass_id as string)) {
+    throw new PassArtifactValidationError("pass_id", `invalid value: ${r.pass_id}`);
+  }
+  if (typeof r.schema_version !== "string" || !r.schema_version) {
+    throw new PassArtifactValidationError("schema_version", "must be a non-empty string");
+  }
+  if (typeof r.manuscript_revision_id !== "string" || !r.manuscript_revision_id) {
+    throw new PassArtifactValidationError("manuscript_revision_id", "must be a non-empty string");
+  }
+  if (typeof r.generated_at !== "string" || !r.generated_at) {
+    throw new PassArtifactValidationError("generated_at", "must be a non-empty string");
+  }
+  if (typeof r.summary !== "string") {
+    throw new PassArtifactValidationError("summary", "must be a string");
+  }
+  if (!Array.isArray(r.criteria)) {
+    throw new PassArtifactValidationError("criteria", "must be an array");
+  }
+  (r.criteria as unknown[]).forEach((c, i) => validateCriterionAssessment(c, `criteria[${i}]`));
+
+  // Provenance
+  if (typeof r.provenance !== "object" || r.provenance === null) {
+    throw new PassArtifactValidationError("provenance", "must be an object");
+  }
+  const prov = r.provenance as Record<string, unknown>;
+  if (typeof prov.evaluator_version !== "string" || !prov.evaluator_version) {
+    throw new PassArtifactValidationError("provenance.evaluator_version", "must be a non-empty string");
+  }
+  if (typeof prov.run_id !== "string" || !prov.run_id) {
+    throw new PassArtifactValidationError("provenance.run_id", "must be a non-empty string");
+  }
+
+  // Validations block
+  if (typeof r.validations !== "object" || r.validations === null) {
+    throw new PassArtifactValidationError("validations", "must be an object");
+  }
+  const v = r.validations as Record<string, unknown>;
+  for (const flag of ["schema_valid", "anchor_contract_valid", "evidence_nonempty", "orphan_reasoning_absent"]) {
+    if (typeof v[flag] !== "boolean") {
+      throw new PassArtifactValidationError(`validations.${flag}`, "must be a boolean");
+    }
+  }
+
+  return raw as PassArtifact;
+}

--- a/schemas/report-summary-v1.ts
+++ b/schemas/report-summary-v1.ts
@@ -78,5 +78,5 @@ export function validateReportSummary(raw: unknown): ReportSummaryProjection {
     assertBoolean(r[boolField], boolField);
   }
 
-  return raw as ReportSummaryProjection;
+  return raw as unknown as ReportSummaryProjection;
 }

--- a/schemas/report-summary-v1.ts
+++ b/schemas/report-summary-v1.ts
@@ -1,0 +1,82 @@
+/**
+ * ReportSummaryProjection v1 — Runtime Validator
+ */
+
+import type { ReportSummaryProjection } from "../lib/jobs/finalize.types";
+
+export class ReportSummaryValidationError extends Error {
+  constructor(
+    public readonly field: string,
+    message: string,
+  ) {
+    super(`[ReportSummary:${field}] ${message}`);
+    this.name = "ReportSummaryValidationError";
+  }
+}
+
+function assertString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ReportSummaryValidationError(field, "must be a non-empty string");
+  }
+}
+
+function assertBoolean(value: unknown, field: string): asserts value is boolean {
+  if (typeof value !== "boolean") {
+    throw new ReportSummaryValidationError(field, "must be a boolean");
+  }
+}
+
+export function validateReportSummary(raw: unknown): ReportSummaryProjection {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ReportSummaryValidationError("root", "must be an object");
+  }
+
+  const r = raw as Record<string, unknown>;
+
+  for (const requiredStringField of [
+    "id",
+    "job_id",
+    "user_id",
+    "canonical_artifact_id",
+    "generated_at",
+    "verdict",
+    "one_paragraph_summary",
+  ] as const) {
+    assertString(r[requiredStringField], requiredStringField);
+  }
+
+  if (
+    typeof r.overall_score_0_100 !== "number"
+    || r.overall_score_0_100 < 0
+    || r.overall_score_0_100 > 100
+  ) {
+    throw new ReportSummaryValidationError("overall_score_0_100", "must be a number in [0, 100]");
+  }
+
+  if (typeof r.confidence_0_1 !== "number" || r.confidence_0_1 < 0 || r.confidence_0_1 > 1) {
+    throw new ReportSummaryValidationError("confidence_0_1", "must be a number in [0, 1]");
+  }
+
+  if (typeof r.warnings_count !== "number" || !Number.isInteger(r.warnings_count) || r.warnings_count < 0) {
+    throw new ReportSummaryValidationError("warnings_count", "must be a non-negative integer");
+  }
+
+  if (!Array.isArray(r.top_3_strengths)) {
+    throw new ReportSummaryValidationError("top_3_strengths", "must be an array");
+  }
+
+  if (!Array.isArray(r.top_3_risks)) {
+    throw new ReportSummaryValidationError("top_3_risks", "must be an array");
+  }
+
+  for (const boolField of [
+    "structural_pass",
+    "refinement_unlocked",
+    "wave_unlocked",
+    "submission_packaging_unlocked",
+  ] as const) {
+    assertBoolean(r[boolField], boolField);
+  }
+
+  return raw as ReportSummaryProjection;
+}

--- a/tests/finalizer/finalizeJob.test.ts
+++ b/tests/finalizer/finalizeJob.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { finalizeJob, type FinalizerStorage } from "@/lib/jobs/finalize";
+import type {
+  EvaluationJob,
+  PassArtifact,
+  ConvergenceArtifact,
+  CanonicalEvaluationArtifact,
+  ReportSummaryProjection,
+} from "@/lib/jobs/finalize.types";
+
+function baseJob(overrides: Partial<EvaluationJob> = {}): EvaluationJob {
+  return {
+    id: "job-1",
+    user_id: "user-1",
+    status: "running",
+    phase: "finalizer",
+    progress_percent: 90,
+    submission_idempotency_key: null,
+    claimed_by: "worker-1",
+    lease_expires_at: "2099-01-01T00:00:00.000Z",
+    attempt_count: 1,
+    next_retry_at: null,
+    failure_code: null,
+    last_error: null,
+    pass1_artifact_id: "p1",
+    pass2_artifact_id: "p2",
+    pass3_artifact_id: "p3",
+    convergence_artifact_id: "conv-1",
+    canonical_artifact_id: null,
+    summary_artifact_id: null,
+    created_at: "2026-04-04T00:00:00.000Z",
+    updated_at: "2026-04-04T00:00:00.000Z",
+    terminal_at: null,
+    ...overrides,
+  };
+}
+
+function basePass(pass_id: "pass1" | "pass2" | "pass3", id: string): PassArtifact {
+  return {
+    id,
+    job_id: "job-1",
+    pass_id,
+    schema_version: "1.0.0",
+    manuscript_revision_id: "rev-1",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    summary: "summary",
+    criteria: [
+      {
+        criterion_id: "clarity",
+        score_0_10: 8,
+        rationale: "Strong clarity",
+        confidence_0_1: 0.9,
+        evidence: [
+          {
+            anchor_id: `${id}-a1`,
+            source_type: "manuscript_chunk",
+            source_ref: "chunk-1",
+            start_offset: 0,
+            end_offset: 10,
+            excerpt: "example",
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    provenance: {
+      evaluator_version: "eval-v1",
+      prompt_pack_version: "prompt-v1",
+      run_id: "run-1",
+    },
+    validations: {
+      schema_valid: true,
+      anchor_contract_valid: true,
+      evidence_nonempty: true,
+      orphan_reasoning_absent: true,
+    },
+  };
+}
+
+function baseConvergence(): ConvergenceArtifact {
+  return {
+    id: "conv-1",
+    job_id: "job-1",
+    schema_version: "1.0.0",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    inputs: {
+      pass1_artifact_id: "p1",
+      pass2_artifact_id: "p2",
+      pass3_artifact_id: "p3",
+    },
+    merged_criteria: [
+      {
+        criterion_id: "clarity",
+        score_0_10: 8,
+        rationale: "Merged rationale",
+        confidence_0_1: 0.88,
+        evidence: [
+          {
+            anchor_id: "conv-a1",
+            source_type: "manuscript_span",
+            source_ref: "span-1",
+            start_offset: 0,
+            end_offset: 12,
+            excerpt: "span",
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    overview_summary: "Converged summary",
+    convergence_notes: [],
+    conflicts_detected: [],
+    conflicts_resolved: [],
+    validations: {
+      schema_valid: true,
+      pass_separation_preserved: true,
+      all_required_passes_present: true,
+      anchor_contract_valid: true,
+    },
+  };
+}
+
+function storageWith(overrides: Partial<FinalizerStorage> = {}): FinalizerStorage {
+  const canonical = async (_artifact: CanonicalEvaluationArtifact) => "canon-1";
+  const summary = async (_summary: ReportSummaryProjection) => "summary-1";
+
+  return {
+    getJob: async () => baseJob(),
+    getPassArtifact: async (artifactId: string) => {
+      if (artifactId === "p1") return basePass("pass1", "p1");
+      if (artifactId === "p2") return basePass("pass2", "p2");
+      if (artifactId === "p3") return basePass("pass3", "p3");
+      return null;
+    },
+    getConvergenceArtifact: async () => baseConvergence(),
+    persistCanonicalArtifact: canonical,
+    persistSummaryProjection: summary,
+    markJobComplete: async () => undefined,
+    markJobFailed: async () => undefined,
+    ...overrides,
+  };
+}
+
+describe("finalizeJob", () => {
+  test("completes successfully with canonical + summary artifact IDs", async () => {
+    const markJobComplete = jest.fn(async (_args: any) => undefined);
+    const markJobFailed = jest.fn(async (_args: any) => undefined);
+
+    const storage = storageWith({ markJobComplete, markJobFailed });
+
+    const result = await finalizeJob(
+      {
+        job_id: "job-1",
+        worker_id: "worker-1",
+        expected_status: "running",
+        expected_phase: "finalizer",
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.final_status).toBe("complete");
+      expect(result.canonical_artifact_id).toBe("canon-1");
+      expect(result.summary_artifact_id).toBe("summary-1");
+    }
+
+    expect(markJobComplete).toHaveBeenCalledTimes(1);
+    expect(markJobFailed).not.toHaveBeenCalled();
+  });
+
+  test("fails closed with MISSING_PASS_ARTIFACT when required pass reference is absent", async () => {
+    const markJobFailed = jest.fn(async (_args: any) => undefined);
+
+    const storage = storageWith({
+      getJob: async () => baseJob({ pass3_artifact_id: null }),
+      markJobFailed,
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: "job-1",
+        worker_id: "worker-1",
+        expected_status: "running",
+        expected_phase: "finalizer",
+      },
+      storage,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      final_status: "failed",
+      failure_code: "MISSING_PASS_ARTIFACT",
+    });
+
+    expect(markJobFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ failure_code: "MISSING_PASS_ARTIFACT" }),
+    );
+  });
+
+  test("fails closed with LEASE_EXPIRED on worker mismatch", async () => {
+    const markJobFailed = jest.fn(async (_args: any) => undefined);
+
+    const storage = storageWith({
+      getJob: async () => baseJob({ claimed_by: "different-worker" }),
+      markJobFailed,
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: "job-1",
+        worker_id: "worker-1",
+        expected_status: "running",
+        expected_phase: "finalizer",
+      },
+      storage,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      final_status: "failed",
+      failure_code: "LEASE_EXPIRED",
+    });
+
+    expect(markJobFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ failure_code: "LEASE_EXPIRED" }),
+    );
+  });
+
+  test("unknown storage errors are classified as VALIDATION_ERROR", async () => {
+    const markJobFailed = jest.fn(async (_args: any) => undefined);
+
+    const storage = storageWith({
+      persistCanonicalArtifact: async () => {
+        throw new Error("db write exploded");
+      },
+      markJobFailed,
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: "job-1",
+        worker_id: "worker-1",
+        expected_status: "running",
+        expected_phase: "finalizer",
+      },
+      storage,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      final_status: "failed",
+      failure_code: "VALIDATION_ERROR",
+    });
+
+    expect(markJobFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ failure_code: "VALIDATION_ERROR" }),
+    );
+  });
+});

--- a/tests/finalizer/validators.test.ts
+++ b/tests/finalizer/validators.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "@jest/globals";
+import { validatePassArtifact } from "@/schemas/pass-artifact-v1";
+import { validateConvergenceArtifact } from "@/schemas/convergence-artifact-v1";
+import { validateCanonicalEvaluationArtifact } from "@/schemas/canonical-evaluation-artifact-v1";
+import { validateReportSummary } from "@/schemas/report-summary-v1";
+
+function validPassArtifact() {
+  return {
+    id: "p1",
+    job_id: "job-1",
+    pass_id: "pass1",
+    schema_version: "1.0.0",
+    manuscript_revision_id: "rev-1",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    summary: "summary",
+    criteria: [
+      {
+        criterion_id: "clarity",
+        score_0_10: 8,
+        rationale: "rationale",
+        confidence_0_1: 0.8,
+        evidence: [
+          {
+            anchor_id: "a1",
+            source_type: "manuscript_chunk",
+            source_ref: "chunk-1",
+            start_offset: 0,
+            end_offset: 10,
+            excerpt: "text",
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    provenance: {
+      evaluator_version: "eval-v1",
+      prompt_pack_version: "prompt-v1",
+      run_id: "run-1",
+    },
+    validations: {
+      schema_valid: true,
+      anchor_contract_valid: true,
+      evidence_nonempty: true,
+      orphan_reasoning_absent: true,
+    },
+  };
+}
+
+function validConvergenceArtifact() {
+  return {
+    id: "conv-1",
+    job_id: "job-1",
+    schema_version: "1.0.0",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    inputs: {
+      pass1_artifact_id: "p1",
+      pass2_artifact_id: "p2",
+      pass3_artifact_id: "p3",
+    },
+    merged_criteria: validPassArtifact().criteria,
+    overview_summary: "summary",
+    convergence_notes: [],
+    conflicts_detected: [],
+    conflicts_resolved: [],
+    validations: {
+      schema_valid: true,
+      pass_separation_preserved: true,
+      all_required_passes_present: true,
+      anchor_contract_valid: true,
+    },
+  };
+}
+
+function validCanonicalEvaluationArtifact() {
+  return {
+    id: "canon-1",
+    job_id: "job-1",
+    schema_version: "1.0.0",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    source: {
+      pass1_artifact_id: "p1",
+      pass2_artifact_id: "p2",
+      pass3_artifact_id: "p3",
+      convergence_artifact_id: "conv-1",
+    },
+    overview: {
+      overall_score_0_100: 80,
+      verdict: "Pass",
+      one_paragraph_summary: "summary",
+      top_strengths: ["s1"],
+      top_risks: ["r1"],
+    },
+    criteria: validPassArtifact().criteria,
+    governance: {
+      confidence_0_1: 0.8,
+      warnings: [],
+      limitations: [],
+      transparency_passed: true,
+      anchor_contract_passed: true,
+      canonical_ready: true,
+    },
+    eligibility: {
+      structural_pass: true,
+      refinement_unlocked: true,
+      wave_unlocked: true,
+      submission_packaging_unlocked: true,
+      reason: null,
+    },
+    provenance: {
+      evaluator_version: "eval-v1",
+      prompt_pack_version: "prompt-v1",
+      run_id: "run-1",
+      finalizer_version: "1.0.0",
+    },
+  };
+}
+
+function validSummary() {
+  return {
+    id: "sum-1",
+    job_id: "job-1",
+    user_id: "user-1",
+    canonical_artifact_id: "canon-1",
+    generated_at: "2026-04-04T00:00:00.000Z",
+    overall_score_0_100: 80,
+    verdict: "Pass",
+    one_paragraph_summary: "summary",
+    top_3_strengths: ["s1"],
+    top_3_risks: ["r1"],
+    confidence_0_1: 0.8,
+    warnings_count: 0,
+    structural_pass: true,
+    refinement_unlocked: true,
+    wave_unlocked: true,
+    submission_packaging_unlocked: true,
+  };
+}
+
+describe("Finalizer schema validators", () => {
+  test("accepts valid pass artifact", () => {
+    expect(validatePassArtifact(validPassArtifact()).id).toBe("p1");
+  });
+
+  test("accepts valid convergence artifact", () => {
+    expect(validateConvergenceArtifact(validConvergenceArtifact()).id).toBe("conv-1");
+  });
+
+  test("accepts valid canonical evaluation artifact", () => {
+    expect(validateCanonicalEvaluationArtifact(validCanonicalEvaluationArtifact()).id).toBe("canon-1");
+  });
+
+  test("accepts valid report summary", () => {
+    expect(validateReportSummary(validSummary()).id).toBe("sum-1");
+  });
+
+  test("rejects invalid pass artifact confidence > 1", () => {
+    const bad = validPassArtifact();
+    bad.criteria[0].confidence_0_1 = 1.2;
+
+    expect(() => validatePassArtifact(bad)).toThrow(/confidence_0_1/i);
+  });
+
+  test("rejects invalid convergence boolean flag type", () => {
+    const bad = validConvergenceArtifact() as any;
+    bad.validations.anchor_contract_valid = "true";
+
+    expect(() => validateConvergenceArtifact(bad)).toThrow(/anchor_contract_valid/i);
+  });
+
+  test("rejects invalid canonical score out of range", () => {
+    const bad = validCanonicalEvaluationArtifact();
+    bad.overview.overall_score_0_100 = 200;
+
+    expect(() => validateCanonicalEvaluationArtifact(bad)).toThrow(/overall_score_0_100/i);
+  });
+
+  test("rejects invalid summary warnings_count", () => {
+    const bad = validSummary() as any;
+    bad.warnings_count = -1;
+
+    expect(() => validateReportSummary(bad)).toThrow(/warnings_count/i);
+  });
+});


### PR DESCRIPTION
## What

Adds the Finalizer proof layer on top of scaffold PR #79:

### Validators (runtime contracts)
- 
- 
- 
- 

### Tests
- 
  - successful complete path
  - missing-pass fail-closed path
  - lease/worker authority fail-closed path
  - unknown storage error classification path
- 
  - valid payload acceptance across all four validators
  - rejection tests for out-of-range and wrong-type violations

## Verification

Executed:
- 
> revisiongrade@1.0.0 pretest
> node scripts/guard-critical-tests.mjs

[guard-critical-tests] OK

> revisiongrade@1.0.0 test
> jest tests/finalizer/finalizeJob.test.ts tests/finalizer/validators.test.ts

Result:
- 2 test suites passed
- 12 tests passed

## Stacking

This PR is intentionally stacked on top of **#79** () to keep scope doctrinally clean:
- #79 = scaffold/contracts/invariants
- this PR = validator + proof layer