### PR TITLE
fix(ci): allow DB password derivation from DB URL in proof gate check

### DIFF
--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -66,11 +66,13 @@ jobs:
           fi
 
           # Required for Supabase CLI auth during migration operations
-          if [[ -z "$SUPABASE_DB_PASSWORD_VAL" ]]; then
-            echo "❌ Missing SUPABASE_DB_PASSWORD_CI (or SUPABASE_DB_PASSWORD fallback)"
+          # DB password can be derived from DB URL at runtime; only fail if BOTH are missing
+          if [[ -z "$SUPABASE_DB_PASSWORD_VAL" && -z "$SUPABASE_DB_URL_VAL" ]]; then
+            echo "Missing SUPABASE_DB_PASSWORD_CI and no SUPABASE_DB_URL to derive from"
             missing=1
+          elif [[ -z "$SUPABASE_DB_PASSWORD_VAL" ]]; then
+            echo "SUPABASE_DB_PASSWORD not set; will derive from SUPABASE_DB_URL at runtime"
           fi
-
           if [ "$missing" -eq 1 ]; then
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
             echo "⚠️  Supabase proof gates cannot run (secrets missing)"


### PR DESCRIPTION
## CI Fix: Proof Gate DB Password Derivation

The proof-availability check was failing because `SUPABASE_DB_PASSWORD_CI` is not set as a standalone secret. However, the actual migration step already derives the DB password from `SUPABASE_DB_URL_CI` at runtime.

**Fix**: Updated the proof gate check to accept `SUPABASE_DB_URL` as a valid substitute for `SUPABASE_DB_PASSWORD` (since the password is embedded in the URL and can be derived).

- If both DB_PASSWORD and DB_URL are missing → still fails (correct)
- If only DB_PASSWORD is missing but DB_URL exists → passes with info message (password derivable)

This clears the last red workflow on main without requiring a new secret.