### PR TITLE
fix(evaluate): enforce ownership and unify canonical report loop

### DIFF
--- a/app/api/evaluations/[jobId]/route.ts
+++ b/app/api/evaluations/[jobId]/route.ts
@@ -47,7 +47,7 @@ export async function GET(
 
     const { data: job, error } = await supabase
       .from("evaluation_jobs")
-      .select("id,status,evaluation_result")
+      .select("id,user_id,status,evaluation_result")
       .eq("id", jobId)
       .maybeSingle();
 
@@ -65,7 +65,11 @@ export async function GET(
       return NextResponse.json(payload, { status: 404 });
     }
 
-    // 3) Ownership: enforced by Supabase RLS via manuscripts.created_by JOIN
+    // 3) Ownership enforcement (service-role bypasses RLS; enforce explicitly)
+    if (job.user_id !== userId) {
+      const payload: Err = { ok: false, error: "Job not found" };
+      return NextResponse.json(payload, { status: 404 });
+    }
 
     // 4) Completion enforcement
     if (job.status !== "complete") {
@@ -78,7 +82,7 @@ export async function GET(
       .from("evaluation_artifacts")
       .select("content")
       .eq("job_id", jobId)
-            .eq("artifact_type", "evaluation_result_v1")
+      .eq("artifact_type", "evaluation_result_v1")
       .maybeSingle();
 
     if (artifactError) {

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -2,6 +2,8 @@
 // Track D: Minimal Report Surface
 import Link from "next/link";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+import { headers } from "next/headers";
 import {
   CRITERIA_KEYS,
   CRITERIA_METADATA,
@@ -11,6 +13,7 @@ import { EvaluationPoller } from "@/components/EvaluationPoller";
 
 type Job = {
   id: string;
+  user_id: string;
   job_type?: string;
   status: "queued" | "running" | "failed" | "complete";
   phase?: string | null;
@@ -65,7 +68,7 @@ async function getJob(jobId: string): Promise<Job | null> {
 
     const { data: job, error } = await supabase
       .from("evaluation_jobs")
-      .select("id, job_type, status, phase, phase_status, total_units, completed_units, failed_units, created_at, updated_at, last_error")
+      .select("id, user_id, job_type, status, phase, phase_status, total_units, completed_units, failed_units, created_at, updated_at, last_error")
       .eq("id", jobId)
       .maybeSingle();
 
@@ -172,13 +175,33 @@ export default async function EvaluationReportPage({
   params: { jobId: string };
 }) {
   const { jobId } = params;
+
+  const sessionUser = await getAuthenticatedUser();
+  const headerOwnerId =
+    process.env.TEST_MODE === "true" && process.env.ALLOW_HEADER_USER_ID === "true"
+      ? (await headers()).get("x-user-id")?.trim() ?? null
+      : null;
+  const ownerId = sessionUser?.id ?? headerOwnerId;
+
+  if (!ownerId) {
+    return (
+      <main className="mx-auto max-w-3xl p-6">
+        <h1 className="text-2xl font-semibold">Evaluation Report</h1>
+        <div className="mt-4 rounded-md bg-yellow-50 border border-yellow-200 p-4">
+          <p className="text-sm text-yellow-800 font-medium">Please sign in to view your evaluation report.</p>
+        </div>
+        <div className="mt-6">
+          <Link href="/login" className="inline-block text-sm text-blue-600 hover:text-blue-700 underline">
+            Go to Sign In
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
   const job = await getJob(jobId);
 
-  if (!job) {
-    // Check if it's an auth issue
-    // Auth is handled by the server client; if job is null, 
-    // it may be auth failure or job not found
-    const hasAccessToken = true; // Server client handles auth transparently
+  if (!job || job.user_id !== ownerId) {
 
     return (
       <main className="mx-auto max-w-3xl p-6">
@@ -186,19 +209,13 @@ export default async function EvaluationReportPage({
         <div className="mt-4 rounded-md bg-yellow-50 border border-yellow-200 p-4">
           <p className="text-sm text-yellow-800 font-medium">Unable to load evaluation</p>
           <p className="mt-2 text-sm text-yellow-700">
-            {!hasAccessToken 
-              ? "Please sign in to view your evaluation report."
-              : `We couldn't find job ${jobId}. It may have expired or been deleted.`
-            }
+            {`We couldn't find job ${jobId}. It may have expired, been deleted, or is not accessible to this account.`}
           </p>
         </div>
 
         <div className="mt-6">
-          <Link 
-            href={!hasAccessToken ? "/login" : "/evaluate"} 
-            className="inline-block text-sm text-blue-600 hover:text-blue-700 underline"
-          >
-            {!hasAccessToken ? "Go to Sign In" : "Back to Evaluate"}
+          <Link href="/evaluate" className="inline-block text-sm text-blue-600 hover:text-blue-700 underline">
+            Back to Evaluate
           </Link>
         </div>
       </main>
@@ -266,7 +283,7 @@ export default async function EvaluationReportPage({
       </div>
 
       <section className="mt-6">
-        <EvaluationPoller jobId={jobId} redirectOnComplete />
+        <EvaluationPoller jobId={jobId} redirectOnComplete={false} />
       </section>
 
       {!isComplete ? (

--- a/app/evaluate/[jobId]/report/page.tsx
+++ b/app/evaluate/[jobId]/report/page.tsx
@@ -14,6 +14,7 @@ type Ok = {
   job_id: string;
   status: string;
   evaluation_result: any;
+  source?: "artifact" | "inline_job_result";
 };
 
 type Err = {
@@ -120,11 +121,17 @@ export default function ReportPage({ params }: { params: { jobId: string } }) {
           </div>
 
           <div style={{ marginTop: 16 }}>
-            <strong>Raw Result (debug)</strong>
-            <pre style={{ whiteSpace: "pre-wrap" }}>
-              {JSON.stringify(data.evaluation_result, null, 2)}
-            </pre>
+            <strong>Artifact type:</strong> {REPORT_ARTIFACT_TYPE}
           </div>
+
+          {process.env.NODE_ENV !== "production" && (
+            <div style={{ marginTop: 16 }}>
+              <strong>Raw Result (debug)</strong>
+              <pre style={{ whiteSpace: "pre-wrap" }}>
+                {JSON.stringify(data.evaluation_result, null, 2)}
+              </pre>
+            </div>
+          )}
         </div>
       ) : null}
     </div>

--- a/components/evaluation/EvaluateEntry.jsx
+++ b/components/evaluation/EvaluateEntry.jsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { appendUserActivity } from "@/lib/activity/userActivity";
 import { useJobs } from "../../lib/jobs/useJobs";
 import { getJobDisplayInfo, getJobStatusBadge } from "../../lib/jobs/ui-helpers";
@@ -21,6 +22,7 @@ import CompletionBanner from "./CompletionBanner";
  * 5. Click "View Evaluation Report" CTA
  */
 export default function EvaluateEntry() {
+  const router = useRouter();
   const { jobs, isLoading, isError } = useJobs();
 
   React.useEffect(() => {
@@ -75,7 +77,22 @@ export default function EvaluateEntry() {
         </div>
 
         {/* Track A: Submission Form */}
-        <ManuscriptSubmissionForm />
+        <ManuscriptSubmissionForm
+          onSubmitSuccess={(data) => {
+            const jobId = data?.job_id;
+            if (!jobId) return;
+
+            appendUserActivity({
+              event: "evaluate.job.created",
+              route: "/evaluate",
+              href: `/evaluate/${jobId}`,
+              linkLabel: "Redirect to job status",
+              detail: `job_id=${jobId}`,
+            });
+
+            router.push(`/evaluate/${jobId}`);
+          }}
+        />
 
         {/* Track C: Completion Banner */}
         {showCompletionBanner && (

--- a/supabase/migrations/20260404120000_create_user_activity_events.sql
+++ b/supabase/migrations/20260404120000_create_user_activity_events.sql
@@ -10,15 +10,6 @@ create table if not exists public.user_activity_events (
   href text,
   link_label text,
   created_at timestamptz not null default now(),
-ng job is Enforce Proof Gates on Main. Its message:
-
-"Supabase proof gates are required on the main branch, but secrets are not configured. Green CI without proof is worse than red CI."
-
-This guard deliberately hard-fails on main when the six Supabase CI secrets (SUPABASE_URL_CI, SUPABASE_SERVICE_ROLE_KEY_CI, SUPABASE_PROJECT_REF_CI, SUPABASE_ACCESS_TOKEN_CI, SUPABASE_DB_URL_CI, SUPABASE_DB_PASSWORD_CI) are absent from GitHub repo settings. On feature branch PRs it degraded to neutral; on main it escalates to failure by design — the governance rule is "proof gates must run or explicitly fail, no silent skipping."
-
-This is not a defect introduced by any of the four PRs. It predates this sprint. Resolution requires provisioning the Supabase CI secrets in repo settings (covered by CI_SECRETS_SETUP.md).
-
-Substantive verdict: the Finalizer stack is clean and settled on main. The only open item is the pre-existing Supabase CI secrets gap.
   constraint fk_user_activity_user
     foreign key (user_id)
     references auth.users(id)


### PR DESCRIPTION
## Summary
- enforce explicit owner check in `GET /api/evaluations/[jobId]` when using admin client
- align artifact lookup/report constant to `evaluation_result_v1`
- make `/evaluate/[jobId]` the canonical report surface (disable poller redirect to thin report page)
- redirect to `/evaluate/[jobId]` immediately after successful submit
- hide raw debug JSON on report page in production
- remove hardcoded auth placeholder (`hasAccessToken = true`) and use real auth/owner resolution

## Validation
- local build passed (`npm run build`)
- no diagnostics errors in modified files

## Risk
Low-medium: scoped to evaluate/report paths; improves security boundary and UX coherence without changing job state transitions.
