### PR TITLE
fix(flow1): restore one_page_summary artifact contract

### DIFF
--- a/app/api/evaluations/[jobId]/route.ts
+++ b/app/api/evaluations/[jobId]/route.ts
@@ -82,7 +82,7 @@ export async function GET(
       .from("evaluation_artifacts")
       .select("content")
       .eq("job_id", jobId)
-      .eq("artifact_type", "evaluation_result_v1")
+      .eq("artifact_type", "one_page_summary")
       .maybeSingle();
 
     if (artifactError) {

--- a/app/evaluate/[jobId]/report/page.tsx
+++ b/app/evaluate/[jobId]/report/page.tsx
@@ -5,9 +5,9 @@ import { useEffect, useState } from "react";
 
 /**
  * Canonical artifact type for Flow 1 one-page summary.
- * Governance: This page must reference the contract-defined artifact type.
+ * Governance: This must match ARTIFACT_TYPES.ONE_PAGE_SUMMARY in writeArtifact.ts.
  */
-const REPORT_ARTIFACT_TYPE = "evaluation_result_v1";
+const REPORT_ARTIFACT_TYPE = "one_page_summary";
 
 type Ok = {
   ok: true;


### PR DESCRIPTION
## Summary
- restore Flow 1 report-reader artifact query to canonical `one_page_summary`
- restore report page canonical constant `REPORT_ARTIFACT_TYPE` to `one_page_summary`
- align reader behavior with `ARTIFACT_TYPES.ONE_PAGE_SUMMARY` contract test

## Why
`main` was failing `__tests__/artifact-type-contract.test.ts` in CI after the reader switched to `evaluation_result_v1` while the canonical Flow 1 artifact contract still requires `one_page_summary`.

## Validation
- `npm test -- __tests__/artifact-type-contract.test.ts --runInBand` ✅

## Notes
- This hotfix is intentionally minimal and scoped to contract restoration.
- Known deferred Supabase credential failures remain documented in `docs/CREDENTIAL_CLOSURE_DECISION_2026-04-04.md`.
