### PR TITLE
feat(finalizer-store): add authoritative read paths for finalizer artifacts

### DIFF
--- a/lib/jobs/invariants.ts
+++ b/lib/jobs/invariants.ts
@@ -136,6 +136,16 @@ export function enforceAnchorIntegrity(
             `Pass ${artifact.pass_id} criterion ${criterion.criterion_id}: phantom anchor`,
           );
         }
+        if (
+          anchor.start_offset !== null
+          && anchor.end_offset !== null
+          && anchor.end_offset < anchor.start_offset
+        ) {
+          throw new InvariantViolation(
+            "ANCHOR_CONTRACT_VIOLATION",
+            `Pass ${artifact.pass_id} criterion ${criterion.criterion_id}: invalid anchor offsets`,
+          );
+        }
       }
     }
   }

--- a/lib/jobs/store.finalizer.ts
+++ b/lib/jobs/store.finalizer.ts
@@ -7,21 +7,24 @@ import type {
   JobAuditEvent,
   PassArtifact,
 } from "./finalize.types";
+import { JOB_STATUS, type JobStatus } from "./types";
 
 const FINALIZER_JOB_SELECT_FIELDS = [
   "id",
   "status",
+  "phase",
   "created_at",
   "updated_at",
   "last_error",
   "manuscript_id",
   "attempt_count",
+  "next_retry_at",
   "next_attempt_at",
   "manuscripts(user_id)",
   "progress",
 ].join(", ");
 
-const ARTIFACT_SELECT_FIELDS = "id, job_id, artifact_type, content, artifact_payload";
+const ARTIFACT_SELECT_FIELDS = "id, job_id, artifact_type, content";
 
 type SupabaseLike = NonNullable<ReturnType<typeof createAdminClient>>;
 
@@ -66,8 +69,33 @@ function extractOwnerUserId(row: any): string {
   return ownerUserId;
 }
 
+function parseJobStatus(value: unknown, jobId: string): JobStatus {
+  switch (value) {
+    case JOB_STATUS.QUEUED:
+    case JOB_STATUS.RUNNING:
+    case JOB_STATUS.COMPLETE:
+    case JOB_STATUS.FAILED:
+      return value;
+    default:
+      throw new Error(
+        `[FINALIZER-STORE] Unsupported job status '${String(value)}' for job ${jobId}`,
+      );
+  }
+}
+
+function requireTimestamp(value: unknown, fieldName: "created_at" | "updated_at", jobId: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `[FINALIZER-STORE] Job ${jobId} missing required ${fieldName} timestamp`,
+    );
+  }
+
+  return value;
+}
+
 function mapRowToFinalizerJob(row: any): EvaluationJob {
   const progress = row?.progress && typeof row.progress === "object" ? row.progress : {};
+  const jobId = String(row?.id ?? "(unknown)");
   const jobPhase =
     typeof row?.phase === "string"
       ? row.phase
@@ -110,9 +138,9 @@ function mapRowToFinalizerJob(row: any): EvaluationJob {
     ?? null;
 
   return {
-    id: String(row.id),
+    id: jobId,
     user_id: extractOwnerUserId(row),
-    status: String(row.status) as EvaluationJob["status"],
+    status: parseJobStatus(row?.status, jobId),
     phase: canonicalPhase,
     progress_percent:
       typeof row?.progress_percent === "number"
@@ -169,8 +197,8 @@ function mapRowToFinalizerJob(row: any): EvaluationJob {
       ?? (typeof progress?.summary_artifact_id === "string"
         ? progress.summary_artifact_id
         : null),
-    created_at: String(row.created_at ?? new Date().toISOString()),
-    updated_at: String(row.updated_at ?? new Date().toISOString()),
+    created_at: requireTimestamp(row?.created_at, "created_at", jobId),
+    updated_at: requireTimestamp(row?.updated_at, "updated_at", jobId),
     terminal_at:
       typeof row?.terminal_at === "string"
         ? row.terminal_at
@@ -180,7 +208,6 @@ function mapRowToFinalizerJob(row: any): EvaluationJob {
 
 function readArtifactPayload(row: any): unknown {
   if (row?.content !== undefined && row?.content !== null) return row.content;
-  if (row?.artifact_payload !== undefined && row?.artifact_payload !== null) return row.artifact_payload;
   throw new Error(
     `[FINALIZER-STORE] Artifact ${row?.id ?? "(unknown)"} missing content payload`,
   );

--- a/lib/jobs/store.finalizer.ts
+++ b/lib/jobs/store.finalizer.ts
@@ -260,7 +260,7 @@ export async function getPassArtifactById(artifactId: string): Promise<PassArtif
       `[FINALIZER-STORE] Pass artifact ${artifactId} failed schema validation: ${parsed.error.message}`,
     );
   }
-  return parsed.data;
+  return parsed.data as PassArtifact;
 }
 
 export async function getConvergenceArtifactById(
@@ -274,7 +274,7 @@ export async function getConvergenceArtifactById(
       `[FINALIZER-STORE] Convergence artifact ${artifactId} failed schema validation: ${parsed.error.message}`,
     );
   }
-  return parsed.data;
+  return parsed.data as ConvergenceArtifact;
 }
 
 export async function writeJobAuditEvent(

--- a/lib/jobs/store.finalizer.ts
+++ b/lib/jobs/store.finalizer.ts
@@ -1,0 +1,270 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ConvergenceArtifactSchema } from "@/schemas/convergence-artifact-v1";
+import { PassArtifactSchema } from "@/schemas/pass-artifact-v1";
+import type {
+  ConvergenceArtifact,
+  EvaluationJob,
+  JobAuditEvent,
+  PassArtifact,
+} from "./finalize.types";
+
+const FINALIZER_JOB_SELECT_FIELDS = [
+  "id",
+  "status",
+  "created_at",
+  "updated_at",
+  "last_error",
+  "manuscript_id",
+  "attempt_count",
+  "next_attempt_at",
+  "manuscripts(user_id)",
+  "progress",
+].join(", ");
+
+const ARTIFACT_SELECT_FIELDS = "id, job_id, artifact_type, content, artifact_payload";
+
+type SupabaseLike = NonNullable<ReturnType<typeof createAdminClient>>;
+
+let _supabase: ReturnType<typeof createAdminClient> | undefined;
+
+export function __resetFinalizerStoreForTests(): void {
+  _supabase = undefined;
+}
+
+function getSupabase(): ReturnType<typeof createAdminClient> {
+  if (_supabase === undefined) {
+    _supabase = createAdminClient({ nullable: true });
+  }
+  return _supabase;
+}
+
+const supabase = new Proxy({} as SupabaseLike, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) {
+      throw new Error(
+        `[FINALIZER-STORE] Supabase unavailable - cannot access .${String(prop)}`,
+      );
+    }
+    return client[prop as keyof SupabaseLike];
+  },
+});
+
+function extractOwnerUserId(row: any): string {
+  const ownerUserId =
+    row?.manuscripts?.user_id
+    ?? (Array.isArray(row?.manuscripts) ? row.manuscripts[0]?.user_id : null)
+    ?? row?.user_id
+    ?? null;
+
+  if (typeof ownerUserId !== "string" || ownerUserId.length === 0) {
+    throw new Error(
+      `[FINALIZER-STORE] Missing ownership user_id for job ${row?.id ?? "(unknown)"}`,
+    );
+  }
+
+  return ownerUserId;
+}
+
+function mapRowToFinalizerJob(row: any): EvaluationJob {
+  const progress = row?.progress && typeof row.progress === "object" ? row.progress : {};
+  const jobPhase =
+    typeof row?.phase === "string"
+      ? row.phase
+      : typeof progress?.phase === "string"
+        ? progress.phase
+        : null;
+
+  // Fail closed: Finalizer requires explicit phase semantics.
+  if (!jobPhase) {
+    throw new Error(
+      `[FINALIZER-STORE] Job ${row?.id ?? "(unknown)"} missing phase required for finalization`,
+    );
+  }
+
+  const canonicalPhase = (() => {
+    switch (jobPhase) {
+      case "submit":
+      case "pass1":
+      case "pass2":
+      case "pass3":
+      case "convergence":
+      case "finalizer":
+      case "report":
+      case "done":
+        return jobPhase;
+      case "phase_1":
+        return "pass1";
+      case "phase_2":
+        return "pass2";
+      default:
+        throw new Error(
+          `[FINALIZER-STORE] Unsupported job phase '${jobPhase}' for finalizer mapping`,
+        );
+    }
+  })();
+
+  const nextRetryAt =
+    row?.next_retry_at
+    ?? row?.next_attempt_at
+    ?? null;
+
+  return {
+    id: String(row.id),
+    user_id: extractOwnerUserId(row),
+    status: String(row.status) as EvaluationJob["status"],
+    phase: canonicalPhase,
+    progress_percent:
+      typeof row?.progress_percent === "number"
+        ? row.progress_percent
+        : typeof progress?.progress_percent === "number"
+          ? progress.progress_percent
+          : 0,
+    submission_idempotency_key:
+      row?.submission_idempotency_key
+      ?? (typeof progress?.submission_idempotency_key === "string"
+        ? progress.submission_idempotency_key
+        : null),
+    claimed_by:
+      row?.claimed_by
+      ?? (typeof progress?.lease_id === "string" ? progress.lease_id : null),
+    lease_expires_at:
+      row?.lease_expires_at
+      ?? (typeof progress?.lease_expires_at === "string" ? progress.lease_expires_at : null),
+    attempt_count:
+      typeof row?.attempt_count === "number"
+        ? row.attempt_count
+        : 0,
+    next_retry_at:
+      typeof nextRetryAt === "string" ? nextRetryAt : null,
+    failure_code:
+      typeof row?.failure_code === "string"
+        ? row.failure_code
+        : null,
+    last_error:
+      typeof row?.last_error === "string"
+        ? row.last_error
+        : null,
+    pass1_artifact_id:
+      row?.pass1_artifact_id
+      ?? (typeof progress?.pass1_artifact_id === "string" ? progress.pass1_artifact_id : null),
+    pass2_artifact_id:
+      row?.pass2_artifact_id
+      ?? (typeof progress?.pass2_artifact_id === "string" ? progress.pass2_artifact_id : null),
+    pass3_artifact_id:
+      row?.pass3_artifact_id
+      ?? (typeof progress?.pass3_artifact_id === "string" ? progress.pass3_artifact_id : null),
+    convergence_artifact_id:
+      row?.convergence_artifact_id
+      ?? (typeof progress?.convergence_artifact_id === "string"
+        ? progress.convergence_artifact_id
+        : null),
+    canonical_artifact_id:
+      row?.canonical_artifact_id
+      ?? (typeof progress?.canonical_artifact_id === "string"
+        ? progress.canonical_artifact_id
+        : null),
+    summary_artifact_id:
+      row?.summary_artifact_id
+      ?? (typeof progress?.summary_artifact_id === "string"
+        ? progress.summary_artifact_id
+        : null),
+    created_at: String(row.created_at ?? new Date().toISOString()),
+    updated_at: String(row.updated_at ?? new Date().toISOString()),
+    terminal_at:
+      typeof row?.terminal_at === "string"
+        ? row.terminal_at
+        : null,
+  };
+}
+
+function readArtifactPayload(row: any): unknown {
+  if (row?.content !== undefined && row?.content !== null) return row.content;
+  if (row?.artifact_payload !== undefined && row?.artifact_payload !== null) return row.artifact_payload;
+  throw new Error(
+    `[FINALIZER-STORE] Artifact ${row?.id ?? "(unknown)"} missing content payload`,
+  );
+}
+
+async function getArtifactRowById(artifactId: string): Promise<any> {
+  const { data, error } = await supabase
+    .from("evaluation_artifacts")
+    .select(ARTIFACT_SELECT_FIELDS)
+    .eq("id", artifactId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(
+      `[FINALIZER-STORE] Failed artifact lookup ${artifactId}: ${error.message}`,
+    );
+  }
+
+  if (!data) {
+    throw new Error(`[FINALIZER-STORE] Artifact not found: ${artifactId}`);
+  }
+
+  return data;
+}
+
+export async function getJobForFinalization(jobId: string): Promise<EvaluationJob> {
+  const { data, error } = await supabase
+    .from("evaluation_jobs")
+    .select(FINALIZER_JOB_SELECT_FIELDS)
+    .eq("id", jobId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`[FINALIZER-STORE] Failed job lookup ${jobId}: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(`[FINALIZER-STORE] Job not found: ${jobId}`);
+  }
+
+  return mapRowToFinalizerJob(data);
+}
+
+export async function getPassArtifactById(artifactId: string): Promise<PassArtifact> {
+  const row = await getArtifactRowById(artifactId);
+  const payload = readArtifactPayload(row);
+  const parsed = PassArtifactSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(
+      `[FINALIZER-STORE] Pass artifact ${artifactId} failed schema validation: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function getConvergenceArtifactById(
+  artifactId: string,
+): Promise<ConvergenceArtifact> {
+  const row = await getArtifactRowById(artifactId);
+  const payload = readArtifactPayload(row);
+  const parsed = ConvergenceArtifactSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error(
+      `[FINALIZER-STORE] Convergence artifact ${artifactId} failed schema validation: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function writeJobAuditEvent(
+  event: Omit<JobAuditEvent, "id" | "created_at">,
+): Promise<void> {
+  const { error } = await supabase
+    .from("evaluation_job_audit_events")
+    .insert({
+      job_id: event.job_id,
+      event_type: event.event_type,
+      actor_id: event.actor_id,
+      failure_code: event.failure_code,
+      message: event.message,
+      metadata: event.metadata,
+    });
+
+  if (error) {
+    throw new Error(`[FINALIZER-STORE] Failed to write audit event: ${error.message}`);
+  }
+}

--- a/schemas/canonical-evaluation-artifact-v1.ts
+++ b/schemas/canonical-evaluation-artifact-v1.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { CriterionAssessmentSchema } from './pass-artifact-v1';
+
+export const EligibilityBlockSchema = z.object({
+  structural_pass: z.boolean(),
+  refinement_unlocked: z.boolean(),
+  wave_unlocked: z.boolean(),
+  submission_packaging_unlocked: z.boolean(),
+  reason: z.string().nullable(),
+});
+
+export const CanonicalEvaluationArtifactSchema = z
+  .object({
+    id: z.string().min(1),
+    job_id: z.string().min(1),
+    schema_version: z.literal('canonical-evaluation-artifact-v1'),
+    generated_at: z.string().datetime(),
+    source: z.object({
+      pass1_artifact_id: z.string().min(1),
+      pass2_artifact_id: z.string().min(1),
+      pass3_artifact_id: z.string().min(1),
+      convergence_artifact_id: z.string().min(1),
+    }),
+    overview: z.object({
+      overall_score_0_100: z.number().min(0).max(100),
+      verdict: z.string().min(1),
+      one_paragraph_summary: z.string().min(1),
+      top_strengths: z.array(z.string()),
+      top_risks: z.array(z.string()),
+    }),
+    criteria: z.array(CriterionAssessmentSchema).min(1),
+    governance: z.object({
+      confidence_0_1: z.number().min(0).max(1),
+      warnings: z.array(z.string()),
+      limitations: z.array(z.string()),
+      transparency_passed: z.boolean(),
+      anchor_contract_passed: z.boolean(),
+      canonical_ready: z.boolean(),
+    }),
+    eligibility: EligibilityBlockSchema,
+    provenance: z.object({
+      evaluator_version: z.string().min(1),
+      prompt_pack_version: z.string().nullable(),
+      run_id: z.string().min(1),
+      finalizer_version: z.string().min(1),
+    }),
+  })
+  .superRefine((value, ctx) => {
+    const ids = [
+      value.source.pass1_artifact_id,
+      value.source.pass2_artifact_id,
+      value.source.pass3_artifact_id,
+    ];
+    if (new Set(ids).size !== 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'pass artifact ids must remain distinct',
+        path: ['source'],
+      });
+    }
+
+    if (!value.governance.canonical_ready) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'canonical artifact must be canonical_ready=true',
+        path: ['governance', 'canonical_ready'],
+      });
+    }
+  });
+
+export type CanonicalEvaluationArtifact = z.infer<typeof CanonicalEvaluationArtifactSchema>;

--- a/schemas/convergence-artifact-v1.ts
+++ b/schemas/convergence-artifact-v1.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { CriterionAssessmentSchema } from './pass-artifact-v1';
+
+export const ConvergenceArtifactSchema = z.object({
+  id: z.string().min(1),
+  job_id: z.string().min(1),
+  schema_version: z.literal('convergence-artifact-v1'),
+  generated_at: z.string().datetime(),
+  inputs: z.object({
+    pass1_artifact_id: z.string().min(1),
+    pass2_artifact_id: z.string().min(1),
+    pass3_artifact_id: z.string().min(1),
+  }),
+  merged_criteria: z.array(CriterionAssessmentSchema).min(1),
+  overview_summary: z.string().min(1),
+  convergence_notes: z.array(z.string()),
+  conflicts_detected: z.array(z.string()),
+  conflicts_resolved: z.array(z.string()),
+  validations: z.object({
+    schema_valid: z.literal(true),
+    pass_separation_preserved: z.boolean(),
+    all_required_passes_present: z.boolean(),
+    anchor_contract_valid: z.boolean(),
+  }),
+});
+
+export type ConvergenceArtifact = z.infer<typeof ConvergenceArtifactSchema>;

--- a/schemas/pass-artifact-v1.ts
+++ b/schemas/pass-artifact-v1.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+export const EvidenceAnchorSchema = z
+  .object({
+    anchor_id: z.string().min(1),
+    source_type: z.enum(['manuscript_chunk', 'manuscript_span', 'criterion_note']),
+    source_ref: z.string().min(1),
+    start_offset: z.number().int().nonnegative().nullable(),
+    end_offset: z.number().int().nonnegative().nullable(),
+    excerpt: z.string().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.start_offset !== null
+      && value.end_offset !== null
+      && value.end_offset < value.start_offset
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'end_offset cannot be less than start_offset',
+        path: ['end_offset'],
+      });
+    }
+  });
+
+export const CriterionAssessmentSchema = z.object({
+  criterion_id: z.string().min(1),
+  score_0_10: z.number().min(0).max(10),
+  rationale: z.string().min(1),
+  confidence_0_1: z.number().min(0).max(1),
+  evidence: z.array(EvidenceAnchorSchema),
+  warnings: z.array(z.string()),
+});
+
+export const PassArtifactSchema = z
+  .object({
+    id: z.string().min(1),
+    job_id: z.string().min(1),
+    pass_id: z.enum(['pass1', 'pass2', 'pass3']),
+    schema_version: z.literal('pass-artifact-v1'),
+    manuscript_revision_id: z.string().min(1),
+    generated_at: z.string().datetime(),
+    summary: z.string().min(1),
+    criteria: z.array(CriterionAssessmentSchema).min(1),
+    provenance: z.object({
+      evaluator_version: z.string().min(1),
+      prompt_pack_version: z.string().nullable(),
+      run_id: z.string().min(1),
+    }),
+    validations: z.object({
+      schema_valid: z.literal(true),
+      anchor_contract_valid: z.boolean(),
+      evidence_nonempty: z.boolean(),
+      orphan_reasoning_absent: z.boolean(),
+    }),
+  })
+  .superRefine((value, ctx) => {
+    for (const criterion of value.criteria) {
+      if (criterion.rationale.trim().length > 0 && criterion.evidence.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `criterion ${criterion.criterion_id} has rationale but no evidence`,
+          path: ['criteria'],
+        });
+      }
+    }
+  });
+
+export type PassArtifact = z.infer<typeof PassArtifactSchema>;

--- a/schemas/report-summary-v1.ts
+++ b/schemas/report-summary-v1.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const ReportSummaryProjectionSchema = z.object({
+  id: z.string().min(1),
+  job_id: z.string().min(1),
+  user_id: z.string().min(1),
+  canonical_artifact_id: z.string().min(1),
+  generated_at: z.string().datetime(),
+  overall_score_0_100: z.number().min(0).max(100),
+  verdict: z.string().min(1),
+  one_paragraph_summary: z.string().min(1),
+  top_3_strengths: z.array(z.string()),
+  top_3_risks: z.array(z.string()),
+  confidence_0_1: z.number().min(0).max(1),
+  warnings_count: z.number().int().nonnegative(),
+  structural_pass: z.boolean(),
+  refinement_unlocked: z.boolean(),
+  wave_unlocked: z.boolean(),
+  submission_packaging_unlocked: z.boolean(),
+});
+
+export type ReportSummaryProjection = z.infer<typeof ReportSummaryProjectionSchema>;

--- a/tests/jobs/failures.test.ts
+++ b/tests/jobs/failures.test.ts
@@ -1,0 +1,24 @@
+import {
+  assertValidFailureCode,
+  isNonTransientFailure,
+  isTransientFailure,
+} from '@/lib/jobs/failures';
+
+describe('failure taxonomy', () => {
+  test('recognizes transient codes narrowly', () => {
+    expect(isTransientFailure('TRANSIENT_NETWORK')).toBe(true);
+    expect(isTransientFailure('TRANSIENT_UPSTREAM')).toBe(true);
+    expect(isTransientFailure('RATE_LIMITED')).toBe(true);
+    expect(isTransientFailure('SCHEMA_ERROR')).toBe(false);
+  });
+
+  test('recognizes non-transient codes', () => {
+    expect(isNonTransientFailure('SCHEMA_ERROR')).toBe(true);
+    expect(isNonTransientFailure('GOVERNANCE_BLOCK')).toBe(true);
+    expect(isNonTransientFailure('ANCHOR_CONTRACT_VIOLATION')).toBe(true);
+  });
+
+  test('rejects invalid failure codes', () => {
+    expect(() => assertValidFailureCode('NOT_REAL')).toThrow();
+  });
+});

--- a/tests/jobs/finalize.test.ts
+++ b/tests/jobs/finalize.test.ts
@@ -1,0 +1,269 @@
+import { finalizeJob, type FinalizerStorage } from '@/lib/jobs/finalize';
+import type {
+  ConvergenceArtifact,
+  EvaluationJob,
+  PassArtifact,
+} from '@/lib/jobs/finalize.types';
+
+function makePass(passId: 'pass1' | 'pass2' | 'pass3', id: string): PassArtifact {
+  return {
+    id,
+    job_id: 'job-1',
+    pass_id: passId,
+    schema_version: 'pass-artifact-v1',
+    manuscript_revision_id: 'rev-1',
+    generated_at: new Date().toISOString(),
+    summary: `${passId} summary`,
+    criteria: [
+      {
+        criterion_id: 'structure',
+        score_0_10: 8,
+        rationale: 'Supported by evidence.',
+        confidence_0_1: 0.8,
+        evidence: [
+          {
+            anchor_id: `${id}-a1`,
+            source_type: 'manuscript_chunk',
+            source_ref: 'chunk-1',
+            start_offset: 10,
+            end_offset: 25,
+            excerpt: 'Example excerpt',
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    provenance: {
+      evaluator_version: 'eval-v1',
+      prompt_pack_version: 'pack-v1',
+      run_id: 'run-1',
+    },
+    validations: {
+      schema_valid: true,
+      anchor_contract_valid: true,
+      evidence_nonempty: true,
+      orphan_reasoning_absent: true,
+    },
+  };
+}
+
+function makeConvergence(): ConvergenceArtifact {
+  return {
+    id: 'conv-1',
+    job_id: 'job-1',
+    schema_version: 'convergence-artifact-v1',
+    generated_at: new Date().toISOString(),
+    inputs: {
+      pass1_artifact_id: 'p1',
+      pass2_artifact_id: 'p2',
+      pass3_artifact_id: 'p3',
+    },
+    merged_criteria: [
+      {
+        criterion_id: 'structure',
+        score_0_10: 8,
+        rationale: 'Merged rationale.',
+        confidence_0_1: 0.85,
+        evidence: [
+          {
+            anchor_id: 'conv-a1',
+            source_type: 'manuscript_chunk',
+            source_ref: 'chunk-1',
+            start_offset: 10,
+            end_offset: 25,
+            excerpt: 'Merged excerpt',
+          },
+        ],
+        warnings: [],
+      },
+    ],
+    overview_summary: 'Overall convergence summary.',
+    convergence_notes: [],
+    conflicts_detected: [],
+    conflicts_resolved: [],
+    validations: {
+      schema_valid: true,
+      pass_separation_preserved: true,
+      all_required_passes_present: true,
+      anchor_contract_valid: true,
+    },
+  };
+}
+
+function makeJob(): EvaluationJob {
+  return {
+    id: 'job-1',
+    user_id: 'user-1',
+    status: 'running',
+    phase: 'finalizer',
+    progress_percent: 95,
+    submission_idempotency_key: 'idem-1',
+    claimed_by: 'worker-1',
+    lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+    attempt_count: 0,
+    next_retry_at: null,
+    failure_code: null,
+    last_error: null,
+    pass1_artifact_id: 'p1',
+    pass2_artifact_id: 'p2',
+    pass3_artifact_id: 'p3',
+    convergence_artifact_id: 'conv-1',
+    canonical_artifact_id: null,
+    summary_artifact_id: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    terminal_at: null,
+  };
+}
+
+function makeStorage(): jest.Mocked<FinalizerStorage> {
+  const pass1 = makePass('pass1', 'p1');
+  const pass2 = makePass('pass2', 'p2');
+  const pass3 = makePass('pass3', 'p3');
+  const convergence = makeConvergence();
+
+  return {
+    getJob: jest.fn(async () => makeJob()),
+    getPassArtifact: jest.fn(async (id: string) => {
+      if (id === 'p1') return pass1;
+      if (id === 'p2') return pass2;
+      if (id === 'p3') return pass3;
+      return null;
+    }),
+    getConvergenceArtifact: jest.fn(async () => convergence),
+    persistCanonicalArtifact: jest.fn(async () => 'canon-1'),
+    persistSummaryProjection: jest.fn(async () => 'summary-1'),
+    markJobComplete: jest.fn(async () => undefined),
+    markJobFailed: jest.fn(async () => undefined),
+  };
+}
+
+describe('finalizeJob', () => {
+  test('completes a valid finalizer path', async () => {
+    const storage = makeStorage();
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(storage.persistCanonicalArtifact).toHaveBeenCalledTimes(1);
+    expect(storage.persistSummaryProjection).toHaveBeenCalledTimes(1);
+    expect(storage.markJobComplete).toHaveBeenCalledTimes(1);
+    expect(storage.markJobFailed).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when a required pass artifact reference is missing', async () => {
+    const storage = makeStorage();
+    storage.getJob.mockResolvedValueOnce({
+      ...makeJob(),
+      pass2_artifact_id: null,
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure_code).toBe('MISSING_PASS_ARTIFACT');
+    }
+    expect(storage.markJobFailed).toHaveBeenCalledTimes(1);
+  });
+
+  test('fails closed when pass artifacts collapse', async () => {
+    const storage = makeStorage();
+    storage.getConvergenceArtifact.mockResolvedValueOnce({
+      ...makeConvergence(),
+      inputs: {
+        pass1_artifact_id: 'p1',
+        pass2_artifact_id: 'p1',
+        pass3_artifact_id: 'p3',
+      },
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure_code).toBe('PASS_CONVERGENCE_FAILURE');
+    }
+  });
+
+  test('fails closed on anchor violation', async () => {
+    const storage = makeStorage();
+    const badPass = makePass('pass1', 'p1');
+    badPass.criteria[0].evidence[0].start_offset = 30;
+    badPass.criteria[0].evidence[0].end_offset = 20;
+
+    storage.getPassArtifact.mockImplementation(async (id: string) => {
+      if (id === 'p1') return badPass;
+      if (id === 'p2') return makePass('pass2', 'p2');
+      if (id === 'p3') return makePass('pass3', 'p3');
+      return null;
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure_code).toBe('ANCHOR_CONTRACT_VIOLATION');
+    }
+  });
+
+  test('fails closed on orphan reasoning', async () => {
+    const storage = makeStorage();
+    const badPass = makePass('pass1', 'p1');
+    badPass.validations.orphan_reasoning_absent = false;
+
+    storage.getPassArtifact.mockImplementation(async (id: string) => {
+      if (id === 'p1') return badPass;
+      if (id === 'p2') return makePass('pass2', 'p2');
+      if (id === 'p3') return makePass('pass3', 'p3');
+      return null;
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure_code).toBe('GOVERNANCE_BLOCK');
+    }
+  });
+});

--- a/tests/jobs/store.finalizer.test.ts
+++ b/tests/jobs/store.finalizer.test.ts
@@ -3,6 +3,7 @@ import {
   getConvergenceArtifactById,
   getJobForFinalization,
   getPassArtifactById,
+  writeJobAuditEvent,
 } from "@/lib/jobs/store.finalizer";
 
 jest.mock("@/lib/supabase/admin");
@@ -14,8 +15,12 @@ function makeSupabaseMock(options: {
   jobRow?: any;
   artifactRow?: any;
   error?: { message: string } | null;
+  insertError?: { message: string } | null;
 }) {
+  const insert = jest.fn(async () => ({ error: options.insertError ?? options.error ?? null }));
+
   return {
+    insert,
     from: jest.fn((table: string) => {
       if (table === "evaluation_jobs") {
         return {
@@ -43,9 +48,13 @@ function makeSupabaseMock(options: {
         };
       }
 
-      return {
-        insert: jest.fn(async () => ({ error: options.error ?? null })),
-      };
+      if (table === "evaluation_job_audit_events") {
+        return {
+          insert,
+        };
+      }
+
+      throw new Error(`Unexpected table access in test: ${table}`);
     }),
   };
 }
@@ -84,8 +93,48 @@ describe("store.finalizer read paths", () => {
 
     expect(job.id).toBe("job-1");
     expect(job.user_id).toBe("user-1");
+    expect(job.status).toBe("running");
     expect(job.phase).toBe("finalizer");
     expect(job.claimed_by).toBe("worker-1");
+  });
+
+  test("fails closed on unsupported job status", async () => {
+    const supabaseMock = makeSupabaseMock({
+      jobRow: {
+        id: "job-1",
+        status: "retry_pending",
+        phase: "phase_1",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        manuscripts: { user_id: "user-1" },
+        progress: {},
+      },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    await expect(getJobForFinalization("job-1")).rejects.toThrow(
+      /unsupported job status/i,
+    );
+  });
+
+  test("fails closed when created_at is missing", async () => {
+    const supabaseMock = makeSupabaseMock({
+      jobRow: {
+        id: "job-1",
+        status: "running",
+        phase: "phase_1",
+        updated_at: new Date().toISOString(),
+        manuscripts: { user_id: "user-1" },
+        progress: {},
+      },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    await expect(getJobForFinalization("job-1")).rejects.toThrow(
+      /missing required created_at timestamp/i,
+    );
   });
 
   test("parses pass artifact payload from evaluation_artifacts", async () => {
@@ -157,5 +206,49 @@ describe("store.finalizer read paths", () => {
     await expect(getConvergenceArtifactById("conv-1")).rejects.toThrow(
       /failed schema validation/i,
     );
+  });
+
+  test("writes audit events with canonical insert payload", async () => {
+    const supabaseMock = makeSupabaseMock({});
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    await writeJobAuditEvent({
+      job_id: "job-1",
+      event_type: "finalizer_started",
+      actor_id: "worker-1",
+      failure_code: null,
+      message: "Finalizer entered",
+      metadata: { phase: "finalizer" },
+    });
+
+    expect(supabaseMock.from).toHaveBeenCalledWith("evaluation_job_audit_events");
+    expect(supabaseMock.insert).toHaveBeenCalledWith({
+      job_id: "job-1",
+      event_type: "finalizer_started",
+      actor_id: "worker-1",
+      failure_code: null,
+      message: "Finalizer entered",
+      metadata: { phase: "finalizer" },
+    });
+  });
+
+  test("surfaces audit write errors without masking them", async () => {
+    const supabaseMock = makeSupabaseMock({
+      insertError: { message: "insert denied" },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    await expect(
+      writeJobAuditEvent({
+        job_id: "job-1",
+        event_type: "finalizer_failed",
+        actor_id: null,
+        failure_code: null,
+        message: "boom",
+        metadata: {},
+      }),
+    ).rejects.toThrow(/failed to write audit event: insert denied/i);
   });
 });

--- a/tests/jobs/store.finalizer.test.ts
+++ b/tests/jobs/store.finalizer.test.ts
@@ -1,0 +1,161 @@
+import {
+  __resetFinalizerStoreForTests,
+  getConvergenceArtifactById,
+  getJobForFinalization,
+  getPassArtifactById,
+} from "@/lib/jobs/store.finalizer";
+
+jest.mock("@/lib/supabase/admin");
+
+const mockCreateAdminClient = require("@/lib/supabase/admin")
+  .createAdminClient as jest.Mock;
+
+function makeSupabaseMock(options: {
+  jobRow?: any;
+  artifactRow?: any;
+  error?: { message: string } | null;
+}) {
+  return {
+    from: jest.fn((table: string) => {
+      if (table === "evaluation_jobs") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              maybeSingle: jest.fn(async () => ({
+                data: options.jobRow ?? null,
+                error: options.error ?? null,
+              })),
+            })),
+          })),
+        };
+      }
+
+      if (table === "evaluation_artifacts") {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              maybeSingle: jest.fn(async () => ({
+                data: options.artifactRow ?? null,
+                error: options.error ?? null,
+              })),
+            })),
+          })),
+        };
+      }
+
+      return {
+        insert: jest.fn(async () => ({ error: options.error ?? null })),
+      };
+    }),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetFinalizerStoreForTests();
+});
+
+describe("store.finalizer read paths", () => {
+  test("maps job row into finalizer job shape", async () => {
+    const supabaseMock = makeSupabaseMock({
+      jobRow: {
+        id: "job-1",
+        status: "running",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        last_error: null,
+        progress: {
+          phase: "finalizer",
+          lease_id: "worker-1",
+          lease_expires_at: new Date(Date.now() + 60_000).toISOString(),
+          pass1_artifact_id: "p1",
+          pass2_artifact_id: "p2",
+          pass3_artifact_id: "p3",
+          convergence_artifact_id: "conv-1",
+        },
+        manuscripts: { user_id: "user-1" },
+        attempt_count: 0,
+      },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    const job = await getJobForFinalization("job-1");
+
+    expect(job.id).toBe("job-1");
+    expect(job.user_id).toBe("user-1");
+    expect(job.phase).toBe("finalizer");
+    expect(job.claimed_by).toBe("worker-1");
+  });
+
+  test("parses pass artifact payload from evaluation_artifacts", async () => {
+    const supabaseMock = makeSupabaseMock({
+      artifactRow: {
+        id: "p1",
+        content: {
+          id: "p1",
+          job_id: "job-1",
+          pass_id: "pass1",
+          schema_version: "pass-artifact-v1",
+          manuscript_revision_id: "rev-1",
+          generated_at: new Date().toISOString(),
+          summary: "pass summary",
+          criteria: [
+            {
+              criterion_id: "structure",
+              score_0_10: 8,
+              rationale: "rationale",
+              confidence_0_1: 0.7,
+              evidence: [
+                {
+                  anchor_id: "a1",
+                  source_type: "manuscript_chunk",
+                  source_ref: "chunk-1",
+                  start_offset: 10,
+                  end_offset: 20,
+                  excerpt: "text",
+                },
+              ],
+              warnings: [],
+            },
+          ],
+          provenance: {
+            evaluator_version: "eval-v1",
+            prompt_pack_version: "pack-v1",
+            run_id: "run-1",
+          },
+          validations: {
+            schema_valid: true,
+            anchor_contract_valid: true,
+            evidence_nonempty: true,
+            orphan_reasoning_absent: true,
+          },
+        },
+      },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    const artifact = await getPassArtifactById("p1");
+    expect(artifact.id).toBe("p1");
+    expect(artifact.pass_id).toBe("pass1");
+  });
+
+  test("fails closed on invalid convergence artifact payload", async () => {
+    const supabaseMock = makeSupabaseMock({
+      artifactRow: {
+        id: "conv-1",
+        content: {
+          id: "conv-1",
+          // missing required fields intentionally
+        },
+      },
+    });
+
+    mockCreateAdminClient.mockReturnValue(supabaseMock);
+
+    await expect(getConvergenceArtifactById("conv-1")).rejects.toThrow(
+      /failed schema validation/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds **fail-closed Finalizer read paths only**, hardened against schema drift and invented runtime state.

It introduces authoritative persistence helpers for:
- `getJobForFinalization(jobId)`
- `getPassArtifactById(artifactId)`
- `getConvergenceArtifactById(artifactId)`
- `writeJobAuditEvent(...)`

## Why
Finalizer must read persisted truth and reject malformed/incomplete state before business logic proceeds. This slice enforces that boundary without introducing write-authority or report-route changes.

## Changes
- Added `lib/jobs/store.finalizer.ts`
  - lazy admin Supabase access with explicit unavailable-client failure
  - `evaluation_jobs` lookup + strict mapping to `EvaluationJob`
  - runtime validation of canonical job status (`queued | running | complete | failed`)
  - explicit `phase` / `next_retry_at` selection and mapping
  - timestamp fail-closed checks (no fabricated `created_at` / `updated_at`)
  - `evaluation_artifacts` lookup by id using durable `content` payload
  - Zod validation via:
    - `PassArtifactSchema`
    - `ConvergenceArtifactSchema`
  - audit write helper for `evaluation_job_audit_events`
- Added `tests/jobs/store.finalizer.test.ts`
  - job row mapping sanity
  - unsupported status fail-closed
  - missing timestamp fail-closed
  - pass artifact parse success
  - convergence artifact invalid payload fail-closed
  - audit insert shape verification
  - audit write error surfacing

## Fail-Closed Guarantees
- Missing Supabase client => explicit throw
- Missing job/artifact => explicit throw
- Missing artifact `content` => explicit throw
- Unsupported job status => explicit throw
- Missing required timestamps => explicit throw
- Invalid pass/convergence payload => explicit throw with schema details
- Audit insert errors => explicit throw

## Test Evidence
Targeted suites green:
- `tests/jobs/store.finalizer.test.ts` (7 passed)
- `tests/jobs/finalize.test.ts` (5 passed)
- `tests/jobs/failures.test.ts` (3 passed)

Total in focused bundle: **15/15 passing**.

## Scope Discipline
This PR does **not** include:
- transactional completion writes
- report-route gating
- DB migrations
- CI workflow edits

Those remain for follow-up persistence slices.
