### PR TITLE
fix(execution-boundary): decouple Phase 2 route from synchronous processor execution

### DIFF
--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -9,7 +9,33 @@ type Params = Promise<{ jobId: string }>;
 
 /**
  * POST /api/jobs/[jobId]/run-phase2
- * INTERNAL ONLY: Service role auth required
+ * INTERNAL ONLY: Service role auth required.
+ *
+ * ─────────────────────────────────────────────────────────────────────
+ * EXECUTION BOUNDARY CONTRACT
+ * ─────────────────────────────────────────────────────────────────────
+ *
+ * This route is a TRIGGER SURFACE only. It does NOT execute the
+ * evaluation pipeline synchronously inside the HTTP request.
+ *
+ * Responsibilities of this route:
+ *   1. Auth gate (service role only)
+ *   2. Job existence + eligibility guard
+ *   3. Optional requeue on force=1
+ *   4. Claim the job (status=running, trigger metadata written)
+ *   5. Fire processEvaluationJob() in a detached async context
+ *   6. Return {ok: true, status: "triggered"} immediately
+ *
+ * Responsibilities that belong ONLY to processEvaluationJob():
+ *   - All AI execution (Pass 1/2/3/4)
+ *   - Artifact persistence
+ *   - status=complete or status=failed writes
+ *
+ * Rationale: Binding deep AI work to the HTTP request lifecycle means
+ * any Vercel timeout or crash before artifact persistence leaves the
+ * job in a dark state. Decoupling ensures durable truth is written
+ * by the processor regardless of HTTP lifecycle events.
+ * ─────────────────────────────────────────────────────────────────────
  */
 export async function POST(req: NextRequest, ctx: { params: Params }) {
   // GOVERNANCE: Service role only (internal/daemon use)
@@ -59,19 +85,55 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
     }
   }
 
-  console.log("Phase2Started", { job_id: jobId });
+  // Claim the job: write trigger metadata before firing processor.
+  // This ensures durable truth exists even if the detached path fails
+  // before processEvaluationJob() writes its first status update.
+  const triggerTime = new Date().toISOString();
+  const { error: claimError } = await supabase
+    .from("evaluation_jobs")
+    .update({
+      phase: "phase_1",
+      phase_status: "triggered",
+      last_error: null,
+      updated_at: triggerTime,
+    })
+    .eq("id", jobId)
+    .eq("status", "queued"); // idempotent guard: only claim if still queued
 
-  const result = await processEvaluationJob(jobId);
-  if (!result.success) {
+  if (claimError) {
     return NextResponse.json(
-      { ok: false, error: result.error || "Canonical phase2 execution failed" },
+      { ok: false, error: `Failed to claim job for execution: ${claimError.message}` },
       { status: 500 }
     );
   }
 
-  // GOVERNANCE: return explicit canonical completion truth
+  console.log("Phase2Triggered", { job_id: jobId, trigger_time: triggerTime });
+
+  // ── Fire and detach ───────────────────────────────────────────────────
+  // processEvaluationJob() owns all execution state from here.
+  // The HTTP response does NOT wait for completion.
+  // Any unhandled error in the detached path is caught and logged;
+  // the processor's internal markFailed() handles job state writes.
+  processEvaluationJob(jobId).catch((unexpectedError) => {
+    // This catch is a last-resort safety net for unexpected throws
+    // that escape the processor's own try/catch. The processor
+    // already writes failed state internally, so this is observability only.
+    console.error("Phase2UnexpectedError", {
+      job_id: jobId,
+      error: unexpectedError instanceof Error ? unexpectedError.message : String(unexpectedError),
+    });
+  });
+
+  // GOVERNANCE: return trigger acknowledgment, NOT completion truth.
+  // Callers must poll job status to determine completion.
   return NextResponse.json(
-    { ok: true, job_id: jobId, status: "complete", phase2: "canonical_pipeline_complete" },
-    { status: 200 }
+    {
+      ok: true,
+      job_id: jobId,
+      status: "triggered",
+      phase2: "canonical_pipeline_triggered",
+      message: "Evaluation pipeline started. Poll job status for completion.",
+    },
+    { status: 202 }
   );
 }


### PR DESCRIPTION
## Problem

`run-phase2/route.ts` was `await`ing `processEvaluationJob()` directly inside the POST handler. This bound deep AI evaluation work (Pass 1 → Pass 2 → Pass 3 → artifact persistence) to the HTTP request lifecycle on Vercel.

**Symptom:** Any Vercel function timeout, connection drop, or platform hard-kill before `upsertEvaluationArtifact()` completed left the job in a dark state — `status=running` forever with no durable truth written. The processor and pipeline were both correct; the execution surface was the problem.

## Root cause

The route was acting as the execution host, not a trigger surface. Vercel's serverless function timeout (10s on hobby, 60s on pro for sync functions) is far shorter than a full 3-pass AI pipeline run.

## Fix

### `app/api/jobs/[jobId]/run-phase2/route.ts` (only file changed)

**Before:**
```ts
const result = await processEvaluationJob(jobId);   // blocking — HTTP waits
return NextResponse.json({ ok: true, status: 'complete' }, { status: 200 });
```

**After:**
```ts
// 1. Claim the job first (idempotent guard: .eq('status', 'queued'))
supabase.from('evaluation_jobs').update({ phase_status: 'triggered' }).eq('id', jobId).eq('status', 'queued');

// 2. Fire and detach — HTTP does NOT wait for completion
processEvaluationJob(jobId).catch((unexpectedError) => {
  console.error('Phase2UnexpectedError', { job_id: jobId, error: ... });
});

// 3. Return 202 immediately — caller must poll for completion
return NextResponse.json({ ok: true, status: 'triggered', phase2: 'canonical_pipeline_triggered' }, { status: 202 });
```

## What did NOT change

- `processor.ts` — untouched. All execution authority, artifact persistence, `markFailed`, `markRunning`, completion state remain there.
- `runPipeline.ts` — untouched. Pass 1/2/3/4 independence guarantees unchanged.
- All governance, quality gate, lessons-learned enforcement unchanged.
- No database schema changes.

## Callers must update their expectation

The route now returns `202 Accepted` with `status: 'triggered'` instead of `200 OK` with `status: 'complete'`. Any caller (daemon, admin script, smoke test) that previously treated the HTTP response as proof of completion **must now poll** `GET /api/jobs/[jobId]` for `status=complete`.

## Governance

Route is now a trigger surface only. Execution authority lives exclusively in `processor.ts → runPipeline.ts`, which is the correct canonical chain per `AI_GOVERNANCE.md`.

---

**Files changed:** 1
**Risk level:** Low — processor and pipeline untouched; only the execution surface contract changes.
**Blocking next step:** Prove end-to-end with one clean run, then return to canon registry hardening.