### PR TITLE
Hardening: pass completion boundary diagnostics + Pass 3 prompt pressure reduction

### DIFF
--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -3,7 +3,7 @@
  *
  * Pass 3 reconciles Pass 1 (craft) and Pass 2 (editorial) outputs,
  * producing a unified dual-axis evaluation.
- * Temperature: 0.2.  Max tokens: 5000.
+ * Temperature: 0.2.  Max tokens: environment-tunable (default 9000).
  */
 
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
@@ -130,10 +130,10 @@ Execution mode: ${executionMode}
 ${buildCoverageDisclosure(coverage, "Pass 3 manuscript reference coverage")}
 
 ## PASS 1 OUTPUT (Craft Execution)
-${params.pass1Json.substring(0, 6000)}
+${params.pass1Json.substring(0, 4000)}
 
 ## PASS 2 OUTPUT (Editorial/Literary Insight)
-${params.pass2Json.substring(0, 6000)}
+${params.pass2Json.substring(0, 4000)}
 
 ## ORIGINAL MANUSCRIPT TEXT (for reference)
 ${promptWindow}

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -101,7 +101,7 @@ export type CreateCompletionFn = (params: {
   max_tokens?: number;
   max_completion_tokens?: number;
   response_format: { type: string };
-}) => Promise<{ choices: { message: { content: string | null } }[]; usage?: CompletionUsage }>;
+}) => Promise<{ choices: CompletionChoice[]; usage?: CompletionUsage }>;
 
 export interface RunPass1Options {
   manuscriptText: string;
@@ -205,7 +205,7 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
       params as Parameters<typeof openai.chat.completions.create>[0],
       { timeout: OPENAI_TIMEOUT_MS },
     ) as Promise<{
-      choices: { message: { content: string | null } }[];
+      choices: CompletionChoice[];
       usage?: CompletionUsage;
     }>;
 }

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -22,6 +22,76 @@ import {
 const PASS1_TEMPERATURE = 0.3;
 const PASS1_MAX_TOKENS = 4000;
 const PASS1_MODEL = "o3";
+const OPENAI_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "120000", 10);
+  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 120_000 ? parsed : 120_000;
+})();
+
+type CompletionChoice = {
+  message?: {
+    content?: unknown;
+    refusal?: unknown;
+  };
+  finish_reason?: unknown;
+};
+
+function extractResponseText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (typeof part !== "object" || part === null) {
+        return "";
+      }
+
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        return record.text;
+      }
+      if (typeof record.content === "string") {
+        return record.content;
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+}
+
+function buildEmptyResponseDiagnostic(params: {
+  model: string;
+  completion: { choices?: unknown; usage?: CompletionUsage };
+  firstChoice: CompletionChoice | undefined;
+  rawContent: unknown;
+}): string {
+  const { model, completion, firstChoice, rawContent } = params;
+  const usage = completion.usage;
+  const finishReason =
+    typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
+  const contentType =
+    rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent;
+  const refusal =
+    typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined;
+  const choiceCount = Array.isArray(completion.choices) ? completion.choices.length : 0;
+
+  return (
+    `[Pass1] Empty response from OpenAI ` +
+    `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
+    `max_output_tokens=${PASS1_MAX_TOKENS}` +
+    `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
+    `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
+    `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
+    `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""})`
+  );
+}
 
 /** Function signature for creating a chat completion (enables DI for testing). */
 export type CreateCompletionFn = (params: {
@@ -66,6 +136,8 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     executionMode: opts.executionMode,
   });
 
+  console.log(`[Pass1] completion request model=${selectedModel}`);
+
   const completion = await createCompletion({
     model: selectedModel,
     messages: [
@@ -77,9 +149,34 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     response_format: { type: "json_object" },
   });
 
-  const responseText = completion.choices[0]?.message?.content;
-  if (!responseText) {
-    throw new Error("[Pass1] Empty response from OpenAI");
+  const firstChoice = completion.choices?.[0] as CompletionChoice | undefined;
+  const rawContent = firstChoice?.message?.content;
+  const responseText = extractResponseText(rawContent);
+
+  if (responseText.trim().length === 0) {
+    const diagnosticMessage = buildEmptyResponseDiagnostic({
+      model: selectedModel,
+      completion,
+      firstChoice,
+      rawContent,
+    });
+
+    console.error("[Pass1] Completion boundary diagnostic", {
+      model: selectedModel,
+      hasChoices: Array.isArray((completion as { choices?: unknown }).choices),
+      choiceCount: Array.isArray((completion as { choices?: unknown[] }).choices)
+        ? (completion as { choices: unknown[] }).choices.length
+        : 0,
+      finishReason:
+        typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown",
+      contentType: rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent,
+      contentPreview: typeof rawContent === "string" ? rawContent.slice(0, 160) : undefined,
+      usage: completion.usage,
+      maxOutputTokens: PASS1_MAX_TOKENS,
+      refusal:
+        typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined,
+    });
+    throw new Error(diagnosticMessage);
   }
 
   opts._onCompletion?.({
@@ -102,9 +199,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass1] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 0 });
+  const openai = new OpenAI({ apiKey, maxRetries: 0, timeout: OPENAI_TIMEOUT_MS });
   return (params) =>
-    openai.chat.completions.create(params as Parameters<typeof openai.chat.completions.create>[0]) as Promise<{
+    openai.chat.completions.create(
+      params as Parameters<typeof openai.chat.completions.create>[0],
+      { timeout: OPENAI_TIMEOUT_MS },
+    ) as Promise<{
       choices: { message: { content: string | null } }[];
       usage?: CompletionUsage;
     }>;

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -24,6 +24,76 @@ import {
 const PASS2_TEMPERATURE = 0.3;
 const PASS2_MAX_TOKENS = 4000;
 const PASS2_MODEL = "o3";
+const OPENAI_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "120000", 10);
+  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 120_000 ? parsed : 120_000;
+})();
+
+type CompletionChoice = {
+  message?: {
+    content?: unknown;
+    refusal?: unknown;
+  };
+  finish_reason?: unknown;
+};
+
+function extractResponseText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (typeof part !== "object" || part === null) {
+        return "";
+      }
+
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        return record.text;
+      }
+      if (typeof record.content === "string") {
+        return record.content;
+      }
+      return "";
+    })
+    .join("")
+    .trim();
+}
+
+function buildEmptyResponseDiagnostic(params: {
+  model: string;
+  completion: { choices?: unknown; usage?: CompletionUsage };
+  firstChoice: CompletionChoice | undefined;
+  rawContent: unknown;
+}): string {
+  const { model, completion, firstChoice, rawContent } = params;
+  const usage = completion.usage;
+  const finishReason =
+    typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
+  const contentType =
+    rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent;
+  const refusal =
+    typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined;
+  const choiceCount = Array.isArray(completion.choices) ? completion.choices.length : 0;
+
+  return (
+    `[Pass2] Empty response from OpenAI ` +
+    `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
+    `max_output_tokens=${PASS2_MAX_TOKENS}` +
+    `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
+    `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
+    `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
+    `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""})`
+  );
+}
 
 /** Function signature for creating a chat completion (enables DI for testing). */
 export type CreateCompletionFn = (params: {
@@ -76,6 +146,8 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     executionMode: opts.executionMode,
   });
 
+  console.log(`[Pass2] completion request model=${selectedModel}`);
+
   const completion = await createCompletion({
     model: selectedModel,
     messages: [
@@ -87,9 +159,34 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     response_format: { type: "json_object" },
   });
 
-  const responseText = completion.choices[0]?.message?.content;
-  if (!responseText) {
-    throw new Error("[Pass2] Empty response from OpenAI");
+  const firstChoice = completion.choices?.[0] as CompletionChoice | undefined;
+  const rawContent = firstChoice?.message?.content;
+  const responseText = extractResponseText(rawContent);
+
+  if (responseText.trim().length === 0) {
+    const diagnosticMessage = buildEmptyResponseDiagnostic({
+      model: selectedModel,
+      completion,
+      firstChoice,
+      rawContent,
+    });
+
+    console.error("[Pass2] Completion boundary diagnostic", {
+      model: selectedModel,
+      hasChoices: Array.isArray((completion as { choices?: unknown }).choices),
+      choiceCount: Array.isArray((completion as { choices?: unknown[] }).choices)
+        ? (completion as { choices: unknown[] }).choices.length
+        : 0,
+      finishReason:
+        typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown",
+      contentType: rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent,
+      contentPreview: typeof rawContent === "string" ? rawContent.slice(0, 160) : undefined,
+      usage: completion.usage,
+      maxOutputTokens: PASS2_MAX_TOKENS,
+      refusal:
+        typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined,
+    });
+    throw new Error(diagnosticMessage);
   }
 
   opts._onCompletion?.({
@@ -112,9 +209,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass2] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 0 });
+  const openai = new OpenAI({ apiKey, maxRetries: 0, timeout: OPENAI_TIMEOUT_MS });
   return (params) =>
-    openai.chat.completions.create(params as Parameters<typeof openai.chat.completions.create>[0]) as Promise<{
+    openai.chat.completions.create(
+      params as Parameters<typeof openai.chat.completions.create>[0],
+      { timeout: OPENAI_TIMEOUT_MS },
+    ) as Promise<{
       choices: { message: { content: string | null } }[];
       usage?: CompletionUsage;
     }>;

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -103,7 +103,7 @@ export type CreateCompletionFn = (params: {
   max_tokens?: number;
   max_completion_tokens?: number;
   response_format: { type: string };
-}) => Promise<{ choices: { message: { content: string | null } }[]; usage?: CompletionUsage }>;
+}) => Promise<{ choices: CompletionChoice[]; usage?: CompletionUsage }>;
 
 export interface RunPass2Options {
   /**
@@ -215,7 +215,7 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
       params as Parameters<typeof openai.chat.completions.create>[0],
       { timeout: OPENAI_TIMEOUT_MS },
     ) as Promise<{
-      choices: { message: { content: string | null } }[];
+      choices: CompletionChoice[];
       usage?: CompletionUsage;
     }>;
 }

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -22,8 +22,89 @@ import {
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
 
 const PASS3_TEMPERATURE = 0.2;
-const PASS3_MAX_TOKENS = 5000;
+const PASS3_MAX_TOKENS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "9000", 10);
+  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 9000;
+})();
 const PASS3_MODEL = "o3";
+const OPENAI_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "120000", 10);
+  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 120_000 ? parsed : 120_000;
+})();
+
+type CompletionChoice = {
+  message?: {
+    content?: unknown;
+    refusal?: unknown;
+  };
+  finish_reason?: unknown;
+};
+
+function extractResponseText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (typeof part !== "object" || part === null) {
+        return "";
+      }
+
+      const record = part as Record<string, unknown>;
+      if (typeof record.text === "string") {
+        return record.text;
+      }
+
+      if (typeof record.content === "string") {
+        return record.content;
+      }
+
+      return "";
+    })
+    .join("")
+    .trim();
+}
+
+function buildEmptyResponseDiagnostic(params: {
+  model: string;
+  completion: { choices?: unknown; usage?: CompletionUsage };
+  firstChoice: CompletionChoice | undefined;
+  rawContent: unknown;
+  coverage: ReturnType<typeof summarizePromptCoverage>;
+  pass1Chars: number;
+  pass2Chars: number;
+}): string {
+  const { model, completion, firstChoice, rawContent, coverage, pass1Chars, pass2Chars } = params;
+  const usage = completion.usage;
+  const finishReason =
+    typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
+  const contentType =
+    rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent;
+  const refusal =
+    typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined;
+  const choiceCount = Array.isArray(completion.choices) ? completion.choices.length : 0;
+  const likelyBudgetPressure = finishReason === "length" ? " budget_exhausted_likely=true" : "";
+
+  return (
+    `[Pass3] Empty response from OpenAI ` +
+    `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
+    `max_output_tokens=${PASS3_MAX_TOKENS} pass1_chars=${pass1Chars} pass2_chars=${pass2Chars} ` +
+    `reference_chars=${coverage.analyzedChars} source_chars=${coverage.sourceChars}` +
+    `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
+    `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
+    `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
+    `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""}` +
+    `${likelyBudgetPressure})`
+  );
+}
 
 /** Function signature for creating a chat completion (enables DI for testing). */
 export type CreateCompletionFn = (params: {
@@ -62,9 +143,12 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
   const selectedModel = getCanonicalPipelineModel(opts.model ?? PASS3_MODEL);
 
+  const pass1Json = JSON.stringify(opts.pass1, null, 2);
+  const pass2Json = JSON.stringify(opts.pass2, null, 2);
+
   const userPrompt = buildPass3UserPrompt({
-    pass1Json: JSON.stringify(opts.pass1, null, 2),
-    pass2Json: JSON.stringify(opts.pass2, null, 2),
+    pass1Json,
+    pass2Json,
     manuscriptText: opts.manuscriptText,
     title: opts.title,
     executionMode: opts.executionMode,
@@ -73,6 +157,8 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   // Compute coverage metadata (for truth enforcement)
   const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
   const coverage = summarizePromptCoverage(opts.manuscriptText, synthesisBudget);
+
+  console.log(`[Pass3] completion request model=${selectedModel}`);
 
   const completion = await createCompletion({
     model: selectedModel,
@@ -85,9 +171,40 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     response_format: { type: "json_object" },
   });
 
-  const responseText = completion.choices[0]?.message?.content;
-  if (!responseText) {
-    throw new Error("[Pass3] Empty response from OpenAI");
+  const firstChoice = completion.choices?.[0] as CompletionChoice | undefined;
+  const rawContent = firstChoice?.message?.content;
+  const responseText = extractResponseText(rawContent);
+
+  if (responseText.trim().length === 0) {
+    const diagnosticMessage = buildEmptyResponseDiagnostic({
+      model: selectedModel,
+      completion,
+      firstChoice,
+      rawContent,
+      coverage,
+      pass1Chars: pass1Json.length,
+      pass2Chars: pass2Json.length,
+    });
+
+    console.error("[Pass3] Completion boundary diagnostic", {
+      model: selectedModel,
+      hasChoices: Array.isArray((completion as { choices?: unknown }).choices),
+      choiceCount: Array.isArray((completion as { choices?: unknown[] }).choices)
+        ? (completion as { choices: unknown[] }).choices.length
+        : 0,
+      finishReason:
+        typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown",
+      contentType: rawContent === null ? "null" : typeof rawContent,
+      contentPreview: typeof rawContent === "string" ? rawContent.slice(0, 160) : undefined,
+      usage: completion.usage,
+      pass1Chars: pass1Json.length,
+      pass2Chars: pass2Json.length,
+      promptCoverage: coverage,
+      maxOutputTokens: PASS3_MAX_TOKENS,
+      refusal:
+        typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined,
+    });
+    throw new Error(diagnosticMessage);
   }
 
   opts._onCompletion?.({
@@ -123,9 +240,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass3] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 0 });
+  const openai = new OpenAI({ apiKey, maxRetries: 0, timeout: OPENAI_TIMEOUT_MS });
   return (params) =>
-    openai.chat.completions.create(params as Parameters<typeof openai.chat.completions.create>[0]) as Promise<{
+    openai.chat.completions.create(
+      params as Parameters<typeof openai.chat.completions.create>[0],
+      { timeout: OPENAI_TIMEOUT_MS },
+    ) as Promise<{
       choices: { message: { content: string | null } }[];
       usage?: CompletionUsage;
     }>;

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -114,7 +114,7 @@ export type CreateCompletionFn = (params: {
   max_tokens?: number;
   max_completion_tokens?: number;
   response_format: { type: string };
-}) => Promise<{ choices: { message: { content: string | null } }[]; usage?: CompletionUsage }>;
+}) => Promise<{ choices: CompletionChoice[]; usage?: CompletionUsage }>;
 
 export interface RunPass3Options {
   pass1: SinglePassOutput;
@@ -246,7 +246,7 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
       params as Parameters<typeof openai.chat.completions.create>[0],
       { timeout: OPENAI_TIMEOUT_MS },
     ) as Promise<{
-      choices: { message: { content: string | null } }[];
+      choices: CompletionChoice[];
       usage?: CompletionUsage;
     }>;
 }

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -786,8 +786,21 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: `Job not found: ${jobError?.message}` };
     }
 
-    if (job.status !== 'queued') {
-      return { success: false, error: `Job status is ${job.status}, not queued` };
+    const progress =
+      job.progress && typeof job.progress === 'object'
+        ? (job.progress as Record<string, unknown>)
+        : {};
+
+    const isPhase1CompleteHandoff =
+      job.status === 'running' &&
+      (job.phase === 'phase_1' || progress.phase === 'phase_1') &&
+      (job.phase_status === 'complete' || progress.phase_status === 'complete');
+
+    if (job.status !== 'queued' && !isPhase1CompleteHandoff) {
+      return {
+        success: false,
+        error: `Job not eligible for processing. status=${job.status}, phase=${job.phase}, phase_status=${job.phase_status}`,
+      };
     }
 
     const progressState =
@@ -925,6 +938,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: missingCrossCheckConfigError };
     }
 
+    console.log(`[Processor] ${jobId}: ENTER runPipeline model=${getCanonicalPipelineModel(openAiModel)}`);
     const pipelineResult = await runPipeline({
       manuscriptText: manuscriptWithContent.content || '',
       workType: manuscriptWithContent.work_type || 'novel',
@@ -935,9 +949,16 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       manuscriptId: String(manuscriptWithContent.id),
       executionMode: 'TRUSTED_PATH',
     });
+    console.log(
+      `[Processor] ${jobId}: EXIT runPipeline ok=${pipelineResult.ok}` +
+        (pipelineResult.ok === false
+          ? ` failed_at=${pipelineResult.failed_at} code=${pipelineResult.error_code}`
+          : ''),
+    );
 
     if (pipelineResult.ok === false) {
       const pipelineError = `[Pipeline:${pipelineResult.failed_at}] ${pipelineResult.error_code} ${pipelineResult.error}`;
+      console.error(`[Processor] Pipeline failed for job ${jobId}: ${pipelineError}`);
       await markFailed(pipelineError);
 
       return { success: false, error: pipelineError };
@@ -962,6 +983,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       crossCheckResult: pipelineResult.cross_check,
       pass4Governance: pipelineResult.pass4_governance,
     });
+    console.log(
+      `[Processor] ${jobId}: evaluationResult synthesized overall=${evaluationResult.overview.overall_score_0_100}`,
+    );
 
     const promptCoverage = summarizePromptCoverage(manuscriptWithContent.content || '');
     evaluationResult.metrics.manuscript = {
@@ -1015,6 +1039,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     }
 
     try {
+      console.log(
+        `[Processor] ${jobId}: ENTER upsertEvaluationArtifact manuscriptId=${job.manuscript_id}`,
+      );
       const artifactId = await upsertEvaluationArtifact({
         supabase,
         jobId: job.id,
@@ -1025,6 +1052,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         artifactVersion: 'evaluation_result_v1',
       });
 
+      console.log(`[Processor] ${jobId}: EXIT upsertEvaluationArtifact id=${artifactId}`);
       console.log(`[Processor] Canonical artifact upserted: ${artifactId}`);
     } catch (artifactError) {
       const errorMsg = artifactError instanceof Error ? artifactError.message : String(artifactError);
@@ -1034,6 +1062,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     }
 
     // 6. Store evaluation result and mark complete only after artifact exists
+    console.log(`[Processor] ${jobId}: ENTER completion update`);
     const { error: updateError } = await supabase
       .from('evaluation_jobs')
       .update({
@@ -1060,6 +1089,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         updated_at: completionTime
       })
       .eq('id', jobId);
+    console.log(
+      `[Processor] ${jobId}: EXIT completion update error=${updateError ? updateError.message : 'none'}`,
+    );
 
     if (updateError) {
       await markFailed(`Completion update failed: ${updateError.message}`);
@@ -1117,6 +1149,7 @@ export async function processQueuedJobs(): Promise<{
     .from('evaluation_jobs')
     .select('id')
     .eq('status', 'queued')
+    .eq('phase_status', 'triggered')
     .order('created_at', { ascending: true })
     .limit(10); // Process max 10 jobs per run
 

--- a/tests/evaluation/pipeline/pass1.test.ts
+++ b/tests/evaluation/pipeline/pass1.test.ts
@@ -54,6 +54,27 @@ function nullCompletion(): CreateCompletionFn {
   });
 }
 
+/** Helper: build a mock completion function that returns structured content parts. */
+function arrayContentCompletion(responseJson: string): CreateCompletionFn {
+  return async () => ({
+    choices: [
+      {
+        message: {
+          content: [{ type: "output_text", text: responseJson }],
+        },
+      },
+    ],
+  });
+}
+
+/** Helper: build a mock completion with finish metadata but no usable content. */
+function lengthLimitedEmptyCompletion(): CreateCompletionFn {
+  return async () => ({
+    choices: [{ message: { content: null }, finish_reason: "length" }],
+    usage: { prompt_tokens: 700, completion_tokens: 4000, total_tokens: 4700 },
+  });
+}
+
 // ── Pure parser tests ─────────────────────────────────────────────────────────
 
 describe("parsePass1Response", () => {
@@ -184,6 +205,32 @@ describe("runPass1", () => {
         _createCompletion: nullCompletion(),
       }),
     ).rejects.toThrow("Empty response from OpenAI");
+  });
+
+  it("accepts structured content-part arrays when the provider does not return a flat string", async () => {
+    const result = await runPass1({
+      manuscriptText: "test",
+      workType: "literary_fiction",
+      title: "Test",
+      registry,
+      openaiApiKey: "sk-test",
+      _createCompletion: arrayContentCompletion(JSON.stringify(makePass1Fixture())),
+    });
+
+    expect(result.criteria).toHaveLength(13);
+  });
+
+  it("includes finish_reason and token usage in enriched empty-response errors", async () => {
+    await expect(
+      runPass1({
+        manuscriptText: "test",
+        workType: "literary_fiction",
+        title: "Test",
+        registry,
+        openaiApiKey: "sk-test",
+        _createCompletion: lengthLimitedEmptyCompletion(),
+      }),
+    ).rejects.toThrow("finish_reason=length");
   });
 
   it("propagates OpenAI errors", async () => {

--- a/tests/evaluation/pipeline/pass2.test.ts
+++ b/tests/evaluation/pipeline/pass2.test.ts
@@ -41,6 +41,27 @@ function mockCompletion(responseJson: string): CreateCompletionFn {
   });
 }
 
+/** Helper: build a mock completion function that returns structured content parts. */
+function arrayContentCompletion(responseJson: string): CreateCompletionFn {
+  return async () => ({
+    choices: [
+      {
+        message: {
+          content: [{ type: "output_text", text: responseJson }],
+        },
+      },
+    ],
+  });
+}
+
+/** Helper: build a mock completion with finish metadata but no usable content. */
+function lengthLimitedEmptyCompletion(): CreateCompletionFn {
+  return async () => ({
+    choices: [{ message: { content: null }, finish_reason: "length" }],
+    usage: { prompt_tokens: 650, completion_tokens: 4000, total_tokens: 4650 },
+  });
+}
+
 // ── Pure parser tests ─────────────────────────────────────────────────────────
 
 describe("parsePass2Response", () => {
@@ -143,5 +164,31 @@ describe("runPass2", () => {
         _createCompletion: emptyCompletion,
       }),
     ).rejects.toThrow();
+  });
+
+  it("accepts structured content-part arrays when the provider does not return a flat string", async () => {
+    const result = await runPass2({
+      manuscriptText: "test",
+      workType: "literary_fiction",
+      title: "Test",
+      registry,
+      openaiApiKey: "sk-test",
+      _createCompletion: arrayContentCompletion(JSON.stringify(makePass2Fixture())),
+    });
+
+    expect(result.criteria).toHaveLength(13);
+  });
+
+  it("includes finish_reason and token usage in enriched empty-response errors", async () => {
+    await expect(
+      runPass2({
+        manuscriptText: "test",
+        workType: "literary_fiction",
+        title: "Test",
+        registry,
+        openaiApiKey: "sk-test",
+        _createCompletion: lengthLimitedEmptyCompletion(),
+      }),
+    ).rejects.toThrow("finish_reason=length");
   });
 });

--- a/tests/evaluation/pipeline/pass3.test.ts
+++ b/tests/evaluation/pipeline/pass3.test.ts
@@ -81,6 +81,27 @@ function nullCompletion(): CreateCompletionFn {
   });
 }
 
+/** Helper: build a mock completion function that returns content parts rather than a flat string. */
+function arrayContentCompletion(responseJson: string): CreateCompletionFn {
+  return async () => ({
+    choices: [
+      {
+        message: {
+          content: [{ type: "output_text", text: responseJson }],
+        },
+      },
+    ],
+  });
+}
+
+/** Helper: build a mock completion function that returns an empty response with finish metadata. */
+function lengthLimitedEmptyCompletion(): CreateCompletionFn {
+  return async () => ({
+    choices: [{ message: { content: null }, finish_reason: "length" }],
+    usage: { prompt_tokens: 1234, completion_tokens: 8000, total_tokens: 9234 },
+  });
+}
+
 // ── Pure parser tests ─────────────────────────────────────────────────────────
 
 describe("parsePass3Response", () => {
@@ -199,6 +220,35 @@ describe("runPass3Synthesis", () => {
         _createCompletion: nullCompletion(),
       }),
     ).rejects.toThrow("Empty response from OpenAI");
+  });
+
+  it("accepts content-part arrays when the provider returns structured content", async () => {
+    const result = await runPass3Synthesis({
+      pass1: makePassOutput(1, "craft_execution"),
+      pass2: makePassOutput(2, "editorial_literary"),
+      manuscriptText: "test",
+      title: "Test",
+      registry,
+      openaiApiKey: "sk-test",
+      _createCompletion: arrayContentCompletion(JSON.stringify(makePass3Fixture())),
+    });
+
+    expect(result.criteria).toHaveLength(13);
+    expect(result.overall.verdict).toBe("revise");
+  });
+
+  it("surfaces finish_reason and token metadata when the response is empty", async () => {
+    await expect(
+      runPass3Synthesis({
+        pass1: makePassOutput(1, "craft_execution"),
+        pass2: makePassOutput(2, "editorial_literary"),
+        manuscriptText: "test",
+        title: "Test",
+        registry,
+        openaiApiKey: "sk-test",
+        _createCompletion: lengthLimitedEmptyCompletion(),
+      }),
+    ).rejects.toThrow("finish_reason=length");
   });
 });
 


### PR DESCRIPTION
## Summary
- harden Pass 1/2/3 completion extraction against empty or structured-content responses
- enrich failure diagnostics with finish reason and usage context
- raise Pass 3 token ceiling and trim inline prior-pass payload pressure
- add focused regression tests for structured content and length-truncation cases

## Notes
- no change to fail-closed semantics
- no change to canon enforcement
- processor change is log enrichment only

## Validation
- focused pass suites green locally: 43/43
- tests run: `tests/evaluation/pipeline/pass1.test.ts`, `tests/evaluation/pipeline/pass2.test.ts`, `tests/evaluation/pipeline/pass3.test.ts`