### PR TITLE
fix: set phase_status=triggered on job insert so cron processor picks up queued jobs

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -1,3 +1,4 @@
+
 // app/api/evaluate/route.ts
 
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -140,6 +141,7 @@ export async function POST(req: Request) {
         user_id: userId,
         job_type: "evaluate_full",
         phase: PHASES.PHASE_1,
+      phase_status: "triggered",
         policy_family: "standard",
         voice_preservation_level: "balanced",
         english_variant: "us",


### PR DESCRIPTION
## Bug

The `processQueuedJobs()` in `processor.ts` queries for `.eq('phase_status', 'triggered')` but `/api/evaluate` never set `phase_status` on the job insert. Jobs were stuck in 'queued' forever because the cron processor couldn't find them.

## Fix

Add `phase_status: "triggered"` to the evaluation_jobs insert in `/api/evaluate/route.ts`.

## Scope

- Single field addition to the job insert object
- No pipeline, test, or UI changes