### PR TITLE
Fix queued evaluation progress display on report page

### DIFF
--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -1,0 +1,37 @@
+import type { JobState } from "@/components/EvaluationPoller";
+
+export type ProgressDisplay = {
+  label: string;
+  valueLabel: string;
+  helperText: string;
+  indeterminate: boolean;
+  percentage: number;
+} | null;
+
+export function getProgressDisplay(
+  job: Pick<JobState, "status" | "progress">
+): ProgressDisplay {
+  if (job.status === "queued") {
+    return {
+      label: "Queue status",
+      valueLabel: "Waiting to start",
+      helperText: "Your job is queued. Progress details will appear here as soon as processing begins.",
+      indeterminate: true,
+      percentage: 0,
+    };
+  }
+
+  if (job.status === "running") {
+    const percentage = Math.max(0, Math.min(100, job.progress));
+
+    return {
+      label: "Progress",
+      valueLabel: `${percentage}%`,
+      helperText: "This page refreshes automatically while your evaluation is running.",
+      indeterminate: false,
+      percentage,
+    };
+  }
+
+  return null;
+}

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -1,0 +1,34 @@
+import { getProgressDisplay } from "@/components/evaluation-poller-display";
+
+describe("getProgressDisplay", () => {
+  test("shows an indeterminate queued progress section", () => {
+    expect(getProgressDisplay({ status: "queued", progress: 0 })).toEqual({
+      label: "Queue status",
+      valueLabel: "Waiting to start",
+      helperText:
+        "Your job is queued. Progress details will appear here as soon as processing begins.",
+      indeterminate: true,
+      percentage: 0,
+    });
+  });
+
+  test("shows determinate running progress", () => {
+    expect(getProgressDisplay({ status: "running", progress: 42 })).toEqual({
+      label: "Progress",
+      valueLabel: "42%",
+      helperText: "This page refreshes automatically while your evaluation is running.",
+      indeterminate: false,
+      percentage: 42,
+    });
+  });
+
+  test("clamps running progress to canonical bounds", () => {
+    expect(getProgressDisplay({ status: "running", progress: 120 })?.percentage).toBe(100);
+    expect(getProgressDisplay({ status: "running", progress: -5 })?.percentage).toBe(0);
+  });
+
+  test("hides progress section for terminal jobs", () => {
+    expect(getProgressDisplay({ status: "complete", progress: 100 })).toBeNull();
+    expect(getProgressDisplay({ status: "failed", progress: 10 })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Render visible queued-state progress in the shared evaluation-poller-display helper
- Preserve determinate progress for running jobs
- Preserve no-progress behavior for terminal states
- Add focused regression coverage for progress display behavior

## Files

- `components/evaluation-poller-display.ts` (new helper)
- `tests/evaluation-poller-display.test.ts` (new test)