### PR TITLE
fix: set phase_status=triggered in Phase 2 trigger routes to match worker selector

### DIFF
--- a/app/api/admin/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/admin/jobs/[jobId]/run-phase2/route.ts
@@ -62,7 +62,7 @@ export async function POST(
     const updatePayload = {
       status: "queued",
       phase: "phase_2",
-      phase_status: "queued",
+      phase_status: "triggered",
       last_error: null,
       updated_at: now,
     };

--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
   const updatePayload = {
     status: "queued",
     phase: "phase_2",
-    phase_status: "queued",
+    phase_status: "triggered",
     last_error: null,
     updated_at: now,
   };


### PR DESCRIPTION
## Bug Fix: Phase 2 Worker Handoff Mismatch

### Problem
The worker `processQueuedJobs()` selects jobs with:
```
.eq('status', 'queued')
.eq('phase_status', 'triggered')
```

But both Phase 2 trigger routes were writing `phase_status: "queued"` instead of `"triggered"`. This meant Phase 2 jobs were never picked up by the worker after the Phase 1 → Phase 2 handoff.

### Fix
Changed `phase_status: "queued"` to `phase_status: "triggered"` in both:
- `app/api/jobs/[jobId]/run-phase2/route.ts` (line 58)
- `app/api/admin/jobs/[jobId]/run-phase2/route.ts` (line 65)

`status` remains `"queued"` — matching the worker selector contract exactly.

### Verification
Both files fetched and verified directly from the branch on GitHub.