### PR TITLE
fix: queued progress display + PhaseStatus type canon alignment

### DIFF
--- a/app/api/admin/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/admin/jobs/[jobId]/run-phase2/route.ts
@@ -62,7 +62,7 @@ export async function POST(
     const updatePayload = {
       status: "queued",
       phase: "phase_2",
-      phase_status: "queued",
+      phase_status: "triggered",
       last_error: null,
       updated_at: now,
     };

--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -55,7 +55,7 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
   const updatePayload = {
     status: "queued",
     phase: "phase_2",
-    phase_status: "queued",
+    phase_status: "triggered",
     last_error: null,
     updated_at: now,
   };

--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -65,11 +65,24 @@ export const JOB_STATUS = {
 export type JobStatus = (typeof JOB_STATUS)[keyof typeof JOB_STATUS];
 
 /**
- * PhaseStatus is CANON-aligned with JobStatus.
- * All phase writers MUST use: "queued" | "running" | "complete" | "failed" | null
- * No granular states (e.g., "processing", "starting") allowed at type level.
+ * PHASE_STATUS_MARKERS — Queue eligibility markers used by worker selectors
+ * These are runtime-only markers that indicate which jobs the worker should pick up.
+ * "triggered" means: job is queued and ready for the next phase executor to claim.
  */
-export type PhaseStatus = JobStatus | null;
+export const PHASE_STATUS_MARKERS = {
+  TRIGGERED: "triggered",
+} as const;
+
+export type PhaseStatusMarker = (typeof PHASE_STATUS_MARKERS)[keyof typeof PHASE_STATUS_MARKERS];
+
+/**
+ * PhaseStatus reflects actual runtime usage:
+ * - JobStatus values (queued, running, complete, failed) for state transitions
+ * - Additional markers (triggered) for worker queue eligibility
+ * 
+ * Worker contract: selects jobs where status='queued' AND phase_status='triggered'
+ */
+export type PhaseStatus = JobStatus | PhaseStatusMarker | null;
 
 /**
  * JOB_CONTRACT_v1 — CANON progress shape (minimum)


### PR DESCRIPTION
## Changes

### 1. Phase 2 trigger handoff fix (84db164)
Changed `phase_status: "queued"` to `phase_status: "triggered"` in both Phase 2 trigger routes so the worker `processQueuedJobs()` can select them.

**Note:** The route-level fix is already on main via PR #99. This commit carries the same change from the branch history.

### 2. PhaseStatus type canon alignment (685127c)
Added `PHASE_STATUS_MARKERS.TRIGGERED = "triggered"` and `PhaseStatusMarker` type to `lib/jobs/types.ts` so the type system reflects the worker's actual selection contract.

### 3. Queued progress UI
Renders progress bar with "Queued / Waiting to start" state for jobs in queued status.