### PR TITLE
Add coverage enforcement to quality gate: block placeholder scores

### DIFF
--- a/__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
+++ b/__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Quality Gate — Coverage enforcement checks.
+ *
+ * Validates that QG_THIN_RATIONALE and QG_LOW_EVIDENCE_COVERAGE
+ * block evaluations with placeholder scores/rationales.
+ */
+
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import {
+  runQualityGate,
+  QG_MIN_RATIONALE_LENGTH,
+  QG_MIN_EVIDENCE_COVERED_CRITERIA,
+  QG_MIN_EVIDENCE_SNIPPET_LENGTH,
+} from "@/lib/evaluation/pipeline/qualityGate";
+import type { SynthesisOutput, SynthesizedCriterion } from "@/lib/evaluation/pipeline/types";
+
+export {};
+
+function makeCriterion(
+  key: CriterionKey,
+  overrides: Partial<SynthesizedCriterion> = {},
+): SynthesizedCriterion {
+  return {
+    key,
+    craft_score: 7,
+    editorial_score: 7,
+    final_score_0_10: 7,
+    score_delta: 0,
+    final_rationale:
+      "This criterion demonstrates strong craft with consistent voice and tonal authority throughout the chapter.",
+    pressure_points: ["Opening scene tension"],
+    decision_points: ["Narrator's choice to continue driving"],
+    consequence_status: "landed",
+    evidence: [
+      { snippet: "The water hadn't just turned brown. It had been fed." },
+    ],
+    recommendations: [
+      {
+        priority: "medium",
+        action:
+          "Consider seeding an earlier water anomaly in the opening two hundred words to prime the reader for the ecological revelation.",
+        expected_impact:
+          "Strengthens the speculative thread and primes readers for eco-horror pay-off.",
+        anchor_snippet: "The water hadn't just turned brown.",
+        source_pass: 3,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSynthesis(
+  criteriaOverrides?: Partial<SynthesizedCriterion>[],
+): SynthesisOutput {
+  const criteria = CRITERIA_KEYS.map((key, i) =>
+    makeCriterion(key, criteriaOverrides?.[i] ?? {}),
+  );
+  return {
+    criteria,
+    overall: {
+      overall_score_0_100: 72,
+      verdict: "revise",
+      one_paragraph_summary:
+        "A well-voiced chapter with atmospheric strength that needs one decision point to convert observation into escalation.",
+      top_3_strengths: ["Voice", "Atmosphere", "Cliff backstory"],
+      top_3_risks: ["Pacing", "Action deficit", "Dialogue underweight"],
+    },
+    metadata: {
+      pass1_model: "gpt-4o",
+      pass2_model: "gpt-4o",
+      pass3_model: "gpt-4o",
+      generated_at: new Date().toISOString(),
+    },
+    partial_evaluation: false,
+  };
+}
+
+describe("Quality Gate — coverage enforcement", () => {
+  test("passes when all criteria have substantive rationale and evidence", () => {
+    const synthesis = makeSynthesis();
+    const result = runQualityGate(synthesis);
+
+    const rationaleCheck = result.checks.find(
+      (c) => c.check_id === "rationale_coverage",
+    );
+    const evidenceCheck = result.checks.find(
+      (c) => c.check_id === "evidence_coverage",
+    );
+
+    expect(rationaleCheck).toBeDefined();
+    expect(rationaleCheck!.passed).toBe(true);
+    expect(evidenceCheck).toBeDefined();
+    expect(evidenceCheck!.passed).toBe(true);
+  });
+
+  test("fails QG_THIN_RATIONALE when criteria have placeholder rationale", () => {
+    const overrides = CRITERIA_KEYS.map((_, i) =>
+      i >= 7 ? { final_rationale: "No analysis." } : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "rationale_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(false);
+    expect(check!.error_code).toBe("QG_THIN_RATIONALE");
+    expect(result.pass).toBe(false);
+  });
+
+  test("fails QG_LOW_EVIDENCE_COVERAGE when too many criteria lack evidence", () => {
+    const overrides = CRITERIA_KEYS.map((_, i) =>
+      i >= 8 ? { evidence: [] } : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "evidence_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(false);
+    expect(check!.error_code).toBe("QG_LOW_EVIDENCE_COVERAGE");
+    expect(result.pass).toBe(false);
+  });
+
+  test("allows up to threshold gap count without failing", () => {
+    const maxPermittedGaps = CRITERIA_KEYS.length - QG_MIN_EVIDENCE_COVERED_CRITERIA;
+    const overrides = CRITERIA_KEYS.map((_, i) =>
+      i >= CRITERIA_KEYS.length - maxPermittedGaps ? { evidence: [] } : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "evidence_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(true);
+  });
+
+  test("detects short evidence snippets as non-substantive", () => {
+    const overrides = CRITERIA_KEYS.map((_, i) =>
+      i >= 8 ? { evidence: [{ snippet: "Short." }] } : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "evidence_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(false);
+    expect(check!.error_code).toBe("QG_LOW_EVIDENCE_COVERAGE");
+  });
+
+  test("exact threshold: rationale at exactly MIN length passes", () => {
+    const exactRationale = "A".repeat(QG_MIN_RATIONALE_LENGTH);
+    const overrides = CRITERIA_KEYS.map(() => ({
+      final_rationale: exactRationale,
+    }));
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "rationale_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(true);
+  });
+
+  test("exact threshold: evidence snippet at exactly MIN length passes", () => {
+    const exactSnippet = "A".repeat(QG_MIN_EVIDENCE_SNIPPET_LENGTH);
+    const overrides = CRITERIA_KEYS.map(() => ({
+      evidence: [{ snippet: exactSnippet }],
+    }));
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "evidence_coverage",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(true);
+  });
+});

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -14,6 +14,8 @@
  *   QG_CRITERIA_MISSING   — output does not contain all 13 criteria
  *   QG_SCORE_RANGE        — score not in integer 0-10
  *   QG_CONSEQUENCE_CONTRACT — missing pressure/decision/consequence contract fields
+ *   QG_THIN_RATIONALE      — criterion rationale < 40 chars
+ *   QG_LOW_EVIDENCE_COVERAGE — too many criteria lack substantive evidence snippets
  *   QG_INDEPENDENCE_VIOLATION — Pass 2 reuses non-manuscript rationale phrasing from Pass 1
  */
 
@@ -26,6 +28,9 @@ export const QG_MAX_EVIDENCE_LENGTH = 200;
 export const QG_MAX_OVERVIEW_LENGTH = 500;
 export const QG_INDEPENDENCE_NGRAM_SIZE = 8;
 export const QG_INDEPENDENCE_MIN_OVERLAPS_PER_CRITERION = 2;
+export const QG_MIN_RATIONALE_LENGTH = 40;
+export const QG_MIN_EVIDENCE_COVERED_CRITERIA = 10;
+export const QG_MIN_EVIDENCE_SNIPPET_LENGTH = 20;
 
 function tokenizeForOverlap(text: string): string[] {
   return text
@@ -218,7 +223,45 @@ export function runQualityGate(
         : "No duplicated recommendations",
   });
 
-  // ── Check 8: Pass independence (rationale phrasing only; calibrated) ─────
+  // ── Check 8: Rationale coverage (≥40 chars per criterion) ───────────────
+  const thinRationales: string[] = [];
+  for (const c of synthesis.criteria) {
+    if (c.final_rationale.trim().length < QG_MIN_RATIONALE_LENGTH) {
+      thinRationales.push(`${c.key} (${c.final_rationale.trim().length} chars)`);
+    }
+  }
+  checks.push({
+    check_id: "rationale_coverage",
+    passed: thinRationales.length === 0,
+    error_code: thinRationales.length > 0 ? "QG_THIN_RATIONALE" : undefined,
+    details:
+      thinRationales.length > 0
+        ? `${thinRationales.length} criterion/criteria have rationale < ${QG_MIN_RATIONALE_LENGTH} chars: ${thinRationales.join(", ")}`
+        : `All criteria have substantive rationale (≥ ${QG_MIN_RATIONALE_LENGTH} chars)`,
+  });
+
+  // ── Check 9: Evidence coverage (≥10 of 13 must have ≥1 snippet ≥20 chars) ──
+  const maxPermittedGaps = CRITERIA_KEYS.length - QG_MIN_EVIDENCE_COVERED_CRITERIA;
+  const underEvidenced: string[] = [];
+  for (const c of synthesis.criteria) {
+    const hasSubstantiveEvidence = c.evidence.some(
+      (e) => e.snippet.trim().length >= QG_MIN_EVIDENCE_SNIPPET_LENGTH,
+    );
+    if (!hasSubstantiveEvidence) {
+      underEvidenced.push(c.key);
+    }
+  }
+  checks.push({
+    check_id: "evidence_coverage",
+    passed: underEvidenced.length <= maxPermittedGaps,
+    error_code: underEvidenced.length > maxPermittedGaps ? "QG_LOW_EVIDENCE_COVERAGE" : undefined,
+    details:
+      underEvidenced.length > 0
+        ? `${underEvidenced.length} criterion/criteria lack substantive evidence: ${underEvidenced.join(", ")} (max ${maxPermittedGaps} permitted)`
+        : "All criteria have substantive evidence",
+  });
+
+  // ── Check 10: Pass independence (rationale phrasing only; calibrated) ────
   if (pass1 && pass2) {
     const ngramSize = QG_INDEPENDENCE_NGRAM_SIZE;
 


### PR DESCRIPTION
## Summary

Adds two new deterministic quality gate checks that block evaluations where Pass 3 produced placeholder scores without substantive rationale or evidence.

---

## What changed

### Quality Gate (`lib/evaluation/pipeline/qualityGate.ts`)

- **QG_THIN_RATIONALE** — Every criterion's `final_rationale` must be ≥ 40 characters.
- **QG_LOW_EVIDENCE_COVERAGE** — At least 10 of 13 criteria must have ≥ 1 evidence snippet ≥ 20 characters.

### Implementation notes

- Added constants:
  - `QG_MIN_RATIONALE_LENGTH = 40`
  - `QG_MIN_EVIDENCE_COVERED_CRITERIA = 10`
  - `QG_MIN_EVIDENCE_SNIPPET_LENGTH = 20`
- Added checks:
  - `rationale_coverage`
  - `evidence_coverage`

### Tests

New file: `__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts`
- 7 tests for pass/fail and threshold boundaries
- Uses canonical `CriterionKey` typing in test helper (no `string`/`any` key coercion)

### No changes to:
- `processor.ts`
- `runPipeline.ts`
- prompt files

---

## Governance notes

- Deterministic-only checks (no AI)
- Gate executes after Pass 3 synthesis and before artifact persistence
- Existing fail-closed pipeline wiring handles enforcement automatically

---

## Focused verification

```sh
npx jest --ci --runInBand --runTestsByPath \
  __tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
```

Expected: **1 suite, 7 tests, 0 failures**