### PR TITLE
Phase 2 quality gate hardening: placeholder rationale, spine evidence, telemetry

### DIFF
--- a/__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
+++ b/__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
@@ -11,6 +11,7 @@ import {
   QG_MIN_RATIONALE_LENGTH,
   QG_MIN_EVIDENCE_COVERED_CRITERIA,
   QG_MIN_EVIDENCE_SNIPPET_LENGTH,
+  summarizeQualityGateFailures,
 } from "@/lib/evaluation/pipeline/qualityGate";
 import type { SynthesisOutput, SynthesizedCriterion } from "@/lib/evaluation/pipeline/types";
 
@@ -183,5 +184,64 @@ describe("Quality Gate — coverage enforcement", () => {
     );
     expect(check).toBeDefined();
     expect(check!.passed).toBe(true);
+  });
+
+  test("fails QG_PLACEHOLDER_RATIONALE for canned fallback language", () => {
+    const overrides = CRITERIA_KEYS.map((_, i) =>
+      i === 0
+        ? {
+            final_rationale:
+              "Neither pass supplied enough direct evidence to score this criterion confidently, so this remains unresolved.",
+          }
+        : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "placeholder_rationale",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(false);
+    expect(check!.error_code).toBe("QG_PLACEHOLDER_RATIONALE");
+    expect(result.pass).toBe(false);
+  });
+
+  test("fails QG_MISSING_REQUIRED_EVIDENCE when a spine criterion lacks evidence", () => {
+    const overrides = CRITERIA_KEYS.map((key) =>
+      key === "concept" ? { evidence: [] } : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const check = result.checks.find(
+      (c) => c.check_id === "required_evidence_spine",
+    );
+    expect(check).toBeDefined();
+    expect(check!.passed).toBe(false);
+    expect(check!.error_code).toBe("QG_MISSING_REQUIRED_EVIDENCE");
+    expect(result.pass).toBe(false);
+  });
+
+  test("summarizes failed checks into telemetry counters", () => {
+    const overrides = CRITERIA_KEYS.map((key) =>
+      key === "concept"
+        ? {
+            final_rationale:
+              "Neither pass supplied enough direct evidence to score this criterion confidently, so this remains unresolved.",
+            evidence: [],
+          }
+        : {},
+    );
+    const synthesis = makeSynthesis(overrides);
+    const result = runQualityGate(synthesis);
+
+    const telemetry = summarizeQualityGateFailures(result.checks);
+    expect(telemetry.total_failed_checks).toBeGreaterThanOrEqual(2);
+    expect(telemetry.failures_by_error_code.QG_PLACEHOLDER_RATIONALE).toBe(1);
+    expect(telemetry.failures_by_error_code.QG_MISSING_REQUIRED_EVIDENCE).toBe(1);
+    expect(telemetry.failed_check_ids).toEqual(
+      expect.arrayContaining(["placeholder_rationale", "required_evidence_spine"]),
+    );
   });
 });

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -15,11 +15,13 @@
  *   QG_SCORE_RANGE        — score not in integer 0-10
  *   QG_CONSEQUENCE_CONTRACT — missing pressure/decision/consequence contract fields
  *   QG_THIN_RATIONALE      — criterion rationale < 40 chars
+ *   QG_PLACEHOLDER_RATIONALE — criterion rationale includes known placeholder phrasing
  *   QG_LOW_EVIDENCE_COVERAGE — too many criteria lack substantive evidence snippets
+ *   QG_MISSING_REQUIRED_EVIDENCE — required spine criteria missing substantive evidence snippets
  *   QG_INDEPENDENCE_VIOLATION — Pass 2 reuses non-manuscript rationale phrasing from Pass 1
  */
 
-import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
 import type { SynthesisOutput, QualityGateResult, QualityGateCheck, SinglePassOutput } from "./types";
 
 export const QG_MIN_REC_LENGTH = 50;
@@ -31,6 +33,34 @@ export const QG_INDEPENDENCE_MIN_OVERLAPS_PER_CRITERION = 2;
 export const QG_MIN_RATIONALE_LENGTH = 40;
 export const QG_MIN_EVIDENCE_COVERED_CRITERIA = 10;
 export const QG_MIN_EVIDENCE_SNIPPET_LENGTH = 20;
+export const QG_PLACEHOLDER_RATIONALE_PATTERNS = Object.freeze([
+  "not directly scored",
+  "no explicit evaluation supplied",
+  "default neutral score",
+  "neither pass supplied",
+  "placeholder",
+]);
+export const QG_SPINE_CRITERIA_REQUIRED_EVIDENCE = Object.freeze<CriterionKey[]>([
+  "concept",
+  "narrativeDrive",
+  "character",
+  "voice",
+  "sceneConstruction",
+]);
+
+export type QualityGateFailureTelemetry = {
+  total_failed_checks: number;
+  failures_by_error_code: Record<string, number>;
+  failed_check_ids: string[];
+};
+
+function normalizeForPhraseMatch(text: string): string {
+  return (text || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function hasSubstantiveEvidence(evidence: Array<{ snippet: string }>): boolean {
+  return evidence.some((e) => e.snippet.trim().length >= QG_MIN_EVIDENCE_SNIPPET_LENGTH);
+}
 
 function tokenizeForOverlap(text: string): string[] {
   return text
@@ -240,14 +270,32 @@ export function runQualityGate(
         : `All criteria have substantive rationale (≥ ${QG_MIN_RATIONALE_LENGTH} chars)`,
   });
 
+  // ── Check 8b: Placeholder rationale phrase detection ───────────────────
+  const placeholderRationales: string[] = [];
+  for (const c of synthesis.criteria) {
+    const normalizedRationale = normalizeForPhraseMatch(c.final_rationale);
+    const matchedPattern = QG_PLACEHOLDER_RATIONALE_PATTERNS.find((pattern) =>
+      normalizedRationale.includes(pattern),
+    );
+    if (matchedPattern) {
+      placeholderRationales.push(`${c.key} (matched: "${matchedPattern}")`);
+    }
+  }
+  checks.push({
+    check_id: "placeholder_rationale",
+    passed: placeholderRationales.length === 0,
+    error_code: placeholderRationales.length > 0 ? "QG_PLACEHOLDER_RATIONALE" : undefined,
+    details:
+      placeholderRationales.length > 0
+        ? `${placeholderRationales.length} criterion/criteria contain placeholder rationale language: ${placeholderRationales.join(", ")}`
+        : "No known placeholder rationale patterns detected",
+  });
+
   // ── Check 9: Evidence coverage (≥10 of 13 must have ≥1 snippet ≥20 chars) ──
   const maxPermittedGaps = CRITERIA_KEYS.length - QG_MIN_EVIDENCE_COVERED_CRITERIA;
   const underEvidenced: string[] = [];
   for (const c of synthesis.criteria) {
-    const hasSubstantiveEvidence = c.evidence.some(
-      (e) => e.snippet.trim().length >= QG_MIN_EVIDENCE_SNIPPET_LENGTH,
-    );
-    if (!hasSubstantiveEvidence) {
+    if (!hasSubstantiveEvidence(c.evidence)) {
       underEvidenced.push(c.key);
     }
   }
@@ -259,6 +307,24 @@ export function runQualityGate(
       underEvidenced.length > 0
         ? `${underEvidenced.length} criterion/criteria lack substantive evidence: ${underEvidenced.join(", ")} (max ${maxPermittedGaps} permitted)`
         : "All criteria have substantive evidence",
+  });
+
+  // ── Check 9b: Spine criteria must always include substantive evidence ───
+  const missingRequiredEvidence: string[] = [];
+  for (const requiredKey of QG_SPINE_CRITERIA_REQUIRED_EVIDENCE) {
+    const criterion = synthesis.criteria.find((c) => c.key === requiredKey);
+    if (!criterion || !hasSubstantiveEvidence(criterion.evidence)) {
+      missingRequiredEvidence.push(requiredKey);
+    }
+  }
+  checks.push({
+    check_id: "required_evidence_spine",
+    passed: missingRequiredEvidence.length === 0,
+    error_code: missingRequiredEvidence.length > 0 ? "QG_MISSING_REQUIRED_EVIDENCE" : undefined,
+    details:
+      missingRequiredEvidence.length > 0
+        ? `Required spine criteria missing substantive evidence: ${missingRequiredEvidence.join(", ")}`
+        : "All required spine criteria include substantive evidence",
   });
 
   // ── Check 10: Pass independence (rationale phrasing only; calibrated) ────
@@ -329,5 +395,21 @@ export function runQualityGate(
     pass: failedHardChecks.length === 0,
     checks,
     warnings,
+  };
+}
+
+export function summarizeQualityGateFailures(checks: QualityGateCheck[]): QualityGateFailureTelemetry {
+  const failedChecks = checks.filter((c) => !c.passed);
+  const failuresByErrorCode: Record<string, number> = {};
+
+  for (const check of failedChecks) {
+    const errorCode = check.error_code ?? "QG_UNKNOWN";
+    failuresByErrorCode[errorCode] = (failuresByErrorCode[errorCode] ?? 0) + 1;
+  }
+
+  return {
+    total_failed_checks: failedChecks.length,
+    failures_by_error_code: failuresByErrorCode,
+    failed_check_ids: failedChecks.map((c) => c.check_id),
   };
 }

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -18,7 +18,10 @@ import { runPass2 as defaultRunPass2 } from "./runPass2";
 import { runPass3Synthesis as defaultRunPass3 } from "./runPass3Synthesis";
 import { runPerplexityCrossCheck, CrossCheckOutput } from "./perplexityCrossCheck";
 import { evaluatePass4Governance } from "@/lib/evaluation/governance/evaluatePass4Governance";
-import { runQualityGate as defaultRunQualityGate } from "./qualityGate";
+import {
+  runQualityGate as defaultRunQualityGate,
+  summarizeQualityGateFailures,
+} from "./qualityGate";
 import type { PipelineResult, SinglePassOutput, SynthesisOutput, QualityGateResult } from "./types";
 import type { EvaluationResultV1 } from "@/schemas/evaluation-result-v1";
 import { PASS1_PROMPT_VERSION } from "./prompts/pass1-craft";
@@ -365,6 +368,14 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     const failedChecks = qualityGate.checks.filter((c) => !c.passed);
     const errorCode = failedChecks[0]?.error_code ?? "QG_UNKNOWN";
     const details = failedChecks.map((c) => c.details ?? c.error_code).join("; ");
+    const qualityGateTelemetry = summarizeQualityGateFailures(qualityGate.checks);
+
+    console.warn("[Pipeline][QualityGate] failure", {
+      manuscript_id: opts.manuscriptId ?? null,
+      work_type: opts.workType,
+      title: opts.title,
+      ...qualityGateTelemetry,
+    });
 
     return {
       ok: false,


### PR DESCRIPTION
## Summary

Phase 2 quality-gate refinements that improve coverage enforcement precision while keeping enforcement deterministic and fail-closed.

This PR adds:
1. placeholder-rationale phrase detection
2. mandatory substantive evidence for spine criteria
3. quality-gate failure telemetry summarization (logged at pipeline failure)

---

## What changed

### `lib/evaluation/pipeline/qualityGate.ts`

Added new deterministic checks and constants:

- **QG_PLACEHOLDER_RATIONALE** (`check_id=placeholder_rationale`)
  - Detects known canned fallback phrasing in `final_rationale`
  - Uses `QG_PLACEHOLDER_RATIONALE_PATTERNS`

- **QG_MISSING_REQUIRED_EVIDENCE** (`check_id=required_evidence_spine`)
  - Requires substantive evidence for spine criteria:
    - `concept`
    - `narrativeDrive`
    - `character`
    - `voice`
    - `sceneConstruction`

- Added helper:
  - `summarizeQualityGateFailures(checks)`
  - Returns counters by error code + failed check IDs

### `lib/evaluation/pipeline/runPipeline.ts`

- On quality-gate failure, logs structured telemetry via `summarizeQualityGateFailures(...)`:
  - `total_failed_checks`
  - `failures_by_error_code`
  - `failed_check_ids`
  - plus manuscript/work metadata

### `__tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts`

Expanded focused suite to 10 tests:
- existing coverage tests remain
- added tests for:
  - `QG_PLACEHOLDER_RATIONALE`
  - `QG_MISSING_REQUIRED_EVIDENCE`
  - telemetry summarization counters

---

## Enforcement behavior

- Gate remains deterministic (no AI calls)
- Enforcement remains at Pass 4 quality gate before persistence
- Any failed hard check still returns pipeline failure (`ok: false`) and prevents artifact persistence

---

## Focused verification

```sh
npx jest --ci --runInBand --runTestsByPath \
  __tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
```

Expected: **1 suite, 10 tests, 0 failures**