### PR TITLE
Maintenance: share placeholder rationale patterns across Pass 3 and quality gate

### DIFF
--- a/lib/evaluation/pipeline/placeholderRationalePatterns.ts
+++ b/lib/evaluation/pipeline/placeholderRationalePatterns.ts
@@ -1,0 +1,7 @@
+export const PLACEHOLDER_RATIONALE_PATTERNS = Object.freeze([
+  "not directly scored",
+  "no explicit evaluation supplied",
+  "default neutral score",
+  "neither pass supplied",
+  "placeholder",
+]);

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -22,6 +22,7 @@
  */
 
 import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
 import type { SynthesisOutput, QualityGateResult, QualityGateCheck, SinglePassOutput } from "./types";
 
 export const QG_MIN_REC_LENGTH = 50;
@@ -33,13 +34,7 @@ export const QG_INDEPENDENCE_MIN_OVERLAPS_PER_CRITERION = 2;
 export const QG_MIN_RATIONALE_LENGTH = 40;
 export const QG_MIN_EVIDENCE_COVERED_CRITERIA = 10;
 export const QG_MIN_EVIDENCE_SNIPPET_LENGTH = 20;
-export const QG_PLACEHOLDER_RATIONALE_PATTERNS = Object.freeze([
-  "not directly scored",
-  "no explicit evaluation supplied",
-  "default neutral score",
-  "neither pass supplied",
-  "placeholder",
-]);
+export const QG_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
 export const QG_SPINE_CRITERIA_REQUIRED_EVIDENCE = Object.freeze<CriterionKey[]>([
   "concept",
   "narrativeDrive",

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -20,6 +20,7 @@ import {
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
+import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
 
 const PASS3_TEMPERATURE = 0.2;
 const PASS3_MAX_TOKENS = (() => {
@@ -28,13 +29,7 @@ const PASS3_MAX_TOKENS = (() => {
 })();
 const PASS3_MODEL = "o3";
 const PASS3_MIN_RATIONALE_LENGTH = 40;
-const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = Object.freeze([
-  "not directly scored",
-  "no explicit evaluation supplied",
-  "default neutral score",
-  "neither pass supplied",
-  "placeholder",
-]);
+const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
 const OPENAI_TIMEOUT_MS = (() => {
   const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "120000", 10);
   return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 120_000 ? parsed : 120_000;


### PR DESCRIPTION
## Summary

Removes drift risk by centralizing placeholder-rationale phrase patterns into a single shared module used by both:
- Pass 3 backfill detector
- Pass 4 quality gate placeholder check

---

## What changed

### New shared module
- `lib/evaluation/pipeline/placeholderRationalePatterns.ts`
  - Exports `PLACEHOLDER_RATIONALE_PATTERNS`

### Updated consumers
- `lib/evaluation/pipeline/qualityGate.ts`
  - `QG_PLACEHOLDER_RATIONALE_PATTERNS` now references shared constant
- `lib/evaluation/pipeline/runPass3Synthesis.ts`
  - Pass 3 backfill placeholder detection now references shared constant

---

## Why

Previously, both files had duplicated local arrays with the same patterns. This creates maintenance drift risk if one side is updated and the other is not.

This PR keeps both enforcement and generation repair on exactly the same placeholder doctrine.

---

## Verification

```sh
npx jest --ci --runInBand --runTestsByPath \
  __tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts \
  __tests__/lib/evaluation/pipeline/qualityGate.coverage.test.ts
```

Result in this branch: **2 suites, 11 tests, 0 failures**