### PR TITLE
feat: PR C lease timeout hardening and dead-lease failure classification

### DIFF
--- a/__tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts
+++ b/__tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts
@@ -1,0 +1,214 @@
+export {};
+
+const createAdminClientMock = jest.fn();
+
+jest.mock("../../../lib/supabase/admin", () => ({
+  createAdminClient: (...args: unknown[]) => createAdminClientMock(...args),
+}));
+
+type DbRow = Record<string, any>;
+
+function makeDbJobRow(overrides: Partial<DbRow> = {}): DbRow {
+  return {
+    id: "job-1",
+    manuscript_id: 42,
+    user_id: "user-1",
+    job_type: "full_evaluation",
+    status: "running",
+    progress: {
+      phase: "phase_1",
+      phase_status: "complete",
+      total_units: 10,
+      completed_units: 10,
+      lease_id: null,
+      lease_expires_at: null,
+    },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    last_heartbeat: null,
+    last_error: null,
+    failure_envelope: null,
+    manuscripts: { user_id: "user-1" },
+    ...overrides,
+  };
+}
+
+function buildSupabaseStub(opts: {
+  getJobRow: DbRow;
+  updateResultRow?: DbRow | null;
+}) {
+  const updatePayloads: Array<Record<string, unknown>> = [];
+
+  const maybeSingle = jest
+    .fn()
+    .mockResolvedValueOnce({ data: opts.getJobRow, error: null })
+    .mockResolvedValue({ data: opts.updateResultRow ?? opts.getJobRow, error: null });
+
+  const updateBuilder: any = {
+    eq: jest.fn(function () {
+      return this;
+    }),
+    or: jest.fn(function () {
+      return this;
+    }),
+    select: jest.fn(function () {
+      this._hasSelect = true;
+      return this;
+    }),
+    maybeSingle,
+    _hasSelect: false,
+  };
+
+  const supabase = {
+    from: jest.fn().mockImplementation((table: string) => {
+      if (table !== "evaluation_jobs") {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      return {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle,
+          }),
+        }),
+        update: jest.fn((payload: Record<string, unknown>) => {
+          updatePayloads.push(payload);
+          return updateBuilder;
+        }),
+      };
+    }),
+  };
+
+  return { supabase, updatePayloads };
+}
+
+describe("acquireLeaseForPhase2 lease timeout hardening", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS;
+    delete process.env.JOB_LEASE_TIMEOUT_SECONDS;
+  });
+
+  test("uses default 300-second lease timeout when ttl is omitted", async () => {
+    const row = makeDbJobRow({
+      progress: {
+        phase: "phase_1",
+        phase_status: "complete",
+        lease_id: null,
+        lease_expires_at: null,
+      },
+    });
+
+    const updateRow = makeDbJobRow({
+      progress: {
+        phase: "phase_2",
+        phase_status: "running",
+        lease_id: "lease-new",
+        lease_expires_at: new Date(Date.now() + 300_000).toISOString(),
+      },
+    });
+
+    const { supabase, updatePayloads } = buildSupabaseStub({
+      getJobRow: row,
+      updateResultRow: updateRow,
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+
+    const before = Date.now();
+    const result = await acquireLeaseForPhase2("job-1", "lease-new");
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    expect(updatePayloads.length).toBeGreaterThan(0);
+
+    const progress = updatePayloads[0].progress as Record<string, unknown>;
+    const expires = new Date(String(progress.lease_expires_at)).getTime();
+    const minExpected = before + 295_000;
+    const maxExpected = after + 305_000;
+    expect(expires).toBeGreaterThanOrEqual(minExpected);
+    expect(expires).toBeLessThanOrEqual(maxExpected);
+  });
+
+  test("marks dead expired lease as failed with LEASE_EXPIRED classification", async () => {
+    const expiredAt = new Date(Date.now() - 60_000).toISOString();
+    const row = makeDbJobRow({
+      progress: {
+        phase: "phase_1",
+        phase_status: "complete",
+        total_units: 10,
+        completed_units: 10,
+        lease_id: "lease-old",
+        lease_expires_at: expiredAt,
+      },
+      last_heartbeat: null,
+    });
+
+    const { supabase, updatePayloads } = buildSupabaseStub({
+      getJobRow: row,
+      updateResultRow: null,
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
+
+    expect(result).toBeNull();
+    expect(updatePayloads.length).toBe(1);
+    expect(updatePayloads[0]).toMatchObject({
+      status: "failed",
+      failure_envelope: expect.objectContaining({
+        error_code: "LEASE_EXPIRED",
+      }),
+      progress: expect.objectContaining({
+        phase_status: "failed",
+        lease_id: null,
+        lease_expires_at: null,
+        error_code: "LEASE_EXPIRED",
+      }),
+    });
+  });
+
+  test("allows reacquire when lease is expired but heartbeat is newer than lease expiry", async () => {
+    const expiredAt = new Date(Date.now() - 60_000).toISOString();
+    const heartbeat = new Date(Date.now() - 10_000).toISOString();
+
+    const row = makeDbJobRow({
+      progress: {
+        phase: "phase_1",
+        phase_status: "complete",
+        total_units: 10,
+        completed_units: 10,
+        lease_id: "lease-old",
+        lease_expires_at: expiredAt,
+      },
+      last_heartbeat: heartbeat,
+    });
+
+    const updateRow = makeDbJobRow({
+      progress: {
+        phase: "phase_2",
+        phase_status: "running",
+        lease_id: "lease-new",
+        lease_expires_at: new Date(Date.now() + 300_000).toISOString(),
+      },
+      last_heartbeat: heartbeat,
+    });
+
+    const { supabase, updatePayloads } = buildSupabaseStub({
+      getJobRow: row,
+      updateResultRow: updateRow,
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
+
+    expect(result).not.toBeNull();
+    expect(updatePayloads.length).toBe(1);
+    expect(updatePayloads[0]).not.toHaveProperty("status", "failed");
+    expect((updatePayloads[0].progress as Record<string, unknown>).lease_id).toBe("lease-new");
+  });
+});

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -59,6 +59,16 @@ const JOB_TYPE_FROM_DB: Record<string, JobType> = {
 const CANON_JOB_STATUS_VALUES = new Set(Object.values(JOB_STATUS));
 const CANON_PHASE_VALUES = new Set(Object.values(PHASES));
 
+const DEFAULT_LEASE_TIMEOUT_SECONDS = (() => {
+  const raw =
+    process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS ??
+    process.env.JOB_LEASE_TIMEOUT_SECONDS ??
+    "300";
+  const parsed = Number.parseInt(raw, 10);
+  // Clamp to [30s, 15m] for safety; default is 5 minutes.
+  return Number.isFinite(parsed) ? Math.min(900, Math.max(30, parsed)) : 300;
+})();
+
 function assertCanonicalStatusValue(value: string): asserts value is JobStatus {
   if (!CANON_JOB_STATUS_VALUES.has(value as JobStatus)) {
     throw new Error(
@@ -310,7 +320,7 @@ export async function safeUpdateJobStatus(
 export async function acquireLeaseForPhase1(
   id: string,
   leaseId: string,
-  ttlSeconds = 300,
+  ttlSeconds = DEFAULT_LEASE_TIMEOUT_SECONDS,
 ): Promise<Job | null> {
   const { data, error } = await supabase.rpc("claim_evaluation_job_phase1", {
     p_job_id: id,
@@ -331,7 +341,7 @@ export async function acquireLeaseForPhase1(
 export async function acquireLeaseForPhase2(
   id: string,
   leaseId: string,
-  ttlSeconds = 300,
+  ttlSeconds = DEFAULT_LEASE_TIMEOUT_SECONDS,
 ): Promise<Job | null> {
   const existing = await getJob(id);
   if (!existing) return null;
@@ -375,6 +385,65 @@ export async function acquireLeaseForPhase2(
 
   if (!isLeaseFree && !isLeaseExpired) {
     return null;
+  }
+
+  // Dead lease hardening: if a lease is expired and no heartbeat has been
+  // recorded beyond lease expiry, classify and fail the job (fail-closed).
+  if (isLeaseExpired) {
+    const heartbeatAt =
+      typeof existing.last_heartbeat === "string" ? new Date(existing.last_heartbeat) : null;
+    const leaseExpiryTime = leaseExpiresAt?.getTime() ?? 0;
+    const heartbeatTime = heartbeatAt?.getTime() ?? 0;
+    const deadLease = !heartbeatAt || heartbeatTime <= leaseExpiryTime;
+
+    if (deadLease) {
+      const nowIso = new Date().toISOString();
+      const errorMessage =
+        "Lease expired with no heartbeat; marking job failed to prevent stuck running state";
+
+      await supabase
+        .from("evaluation_jobs")
+        .update({
+          status: JOB_STATUS.FAILED,
+          last_error: errorMessage,
+          failure_envelope: {
+            error_code: "LEASE_EXPIRED",
+            code: "LEASE_EXPIRED",
+            message: errorMessage,
+            retryable: false,
+            phase: PHASES.PHASE_2,
+            provider: null,
+            occurred_at: nowIso,
+            context: {
+              lease_id: existingLeaseId,
+              lease_expires_at: leaseExpiresAtRaw ?? null,
+              last_heartbeat: existing.last_heartbeat,
+            },
+          },
+          progress: {
+            ...existing.progress,
+            phase: PHASES.PHASE_2,
+            phase_status: JOB_STATUS.FAILED,
+            message: "Phase 2 lease expired without heartbeat",
+            error_code: "LEASE_EXPIRED",
+            lease_id: null,
+            lease_expires_at: null,
+            finished_at: nowIso,
+          },
+          updated_at: nowIso,
+        })
+        .eq("id", id)
+        .eq("status", JOB_STATUS.RUNNING);
+
+      console.warn("[Phase2LeaseDeadJobFailed]", {
+        job_id: id,
+        lease_id: existingLeaseId,
+        lease_expires_at: leaseExpiresAtRaw,
+        last_heartbeat: existing.last_heartbeat,
+      });
+
+      return null;
+    }
   }
 
   if (isLeaseExpired) {

--- a/lib/jobs/phase2.ts
+++ b/lib/jobs/phase2.ts
@@ -8,6 +8,15 @@ import { writeArtifact, ARTIFACT_TYPES } from "@/lib/artifacts/writeArtifact";
 import type { ReportContent, Credibility, RubricAxis } from "@/lib/evaluation/report-types";
 import { checkPhase1GateForJob } from "@/lib/evaluation/pipeline/gatePhase2OnPhase1";
 
+const PHASE2_LEASE_TIMEOUT_SECONDS = (() => {
+  const raw =
+    process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS ??
+    process.env.JOB_LEASE_TIMEOUT_SECONDS ??
+    "300";
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? Math.min(900, Math.max(30, parsed)) : 300;
+})();
+
 const LEGACY_PHASE2_RUNTIME_ENABLED = process.env.ENABLE_LEGACY_PHASE2_RUNTIME === "1";
 
 export const PHASE_2_STATES = {
@@ -368,7 +377,7 @@ export async function runPhase2(jobId: string): Promise<void> {
     lease_expires_at: job.progress.lease_expires_at,
   });
 
-  const leasedJob = await acquireLeaseForPhase2(jobId, leaseId, 30);
+    const leasedJob = await acquireLeaseForPhase2(jobId, leaseId, PHASE2_LEASE_TIMEOUT_SECONDS);
   if (!leasedJob) {
     console.log("Phase2LeaseNotAcquired", {
       job_id: jobId,

--- a/scripts/jobs-lease-contention-test.mjs
+++ b/scripts/jobs-lease-contention-test.mjs
@@ -4,9 +4,9 @@
  *
  * Tests that only one Phase 2 worker can acquire the lease at a time:
  * 1. Complete Phase 1
- * 2. Start two Phase 2 workers simultaneously
+ * 2. Start 10+ Phase 2 workers simultaneously
  * 3. Verify only one acquires the lease
- * 4. Verify the other logs "lease not acquired" and exits cleanly
+ * 4. Verify the rest log "lease not acquired" and exit cleanly
  */
 import { getBaseUrl } from "./base-url.mjs";
 import { jfetch, must, sleep } from "./_http.mjs";
@@ -14,6 +14,7 @@ import { skipIfMemoryMode } from "./_skip.mjs";
 
 async function main() {
   const BASE = await getBaseUrl();
+  const workerCount = Math.max(10, Number.parseInt(process.env.LEASE_TEST_WORKERS || "10", 10) || 10);
   console.log(`Lease Contention Test - ${new Date().toISOString()}`);
 
   // Check if we're in memory mode (no Supabase worker)
@@ -67,31 +68,25 @@ async function main() {
     await sleep(1000);
   }
 
-  // 3) Start two Phase 2 workers simultaneously
-  console.log("Starting two Phase 2 workers simultaneously...");
+  // 3) Start N Phase 2 workers simultaneously
+  console.log(`Starting ${workerCount} Phase 2 workers simultaneously...`);
 
-  const worker1Promise = jfetch(`${BASE}/api/jobs/${jobId}/run-phase2`, {
-    method: "POST",
-  }).then((r) => ({ worker: 1, status: r.status, ok: r.ok }));
-
-  const worker2Promise = jfetch(`${BASE}/api/jobs/${jobId}/run-phase2`, {
-    method: "POST",
-  }).then((r) => ({ worker: 2, status: r.status, ok: r.ok }));
-
-  const [result1, result2] = await Promise.all([
-    worker1Promise,
-    worker2Promise,
-  ]);
-
-  console.log(
-    `Worker 1: ${result1.status} ${result1.ok ? "OK" : "FAILED"}`,
-  );
-  console.log(
-    `Worker 2: ${result2.status} ${result2.ok ? "OK" : "FAILED"}`,
+  const workerPromises = Array.from({ length: workerCount }, (_, idx) =>
+    jfetch(`${BASE}/api/jobs/${jobId}/run-phase2`, {
+      method: "POST",
+    }).then((r) => ({ worker: idx + 1, status: r.status, ok: r.ok })),
   );
 
-  // Both should return 202 (accepted), but only one will actually acquire the lease
-  if (!result1.ok || !result2.ok) {
+  const results = await Promise.all(workerPromises);
+
+  for (const result of results) {
+    console.log(
+      `Worker ${result.worker}: ${result.status} ${result.ok ? "OK" : "FAILED"}`,
+    );
+  }
+
+  // All should return accepted/ok, but only one will actually acquire lease in runtime.
+  if (results.some((r) => !r.ok)) {
     console.error("FAIL: One or both workers returned non-OK status");
     process.exit(1);
   }
@@ -131,7 +126,7 @@ async function main() {
   }
 
   // Success criteria:
-  // 1. Both workers returned 202 Accepted
+  // 1. All workers returned 202 Accepted
   // 2. Job completed successfully (only one worker actually ran)
   // 3. No errors or duplicate processing
   console.log("✓ PASS: Lease contention handled correctly");

--- a/scripts/jobs-test-contention.mjs
+++ b/scripts/jobs-test-contention.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+/**
+ * Backward-compatible alias for lease contention test harness.
+ * Maintains docs/issue reference to scripts/jobs-test-contention.mjs.
+ */
+import "./jobs-lease-contention-test.mjs";


### PR DESCRIPTION
## PR C — Lease timeout hardening (Issue #54)\n\nImplements the next reliability gate after PR B atomic claiming.\n\n### What changed\n- Added configurable lease timeout with **default 300s (5 minutes)** via:\n  - \n  - fallback \n- Updated Phase 2 lease acquisition to use configurable timeout (removed hardcoded 30s).\n- Hardened  dead-lease handling:\n  - If lease is expired **and** heartbeat is missing/stale, job transitions to \n  - Writes classified failure envelope with \n  - Clears lease fields to prevent stuck-running jobs\n- Upgraded contention harness for 10+ workers and added compatibility alias script:\n  -  now runs >=10 workers\n  -  alias added\n- Added focused unit tests:\n  - \n\n### Validation\n- 
> revisiongrade@1.0.0 pretest
> node scripts/guard-critical-tests.mjs

[guard-critical-tests] OK

> revisiongrade@1.0.0 test
> jest __tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts --runInBand

  console.warn
    [Phase2LeaseDeadJobFailed] {
      job_id: 'job-1',
      lease_id: 'lease-old',
      lease_expires_at: '2026-04-13T18:05:40.928Z',
      last_heartbeat: null
    }

      436 |         .eq("status", JOB_STATUS.RUNNING);
      437 |
    > 438 |       console.warn("[Phase2LeaseDeadJobFailed]", {
          |               ^
      439 |         job_id: id,
      440 |         lease_id: existingLeaseId,
      441 |         lease_expires_at: leaseExpiresAtRaw,

      at warn (lib/jobs/jobStore.supabase.ts:438:15)
      at Object.<anonymous> (__tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts:156:20)

  console.log
    [Phase2LeaseExpired] job_id=job-1 old_lease_id=lease-old resuming_from=-1

      at log (lib/jobs/jobStore.supabase.ts:450:13)\n- 
> revisiongrade@1.0.0 pretest
> node scripts/guard-critical-tests.mjs

[guard-critical-tests] OK

> revisiongrade@1.0.0 test
> jest lib/jobs/phase1.test.ts __tests__/lib/jobs/phase-routing.guards.test.ts --runInBand\n\nCloses #54