### PR TITLE
fix: canonicalize queue state and centralize runtime policy (PR D)

### DIFF
--- a/__tests__/lib/jobs/phase-routing.guards.test.ts
+++ b/__tests__/lib/jobs/phase-routing.guards.test.ts
@@ -12,7 +12,7 @@ describe("phase routing guards for queued jobs", () => {
       status: "queued",
       progress: {
         phase: "phase_2",
-        phase_status: "triggered",
+        phase_status: "queued",
         total_units: null,
         completed_units: null,
       },
@@ -32,12 +32,12 @@ describe("phase routing guards for queued jobs", () => {
       {
         id: "job-phase1",
         status: "queued",
-        progress: { phase: "phase_1", phase_status: "triggered" },
+        progress: { phase: "phase_1", phase_status: "queued" },
       },
       {
         id: "job-phase2",
         status: "queued",
-        progress: { phase: "phase_2", phase_status: "triggered" },
+        progress: { phase: "phase_2", phase_status: "queued" },
       },
       {
         id: "job-phase2-eligible",

--- a/app/api/admin/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/admin/jobs/[jobId]/run-phase2/route.ts
@@ -101,7 +101,7 @@ export async function POST(
       return NextResponse.json(payload, { status: 409 });
     }
 
-    console.log("AdminPhase2Triggered", {
+    console.log("AdminPhase2Queued", {
       job_id: jobId,
       trigger_time: now,
       force,

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -156,7 +156,7 @@ export async function POST(req: Request) {
         user_id: userId,
         job_type: "evaluate_full",
         phase: PHASES.PHASE_1,
-      phase_status: "triggered",
+        phase_status: "queued",
         policy_family: "standard",
         voice_preservation_level: "balanced",
         english_variant: "us",

--- a/app/api/internal/jobs/route.ts
+++ b/app/api/internal/jobs/route.ts
@@ -35,7 +35,7 @@ export function selectEligibleJobs(allJobs: Awaited<ReturnType<typeof getAllJobs
     (j) =>
       j.status === "queued" &&
       j.progress?.phase === PHASES.PHASE_1 &&
-      (j.progress?.phase_status === "queued" || j.progress?.phase_status === "triggered"),
+      j.progress?.phase_status === "queued",
   );
 
   const phase2Candidates = allJobs.filter(

--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -102,7 +102,7 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
     );
   }
 
-  console.log("Phase2Triggered", {
+  console.log("Phase2Queued", {
     job_id: jobId,
     trigger_time: now,
     force,

--- a/lib/evaluation/config.ts
+++ b/lib/evaluation/config.ts
@@ -1,0 +1,20 @@
+export function getEvalPassTimeoutMs(): number {
+  const parsed = Number.parseInt(process.env.EVAL_PASS_TIMEOUT_MS || "180000", 10);
+  return Number.isFinite(parsed) && parsed >= 10_000 && parsed <= 180_000 ? parsed : 180_000;
+}
+
+export function getEvalOpenAiTimeoutMs(): number {
+  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "180000", 10);
+  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 180_000 ? parsed : 180_000;
+}
+
+export function assertEvalTimeoutConfig(): void {
+  const passTimeoutMs = getEvalPassTimeoutMs();
+  const openAiTimeoutMs = getEvalOpenAiTimeoutMs();
+
+  if (openAiTimeoutMs < passTimeoutMs) {
+    throw new Error(
+      `[CONFIG_ERROR] EVAL_OPENAI_TIMEOUT_MS (${openAiTimeoutMs}) must be >= EVAL_PASS_TIMEOUT_MS (${passTimeoutMs})`,
+    );
+  }
+}

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -18,14 +18,12 @@ import {
   buildOpenAITemperatureParam,
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
+import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 
 const PASS1_TEMPERATURE = 0.3;
 const PASS1_MAX_TOKENS = 4000;
 const PASS1_MODEL = "o3";
-const OPENAI_TIMEOUT_MS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "180000", 10);
-  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 180_000 ? parsed : 180_000;
-})();
+const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 type CompletionChoice = {
   message?: {

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -20,14 +20,12 @@ import {
   buildOpenAITemperatureParam,
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
+import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 
 const PASS2_TEMPERATURE = 0.3;
 const PASS2_MAX_TOKENS = 4000;
 const PASS2_MODEL = "o3";
-const OPENAI_TIMEOUT_MS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "180000", 10);
-  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 180_000 ? parsed : 180_000;
-})();
+const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 type CompletionChoice = {
   message?: {

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -19,6 +19,7 @@ import {
   buildOpenAITemperatureParam,
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
+import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
 
@@ -30,10 +31,7 @@ const PASS3_MAX_TOKENS = (() => {
 const PASS3_MODEL = "o3";
 const PASS3_MIN_RATIONALE_LENGTH = 40;
 const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
-const OPENAI_TIMEOUT_MS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || "180000", 10);
-  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 180_000 ? parsed : 180_000;
-})();
+const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 type CompletionChoice = {
   message?: {

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -72,6 +72,11 @@ import {
   getCanonicalPipelineModel,
   getExternalAdjudicationMode,
 } from '@/lib/evaluation/policy';
+import {
+  assertEvalTimeoutConfig,
+  getEvalOpenAiTimeoutMs,
+  getEvalPassTimeoutMs,
+} from '@/lib/evaluation/config';
 import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 
@@ -96,19 +101,9 @@ const evalMinManuscriptChars = (() => {
   return 200 * 5; // 200 words default
 })();
 const openAiModel = (process.env.EVAL_OPENAI_MODEL || 'o3').trim() || 'o3';
-const evalPassTimeoutMs = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS_TIMEOUT_MS || '180000', 10);
-  return Number.isFinite(parsed) && parsed >= 10_000 && parsed <= 180_000 ? parsed : 180_000;
-})();
-const evalOpenAiTimeoutMs = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_OPENAI_TIMEOUT_MS || '180000', 10);
-  return Number.isFinite(parsed) && parsed >= 1_000 && parsed <= 180_000 ? parsed : 180_000;
-})();
-if (evalOpenAiTimeoutMs < evalPassTimeoutMs) {
-  throw new Error(
-    `[CONFIG_ERROR] EVAL_OPENAI_TIMEOUT_MS (${evalOpenAiTimeoutMs}) must be >= EVAL_PASS_TIMEOUT_MS (${evalPassTimeoutMs})`,
-  );
-}
+const evalPassTimeoutMs = getEvalPassTimeoutMs();
+const evalOpenAiTimeoutMs = getEvalOpenAiTimeoutMs();
+assertEvalTimeoutConfig();
 const EVALUATION_PROGRESS_TOTAL_UNITS = 3;
 const staleRunningMinutes = (() => {
   const parsed = Number.parseInt(process.env.EVAL_STALE_RUNNING_MINUTES || '10', 10);

--- a/lib/jobs/config.ts
+++ b/lib/jobs/config.ts
@@ -1,4 +1,27 @@
 /**
+ * Canonical lease-timeout policy for job phase execution.
+ *
+ * Env precedence:
+ * 1) JOB_PHASE_LEASE_TIMEOUT_SECONDS
+ * 2) JOB_LEASE_TIMEOUT_SECONDS (legacy compatibility)
+ * 3) default 300s
+ *
+ * Clamped to [30s, 900s] for safety.
+ */
+export function getLeaseTimeoutSeconds(): number {
+  const raw =
+    process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS ??
+    process.env.JOB_LEASE_TIMEOUT_SECONDS ??
+    "300";
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    return 300;
+  }
+
+  return Math.min(900, Math.max(30, parsed));
+}
+/**
  * Job System Configuration
  *
  * Central configuration and startup validation for job system.

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -7,6 +7,7 @@ import {
   validateProgressSchema,
 } from "./canon";
 import { Job, JobStatus, JobType, PHASES, Phase, JOB_STATUS, JobProgress } from "./types";
+import { getLeaseTimeoutSeconds } from "./config";
 
 const JOB_SELECT_FIELDS =
   "id, manuscript_id, user_id, job_type, status, progress, created_at, updated_at, last_heartbeat, last_error, failure_envelope, manuscripts(user_id)";
@@ -59,15 +60,7 @@ const JOB_TYPE_FROM_DB: Record<string, JobType> = {
 const CANON_JOB_STATUS_VALUES = new Set(Object.values(JOB_STATUS));
 const CANON_PHASE_VALUES = new Set(Object.values(PHASES));
 
-const DEFAULT_LEASE_TIMEOUT_SECONDS = (() => {
-  const raw =
-    process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS ??
-    process.env.JOB_LEASE_TIMEOUT_SECONDS ??
-    "300";
-  const parsed = Number.parseInt(raw, 10);
-  // Clamp to [30s, 15m] for safety; default is 5 minutes.
-  return Number.isFinite(parsed) ? Math.min(900, Math.max(30, parsed)) : 300;
-})();
+const DEFAULT_LEASE_TIMEOUT_SECONDS = getLeaseTimeoutSeconds();
 
 function assertCanonicalStatusValue(value: string): asserts value is JobStatus {
   if (!CANON_JOB_STATUS_VALUES.has(value as JobStatus)) {

--- a/lib/jobs/phase1.ts
+++ b/lib/jobs/phase1.ts
@@ -80,8 +80,7 @@ export async function runPhase1(jobId: string): Promise<void> {
   const isPhase1QueuedCandidate =
     job.status === JOB_STATUS.QUEUED &&
     initialProgress.phase === PHASES.PHASE_1 &&
-    (initialProgress.phase_status === PHASE_1_STATES.QUEUED ||
-      initialProgress.phase_status === "triggered");
+    initialProgress.phase_status === PHASE_1_STATES.QUEUED;
 
   if (!isPhase1QueuedCandidate) {
     console.log("Phase1RejectedNotEligible", {

--- a/lib/jobs/phase2.ts
+++ b/lib/jobs/phase2.ts
@@ -7,15 +7,9 @@ import { JOB_STATUS, PHASES } from "./types";
 import { writeArtifact, ARTIFACT_TYPES } from "@/lib/artifacts/writeArtifact";
 import type { ReportContent, Credibility, RubricAxis } from "@/lib/evaluation/report-types";
 import { checkPhase1GateForJob } from "@/lib/evaluation/pipeline/gatePhase2OnPhase1";
+import { getLeaseTimeoutSeconds } from "./config";
 
-const PHASE2_LEASE_TIMEOUT_SECONDS = (() => {
-  const raw =
-    process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS ??
-    process.env.JOB_LEASE_TIMEOUT_SECONDS ??
-    "300";
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) ? Math.min(900, Math.max(30, parsed)) : 300;
-})();
+const PHASE2_LEASE_TIMEOUT_SECONDS = getLeaseTimeoutSeconds();
 
 const LEGACY_PHASE2_RUNTIME_ENABLED = process.env.ENABLE_LEGACY_PHASE2_RUNTIME === "1";
 

--- a/lib/jobs/store.ts
+++ b/lib/jobs/store.ts
@@ -79,7 +79,7 @@ export function canRunPhase(
     const phase1QueuedCandidate =
       job.status === JOB_STATUS.QUEUED &&
       progress.phase === PHASES.PHASE_1 &&
-      (progress.phase_status === JOB_STATUS.QUEUED || progress.phase_status === "triggered");
+      progress.phase_status === JOB_STATUS.QUEUED;
 
     if (!phase1QueuedCandidate) {
       return {

--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -65,24 +65,10 @@ export const JOB_STATUS = {
 export type JobStatus = (typeof JOB_STATUS)[keyof typeof JOB_STATUS];
 
 /**
- * PHASE_STATUS_MARKERS — Queue eligibility markers used by worker selectors
- * These are runtime-only markers that indicate which jobs the worker should pick up.
- * "triggered" means: job is queued and ready for the next phase executor to claim.
+ * PhaseStatus is canonical JobStatus (or null).
+ * Worker contract: selects jobs where status='queued' AND phase_status='queued'.
  */
-export const PHASE_STATUS_MARKERS = {
-  TRIGGERED: "triggered",
-} as const;
-
-export type PhaseStatusMarker = (typeof PHASE_STATUS_MARKERS)[keyof typeof PHASE_STATUS_MARKERS];
-
-/**
- * PhaseStatus reflects actual runtime usage:
- * - JobStatus values (queued, running, complete, failed) for state transitions
- * - Additional markers (triggered) for worker queue eligibility
- * 
- * Worker contract: selects jobs where status='queued' AND phase_status='triggered'
- */
-export type PhaseStatus = JobStatus | PhaseStatusMarker | null;
+export type PhaseStatus = JobStatus | null;
 
 /**
  * JOB_CONTRACT_v1 — CANON progress shape (minimum)


### PR DESCRIPTION
## Summary
- remove remaining durable queue-state drift so `queued` is the only queue truth
- centralize lease-timeout policy in `lib/jobs/config.ts`
- centralize evaluation timeout parsing and invariant enforcement in `lib/evaluation/config.ts`
- align routes, selectors, tests, and runtime guards with canonical queue semantics

## Verification
- `npm test -- __tests__/lib/evaluation/architecture-invariants.test.ts __tests__/lib/jobs/phase-routing.guards.test.ts __tests__/lib/evaluation/processor.config-invariant.test.ts __tests__/lib/evaluation/processor.phase-routing.test.ts __tests__/lib/evaluation/processor.canonical-pipeline.test.ts __tests__/lib/evaluation/processor.short-text.test.ts tests/evaluation/pipeline/pipeline-independence.test.ts tests/evaluation/pipeline/pipeline-e2e.test.ts --runInBand`

Closes #118
