### PR TITLE
feat: atomic Phase 2 claim and auditable dead-lease writes (PR E)

### DIFF
--- a/__tests__/lib/jobs/jobStore.phase2-atomic-claim.test.ts
+++ b/__tests__/lib/jobs/jobStore.phase2-atomic-claim.test.ts
@@ -1,0 +1,152 @@
+export {};
+
+const createAdminClientMock = jest.fn();
+
+jest.mock("../../../lib/supabase/admin", () => ({
+  createAdminClient: (...args: unknown[]) => createAdminClientMock(...args),
+}));
+
+type DbRow = Record<string, any>;
+
+function makeDbJobRow(overrides: Partial<DbRow> = {}): DbRow {
+  return {
+    id: "job-1",
+    manuscript_id: 42,
+    user_id: "user-1",
+    job_type: "full_evaluation",
+    status: "running",
+    progress: {
+      phase: "phase_1",
+      phase_status: "complete",
+      total_units: 10,
+      completed_units: 10,
+      lease_id: null,
+      lease_expires_at: null,
+    },
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    last_heartbeat: null,
+    last_error: null,
+    failure_envelope: null,
+    manuscripts: { user_id: "user-1" },
+    ...overrides,
+  };
+}
+
+function buildSupabaseStub(opts: {
+  getJobRows?: DbRow[];
+  rpcImpl?: (fn: string, params: Record<string, unknown>) => Promise<{ data: DbRow[] | null; error: { message: string } | null }>;
+}) {
+  const getJobRows = opts.getJobRows ?? [makeDbJobRow()];
+  const getJobMaybeSingle = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ data: getJobRows.shift() ?? null, error: null }));
+
+  const rpc = jest.fn().mockImplementation((fn: string, params: Record<string, unknown>) => {
+    if (opts.rpcImpl) {
+      return opts.rpcImpl(fn, params);
+    }
+    return Promise.resolve({ data: [], error: null });
+  });
+
+  return {
+    rpc,
+    from: jest.fn().mockImplementation((table: string) => {
+      if (table !== "evaluation_jobs") {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      return {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: getJobMaybeSingle,
+          }),
+        }),
+        update: jest.fn(() => ({
+          eq: jest.fn().mockReturnThis(),
+          select: jest.fn().mockReturnThis(),
+          maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        })),
+      };
+    }),
+  };
+}
+
+describe("acquireLeaseForPhase2 atomic claim", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete process.env.JOB_PHASE_LEASE_TIMEOUT_SECONDS;
+    delete process.env.JOB_LEASE_TIMEOUT_SECONDS;
+  });
+
+  test("uses claim_evaluation_job_phase2 RPC for successful claim ownership", async () => {
+    const claimedRow = makeDbJobRow({
+      progress: {
+        phase: "phase_2",
+        phase_status: "running",
+        lease_id: "lease-new",
+        lease_expires_at: new Date(Date.now() + 300_000).toISOString(),
+      },
+    });
+
+    const supabase = buildSupabaseStub({
+      rpcImpl: async () => ({ data: [claimedRow], error: null }),
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
+
+    expect(result).not.toBeNull();
+    expect(supabase.rpc).toHaveBeenCalledWith("claim_evaluation_job_phase2", {
+      p_job_id: "job-1",
+      p_lease_id: "lease-new",
+      p_ttl_seconds: 300,
+    });
+  });
+
+  test("concurrent claim attempts cannot both win", async () => {
+    const claimedRow = makeDbJobRow({
+      progress: {
+        phase: "phase_2",
+        phase_status: "running",
+        lease_id: "lease-a",
+        lease_expires_at: new Date(Date.now() + 300_000).toISOString(),
+      },
+    });
+
+    let callCount = 0;
+    const supabase = buildSupabaseStub({
+      getJobRows: [makeDbJobRow(), makeDbJobRow()],
+      rpcImpl: async () => {
+        callCount += 1;
+        return callCount === 1
+          ? { data: [claimedRow], error: null }
+          : { data: [], error: null };
+      },
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const [first, second] = await Promise.all([
+      acquireLeaseForPhase2("job-1", "lease-a", 300),
+      acquireLeaseForPhase2("job-1", "lease-b", 300),
+    ]);
+
+    const wins = [first, second].filter(Boolean);
+    expect(wins).toHaveLength(1);
+  });
+
+  test("returns null when RPC reports no claim for non-eligible or lost-race case", async () => {
+    const supabase = buildSupabaseStub({
+      rpcImpl: async () => ({ data: [], error: null }),
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
+
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts
+++ b/__tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts
@@ -35,31 +35,34 @@ function makeDbJobRow(overrides: Partial<DbRow> = {}): DbRow {
 
 function buildSupabaseStub(opts: {
   getJobRow: DbRow;
+  rpcResultRows?: DbRow[] | null;
+  rpcError?: { message: string } | null;
   updateResultRow?: DbRow | null;
 }) {
   const updatePayloads: Array<Record<string, unknown>> = [];
 
-  const maybeSingle = jest
+  const getJobMaybeSingle = jest
     .fn()
-    .mockResolvedValueOnce({ data: opts.getJobRow, error: null })
-    .mockResolvedValue({ data: opts.updateResultRow ?? opts.getJobRow, error: null });
+    .mockResolvedValue({ data: opts.getJobRow, error: null });
+
+  const updateMaybeSingle = jest
+    .fn()
+    .mockResolvedValue({ data: opts.updateResultRow ?? null, error: null });
 
   const updateBuilder: any = {
     eq: jest.fn(function () {
-      return this;
-    }),
-    or: jest.fn(function () {
       return this;
     }),
     select: jest.fn(function () {
       this._hasSelect = true;
       return this;
     }),
-    maybeSingle,
+    maybeSingle: updateMaybeSingle,
     _hasSelect: false,
   };
 
   const supabase = {
+    rpc: jest.fn().mockResolvedValue({ data: opts.rpcResultRows ?? [], error: opts.rpcError ?? null }),
     from: jest.fn().mockImplementation((table: string) => {
       if (table !== "evaluation_jobs") {
         throw new Error(`Unexpected table: ${table}`);
@@ -68,7 +71,7 @@ function buildSupabaseStub(opts: {
       return {
         select: jest.fn().mockReturnValue({
           eq: jest.fn().mockReturnValue({
-            maybeSingle,
+            maybeSingle: getJobMaybeSingle,
           }),
         }),
         update: jest.fn((payload: Record<string, unknown>) => {
@@ -100,7 +103,7 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
       },
     });
 
-    const updateRow = makeDbJobRow({
+    const claimedRow = makeDbJobRow({
       progress: {
         phase: "phase_2",
         phase_status: "running",
@@ -111,7 +114,7 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
 
     const { supabase, updatePayloads } = buildSupabaseStub({
       getJobRow: row,
-      updateResultRow: updateRow,
+      rpcResultRows: [claimedRow],
     });
     createAdminClientMock.mockReturnValue(supabase as any);
 
@@ -122,14 +125,12 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
     const after = Date.now();
 
     expect(result).not.toBeNull();
-    expect(updatePayloads.length).toBeGreaterThan(0);
-
-    const progress = updatePayloads[0].progress as Record<string, unknown>;
-    const expires = new Date(String(progress.lease_expires_at)).getTime();
-    const minExpected = before + 295_000;
-    const maxExpected = after + 305_000;
-    expect(expires).toBeGreaterThanOrEqual(minExpected);
-    expect(expires).toBeLessThanOrEqual(maxExpected);
+    expect(updatePayloads).toHaveLength(0);
+    expect(supabase.rpc).toHaveBeenCalledWith("claim_evaluation_job_phase2", {
+      p_job_id: "job-1",
+      p_lease_id: "lease-new",
+      p_ttl_seconds: 300,
+    });
   });
 
   test("marks dead expired lease as failed with LEASE_EXPIRED classification", async () => {
@@ -146,9 +147,10 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
       last_heartbeat: null,
     });
 
+    const failedRow = makeDbJobRow({ status: "failed" });
     const { supabase, updatePayloads } = buildSupabaseStub({
       getJobRow: row,
-      updateResultRow: null,
+      updateResultRow: failedRow,
     });
     createAdminClientMock.mockReturnValue(supabase as any);
 
@@ -157,6 +159,7 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
 
     expect(result).toBeNull();
     expect(updatePayloads.length).toBe(1);
+    expect(supabase.rpc).not.toHaveBeenCalled();
     expect(updatePayloads[0]).toMatchObject({
       status: "failed",
       failure_envelope: expect.objectContaining({
@@ -187,7 +190,7 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
       last_heartbeat: heartbeat,
     });
 
-    const updateRow = makeDbJobRow({
+    const claimedRow = makeDbJobRow({
       progress: {
         phase: "phase_2",
         phase_status: "running",
@@ -199,7 +202,7 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
 
     const { supabase, updatePayloads } = buildSupabaseStub({
       getJobRow: row,
-      updateResultRow: updateRow,
+      rpcResultRows: [claimedRow],
     });
     createAdminClientMock.mockReturnValue(supabase as any);
 
@@ -207,8 +210,41 @@ describe("acquireLeaseForPhase2 lease timeout hardening", () => {
     const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
 
     expect(result).not.toBeNull();
-    expect(updatePayloads.length).toBe(1);
-    expect(updatePayloads[0]).not.toHaveProperty("status", "failed");
-    expect((updatePayloads[0].progress as Record<string, unknown>).lease_id).toBe("lease-new");
+    expect(updatePayloads).toHaveLength(0);
+    expect(supabase.rpc).toHaveBeenCalledWith("claim_evaluation_job_phase2", {
+      p_job_id: "job-1",
+      p_lease_id: "lease-new",
+      p_ttl_seconds: 300,
+    });
+  });
+
+  test("logs lost-race outcome when dead-lease failure write updates zero rows", async () => {
+    const expiredAt = new Date(Date.now() - 60_000).toISOString();
+    const row = makeDbJobRow({
+      progress: {
+        phase: "phase_1",
+        phase_status: "complete",
+        lease_id: "lease-old",
+        lease_expires_at: expiredAt,
+      },
+      last_heartbeat: null,
+    });
+
+    const { supabase } = buildSupabaseStub({
+      getJobRow: row,
+      updateResultRow: null,
+    });
+    createAdminClientMock.mockReturnValue(supabase as any);
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const { acquireLeaseForPhase2 } = await import("../../../lib/jobs/jobStore.supabase");
+    const result = await acquireLeaseForPhase2("job-1", "lease-new", 300);
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Phase2LeaseDeadJobLostRace]",
+      expect.objectContaining({ job_id: "job-1", lease_id: "lease-old" }),
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -394,7 +394,7 @@ export async function acquireLeaseForPhase2(
       const errorMessage =
         "Lease expired with no heartbeat; marking job failed to prevent stuck running state";
 
-      await supabase
+      const { data: failedRow, error: failError } = await supabase
         .from("evaluation_jobs")
         .update({
           status: JOB_STATUS.FAILED,
@@ -426,14 +426,29 @@ export async function acquireLeaseForPhase2(
           updated_at: nowIso,
         })
         .eq("id", id)
-        .eq("status", JOB_STATUS.RUNNING);
+        .eq("status", JOB_STATUS.RUNNING)
+        .select(JOB_SELECT_FIELDS)
+        .maybeSingle();
 
-      console.warn("[Phase2LeaseDeadJobFailed]", {
-        job_id: id,
-        lease_id: existingLeaseId,
-        lease_expires_at: leaseExpiresAtRaw,
-        last_heartbeat: existing.last_heartbeat,
-      });
+      if (failError) {
+        throw new Error(`Failed to classify dead phase2 lease: ${failError.message}`);
+      }
+
+      if (failedRow) {
+        console.warn("[Phase2LeaseDeadJobFailed]", {
+          job_id: id,
+          lease_id: existingLeaseId,
+          lease_expires_at: leaseExpiresAtRaw,
+          last_heartbeat: existing.last_heartbeat,
+        });
+      } else {
+        console.warn("[Phase2LeaseDeadJobLostRace]", {
+          job_id: id,
+          lease_id: existingLeaseId,
+          lease_expires_at: leaseExpiresAtRaw,
+          last_heartbeat: existing.last_heartbeat,
+        });
+      }
 
       return null;
     }
@@ -447,49 +462,18 @@ export async function acquireLeaseForPhase2(
     );
   }
 
-  const expiresAt = new Date(now.getTime() + ttlSeconds * 1000).toISOString();
-
-  // If resuming, do NOT rewrite phase/phase_status; keep them stable.
-  // If entering from phase1/complete, flip into phase2/running.
-  const mergedProgress = isPhase2Resumable
-    ? {
-        ...existing.progress,
-        lease_id: leaseId,
-        lease_expires_at: expiresAt,
-      }
-    : {
-        ...existing.progress,
-        lease_id: leaseId,
-        lease_expires_at: expiresAt,
-        phase: PHASES.PHASE_2,
-        phase_status: "running",
-      };
-
-  // Optimistic concurrency: prevents concurrent lease acquires / progress stomps
-  const { data, error } = await supabase
-    .from("evaluation_jobs")
-    .update({
-      progress: mergedProgress,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", id)
-    .eq("status", "running")
-    .eq("updated_at", existing.updated_at)
-    .or(
-      [
-        "and(progress->>phase.eq.phase_1,progress->>phase_status.eq.complete)",
-        "and(progress->>phase.eq.phase_2,progress->>phase_status.eq.running)",
-      ].join(","),
-    )
-    .select(JOB_SELECT_FIELDS)
-    .maybeSingle();
+  const { data, error } = await supabase.rpc("claim_evaluation_job_phase2", {
+    p_job_id: id,
+    p_lease_id: leaseId,
+    p_ttl_seconds: ttlSeconds,
+  });
 
   if (error) {
-    throw new Error(`Failed to acquire phase2 lease: ${error.message}`);
+    throw new Error(`claim_evaluation_job_phase2 RPC failed: ${error.message}`);
   }
 
-  if (!data) return null;
-  return mapDbRowToJob(data);
+  if (!data || data.length === 0) return null;
+  return mapDbRowToJob(data[0]);
 }
 
 export async function incrementCounter(

--- a/supabase/migrations/20260413000003_create_claim_evaluation_job_phase2_rpc.sql
+++ b/supabase/migrations/20260413000003_create_claim_evaluation_job_phase2_rpc.sql
@@ -1,0 +1,65 @@
+-- Migration: claim_evaluation_job_phase2 RPC
+-- Purpose: Atomic job claiming for PHASE 2 to prevent app-layer claim races
+--
+-- Claim contract:
+--   - job must already be status='running'
+--   - eligible handoff state: progress.phase='phase_1' AND progress.phase_status='complete'
+--   - eligible resume state: progress.phase='phase_2' AND progress.phase_status='running'
+--   - lease must be free OR expired with heartbeat newer than expiry
+
+CREATE OR REPLACE FUNCTION public.claim_evaluation_job_phase2(
+  p_job_id uuid,
+  p_lease_id text,
+  p_ttl_seconds integer DEFAULT 300
+)
+RETURNS SETOF public.evaluation_jobs
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  UPDATE public.evaluation_jobs
+  SET
+    progress = jsonb_set(
+      jsonb_set(
+        jsonb_set(
+          jsonb_set(
+            COALESCE(progress, '{}'::jsonb),
+            '{lease_id}', to_jsonb(p_lease_id)
+          ),
+          '{lease_expires_at}', to_jsonb((now() + make_interval(secs => p_ttl_seconds))::text)
+        ),
+        '{phase}', '"phase_2"'
+      ),
+      '{phase_status}', '"running"'
+    ),
+    updated_at = now()
+  WHERE
+    id = p_job_id
+    AND status = 'running'
+    AND (
+      (
+        COALESCE(progress->>'phase', '') = 'phase_1'
+        AND COALESCE(progress->>'phase_status', '') = 'complete'
+      )
+      OR
+      (
+        COALESCE(progress->>'phase', '') = 'phase_2'
+        AND COALESCE(progress->>'phase_status', '') = 'running'
+      )
+    )
+    AND (
+      COALESCE(progress->>'lease_id', '') = ''
+      OR (
+        COALESCE(progress->>'lease_expires_at', '') <> ''
+        AND (progress->>'lease_expires_at')::timestamptz <= now()
+        AND last_heartbeat IS NOT NULL
+        AND last_heartbeat::timestamptz > (progress->>'lease_expires_at')::timestamptz
+      )
+    )
+  RETURNING *;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_evaluation_job_phase2(uuid, text, integer) FROM public;
+GRANT EXECUTE ON FUNCTION public.claim_evaluation_job_phase2(uuid, text, integer) TO service_role;
+
+COMMENT ON FUNCTION public.claim_evaluation_job_phase2 IS
+'PR E: Atomic Phase 2 claim RPC. Prevents concurrent Phase 2 claim races by moving ownership gating into SQL.';


### PR DESCRIPTION
## Summary
- add DB-atomic `claim_evaluation_job_phase2` RPC for Phase 2 ownership
- replace app-layer optimistic claim update with RPC-backed claim semantics
- verify dead-lease failure writes and distinguish landed-vs-lost-race outcomes
- add focused atomic-claim and dead-lease race-boundary tests

## Verification
- `npm test -- __tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts __tests__/lib/jobs/jobStore.phase2-atomic-claim.test.ts --runInBand`
- `npm test -- __tests__/lib/jobs/phase-routing.guards.test.ts __tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts __tests__/lib/jobs/jobStore.phase2-atomic-claim.test.ts --runInBand`

## Notes
- `node scripts/jobs-test-contention.mjs` was probed, but this workspace does not have the required live app/server + real backing services (`http://localhost:3000` fetch failed). That remains a post-merge live proof gate, not a local substitute.

Closes #119
