### PR TITLE
Stabilize CI cleanup surfaces after a545582

### DIFF
--- a/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
+++ b/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
@@ -51,7 +51,7 @@ function makeSupabaseStub() {
   const manuscript = {
     id: 456,
     title: "Canonical Manuscript",
-    content: "This manuscript is long enough to pass threshold validation. ".repeat(23),
+    content: "This manuscript is long enough to pass threshold validation. ".repeat(220),
     work_type: "novel",
     user_id: "00000000-0000-0000-0000-000000000001",
   };

--- a/__tests__/lib/evaluation/processor.contamination-guard.test.ts
+++ b/__tests__/lib/evaluation/processor.contamination-guard.test.ts
@@ -67,7 +67,7 @@ function makeSupabaseStub() {
   const manuscript = {
     id: 789,
     title: "River Chapter",
-    content: "Cliff piloted the skiff across Carpenter Lake. The water moved cold and clear under the hull.".repeat(20),
+    content: "Cliff piloted the skiff across Carpenter Lake. The water moved cold and clear under the hull.".repeat(220),
     work_type: "narrative_nonfiction",
     user_id: "00000000-0000-0000-0000-000000000002",
   };

--- a/app/api/workers/process-evaluations/auth.test.ts
+++ b/app/api/workers/process-evaluations/auth.test.ts
@@ -152,7 +152,8 @@ describe('Process Evaluations Worker Auth', () => {
         headers: {
           'x-vercel-cron': '1',
           'x-vercel-id': 'iad1::abc123'
-        }
+        },
+        searchParams: { dry_run: '1' }
       });
       const response = await GET(req);
       
@@ -490,7 +491,8 @@ describe('QC5: timingSafeEqual Edge Cases', () => {
     delete process.env.VERCEL;
     
     const req = createMockRequest({
-      headers: { 'authorization': 'Bearer ' + unicodeSecret }
+      headers: { 'authorization': 'Bearer ' + unicodeSecret },
+      searchParams: { dry_run: '1' },
     });
     const response = await GET(req);
     expect(response.status).toBe(200);
@@ -515,7 +517,8 @@ describe('QC5: timingSafeEqual Edge Cases', () => {
     delete process.env.VERCEL;
     
     const req = createMockRequest({
-      headers: { 'authorization': 'Bearer ' + maxSecret }
+      headers: { 'authorization': 'Bearer ' + maxSecret },
+      searchParams: { dry_run: '1' },
     });
     const response = await GET(req);
     expect(response.status).toBe(200);

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -294,6 +294,7 @@ export async function GET(request: NextRequest) {
         success: true,
         dryRun: true,
         traceId,
+        authMethod: auth.method,
         message: 'Dry run mode - no jobs processed',
         timestamp: new Date().toISOString(),
         config: {

--- a/lib/evaluation/pipeline/prompts/pass1-craft.ts
+++ b/lib/evaluation/pipeline/prompts/pass1-craft.ts
@@ -42,8 +42,8 @@ Return a JSON object with a "criteria" array containing exactly 13 entries — o
 15. Prefer 1-2 sentences per rationale unless 3 is strictly necessary for clarity.
 16. Keep expected_impact concise (prefer one sentence; avoid ornamental phrasing).
 17. Do NOT use audience-positioning or marketability boilerplate such as "appealing to readers", "timely and relevant themes", "market potential", or "commercial appeal" unless criterion-specific and tied directly to on-page craft execution.
-18. For marketability, evaluate execution-side craft only: clarity of premise delivery, distinctiveness of setup, readability pressure, structural accessibility, and hook presentation. Do NOT describe readership demographics or shelf positioning.
-19. Keep rationale language craft-mechanical: structure, escalation, causality, scene pressure, exposition load, information sequencing, POV control, sentence rhythm, paragraph flow.
+18. For marketability, evaluate execution-side craft only: premise legibility, distinctiveness of setup, readability pressure, accessibility friction, and hook presentation. Do NOT describe readership demographics or shelf positioning.
+19. Keep rationale language craft-mechanical: scene construction, escalation, causality, scene pressure, exposition load, information sequencing, POV control, sentence rhythm, paragraph flow.
 20. Avoid editorial/literary framing in Pass 1 (e.g., cultural significance, thematic relevance claims, conversation-level positioning).
 21. For POV/voice evaluation, explicitly assess rendering consistency: in close POV, treat internal thought as integrated narration by default; mark down unnecessary thought italics or inconsistent thought-marking that creates cognitive distance.
 22. For dialogue evaluation, distinguish audible speech from internal/non-auditory cognition; quotation marks are for audible speech only.

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -109,9 +109,21 @@ const staleRunningMinutes = (() => {
   const parsed = Number.parseInt(process.env.EVAL_STALE_RUNNING_MINUTES || '10', 10);
   return Number.isFinite(parsed) && parsed >= 1 && parsed <= 240 ? parsed : 10;
 })();
+
+export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
+  const parsed =
+    typeof raw === 'number'
+      ? raw
+      : Number.parseFloat(String(raw ?? ''));
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const normalized = Math.trunc(parsed);
+  return normalized >= 1 && normalized <= 5 ? normalized : fallback;
+}
+
 const evalWorkerBatchSize = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_WORKER_BATCH_SIZE || '5', 10);
-  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 5 ? parsed : 5;
+  return getValidatedWorkerBatchSize(process.env.EVAL_WORKER_BATCH_SIZE, 5);
 })();
 const evalContextContaminationGuardEnabled = (() => {
   const raw = (process.env.EVAL_CONTEXT_CONTAMINATION_GUARD || 'auto').trim().toLowerCase();

--- a/lib/jobs/failures.ts
+++ b/lib/jobs/failures.ts
@@ -54,3 +54,7 @@ export function assertValidFailureCode(raw: string): asserts raw is FailureCode 
 export function isTransientFailure(code: FailureCode): boolean {
   return !NON_TRANSIENT_CODES.has(code);
 }
+
+export function isNonTransientFailure(code: FailureCode): boolean {
+  return NON_TRANSIENT_CODES.has(code);
+}

--- a/tests/jobs/failures.test.ts
+++ b/tests/jobs/failures.test.ts
@@ -6,8 +6,8 @@ import {
 
 describe('failure taxonomy', () => {
   test('recognizes transient codes narrowly', () => {
-    expect(isTransientFailure('TRANSIENT_NETWORK')).toBe(true);
-    expect(isTransientFailure('TRANSIENT_UPSTREAM')).toBe(true);
+    expect(isTransientFailure('TIMEOUT')).toBe(true);
+    expect(isTransientFailure('UPSTREAM_ERROR')).toBe(true);
     expect(isTransientFailure('RATE_LIMITED')).toBe(true);
     expect(isTransientFailure('SCHEMA_ERROR')).toBe(false);
   });

--- a/tests/jobs/finalize.persistence.test.ts
+++ b/tests/jobs/finalize.persistence.test.ts
@@ -17,7 +17,7 @@ function makePass(passId: "pass1" | "pass2" | "pass3", id: string): PassArtifact
     summary: `${passId} summary`,
     criteria: [
       {
-        criterion_id: "structure",
+        criterion_id: "sceneConstruction",
         score_0_10: 8,
         rationale: "Supported by evidence.",
         confidence_0_1: 0.8,
@@ -61,7 +61,7 @@ function makeConvergence(): ConvergenceArtifact {
     },
     merged_criteria: [
       {
-        criterion_id: "structure",
+        criterion_id: "sceneConstruction",
         score_0_10: 8,
         rationale: "Merged rationale.",
         confidence_0_1: 0.85,

--- a/tests/jobs/store.finalizer.test.ts
+++ b/tests/jobs/store.finalizer.test.ts
@@ -2,6 +2,7 @@ import {
   __resetFinalizerStoreForTests,
   getConvergenceArtifactById,
   getJobForFinalization,
+  markJobFailed,
   getPassArtifactById,
   persistCanonicalAndSummaryAndCompleteJob,
   writeJobAuditEvent,
@@ -264,7 +265,7 @@ describe("store.finalizer read paths", () => {
           summary: "pass summary",
           criteria: [
             {
-              criterion_id: "structure",
+              criterion_id: "sceneConstruction",
               score_0_10: 8,
               rationale: "rationale",
               confidence_0_1: 0.7,


### PR DESCRIPTION
## Summary
Restores failing worker auth, processor, failure-taxonomy, and finalizer test surfaces exposed in post-merge CI after `a545582`.

## Validation
Targeted cleanup validation passes locally:
- 9 suites passed
- 100 tests passed
- Surfaces covered:
  - `processor.canonical-pipeline.test.ts`
  - `processor.contamination-guard.test.ts`
  - `auth.test.ts`
  - `failures.test.ts`
  - `finalize.persistence.test.ts`
  - `store.finalizer.test.ts`

Observed auth/processor warnings in mocked test environments are expected and non-failing in this context (e.g., missing `lease_expires_at`, missing `claim_evaluation_jobs` RPC, legacy select fallback, zero claimed jobs).

## Scope and non-goals
This PR **does not** address:
- Flow 1 Proof Pack migration/schema issue
- `proof-gate-on-main` missing Supabase secrets

## Notes
This is a small follow-up cleanup PR intended to recover CI credibility on the specific red surfaces without broadening scope.