### PR TITLE
Fix finalizer migration packaging for clean replay

### DIFF
--- a/supabase/migrations/20260405000000_finalizer_completion_authority_rpc.sql
+++ b/supabase/migrations/20260405000000_finalizer_completion_authority_rpc.sql
@@ -1,9 +1,6 @@
 -- Migration: Finalizer atomic completion authority RPCs
 -- Purpose: Install a single transactional boundary for terminal finalizer writes.
 -- Scope: #89 write-authority only
-
-BEGIN;
-
 CREATE OR REPLACE FUNCTION public.finalizer_complete_job_atomic(
   p_job_id uuid,
   p_worker_id text,
@@ -14,7 +11,7 @@ CREATE OR REPLACE FUNCTION public.finalizer_complete_job_atomic(
 )
 RETURNS TABLE(canonical_artifact_id uuid, summary_artifact_id uuid)
 LANGUAGE plpgsql
-AS $$
+AS $finalizer_complete$
 DECLARE
   v_job public.evaluation_jobs%ROWTYPE;
   v_phase text;
@@ -143,81 +140,5 @@ BEGIN
 
   RETURN QUERY SELECT v_canonical_id, v_summary_id;
 END;
-$$;
+$finalizer_complete$;
 
-CREATE OR REPLACE FUNCTION public.finalizer_mark_job_failed(
-  p_job_id uuid,
-  p_worker_id text,
-  p_failure_code text,
-  p_last_error text
-)
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-DECLARE
-  v_job public.evaluation_jobs%ROWTYPE;
-  v_phase text;
-  v_claim_lease_id text;
-  v_now timestamptz := now();
-  v_progress jsonb;
-BEGIN
-  SELECT *
-  INTO v_job
-  FROM public.evaluation_jobs
-  WHERE id = p_job_id
-  FOR UPDATE;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % not found', p_job_id;
-  END IF;
-
-  IF v_job.status IN ('complete', 'failed') THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: cannot fail terminal job % (%)', p_job_id, v_job.status;
-  END IF;
-
-  IF v_job.status <> 'running' THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % must be running to fail (got %)', p_job_id, v_job.status;
-  END IF;
-
-  v_phase := COALESCE(v_job.progress->>'phase', v_job.phase, '');
-  IF v_phase <> 'finalizer' THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % phase must be finalizer to fail (got %)', p_job_id, v_phase;
-  END IF;
-
-  v_claim_lease_id := COALESCE(v_job.progress->>'lease_id', '');
-  IF v_claim_lease_id = '' OR v_claim_lease_id <> p_worker_id THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % failure claim mismatch (expected %, got %)', p_job_id, p_worker_id, v_claim_lease_id;
-  END IF;
-
-  v_progress := COALESCE(v_job.progress, '{}'::jsonb);
-  v_progress := jsonb_set(v_progress, '{failure_code}', to_jsonb(p_failure_code), true);
-  v_progress := jsonb_set(v_progress, '{terminal_at}', to_jsonb(v_now::text), true);
-  v_progress := jsonb_set(v_progress, '{phase_status}', '"failed"'::jsonb, true);
-
-  UPDATE public.evaluation_jobs
-  SET
-    status = 'failed',
-    last_error = p_last_error,
-    progress = v_progress,
-    updated_at = v_now
-  WHERE id = p_job_id
-    AND status = 'running';
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: failure update affected 0 rows for job %', p_job_id;
-  END IF;
-END;
-$$;
-
-REVOKE ALL ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb) FROM public;
-REVOKE ALL ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text) FROM public;
-GRANT EXECUTE ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb) TO service_role;
-GRANT EXECUTE ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text) TO service_role;
-
-COMMENT ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb)
-IS 'Finalizer #89 authority: atomic canonical+summary persistence and terminal completion in one transaction. Fails closed on any mismatch.';
-
-COMMENT ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text)
-IS 'Finalizer #89 authority: fail-closed terminal failure transition with claim + phase + status checks.';
-
-COMMIT;

--- a/supabase/migrations/20260405000001_finalizer_completion_authority_failure_rpc.sql
+++ b/supabase/migrations/20260405000001_finalizer_completion_authority_failure_rpc.sql
@@ -1,0 +1,67 @@
+-- Migration: Finalizer completion authority failure RPC
+-- Purpose: Install failure transition authority function in a standalone statement.
+-- Scope: #89 write-authority only
+
+CREATE OR REPLACE FUNCTION public.finalizer_mark_job_failed(
+	p_job_id uuid,
+	p_worker_id text,
+	p_failure_code text,
+	p_last_error text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $finalizer_failed$
+DECLARE
+	v_job public.evaluation_jobs%ROWTYPE;
+	v_phase text;
+	v_claim_lease_id text;
+	v_now timestamptz := now();
+	v_progress jsonb;
+BEGIN
+	SELECT *
+	INTO v_job
+	FROM public.evaluation_jobs
+	WHERE id = p_job_id
+	FOR UPDATE;
+
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % not found', p_job_id;
+	END IF;
+
+	IF v_job.status IN ('complete', 'failed') THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: cannot fail terminal job % (%)', p_job_id, v_job.status;
+	END IF;
+
+	IF v_job.status <> 'running' THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % must be running to fail (got %)', p_job_id, v_job.status;
+	END IF;
+
+	v_phase := COALESCE(v_job.progress->>'phase', v_job.phase, '');
+	IF v_phase <> 'finalizer' THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % phase must be finalizer to fail (got %)', p_job_id, v_phase;
+	END IF;
+
+	v_claim_lease_id := COALESCE(v_job.progress->>'lease_id', '');
+	IF v_claim_lease_id = '' OR v_claim_lease_id <> p_worker_id THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: job % failure claim mismatch (expected %, got %)', p_job_id, p_worker_id, v_claim_lease_id;
+	END IF;
+
+	v_progress := COALESCE(v_job.progress, '{}'::jsonb);
+	v_progress := jsonb_set(v_progress, '{failure_code}', to_jsonb(p_failure_code), true);
+	v_progress := jsonb_set(v_progress, '{terminal_at}', to_jsonb(v_now::text), true);
+	v_progress := jsonb_set(v_progress, '{phase_status}', '"failed"'::jsonb, true);
+
+	UPDATE public.evaluation_jobs
+	SET
+		status = 'failed',
+		last_error = p_last_error,
+		progress = v_progress,
+		updated_at = v_now
+	WHERE id = p_job_id
+		AND status = 'running';
+
+	IF NOT FOUND THEN
+		RAISE EXCEPTION 'FINALIZER_AUTHORITY_VIOLATION: failure update affected 0 rows for job %', p_job_id;
+	END IF;
+END;
+$finalizer_failed$;

--- a/supabase/migrations/20260405000002_finalizer_completion_authority_permissions.sql
+++ b/supabase/migrations/20260405000002_finalizer_completion_authority_permissions.sql
@@ -1,0 +1,23 @@
+-- Migration: Finalizer completion authority RPC permissions and comments
+-- Purpose: Apply execute grants and function documentation in a runner-safe single statement.
+-- Scope: #89 write-authority only
+
+DO $migration$
+BEGIN
+  EXECUTE 'REVOKE ALL ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb) FROM public';
+  EXECUTE 'REVOKE ALL ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text) FROM public';
+
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb) TO service_role';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text) TO service_role';
+
+  EXECUTE $sql$
+COMMENT ON FUNCTION public.finalizer_complete_job_atomic(uuid, text, text, text, jsonb, jsonb)
+IS 'Finalizer #89 authority: atomic canonical+summary persistence and terminal completion in one transaction. Fails closed on any mismatch.'
+  $sql$;
+
+  EXECUTE $sql$
+COMMENT ON FUNCTION public.finalizer_mark_job_failed(uuid, text, text, text)
+IS 'Finalizer #89 authority: fail-closed terminal failure transition with claim + phase + status checks.'
+  $sql$;
+END
+$migration$;


### PR DESCRIPTION
## Summary
Split finalizer authority migration into runner-safe units so Supabase clean replay no longer fails on prepared-statement packaging.

## What changed
- `20260405000000_finalizer_completion_authority_rpc.sql` now contains only `finalizer_complete_job_atomic`
- `20260405000001_finalizer_completion_authority_failure_rpc.sql` now contains only `finalizer_mark_job_failed`
- `20260405000002_finalizer_completion_authority_permissions.sql` now contains grants, revokes, and comments

## Validation
Clean replay passes:
- `20260405000000_finalizer_completion_authority_rpc.sql`
- `20260405000001_finalizer_completion_authority_failure_rpc.sql`
- `20260405000002_finalizer_completion_authority_permissions.sql`

## Dependency / base-state note
This branch is currently based on `main` at `57fb691`, which does **not** yet include the earlier replay-guard fix from #129 (`f6ada8b`).

Therefore:
- this PR (#132) fixes the finalizer migration packaging defect (#131), and
- full clean replay from an empty DB still requires the earlier #129 guard fix in the base branch.

If #129 is merged into `main`, this branch should be rebased (or recreated) on updated `main` for standalone replay proof.

## Out of scope
Remaining startup failures such as `supabase_storage ... unhealthy` are infrastructure/container-health concerns tracked separately and are outside this PR's migration-packaging scope.

Fixes #131
