### PR TITLE
#136 Reducer-first Pass3 narrowing + validation

### DIFF
--- a/lib/evaluation/pipeline/comparisonPacket.ts
+++ b/lib/evaluation/pipeline/comparisonPacket.ts
@@ -13,7 +13,7 @@ export type DisputedExcerptWindow = {
 export type ComparisonPacketCriterion = {
   key: CriterionKey;
   state: ComparisonState;
-  score_delta: number;
+  score_delta: number | null;
   pass1_score: number | null;
   pass1_mechanism_summary: string;
   pass1_evidence: EvidenceAnchor[];
@@ -65,10 +65,10 @@ function dedupeEvidence(evidence: EvidenceAnchor[], maxItems: number): EvidenceA
   const seen = new Set<string>();
 
   for (const anchor of evidence) {
-    const snippet = normalizeWhitespace(String(anchor.snippet ?? "")).slice(0, MAX_SNIPPET_CHARS);
+    const snippet = String(anchor.snippet ?? "").trim().slice(0, MAX_SNIPPET_CHARS);
     if (!snippet) continue;
 
-    const signature = snippet.toLowerCase();
+    const signature = normalizeWhitespace(snippet).toLowerCase();
     if (seen.has(signature)) continue;
     seen.add(signature);
 
@@ -152,14 +152,15 @@ export function buildComparisonPacket(
 
     const state = classifyState(pass1Score, pass2Score);
     const scoreDelta =
-      pass1Score !== null && pass2Score !== null ? Math.abs(pass1Score - pass2Score) : 0;
+      pass1Score !== null && pass2Score !== null ? Math.abs(pass1Score - pass2Score) : null;
 
-    const pass1Evidence = dedupeEvidence(pass1Criterion?.evidence ?? [], maxEvidencePerCriterion);
+    const rawPass1Evidence = pass1Criterion?.evidence ?? [];
+    const pass1Evidence = dedupeEvidence(rawPass1Evidence, maxEvidencePerCriterion);
 
     const disputedExcerptWindow = extractDisputedExcerptWindow({
       state,
       manuscriptText: options.manuscriptText,
-      evidence: pass1Evidence,
+      evidence: rawPass1Evidence,
       excerptRadiusChars,
     });
 

--- a/lib/evaluation/pipeline/comparisonPacket.ts
+++ b/lib/evaluation/pipeline/comparisonPacket.ts
@@ -1,0 +1,194 @@
+import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+import type { CriterionKey } from "@/schemas/criteria-keys";
+import type { EvidenceAnchor, SinglePassOutput } from "./types";
+
+export type ComparisonState = "agree" | "soft_divergence" | "hard_divergence" | "missing_or_invalid";
+
+export type DisputedExcerptWindow = {
+  char_start: number;
+  char_end: number;
+  snippet: string;
+};
+
+export type ComparisonPacketCriterion = {
+  key: CriterionKey;
+  state: ComparisonState;
+  score_delta: number;
+  pass1_score: number | null;
+  pass1_mechanism_summary: string;
+  pass1_evidence: EvidenceAnchor[];
+  pass2_score: number | null;
+  pass2_rationale_short: string;
+  disputed_excerpt_window?: DisputedExcerptWindow;
+};
+
+export type ComparisonPacket = {
+  criteria: ComparisonPacketCriterion[];
+  criteria_count_by_state: Record<ComparisonState, number>;
+};
+
+export type BuildComparisonPacketOptions = {
+  manuscriptText?: string;
+  excerptRadiusChars?: number;
+  maxEvidencePerCriterion?: number;
+};
+
+const DEFAULT_EXCERPT_RADIUS_CHARS = 220;
+const DEFAULT_MAX_EVIDENCE_PER_CRITERION = 3;
+const MAX_SNIPPET_CHARS = 200;
+const MAX_SUMMARY_CHARS = 220;
+const MAX_RATIONALE_SHORT_CHARS = 220;
+
+function toCriterionMap(pass: SinglePassOutput): Map<CriterionKey, SinglePassOutput["criteria"][number]> {
+  return new Map(pass.criteria.map((criterion) => [criterion.key, criterion]));
+}
+
+function isValidScore(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 10;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function toFirstSentence(text: string, maxChars: number): string {
+  const normalized = normalizeWhitespace(text);
+  if (!normalized) return "";
+
+  const parts = normalized.split(/(?<=[.!?])\s+/);
+  const first = parts[0] || normalized;
+  return first.length <= maxChars ? first : first.slice(0, maxChars).trim();
+}
+
+function dedupeEvidence(evidence: EvidenceAnchor[], maxItems: number): EvidenceAnchor[] {
+  const out: EvidenceAnchor[] = [];
+  const seen = new Set<string>();
+
+  for (const anchor of evidence) {
+    const snippet = normalizeWhitespace(String(anchor.snippet ?? "")).slice(0, MAX_SNIPPET_CHARS);
+    if (!snippet) continue;
+
+    const signature = snippet.toLowerCase();
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+
+    out.push({
+      snippet,
+      char_start: typeof anchor.char_start === "number" ? anchor.char_start : undefined,
+      char_end: typeof anchor.char_end === "number" ? anchor.char_end : undefined,
+      segment_id: typeof anchor.segment_id === "string" ? anchor.segment_id : undefined,
+    });
+
+    if (out.length >= maxItems) break;
+  }
+
+  return out;
+}
+
+function classifyState(pass1Score: number | null, pass2Score: number | null): ComparisonState {
+  if (!isValidScore(pass1Score) || !isValidScore(pass2Score)) {
+    return "missing_or_invalid";
+  }
+
+  const delta = Math.abs(pass1Score - pass2Score);
+  if (delta <= 1) return "agree";
+  if (delta <= 3) return "soft_divergence";
+  return "hard_divergence";
+}
+
+function extractDisputedExcerptWindow(params: {
+  state: ComparisonState;
+  manuscriptText?: string;
+  evidence: EvidenceAnchor[];
+  excerptRadiusChars: number;
+}): DisputedExcerptWindow | undefined {
+  const { state, manuscriptText, evidence, excerptRadiusChars } = params;
+  if (state !== "soft_divergence" && state !== "hard_divergence") return undefined;
+  if (!manuscriptText) return undefined;
+
+  const rangedAnchor = evidence.find(
+    (anchor) => typeof anchor.char_start === "number" && typeof anchor.char_end === "number",
+  );
+
+  if (!rangedAnchor || rangedAnchor.char_start === undefined || rangedAnchor.char_end === undefined) {
+    return undefined;
+  }
+
+  const sourceLength = manuscriptText.length;
+  const start = Math.max(0, rangedAnchor.char_start - excerptRadiusChars);
+  const end = Math.min(sourceLength, rangedAnchor.char_end + excerptRadiusChars);
+
+  if (end <= start) return undefined;
+
+  return {
+    char_start: start,
+    char_end: end,
+    snippet: manuscriptText.slice(start, end),
+  };
+}
+
+export function buildComparisonPacket(
+  pass1: SinglePassOutput,
+  pass2: SinglePassOutput,
+  options: BuildComparisonPacketOptions = {},
+): ComparisonPacket {
+  const pass1ByKey = toCriterionMap(pass1);
+  const pass2ByKey = toCriterionMap(pass2);
+
+  const excerptRadiusChars = options.excerptRadiusChars ?? DEFAULT_EXCERPT_RADIUS_CHARS;
+  const maxEvidencePerCriterion =
+    options.maxEvidencePerCriterion ?? DEFAULT_MAX_EVIDENCE_PER_CRITERION;
+
+  const criteria: ComparisonPacketCriterion[] = CRITERIA_KEYS.map((key) => {
+    const pass1Criterion = pass1ByKey.get(key);
+    const pass2Criterion = pass2ByKey.get(key);
+
+    const pass1Score = isValidScore(pass1Criterion?.score_0_10 ?? null)
+      ? pass1Criterion!.score_0_10
+      : null;
+    const pass2Score = isValidScore(pass2Criterion?.score_0_10 ?? null)
+      ? pass2Criterion!.score_0_10
+      : null;
+
+    const state = classifyState(pass1Score, pass2Score);
+    const scoreDelta =
+      pass1Score !== null && pass2Score !== null ? Math.abs(pass1Score - pass2Score) : 0;
+
+    const pass1Evidence = dedupeEvidence(pass1Criterion?.evidence ?? [], maxEvidencePerCriterion);
+
+    const disputedExcerptWindow = extractDisputedExcerptWindow({
+      state,
+      manuscriptText: options.manuscriptText,
+      evidence: pass1Evidence,
+      excerptRadiusChars,
+    });
+
+    return {
+      key,
+      state,
+      score_delta: scoreDelta,
+      pass1_score: pass1Score,
+      pass1_mechanism_summary: toFirstSentence(pass1Criterion?.rationale ?? "", MAX_SUMMARY_CHARS),
+      pass1_evidence: pass1Evidence,
+      pass2_score: pass2Score,
+      pass2_rationale_short: toFirstSentence(pass2Criterion?.rationale ?? "", MAX_RATIONALE_SHORT_CHARS),
+      disputed_excerpt_window: disputedExcerptWindow,
+    };
+  });
+
+  const criteria_count_by_state: Record<ComparisonState, number> = {
+    agree: 0,
+    soft_divergence: 0,
+    hard_divergence: 0,
+    missing_or_invalid: 0,
+  };
+
+  for (const criterion of criteria) {
+    criteria_count_by_state[criterion.state] += 1;
+  }
+
+  return {
+    criteria,
+    criteria_count_by_state,
+  };
+}

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -7,6 +7,12 @@
  */
 
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+import {
+  buildCoverageDisclosure,
+  buildPromptInputWindow,
+  getDefaultSynthesisReferenceCharBudget,
+  summarizePromptCoverage,
+} from "../promptInput";
 
 export const PASS3_PROMPT_VERSION = "pass3-synthesis-v4";
 
@@ -52,6 +58,18 @@ export function buildPass3UserPrompt(params: {
   executionMode?: "TRUSTED_PATH" | "STUDIO";
 }): string {
   const executionMode = params.executionMode ?? "TRUSTED_PATH";
+  const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
+  const synthesisWindow = params.manuscriptText
+    ? buildPromptInputWindow(params.manuscriptText, synthesisBudget)
+    : "";
+  const synthesisCoverage = params.manuscriptText
+    ? summarizePromptCoverage(params.manuscriptText, synthesisBudget)
+    : null;
+  const coverageDisclosure = synthesisCoverage
+    ? buildCoverageDisclosure(synthesisCoverage, "Synthesis reference coverage")
+    : "Synthesis reference coverage: unavailable (comparison packet-only execution).";
+  const referenceSnippet = synthesisWindow.length > 0 ? synthesisWindow.substring(0, 600) : "[reference omitted]";
+
   return `Synthesize these two independent evaluation passes for the manuscript titled "${params.title}".
 
 Execution mode: ${executionMode}
@@ -67,6 +85,10 @@ Do NOT re-litigate agreed criteria.
 Do NOT add evidence, recommendations, delta_explanation, craft_score, or editorial_score for agree criteria.
 Do NOT return criteria as { agree:[], soft_divergence:[] ... }; return a single criteria[] array.
 Target total visible output under 1500 tokens.
+
+Coverage truth signal:
+- ${coverageDisclosure}
+- Reference snippet (context anchor only): ${referenceSnippet}
 
 ## PASS 1 / PASS 2 COMPARISON PACKET (Deterministic)
 ${params.comparisonPacketJson.substring(0, 3500)}

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -14,13 +14,12 @@ import {
   summarizePromptCoverage,
 } from "../promptInput";
 
-export const PASS3_PROMPT_VERSION = "pass3-synthesis-v3";
+export const PASS3_PROMPT_VERSION = "pass3-synthesis-v4";
 
 export const PASS3_SYSTEM_PROMPT = `You are Pass 3: convergence and arbitration authority.
 
 You will receive:
-- Pass 1 output: Craft Execution analysis (structural/mechanical)
-- Pass 2 output: Editorial/Literary Insight analysis (interpretive/thematic)
+- Deterministic comparison packet derived from Pass 1 + Pass 2
 - Original manuscript text
 
 Your job is to compare, expose agreement and divergence, and produce a governed final decision.
@@ -30,6 +29,7 @@ Your job is to compare, expose agreement and divergence, and produce a governed 
 2. Do NOT silently overwrite disagreement.
 3. Do NOT hide meaningful divergence by score averaging alone.
 4. Every major arbitration decision MUST include evidence-backed reasoning.
+4b. Treat the comparison packet as canonical Pass 1/Pass 2 input. Do NOT expect raw pass payloads.
 5. Preserve narrative-mode awareness: do NOT flatten documentary/dossier/reflective chapters into generic scene-work judgments.
 6. For each criterion, explicitly trace: pressure signal -> decision inflection -> consequence trajectory.
 7. Do NOT leave consequence state implicit; classify each criterion as landed, deferred, or dissipated.
@@ -117,8 +117,7 @@ ${CRITERIA_KEYS.map((k, i) => `${i + 1}. ${k}`).join("\n")}
 }`;
 
 export function buildPass3UserPrompt(params: {
-  pass1Json: string;
-  pass2Json: string;
+  comparisonPacketJson: string;
   manuscriptText: string;
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
@@ -132,11 +131,8 @@ export function buildPass3UserPrompt(params: {
 Execution mode: ${executionMode}
 ${buildCoverageDisclosure(coverage, "Pass 3 manuscript reference coverage")}
 
-## PASS 1 OUTPUT (Craft Execution)
-${params.pass1Json.substring(0, 4000)}
-
-## PASS 2 OUTPUT (Editorial/Literary Insight)
-${params.pass2Json.substring(0, 4000)}
+## PASS 1 / PASS 2 COMPARISON PACKET (Deterministic)
+${params.comparisonPacketJson.substring(0, 6000)}
 
 ## ORIGINAL MANUSCRIPT TEXT (for reference)
 ${promptWindow}
@@ -147,6 +143,7 @@ Mandatory behavior:
 - Preserve major disagreement visibility.
 - Provide explicit arbitration rationale for divergence.
 - Do not silently merge conflicting conclusions.
+- Do not request or assume raw pass payloads; use the comparison packet fields as provided.
 - Preserve narrative-mode distinctions when reconciling pacing, narrativeDrive, and character judgments.
 - If a chapter accumulates pressure through archives, reflection, or system mapping, distinguish that from true absence of movement.
 - For each criterion, identify concrete pressure, then the chapter-level decision (or non-decision), then the resulting consequence.

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -11,17 +11,15 @@ import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 export const PASS3_PROMPT_VERSION = "pass3-synthesis-v4";
 
 export const PASS3_SYSTEM_PROMPT = `You are Pass 3: convergence and arbitration authority.
-Input: deterministic comparison packet + manuscript text.
-
 Rules:
 - Do NOT perform a new unconstrained evaluation.
 - Do NOT silently overwrite disagreement.
 - Use the packet as canonical input; do not expect raw pass payloads.
 - For each criterion, explicitly trace pressure signal -> decision inflection -> consequence trajectory.
+- pressure->decision->consequence logic.
 - Classify consequence_status as landed|deferred|dissipated.
 - If |craft_score-editorial_score| > 2, include delta_explanation and explicit arbitration logic.
 - Preserve narrative-mode distinctions (scene vs dossier/reflective progression).
-- Use manuscript-grounded evidence only.
 
 Scoring:
 - Integer scores only (0-10).
@@ -32,11 +30,13 @@ Mechanism constraints:
 - voice rationale must name at least one POV/voice mechanism (e.g., psychic distance, diction, syntax, focalization).
 - dialogue rationale must name at least one attribution/rendering mechanism (e.g., tags, beats, subtext).
 
-Recommendations:
-- Merge complementary advice, dedupe true duplicates, keep valid anchor_snippet, set source_pass (1|2|3).
-
 Return ONLY JSON with keys:
-- criteria[]: key, craft_score, editorial_score, final_score_0_10, score_delta, optional delta_explanation, final_rationale (must include pressure->decision->consequence logic), pressure_points[], decision_points[], consequence_status, optional deferred_consequence_risk, evidence[], recommendations[].
+- criteria MUST be a flat array of criterion objects (one per key), not grouped/nested by state.
+- criteria[] by state:
+  - agree: key, final_score_0_10, final_rationale="Confirmed."
+  - soft_divergence: key, final_score_0_10, final_rationale
+  - hard_divergence: key, final_score_0_10, final_rationale, disputed=true
+  - missing_or_invalid: key, final_score_0_10, final_rationale
 - agreement_map[]
 - divergence_map[] with arbitration_rationale
 - overall { overall_score_0_100, verdict(pass|revise|fail), one_paragraph_summary<=500, top_3_strengths[3], top_3_risks[3] }
@@ -55,6 +55,18 @@ export function buildPass3UserPrompt(params: {
   return `Synthesize these two independent evaluation passes for the manuscript titled "${params.title}".
 
 Execution mode: ${executionMode}
+
+OUTPUT BUDGET BY STATE (STRICT):
+- agree (score_delta <= 1): emit ONLY { key, final_score_0_10, final_rationale: "Confirmed." }
+- soft_divergence (score_delta 2-3): emit ONLY { key, final_score_0_10, final_rationale } with 1 sentence
+- hard_divergence (score_delta >= 4): emit ONLY { key, final_score_0_10, final_rationale } with 2 sentences + disputed=true
+- missing_or_invalid: emit concise corrective rationale, no long prose
+- overall: verdict + overall_score_0_100 + one_paragraph_summary (max 3 sentences) + top_3_strengths + top_3_risks
+
+Do NOT re-litigate agreed criteria.
+Do NOT add evidence, recommendations, delta_explanation, craft_score, or editorial_score for agree criteria.
+Do NOT return criteria as { agree:[], soft_divergence:[] ... }; return a single criteria[] array.
+Target total visible output under 1500 tokens.
 
 ## PASS 1 / PASS 2 COMPARISON PACKET (Deterministic)
 ${params.comparisonPacketJson.substring(0, 3500)}

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -7,135 +7,57 @@
  */
 
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
-import {
-  buildCoverageDisclosure,
-  buildPromptInputWindow,
-  getDefaultSynthesisReferenceCharBudget,
-  summarizePromptCoverage,
-} from "../promptInput";
 
 export const PASS3_PROMPT_VERSION = "pass3-synthesis-v4";
 
 export const PASS3_SYSTEM_PROMPT = `You are Pass 3: convergence and arbitration authority.
+Input: deterministic comparison packet + manuscript text.
 
-You will receive:
-- Deterministic comparison packet derived from Pass 1 + Pass 2
-- Original manuscript text
+Rules:
+- Do NOT perform a new unconstrained evaluation.
+- Do NOT silently overwrite disagreement.
+- Use the packet as canonical input; do not expect raw pass payloads.
+- For each criterion, explicitly trace pressure signal -> decision inflection -> consequence trajectory.
+- Classify consequence_status as landed|deferred|dissipated.
+- If |craft_score-editorial_score| > 2, include delta_explanation and explicit arbitration logic.
+- Preserve narrative-mode distinctions (scene vs dossier/reflective progression).
+- Use manuscript-grounded evidence only.
 
-Your job is to compare, expose agreement and divergence, and produce a governed final decision.
+Scoring:
+- Integer scores only (0-10).
+- If delta <= 2, final_score_0_10 should be rounded average.
+- If delta > 2, final score must favor the more diagnostic axis and justify why.
 
-## SYNTHESIS RULES
-1. Do NOT perform a fresh unconstrained evaluation.
-2. Do NOT silently overwrite disagreement.
-3. Do NOT hide meaningful divergence by score averaging alone.
-4. Every major arbitration decision MUST include evidence-backed reasoning.
-4b. Treat the comparison packet as canonical Pass 1/Pass 2 input. Do NOT expect raw pass payloads.
-5. Preserve narrative-mode awareness: do NOT flatten documentary/dossier/reflective chapters into generic scene-work judgments.
-6. For each criterion, explicitly trace: pressure signal -> decision inflection -> consequence trajectory.
-7. Do NOT leave consequence state implicit; classify each criterion as landed, deferred, or dissipated.
-8. Never emit canned fallback rationale phrases (e.g., "neither pass supplied", "default neutral score", "placeholder").
+Mechanism constraints:
+- voice rationale must name at least one POV/voice mechanism (e.g., psychic distance, diction, syntax, focalization).
+- dialogue rationale must name at least one attribution/rendering mechanism (e.g., tags, beats, subtext).
 
-### Score Reconciliation
-- If craft_score and editorial_score differ by ≤2: use the mathematical average (rounded to nearest integer)  
-- If they differ by >2: you MUST explain the divergence in "delta_explanation"; the final score should reflect which axis is more diagnostic for this criterion
-9. For the "voice" criterion, final_rationale MUST reference at least one specific POV/voice mechanism (e.g., narrative perspective, psychic distance, interiority, diction, register, tone, syntax, rhythm, free indirect discourse, sensory rendering, focalization). Generic praise or criticism without mechanism language will be rejected by the Quality Gate.
-10. For the "dialogue" criterion, final_rationale MUST reference at least one attribution/rendering mechanism (e.g., dialogue tags, speaker attribution, beats, quotation use, subtext mechanics).
-- All scores are integers 0-10 — no fractions
+Recommendations:
+- Merge complementary advice, dedupe true duplicates, keep valid anchor_snippet, set source_pass (1|2|3).
 
-### Recommendation Synthesis
-- Merge complementary recommendations from both passes
-- Remove genuine duplicates (same advice, different wording)
-- Mark each recommendation with "source_pass": 1, 2, or 3 (3 = your synthesis added it)
-- Every recommendation must still have a valid "anchor_snippet" from the manuscript
+Return ONLY JSON with keys:
+- criteria[]: key, craft_score, editorial_score, final_score_0_10, score_delta, optional delta_explanation, final_rationale (must include pressure->decision->consequence logic), pressure_points[], decision_points[], consequence_status, optional deferred_consequence_risk, evidence[], recommendations[].
+- agreement_map[]
+- divergence_map[] with arbitration_rationale
+- overall { overall_score_0_100, verdict(pass|revise|fail), one_paragraph_summary<=500, top_3_strengths[3], top_3_risks[3] }
+- metadata { pass1_model, pass2_model, pass3_model, generated_at }
 
-### Overall Assessment
-- Compute overall_score_0_100 as the weighted average of all 13 final_score_0_10 values × 10
-- verdict: "pass" if ≥ 75, "fail" if ≤ 40, "revise" otherwise
-- one_paragraph_summary: ≤500 characters — executive-level assessment
-- top_3_strengths and top_3_risks: most diagnostic issues only
-
-## CRITERIA TO SYNTHESIZE
-${CRITERIA_KEYS.map((k, i) => `${i + 1}. ${k}`).join("\n")}
-
-## OUTPUT FORMAT (return ONLY this JSON, no markdown, no code fences)
-{
-  "criteria": [
-    {
-      "key": "<criterion_key>",
-      "craft_score": <integer 0-10>,
-      "editorial_score": <integer 0-10>,
-      "final_score_0_10": <integer 0-10>,
-      "score_delta": <|craft_score - editorial_score|>,
-      "delta_explanation": "<required if score_delta > 2, otherwise omit>",
-      "final_rationale": "<synthesized reasoning from both axes, 2-4 sentences including pressure->decision->consequence logic>",
-      "pressure_points": ["<where pressure enters/escalates>", "<optional second point>"],
-      "decision_points": ["<decision reached or avoided>", "<optional second point>"],
-      "consequence_status": "landed|deferred|dissipated",
-      "deferred_consequence_risk": "<required when consequence_status=deferred>",
-      "evidence": [
-        { "snippet": "<verbatim, ≤200 chars>", "char_start": <number>, "char_end": <number> }
-      ],
-      "recommendations": [
-        {
-          "priority": "high|medium|low",
-          "action": "<50-300 chars, references anchor_snippet>",
-          "expected_impact": "<concrete improvement>",
-          "anchor_snippet": "<specific text from manuscript>",
-          "source_pass": 1 | 2 | 3
-        }
-      ]
-    }
-  ],
-  "agreement_map": [
-    {
-      "key": "<criterion_key>",
-      "agreement": "<where pass1 and pass2 agree>"
-    }
-  ],
-  "divergence_map": [
-    {
-      "key": "<criterion_key>",
-      "pass1_position": "<summary>",
-      "pass2_position": "<summary>",
-      "nature_of_divergence": "<what differs>",
-      "arbitration_rationale": "<why final decision chosen>"
-    }
-  ],
-  "overall": {
-    "overall_score_0_100": <0-100>,
-    "verdict": "pass|revise|fail",
-    "one_paragraph_summary": "<≤500 chars>",
-    "top_3_strengths": ["<strength 1>", "<strength 2>", "<strength 3>"],
-    "top_3_risks": ["<risk 1>", "<risk 2>", "<risk 3>"]
-  },
-  "metadata": {
-    "pass1_model": "<from pass1 output>",
-    "pass2_model": "<from pass2 output>",
-    "pass3_model": "<your model id>",
-    "generated_at": "<ISO 8601 timestamp>"
-  }
-}`;
+Criteria keys:
+${CRITERIA_KEYS.join(", ")}`;
 
 export function buildPass3UserPrompt(params: {
   comparisonPacketJson: string;
-  manuscriptText: string;
+  manuscriptText?: string;
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
 }): string {
   const executionMode = params.executionMode ?? "TRUSTED_PATH";
-  const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
-  const promptWindow = buildPromptInputWindow(params.manuscriptText, synthesisBudget);
-  const coverage = summarizePromptCoverage(params.manuscriptText, synthesisBudget);
   return `Synthesize these two independent evaluation passes for the manuscript titled "${params.title}".
 
 Execution mode: ${executionMode}
-${buildCoverageDisclosure(coverage, "Pass 3 manuscript reference coverage")}
 
 ## PASS 1 / PASS 2 COMPARISON PACKET (Deterministic)
-${params.comparisonPacketJson.substring(0, 6000)}
-
-## ORIGINAL MANUSCRIPT TEXT (for reference)
-${promptWindow}
+${params.comparisonPacketJson.substring(0, 3500)}
 
 Reconcile both perspectives into a unified evaluation.
 Mandatory behavior:

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -27,7 +27,6 @@ const PASS1_MAX_TOKENS = (() => {
   return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 8000 ? parsed : 3500;
 })();
 const PASS1_MODEL = "o3";
-const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 function nowMs(): number {
   return Date.now();
@@ -211,7 +210,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
       model_call_ms: modelCallMs,
       parse_validation_ms: parseValidationMs,
       total_ms: totalMs,
-      configured_timeout_ms: OPENAI_TIMEOUT_MS,
+      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
       configured_max_tokens: configuredMaxTokens,
       usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
       usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -284,7 +283,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     model_call_ms: modelCallMs,
     parse_validation_ms: parseValidationMs,
     total_ms: totalMs,
-    configured_timeout_ms: OPENAI_TIMEOUT_MS,
+    configured_timeout_ms: getEvalOpenAiTimeoutMs(),
     configured_max_tokens: configuredMaxTokens,
     usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
     usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -303,11 +302,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass1] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: OPENAI_TIMEOUT_MS });
+  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(
       params as Parameters<typeof openai.chat.completions.create>[0],
-      { timeout: OPENAI_TIMEOUT_MS },
+      { timeout: timeoutMs },
     ) as Promise<{
       choices: CompletionChoice[];
       usage?: CompletionUsage;

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -29,7 +29,6 @@ const PASS2_MAX_TOKENS = (() => {
   return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 8000 ? parsed : 2500;
 })();
 const PASS2_MODEL = "o3";
-const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 function nowMs(): number {
   return Date.now();
@@ -223,7 +222,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
       model_call_ms: modelCallMs,
       parse_validation_ms: parseValidationMs,
       total_ms: totalMs,
-      configured_timeout_ms: OPENAI_TIMEOUT_MS,
+      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
       configured_max_tokens: configuredMaxTokens,
       usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
       usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -297,7 +296,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     model_call_ms: modelCallMs,
     parse_validation_ms: parseValidationMs,
     total_ms: totalMs,
-    configured_timeout_ms: OPENAI_TIMEOUT_MS,
+    configured_timeout_ms: getEvalOpenAiTimeoutMs(),
     configured_max_tokens: configuredMaxTokens,
     usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
     usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -316,11 +315,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass2] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: OPENAI_TIMEOUT_MS });
+  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(
       params as Parameters<typeof openai.chat.completions.create>[0],
-      { timeout: OPENAI_TIMEOUT_MS },
+      { timeout: timeoutMs },
     ) as Promise<{
       choices: CompletionChoice[];
       usage?: CompletionUsage;

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -6,7 +6,7 @@
  * as a deterministic fallback if the AI response is incomplete.
  *
  * Temperature: 0.2 (per Vol III Tools §PASS3 — lower for precision)
- * Max tokens: 7000 (default, override via EVAL_PASS3_MAX_TOKENS)
+ * Max tokens: 3500 (default, override via EVAL_PASS3_MAX_TOKENS)
  */
 
 import OpenAI from "openai";
@@ -27,8 +27,8 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 
 const PASS3_TEMPERATURE = 0.2;
 const PASS3_MAX_TOKENS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "7000", 10);
-  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 7000;
+  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "3500", 10);
+  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 3500;
 })();
 const PASS3_MODEL = "o3";
 const PASS3_PROMPT_MAX_CHARS = (() => {

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -6,7 +6,7 @@
  * as a deterministic fallback if the AI response is incomplete.
  *
  * Temperature: 0.2 (per Vol III Tools §PASS3 — lower for precision)
- * Max tokens: 9000 (default, override via EVAL_PASS3_MAX_TOKENS)
+ * Max tokens: 7000 (default, override via EVAL_PASS3_MAX_TOKENS)
  */
 
 import OpenAI from "openai";
@@ -27,8 +27,8 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 
 const PASS3_TEMPERATURE = 0.2;
 const PASS3_MAX_TOKENS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "9000", 10);
-  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 9000;
+  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "7000", 10);
+  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 7000;
 })();
 const PASS3_MODEL = "o3";
 const PASS3_PROMPT_MAX_CHARS = (() => {
@@ -37,7 +37,6 @@ const PASS3_PROMPT_MAX_CHARS = (() => {
 })();
 const PASS3_MIN_RATIONALE_LENGTH = 40;
 const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
-const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
 
 type CompletionChoice = {
   message?: {
@@ -131,6 +130,42 @@ function assertPass3PromptTripwires(userPrompt: string): void {
   }
 }
 
+function buildPromptPacketFromComparison(packet: ReturnType<typeof buildComparisonPacket>) {
+  const criteria = packet.criteria.map((criterion) => {
+    const base = {
+      key: criterion.key,
+      state: criterion.state,
+      score_delta: criterion.score_delta,
+      pass1_score: criterion.pass1_score,
+      pass2_score: criterion.pass2_score,
+      pass1_mechanism_summary: criterion.pass1_mechanism_summary,
+      pass2_rationale_short: criterion.pass2_rationale_short,
+    };
+
+    if (criterion.state === "soft_divergence" || criterion.state === "hard_divergence") {
+      return {
+        ...base,
+        pass1_evidence: criterion.pass1_evidence.slice(0, 1),
+        disputed_excerpt_window: criterion.disputed_excerpt_window,
+      };
+    }
+
+    if (criterion.state === "missing_or_invalid") {
+      return {
+        ...base,
+        pass1_evidence: criterion.pass1_evidence.slice(0, 1),
+      };
+    }
+
+    return base;
+  });
+
+  return {
+    criteria_count_by_state: packet.criteria_count_by_state,
+    criteria,
+  };
+}
+
 /** Function signature for creating a chat completion (enables DI for testing). */
 export type CreateCompletionFn = (params: {
   model: string;
@@ -171,7 +206,8 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   const comparisonPacket = buildComparisonPacket(opts.pass1, opts.pass2, {
     manuscriptText: opts.manuscriptText,
   });
-  const comparisonPacketJson = JSON.stringify(comparisonPacket);
+  const promptPacket = buildPromptPacketFromComparison(comparisonPacket);
+  const comparisonPacketJson = JSON.stringify(promptPacket);
 
   const userPrompt = buildPass3UserPrompt({
     comparisonPacketJson,
@@ -180,6 +216,15 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     executionMode: opts.executionMode,
   });
   assertPass3PromptTripwires(userPrompt);
+
+  console.log("[Pass3][ReducerTelemetry]", {
+    prompt_version: PASS3_PROMPT_VERSION,
+    criteria_count_by_state: comparisonPacket.criteria_count_by_state,
+    comparison_packet_chars: comparisonPacketJson.length,
+    system_prompt_chars: PASS3_SYSTEM_PROMPT.length,
+    user_prompt_chars: userPrompt.length,
+    max_output_tokens: PASS3_MAX_TOKENS,
+  });
   
   // Compute coverage metadata (for truth enforcement)
   const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
@@ -308,11 +353,12 @@ function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
   if (!apiKey) {
     throw new Error("[Pass3] OPENAI_API_KEY is not configured");
   }
-  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: OPENAI_TIMEOUT_MS });
+  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const openai = new OpenAI({ apiKey, maxRetries: 2, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(
       params as Parameters<typeof openai.chat.completions.create>[0],
-      { timeout: OPENAI_TIMEOUT_MS },
+      { timeout: timeoutMs },
     ) as Promise<{
       choices: CompletionChoice[];
       usage?: CompletionUsage;

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -19,6 +19,7 @@ import {
   buildOpenAITemperatureParam,
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
+import { buildComparisonPacket } from "./comparisonPacket";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
@@ -30,6 +31,10 @@ const PASS3_MAX_TOKENS = (() => {
   return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 9000;
 })();
 const PASS3_MODEL = "o3";
+const PASS3_PROMPT_MAX_CHARS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_PASS3_PROMPT_MAX_CHARS || "40000", 10);
+  return Number.isFinite(parsed) && parsed >= 8000 && parsed <= 120000 ? parsed : 40000;
+})();
 const PASS3_MIN_RATIONALE_LENGTH = 40;
 const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
 const OPENAI_TIMEOUT_MS = getEvalOpenAiTimeoutMs();
@@ -81,10 +86,10 @@ function buildEmptyResponseDiagnostic(params: {
   firstChoice: CompletionChoice | undefined;
   rawContent: unknown;
   coverage: ReturnType<typeof summarizePromptCoverage>;
-  pass1Chars: number;
-  pass2Chars: number;
+  comparisonPacketChars: number;
+  promptChars: number;
 }): string {
-  const { model, completion, firstChoice, rawContent, coverage, pass1Chars, pass2Chars } = params;
+  const { model, completion, firstChoice, rawContent, coverage, comparisonPacketChars, promptChars } = params;
   const usage = completion.usage;
   const finishReason =
     typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
@@ -98,7 +103,7 @@ function buildEmptyResponseDiagnostic(params: {
   return (
     `[Pass3] Empty response from OpenAI ` +
     `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
-    `max_output_tokens=${PASS3_MAX_TOKENS} pass1_chars=${pass1Chars} pass2_chars=${pass2Chars} ` +
+    `max_output_tokens=${PASS3_MAX_TOKENS} prompt_chars=${promptChars} comparison_packet_chars=${comparisonPacketChars} ` +
     `reference_chars=${coverage.analyzedChars} source_chars=${coverage.sourceChars}` +
     `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
     `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
@@ -106,6 +111,24 @@ function buildEmptyResponseDiagnostic(params: {
     `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""}` +
     `${likelyBudgetPressure})`
   );
+}
+
+function assertPass3PromptTripwires(userPrompt: string): void {
+  if (userPrompt.length > PASS3_PROMPT_MAX_CHARS) {
+    throw new Error(
+      `[Pass3] PROMPT_TOO_LARGE: prompt_chars=${userPrompt.length} limit=${PASS3_PROMPT_MAX_CHARS}`,
+    );
+  }
+
+  const hasLegacySectionHeaders =
+    userPrompt.includes("## PASS 1 OUTPUT (Craft Execution)") ||
+    userPrompt.includes("## PASS 2 OUTPUT (Editorial/Literary Insight)");
+  const hasRawPass1Shape = /"pass"\s*:\s*1\s*,\s*"axis"\s*:\s*"craft_execution"/.test(userPrompt);
+  const hasRawPass2Shape = /"pass"\s*:\s*2\s*,\s*"axis"\s*:\s*"editorial_literary"/.test(userPrompt);
+
+  if (hasLegacySectionHeaders || (hasRawPass1Shape && hasRawPass2Shape)) {
+    throw new Error("[Pass3] RAW_PASS_PAYLOAD_DETECTED: raw pass payload is forbidden in Pass 3 prompt input");
+  }
 }
 
 /** Function signature for creating a chat completion (enables DI for testing). */
@@ -145,17 +168,18 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
   const selectedModel = getCanonicalPipelineModel(opts.model ?? PASS3_MODEL);
 
-  // Compact JSON reduces prompt token load and latency while preserving content.
-  const pass1Json = JSON.stringify(opts.pass1);
-  const pass2Json = JSON.stringify(opts.pass2);
+  const comparisonPacket = buildComparisonPacket(opts.pass1, opts.pass2, {
+    manuscriptText: opts.manuscriptText,
+  });
+  const comparisonPacketJson = JSON.stringify(comparisonPacket);
 
   const userPrompt = buildPass3UserPrompt({
-    pass1Json,
-    pass2Json,
+    comparisonPacketJson,
     manuscriptText: opts.manuscriptText,
     title: opts.title,
     executionMode: opts.executionMode,
   });
+  assertPass3PromptTripwires(userPrompt);
   
   // Compute coverage metadata (for truth enforcement)
   const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
@@ -185,8 +209,8 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
       firstChoice,
       rawContent,
       coverage,
-      pass1Chars: pass1Json.length,
-      pass2Chars: pass2Json.length,
+      comparisonPacketChars: comparisonPacketJson.length,
+      promptChars: userPrompt.length,
     });
 
     console.error("[Pass3] Completion boundary diagnostic", {
@@ -200,8 +224,8 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
       contentType: rawContent === null ? "null" : typeof rawContent,
       contentPreview: typeof rawContent === "string" ? rawContent.slice(0, 160) : undefined,
       usage: completion.usage,
-      pass1Chars: pass1Json.length,
-      pass2Chars: pass2Json.length,
+      comparisonPacketChars: comparisonPacketJson.length,
+      promptChars: userPrompt.length,
       promptCoverage: coverage,
       maxOutputTokens: PASS3_MAX_TOKENS,
       refusal:

--- a/scripts/pipeline/run-dominatus-i4-eval.ts
+++ b/scripts/pipeline/run-dominatus-i4-eval.ts
@@ -5,6 +5,7 @@ import { runPipeline } from "@/lib/evaluation/pipeline/runPipeline";
 import { runPass1 } from "@/lib/evaluation/pipeline/runPass1";
 import { runPass2 } from "@/lib/evaluation/pipeline/runPass2";
 import { runPass3Synthesis } from "@/lib/evaluation/pipeline/runPass3Synthesis";
+import { buildComparisonPacket } from "@/lib/evaluation/pipeline/comparisonPacket";
 import { runQualityGate } from "@/lib/evaluation/pipeline/qualityGate";
 import { PASS1_SYSTEM_PROMPT, buildPass1UserPrompt } from "@/lib/evaluation/pipeline/prompts/pass1-craft";
 import { PASS2_SYSTEM_PROMPT, buildPass2UserPrompt } from "@/lib/evaluation/pipeline/prompts/pass2-editorial";
@@ -271,8 +272,11 @@ async function main(): Promise<void> {
 
   const pass3UserPrompt = pass1Parsed && pass2Parsed
     ? buildPass3UserPrompt({
-        pass1Json: JSON.stringify(pass1Parsed, null, 2),
-        pass2Json: JSON.stringify(pass2Parsed, null, 2),
+        comparisonPacketJson: JSON.stringify(
+          buildComparisonPacket(pass1Parsed, pass2Parsed, { manuscriptText }),
+          null,
+          2,
+        ),
         manuscriptText,
         title,
         executionMode: mode,

--- a/scripts/pipeline/run-phase2-7-real-run.ts
+++ b/scripts/pipeline/run-phase2-7-real-run.ts
@@ -139,6 +139,18 @@ async function main(): Promise<void> {
     positiveIntOrUndefined(getArg("pass-timeout-ms")) ??
     positiveIntOrUndefined(process.env.EVAL_PASS_TIMEOUT_MS);
 
+  if (passTimeoutMs) {
+    const envPassTimeout = positiveIntOrUndefined(process.env.EVAL_PASS_TIMEOUT_MS);
+    const envOpenAiTimeout = positiveIntOrUndefined(process.env.EVAL_OPENAI_TIMEOUT_MS);
+
+    if (!envPassTimeout || envPassTimeout < passTimeoutMs) {
+      process.env.EVAL_PASS_TIMEOUT_MS = String(passTimeoutMs);
+    }
+    if (!envOpenAiTimeout || envOpenAiTimeout < passTimeoutMs) {
+      process.env.EVAL_OPENAI_TIMEOUT_MS = String(passTimeoutMs);
+    }
+  }
+
   const outputDir =
     getArg("output-dir") ??
     getArg("output") ??

--- a/tests/evaluation/pipeline/comparisonPacket.test.ts
+++ b/tests/evaluation/pipeline/comparisonPacket.test.ts
@@ -130,4 +130,65 @@ describe("buildComparisonPacket", () => {
     expect(voice.state).toBe("agree");
     expect(voice.disputed_excerpt_window).toBeUndefined();
   });
+
+  it("extracts disputed excerpt from raw evidence even when bounded evidence omits ranged anchor", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const manuscriptText = "A".repeat(2000) + "ANCHOR" + "B".repeat(2000);
+
+    const concept1 = pass1.criteria.find((c) => c.key === "concept")!;
+    const concept2 = pass2.criteria.find((c) => c.key === "concept")!;
+    concept1.score_0_10 = 9;
+    concept2.score_0_10 = 5; // hard divergence
+    concept1.evidence = [
+      { snippet: "first plain anchor" },
+      { snippet: "second plain anchor" },
+      { snippet: "ranged anchor", char_start: 1998, char_end: 2004 },
+    ];
+
+    const packet = buildComparisonPacket(pass1, pass2, {
+      manuscriptText,
+      excerptRadiusChars: 5,
+      maxEvidencePerCriterion: 2,
+    });
+
+    const concept = packet.criteria.find((c) => c.key === "concept")!;
+    expect(concept.pass1_evidence).toHaveLength(2);
+    expect(concept.pass1_evidence.every((e) => typeof e.char_start !== "number")).toBe(true);
+    expect(concept.disputed_excerpt_window).toBeDefined();
+    expect(concept.disputed_excerpt_window?.char_start).toBe(1993);
+    expect(concept.disputed_excerpt_window?.char_end).toBe(2009);
+  });
+
+  it("preserves verbatim snippet spacing while still deduping by normalized text", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const target = pass1.criteria.find((c) => c.key === "theme")!;
+    target.evidence = [
+      { snippet: "Line  one   has   spacing" },
+      { snippet: "Line one has spacing" },
+    ];
+
+    const packet = buildComparisonPacket(pass1, pass2);
+    const theme = packet.criteria.find((c) => c.key === "theme")!;
+
+    expect(theme.pass1_evidence).toHaveLength(1);
+    expect(theme.pass1_evidence[0]?.snippet).toBe("Line  one   has   spacing");
+  });
+
+  it("sets score_delta to null when either score is missing or invalid", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const dialoguePass2 = pass2.criteria.find((c) => c.key === "dialogue")!;
+    dialoguePass2.score_0_10 = Number.NaN;
+
+    const packet = buildComparisonPacket(pass1, pass2);
+    const dialogue = packet.criteria.find((c) => c.key === "dialogue")!;
+
+    expect(dialogue.state).toBe("missing_or_invalid");
+    expect(dialogue.score_delta).toBeNull();
+  });
 });

--- a/tests/evaluation/pipeline/comparisonPacket.test.ts
+++ b/tests/evaluation/pipeline/comparisonPacket.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "@jest/globals";
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import { buildComparisonPacket } from "@/lib/evaluation/pipeline/comparisonPacket";
+import type { SinglePassOutput, EvidenceAnchor } from "@/lib/evaluation/pipeline/types";
+
+function makeEvidence(snippet: string, char_start?: number, char_end?: number): EvidenceAnchor[] {
+  return [{ snippet, char_start, char_end }];
+}
+
+function makePass(pass: 1 | 2, axis: "craft_execution" | "editorial_literary"): SinglePassOutput {
+  return {
+    pass,
+    axis,
+    criteria: CRITERIA_KEYS.map((key) => ({
+      key,
+      score_0_10: 7,
+      rationale: `${axis} rationale for ${key}. Secondary sentence should be ignored.`,
+      evidence: makeEvidence(`Evidence for ${key}.`, 100, 140),
+      recommendations: [],
+    })),
+    model: "o3",
+    prompt_version: pass === 1 ? "pass1-craft-v5-compat" : "pass2-editorial-v5-judgment",
+    temperature: 0.3,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+describe("buildComparisonPacket", () => {
+  it("emits one criterion packet per canonical key in canonical order", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const packet = buildComparisonPacket(pass1, pass2);
+
+    expect(packet.criteria).toHaveLength(CRITERIA_KEYS.length);
+    expect(packet.criteria.map((c) => c.key)).toEqual(CRITERIA_KEYS);
+  });
+
+  it("classifies agree / soft_divergence / hard_divergence from score deltas", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const setScore = (key: CriterionKey, pass1Score: number, pass2Score: number) => {
+      const c1 = pass1.criteria.find((c) => c.key === key)!;
+      const c2 = pass2.criteria.find((c) => c.key === key)!;
+      c1.score_0_10 = pass1Score;
+      c2.score_0_10 = pass2Score;
+    };
+
+    setScore("concept", 7, 8); // delta 1 => agree
+    setScore("character", 9, 7); // delta 2 => soft
+    setScore("voice", 10, 5); // delta 5 => hard
+
+    const packet = buildComparisonPacket(pass1, pass2);
+
+    const concept = packet.criteria.find((c) => c.key === "concept");
+    const character = packet.criteria.find((c) => c.key === "character");
+    const voice = packet.criteria.find((c) => c.key === "voice");
+
+    expect(concept?.state).toBe("agree");
+    expect(character?.state).toBe("soft_divergence");
+    expect(voice?.state).toBe("hard_divergence");
+    expect(packet.criteria_count_by_state.agree).toBeGreaterThanOrEqual(1);
+    expect(packet.criteria_count_by_state.soft_divergence).toBeGreaterThanOrEqual(1);
+    expect(packet.criteria_count_by_state.hard_divergence).toBeGreaterThanOrEqual(1);
+  });
+
+  it("classifies missing_or_invalid when a criterion is missing in either pass", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    pass2.criteria = pass2.criteria.filter((c) => c.key !== "dialogue");
+
+    const packet = buildComparisonPacket(pass1, pass2);
+    const dialogue = packet.criteria.find((c) => c.key === "dialogue");
+
+    expect(dialogue?.state).toBe("missing_or_invalid");
+    expect(dialogue?.pass2_score).toBeNull();
+    expect(packet.criteria_count_by_state.missing_or_invalid).toBeGreaterThanOrEqual(1);
+  });
+
+  it("dedupes repeated pass1 evidence snippets per criterion", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const target = pass1.criteria.find((c) => c.key === "theme")!;
+    target.evidence = [
+      { snippet: "Repeated snippet.", char_start: 10, char_end: 20 },
+      { snippet: "Repeated snippet.", char_start: 30, char_end: 40 },
+      { snippet: "Distinct snippet.", char_start: 50, char_end: 60 },
+    ];
+
+    const packet = buildComparisonPacket(pass1, pass2);
+    const theme = packet.criteria.find((c) => c.key === "theme")!;
+
+    expect(theme.pass1_evidence).toHaveLength(2);
+    expect(theme.pass1_evidence.map((e) => e.snippet)).toEqual([
+      "Repeated snippet.",
+      "Distinct snippet.",
+    ]);
+  });
+
+  it("includes disputed_excerpt_window only for divergence states when manuscript text is provided", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const manuscriptText = "A".repeat(1000) + "DISPUTED" + "B".repeat(1000);
+
+    const concept1 = pass1.criteria.find((c) => c.key === "concept")!;
+    const concept2 = pass2.criteria.find((c) => c.key === "concept")!;
+    concept1.score_0_10 = 9;
+    concept2.score_0_10 = 5; // hard divergence
+    concept1.evidence = [{ snippet: "Concept anchor", char_start: 995, char_end: 1005 }];
+
+    const voice1 = pass1.criteria.find((c) => c.key === "voice")!;
+    const voice2 = pass2.criteria.find((c) => c.key === "voice")!;
+    voice1.score_0_10 = 7;
+    voice2.score_0_10 = 7; // agree
+
+    const packet = buildComparisonPacket(pass1, pass2, { manuscriptText, excerptRadiusChars: 10 });
+
+    const concept = packet.criteria.find((c) => c.key === "concept")!;
+    const voice = packet.criteria.find((c) => c.key === "voice")!;
+
+    expect(concept.state).toBe("hard_divergence");
+    expect(concept.disputed_excerpt_window).toBeDefined();
+    expect(concept.disputed_excerpt_window?.char_start).toBe(985);
+    expect(concept.disputed_excerpt_window?.char_end).toBe(1015);
+
+    expect(voice.state).toBe("agree");
+    expect(voice.disputed_excerpt_window).toBeUndefined();
+  });
+});

--- a/tests/evaluation/pipeline/prompt-pack.test.ts
+++ b/tests/evaluation/pipeline/prompt-pack.test.ts
@@ -52,6 +52,7 @@ describe("prompt pack governance specs", () => {
     expect(PASS3_SYSTEM_PROMPT).toContain("Do NOT silently overwrite disagreement");
     expect(PASS3_SYSTEM_PROMPT).toContain("pressure signal -> decision inflection -> consequence trajectory");
     expect(PASS3_SYSTEM_PROMPT).toContain("pressure->decision->consequence logic");
+    expect(PASS3_SYSTEM_PROMPT.length).toBeLessThan(2000);
 
     const userPrompt = buildPass3UserPrompt({
       comparisonPacketJson: "{\"criteria\":[],\"criteria_count_by_state\":{\"agree\":0,\"soft_divergence\":0,\"hard_divergence\":0,\"missing_or_invalid\":0}}",

--- a/tests/evaluation/pipeline/prompt-pack.test.ts
+++ b/tests/evaluation/pipeline/prompt-pack.test.ts
@@ -54,8 +54,7 @@ describe("prompt pack governance specs", () => {
     expect(PASS3_SYSTEM_PROMPT).toContain("pressure->decision->consequence logic");
 
     const userPrompt = buildPass3UserPrompt({
-      pass1Json: "{\"criteria\":[]}",
-      pass2Json: "{\"criteria\":[]}",
+      comparisonPacketJson: "{\"criteria\":[],\"criteria_count_by_state\":{\"agree\":0,\"soft_divergence\":0,\"hard_divergence\":0,\"missing_or_invalid\":0}}",
       manuscriptText: "Sample manuscript text.",
       title: "DOMINATUS I:4",
       executionMode: "TRUSTED_PATH",


### PR DESCRIPTION
## Scope
Reducer-first progression for #136.

This PR now includes:
1) **Step 1**: pure deterministic comparison packet builder + tests.
2) **Step 2**: Pass 3 wiring to consume comparison packet input (instead of raw Pass1/Pass2 payloads) with fail-closed tripwires.
3) **Step 3**: Pass 3 system prompt compression (<2000 chars).
4) **Step 4**: thin prompt packet shaping + timeout hardening to prevent stale low-timeout env capture.
5) **Step 5 (output-side control)**: state-aware compact output schema + Pass 3 cap tuning.

## Files
- `lib/evaluation/pipeline/comparisonPacket.ts`
- `tests/evaluation/pipeline/comparisonPacket.test.ts`
- `lib/evaluation/pipeline/prompts/pass3-synthesis.ts`
- `lib/evaluation/pipeline/runPass3Synthesis.ts`
- `lib/evaluation/pipeline/runPass1.ts`
- `lib/evaluation/pipeline/runPass2.ts`
- `tests/evaluation/pipeline/prompt-pack.test.ts`
- `scripts/pipeline/run-phase2-7-real-run.ts`
- `scripts/pipeline/run-dominatus-i4-eval.ts`

## What this adds
- Deterministic comparison packet model with criterion state classification.
- Pass 3 prompt input narrowed to packet-only payload path.
- Fail-closed tripwires:
  - `PROMPT_TOO_LARGE`
  - `RAW_PASS_PAYLOAD_DETECTED`
- Pass 3 prompt compression guard (`PASS3_SYSTEM_PROMPT.length < 2000`).
- Thin prompt packet shaping (`agree` criteria keep minimal fields; divergence paths keep targeted evidence/window).
- Timeout hardening:
  - Pass 1/2/3 OpenAI timeout values now read at call-time.
  - Real-run harness raises timeout env vars when CLI timeout exceeds env defaults.
- Reducer telemetry emitted each run:
  - `criteria_count_by_state`
  - `comparison_packet_chars`
  - `user_prompt_chars`
- Output-side control:
  - State-aware output budget instructions.
  - Flat `criteria[]` requirement (no grouped-by-state nested output).
  - Pass 3 max output cap default tuned to `3500` (safe vs truncation seen at `3000`).

## Real-model validation (Chapter 11c, o3)
Artifacts:
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_r1` (pre-thin baseline on this branch)
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_postfix_r1`
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_postfix_r2`
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_postfix_r3`
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_cap3000_r1` (observed truncation pressure)
- `docs/operations/evidence/runs/2026-04-15_issue136_reducer_validation_o3_cap3500_r2` (stable compact output)

Pass 3 token / runtime progression (o3):
- Pre-thin baseline (`o3_r1`):
  - `prompt_tokens=6211`, `completion_tokens=5053`, `pass3_ms=42055`
- Post-thin (before output cap tuning), median:
  - `prompt_tokens=1447`, `completion_tokens=4968`
- With output-side controls (`cap3500_r2`):
  - `prompt_tokens=1692`, `completion_tokens=3297`, `pass3_ms=28344`

Observed reducer telemetry confirms narrowed prompt path:
- prior path: `user_prompt_chars` ~ `25381`
- thin path: `user_prompt_chars` ~ `4716`
- capped/shape-disciplined run: `user_prompt_chars` ~ `5552` (extra schema directives) with lower completion output.

## Verification
- `npm test -- tests/evaluation/pipeline/prompt-pack.test.ts tests/evaluation/pipeline/pass3.test.ts tests/evaluation/pipeline/comparisonPacket.test.ts --runInBand`
- 31/31 tests passing.
- Real runs completed with `quality_gate_pass=true` for post-thin and cap3500 validation runs.

Refs: #136
