### PR TITLE
hotfix: make run-phase2 routes persist phase_2 state monotonically

### DIFF
--- a/app/api/admin/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/admin/jobs/[jobId]/run-phase2/route.ts
@@ -2,23 +2,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/admin/requireAdmin";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { processEvaluationJob } from "@/lib/evaluation/processor";
 import { getDevHeaderActor } from "@/lib/auth/devHeaderActor";
 
-type Ok = { ok: true; job_id: string; phase2: "canonical_pipeline_complete" };
 type Err = { ok: false; error: string; details?: string };
 
 export async function POST(
   req: NextRequest,
   ctx: { params: { jobId: string } }
 ) {
-  // 1) Admin gate: dev header actor (test-mode only) OR production auth
+  // Admin gate: dev header actor OR production auth
   const actor = getDevHeaderActor(req);
-  if (actor?.isAdmin) {
-    // Dev-only admin bypass: TEST_MODE + ALLOW_HEADER_USER_ID are both true
-    // and actor has admin signal — continue to phase2 logic
-  } else {
-    // Production path: require real Supabase session + admin role
+  if (!actor?.isAdmin) {
     const denied = await requireAdmin(req);
     if (denied) return denied;
   }
@@ -30,7 +24,7 @@ export async function POST(
 
     const { data: jobRow, error: jobReadError } = await supabase
       .from("evaluation_jobs")
-      .select("id,status,last_error")
+      .select("id,status,phase,phase_status,progress,last_error")
       .eq("id", jobId)
       .single();
 
@@ -43,58 +37,70 @@ export async function POST(
       return NextResponse.json(payload, { status: 404 });
     }
 
-    if (jobRow.status !== "queued") {
-      if (!force) {
-        const payload: Err = {
-          ok: false,
-          error: "Job must be queued to run canonical phase2",
-          details: `Current status=${jobRow.status}. Re-run with ?force=1 to requeue and execute.`,
-        };
-        return NextResponse.json(payload, { status: 409 });
-      }
+    const progress =
+      jobRow.progress && typeof jobRow.progress === "object"
+        ? (jobRow.progress as Record<string, unknown>)
+        : {};
 
-      const { error: requeueError } = await supabase
-        .from("evaluation_jobs")
-        .update({
-          status: "queued",
-          phase: "phase_1",
-          phase_status: "queued",
-          last_error: null,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", jobId);
+    const isPhase1CompleteHandoff =
+      jobRow.status === "running" &&
+      (jobRow.phase === "phase_1" || progress.phase === "phase_1") &&
+      (jobRow.phase_status === "complete" || progress.phase_status === "complete");
 
-      if (requeueError) {
-        const payload: Err = {
-          ok: false,
-          error: "Failed to requeue job",
-          details: requeueError.message,
-        };
-        return NextResponse.json(payload, { status: 500 });
-      }
-    }
+    const isQueued = jobRow.status === "queued";
 
-    const result = await processEvaluationJob(jobId);
-
-    if (!result.success) {
+    if (!isQueued && !isPhase1CompleteHandoff && !force) {
       const payload: Err = {
         ok: false,
-        error: "Failed to run canonical phase2",
-        details: result.error,
+        error: "Job is not eligible for Phase 2 trigger",
+        details: `status=${jobRow.status}, phase=${jobRow.phase}, phase_status=${jobRow.phase_status}`,
+      };
+      return NextResponse.json(payload, { status: 409 });
+    }
+
+    const now = new Date().toISOString();
+
+    const updatePayload = {
+      status: "queued",
+      phase: "phase_2",
+      phase_status: "triggered",
+      last_error: null,
+      updated_at: now,
+    };
+
+    const { error: updateError } = await supabase
+      .from("evaluation_jobs")
+      .update(updatePayload)
+      .eq("id", jobId);
+
+    if (updateError) {
+      const payload: Err = {
+        ok: false,
+        error: "Failed to queue job for worker execution",
+        details: updateError.message,
       };
       return NextResponse.json(payload, { status: 500 });
     }
 
-    const payload: Ok = {
-      ok: true,
+    console.log("AdminPhase2Triggered", {
       job_id: jobId,
-      phase2: "canonical_pipeline_complete",
-    };
-    return NextResponse.json(payload, { status: 200 });
+      trigger_time: now,
+      force,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        job_id: jobId,
+        status: "queued",
+        phase2: "canonical_pipeline_queued",
+      },
+      { status: 202 }
+    );
   } catch (err) {
     const payload: Err = {
       ok: false,
-      error: "Failed to run phase2",
+      error: "Failed to trigger phase2",
       details: err instanceof Error ? err.message : "Unknown error",
     };
     return NextResponse.json(payload, { status: 500 });

--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -3,42 +3,15 @@ import { getJob, canRunPhase } from "@/lib/jobs/store";
 import { checkServiceRoleAuth } from "@/lib/auth/api";
 import { PHASES } from "@/lib/jobs/types";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { processEvaluationJob } from "@/lib/evaluation/processor";
 
 type Params = Promise<{ jobId: string }>;
 
 /**
- * POST /api/jobs/[jobId]/run-phase2
- * INTERNAL ONLY: Service role auth required.
- *
- * ─────────────────────────────────────────────────────────────────────
- * EXECUTION BOUNDARY CONTRACT
- * ─────────────────────────────────────────────────────────────────────
- *
- * This route is a TRIGGER SURFACE only. It does NOT execute the
- * evaluation pipeline synchronously inside the HTTP request.
- *
- * Responsibilities of this route:
- *   1. Auth gate (service role only)
- *   2. Job existence + eligibility guard
- *   3. Optional requeue on force=1
- *   4. Claim the job (status=running, trigger metadata written)
- *   5. Fire processEvaluationJob() in a detached async context
- *   6. Return {ok: true, status: "triggered"} immediately
- *
- * Responsibilities that belong ONLY to processEvaluationJob():
- *   - All AI execution (Pass 1/2/3/4)
- *   - Artifact persistence
- *   - status=complete or status=failed writes
- *
- * Rationale: Binding deep AI work to the HTTP request lifecycle means
- * any Vercel timeout or crash before artifact persistence leaves the
- * job in a dark state. Decoupling ensures durable truth is written
- * by the processor regardless of HTTP lifecycle events.
- * ─────────────────────────────────────────────────────────────────────
+ * Phase 2 trigger route
+ * HARD RULE: This route NEVER executes the pipeline.
+ * It ONLY queues work for the worker.
  */
 export async function POST(req: NextRequest, ctx: { params: Params }) {
-  // GOVERNANCE: Service role only (internal/daemon use)
   if (!checkServiceRoleAuth(req)) {
     return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
   }
@@ -52,87 +25,65 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
     return NextResponse.json({ ok: false, error: "Job not found" }, { status: 404 });
   }
 
-  if (job.status !== "queued") {
-    if (!force) {
-      const eligibility = canRunPhase(job, PHASES.PHASE_2);
-      return NextResponse.json(
-        {
-          ok: false,
-          error:
-            eligibility.reason ||
-            `Job must be queued for canonical execution. Current status=${job.status}`,
-        },
-        { status: 409 }
-      );
-    }
+  const progress =
+    job.progress && typeof job.progress === "object"
+      ? (job.progress as Record<string, unknown>)
+      : {};
 
-    const { error: requeueError } = await supabase
-      .from("evaluation_jobs")
-      .update({
-        status: "queued",
-        phase: "phase_1",
-        phase_status: "queued",
-        last_error: null,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", jobId);
+  const isPhase1CompleteHandoff =
+    job.status === "running" &&
+    progress.phase === "phase_1" &&
+    progress.phase_status === "complete";
 
-    if (requeueError) {
-      return NextResponse.json(
-        { ok: false, error: `Failed to requeue job: ${requeueError.message}` },
-        { status: 500 }
-      );
-    }
+  const isQueued = job.status === "queued";
+
+  if (!isQueued && !isPhase1CompleteHandoff && !force) {
+    const eligibility = canRunPhase(job, PHASES.PHASE_2);
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          eligibility.reason ||
+          `Not eligible. status=${job.status}, phase=${progress.phase}, phase_status=${progress.phase_status}`,
+      },
+      { status: 409 }
+    );
   }
 
-  // Claim the job: write trigger metadata before firing processor.
-  // This ensures durable truth exists even if the detached path fails
-  // before processEvaluationJob() writes its first status update.
-  const triggerTime = new Date().toISOString();
-  const { error: claimError } = await supabase
-    .from("evaluation_jobs")
-    .update({
-      phase: "phase_1",
-      phase_status: "triggered",
-      last_error: null,
-      updated_at: triggerTime,
-    })
-    .eq("id", jobId)
-    .eq("status", "queued"); // idempotent guard: only claim if still queued
+  const now = new Date().toISOString();
 
-  if (claimError) {
+  const updatePayload = {
+    status: "queued",
+    phase: "phase_2",
+    phase_status: "triggered",
+    last_error: null,
+    updated_at: now,
+  };
+
+  const { error } = await supabase
+    .from("evaluation_jobs")
+    .update(updatePayload)
+    .eq("id", jobId);
+
+  if (error) {
     return NextResponse.json(
-      { ok: false, error: `Failed to claim job for execution: ${claimError.message}` },
+      { ok: false, error: `Queue failed: ${error.message}` },
       { status: 500 }
     );
   }
 
-  console.log("Phase2Triggered", { job_id: jobId, trigger_time: triggerTime });
-
-  // ── Fire and detach ───────────────────────────────────────────────────
-  // processEvaluationJob() owns all execution state from here.
-  // The HTTP response does NOT wait for completion.
-  // Any unhandled error in the detached path is caught and logged;
-  // the processor's internal markFailed() handles job state writes.
-  processEvaluationJob(jobId).catch((unexpectedError) => {
-    // This catch is a last-resort safety net for unexpected throws
-    // that escape the processor's own try/catch. The processor
-    // already writes failed state internally, so this is observability only.
-    console.error("Phase2UnexpectedError", {
-      job_id: jobId,
-      error: unexpectedError instanceof Error ? unexpectedError.message : String(unexpectedError),
-    });
+  console.log("Phase2Triggered", {
+    job_id: jobId,
+    trigger_time: now,
+    force,
   });
 
-  // GOVERNANCE: return trigger acknowledgment, NOT completion truth.
-  // Callers must poll job status to determine completion.
   return NextResponse.json(
     {
       ok: true,
       job_id: jobId,
-      status: "triggered",
-      phase2: "canonical_pipeline_triggered",
-      message: "Evaluation pipeline started. Poll job status for completion.",
+      status: "queued",
+      phase2: "canonical_pipeline_queued",
     },
     { status: 202 }
   );


### PR DESCRIPTION
Single-commit hotfix from branch `hotfix/phase2-route-monotonic-state`. Ensures run-phase2 routes persist phase_2 state without regression. Branch has been open without a PR since last week.