### PR TITLE
fix: add checkDestructionGuards alias for pipeline compat

### DIFF
--- a/lib/revision/governance/destruction-guards.ts
+++ b/lib/revision/governance/destruction-guards.ts
@@ -45,3 +45,6 @@ export function passesDestructionGuards(
 
   return { ok: true };
 }
+
+/** @deprecated Use passesDestructionGuards. Alias kept for pipeline compat. */
+export { passesDestructionGuards as checkDestructionGuards };


### PR DESCRIPTION
Single-commit fix adding `checkDestructionGuards` alias for pipeline compatibility. Branch open without a PR for 13 days.