### PR TITLE
test(benchmarks): Phase 1 safe imports from normalization/reconciliation-v1

### DIFF
--- a/tests/fixtures/benchmarks/behavioral-not-inventory.fixture.json
+++ b/tests/fixtures/benchmarks/behavioral-not-inventory.fixture.json
@@ -1,0 +1,72 @@
+{
+  "fixture": "behavioral-not-inventory",
+  "version": "1.1.0",
+  "benchmarkTruth": "behavioral",
+  "description": "Behavioral contradiction vs inventory detection. RevisionGrade MUST distinguish character behavioral contradictions from simple inventory lists. The Cliff prices line is the canonical test case.",
+  "source": {
+    "manuscript": "dominatus-i4-thirst-for-change",
+    "chapter": "I:4",
+    "densityClass": "variable",
+    "sourceStatus": "canonical_cliff_prices_line_not_found_in_repo",
+    "fallbackSourceFile": "manuscripts/dominatus-i4-thirst-for-change.txt"
+  },
+  "input": {
+    "passages": [
+      {
+        "id": "behavioral-contradiction",
+        "textSource": "file",
+        "filePath": "manuscripts/dominatus-i4-thirst-for-change.txt",
+        "startMarker": "Hyla gathered what little air she could.",
+        "endMarker": "Then— A pulse.",
+        "passageHint": "protected",
+        "expectedClassification": "behavioral_contradiction",
+        "shouldFlag": true,
+        "shouldCompress": false
+      },
+      {
+        "id": "inventory-list",
+        "textSource": "file",
+        "filePath": "manuscripts/dominatus-i4-thirst-for-change.txt",
+        "startMarker": "leaving the land drenched in slick rainbows:",
+        "endMarker": "Ford. Toyota. Chevrolet.",
+        "passageHint": "compressible",
+        "expectedClassification": "inventory",
+        "shouldFlag": false,
+        "shouldCompress": true
+      },
+      {
+        "id": "cliff-prices-canonical",
+        "textSource": "file",
+        "filePath": "manuscripts/dominatus-i4-thirst-for-change.txt",
+        "startMarker": "They show no regard for other life—killing insects, felling squirrels, trapping rabbits, and laying low the great beasts: the deer and the bear.",
+        "endMarker": "The only ones who fight back,” she continued,”are the silver-scaled serpents of the abyss…",
+        "passageHint": "protected",
+        "expectedClassification": "behavioral_contradiction",
+        "shouldFlag": true,
+        "shouldCompress": false
+      }
+    ],
+    "profile": "generic",
+    "mode": "standard"
+  },
+  "expectedBehavior": {
+    "behavioralContradictionDetected": true,
+    "inventoryCorrectlyClassified": true,
+    "falsePositiveProtection": true,
+    "cliffPricesLineProtected": true
+  },
+  "failConditions": [
+    "Behavioral contradiction classified as inventory",
+    "Inventory classified as behavioral contradiction",
+    "Cliff prices line compressed or removed",
+    "behavioral_contradiction treated same as inventory",
+    "High-density suppression applied to behavioral passage"
+  ],
+  "passConditions": [
+    "behavioral-contradiction passage flagged correctly",
+    "inventory-list passage classified for compression",
+    "cliff-prices-canonical passage protected from compression",
+    "Classification distinguishes behavioral vs inventory semantics",
+    "No false positives on behavioral contradiction detection"
+  ]
+}

--- a/tests/fixtures/benchmarks/i47-max-density.fixture.json
+++ b/tests/fixtures/benchmarks/i47-max-density.fixture.json
@@ -1,0 +1,57 @@
+{
+  "fixture": "i47-max-density",
+  "version": "1.0.1",
+  "benchmarkTruth": "I:47",
+  "description": "DOMINATUS I:47 zero-compression ritual-dense passage. RevisionGrade MUST preserve 100% of ritual escalation, sensory layering, rhythm chains, and mythic tone.",
+  "source": {
+    "manuscript": "dominatus",
+    "chapter": "I:4",
+    "file": "manuscripts/dominatus-i4-thirst-for-change.txt",
+    "section": "I:4.3",
+    "startMarker": "DOMINATUS I:4\u229a",
+    "endMarker": "DOMINATUS I:4\u221e",
+    "densityClass": "max",
+    "wordCount": 312,
+    "loadStrategy": "file-reference"
+  },
+  "input": {
+    "textSource": "file",
+    "filePath": "manuscripts/dominatus-i4-thirst-for-change.txt",
+    "extractionMethod": "marker-bounded",
+    "startMarker": "They debated as the waters darkened",
+    "endMarker": "We will remember the last.",
+    "profile": "dominatus",
+    "mode": "revision"
+  },
+  "expectedBehavior": {
+    "compressionRate": 0,
+    "ritualEscalationPreserved": true,
+    "sensoryLayeringPreserved": true,
+    "rhythmChainsPreserved": true,
+    "mythicTonePreserved": true,
+    "zeroCompressionIsValidState": true,
+    "expectedOutputIdenticalToInput": true
+  },
+  "failConditions": [
+    "Any compression applied to ritual-dense passage",
+    "Flattening of escalation arc",
+    "Cutting sensory layering",
+    "Breaking rhythm chains",
+    "Reducing mythic tone",
+    "Using literary_dense as catch-all classification",
+    "Output differs from input by even one character"
+  ],
+  "passConditions": [
+    "Output identical to input (0% compression)",
+    "Density classification = max_ritual",
+    "No revision proposals generated for ritual content",
+    "Profile-specific signal recognized: dominatus.ritual_escalation"
+  ],
+  "runtimeWiring": {
+    "pipelinePath": "lib/revision/wavePlanner.ts",
+    "registryPath": "lib/revision/waveRegistry.ts",
+    "expectedWaveModules": ["wave-31-lw"],
+    "profileConfigPath": "lib/revision/profiles/dominatus.ts",
+    "evaluationMethod": "diff-input-output"
+  }
+}

--- a/tests/fixtures/benchmarks/ltrd-ch2-contrast.fixture.json
+++ b/tests/fixtures/benchmarks/ltrd-ch2-contrast.fixture.json
@@ -1,0 +1,45 @@
+{
+  "fixture": "ltrd-ch2-contrast",
+  "version": "1.2.0",
+  "benchmarkTruth": "LTRD Ch.2",
+  "description": "Let The River Decide Ch.2 — selective compression for moderate-density literary prose. RevisionGrade MUST apply 5-8% compression while preserving narrative texture.",
+  "source": {
+    "manuscript": "let-the-river-decide",
+    "chapter": "Ch.2",
+    "densityClass": "moderate",
+    "sourceFile": "manuscripts/let-the-river-decide-ch2.txt",
+    "sourceSection": "anthony-cake-offering"
+  },
+  "input": {
+    "textSource": "file",
+    "filePath": "manuscripts/let-the-river-decide-ch2.txt",
+    "extractionMethod": "marker-bounded",
+    "startMarker": "Didn’t move until we ate—all of it.",
+    "endMarker": "Maybe something else.",
+    "passageHint": "compressible",
+    "profile": "let-the-river-decide",
+    "mode": "standard"
+  },
+  "expectedBehavior": {
+    "compressionRateMin": 0.05,
+    "compressionRateMax": 0.08,
+    "narrativeTexturePreserved": true,
+    "chainsawCompressionForbidden": true,
+    "overCompressionDetected": false,
+    "profileDrivenSignals": true
+  },
+  "failConditions": [
+    "Compression exceeds 8%",
+    "Compression below 5% (under-revision)",
+    "Chainsaw texture detected in output",
+    "Sensory layering removed from moderate-density passages",
+    "Generic compression applied without profile awareness"
+  ],
+  "passConditions": [
+    "Compression rate between 5-8%",
+    "Density classification = moderate_literary",
+    "Revision proposals target only low-signal passages",
+    "High-signal passages preserved intact",
+    "Profile-specific config applied: let-the-river-decide.selective_compression"
+  ]
+}

--- a/tests/fixtures/benchmarks/ltrd-ch2-dialogue-stress.fixture.json
+++ b/tests/fixtures/benchmarks/ltrd-ch2-dialogue-stress.fixture.json
@@ -1,0 +1,67 @@
+{
+  "fixture": "ltrd-ch2-dialogue-stress",
+  "version": "1.0.0",
+  "benchmarkTruth": "LTRD Ch.2 Dialogue Stress Test",
+  "description": "Dialogue-heavy passage from LTRD Ch.2 (Anthony-William exchange). Tests that multi-speaker dialogue with meaning-bearing interaction, rhythm, and subtext is PROTECTED from compression. Expects 0-2% compression maximum (narration only, dialogue untouched).",
+  "source": {
+    "manuscript": "let-the-river-decide",
+    "chapter": "Ch.2",
+    "densityClass": "dialogue-heavy",
+    "sourceFile": "manuscripts/let-the-river-decide-ch2.txt",
+    "sourceSection": "anthony-william-ceremony-exchange"
+  },
+  "input": {
+    "textSource": "file",
+    "filePath": "manuscripts/let-the-river-decide-ch2.txt",
+    "extractionMethod": "marker-bounded",
+    "startMarker": "In both hands, he carried a small foil tray",
+    "endMarker": "Your brother knew. He saw it first.",
+    "passageHint": "protected",
+    "profile": "let-the-river-decide",
+    "mode": "standard"
+  },
+  "expectedBehavior": {
+    "compressionRateMin": 0.0,
+    "compressionRateMax": 0.02,
+    "dialogueTextPreserved": true,
+    "dialogueLineOrderPreserved": true,
+    "dialogueCompressionForbidden": true,
+    "narrativeCompressionAllowed": true,
+    "narrationRoundingOnlyEliminated": true
+  },
+  "failConditions": [
+    "Dialogue compression detected (lines merged, phrasing rewritten)",
+    "Dialogue text altered byte-for-byte (string equality check fails)",
+    "Dialogue line order changed",
+    "Multi-speaker exchange compressed below natural rhythm",
+    "Meaning-bearing repetition removed (e.g., Anthony's repeated 'he said')",
+    "Compression exceeds 2%"
+  ],
+  "passConditions": [
+    "Compression rate between 0-2%",
+    "Classification = dialogue (multi-speaker, meaning-bearing)",
+    "All dialogue lines preserved byte-identical",
+    "Line order preserved for all speakers",
+    "Only surrounding narration and tag cleanup applied",
+    "Dialogue immutability assertion passes"
+  ],
+  "immutabilityChecks": {
+    "requiredDialoguePreservation": [
+      "\"For you,\" he said.",
+      "\"From William. Give some to the dogs too. It's a healthy choice.\"",
+      "\"It's not chocolate,\" Anthony said.",
+      "\"Looks like it. But it's ground black spruce bark and fireweed honey. For ceremony. Safe for all kin—two- and four-legged.\"",
+      "\"Wow. Looks like chocolate cake.\"",
+      "\"You brought ghosts with you,\" he said.",
+      "\"What kind of ghosts?\"",
+      "\"The kind that don't leave. The kind that call back when you step too close.\"",
+      "\"These aren't the ones taken,\" he said.",
+      "\"They're the ones spoken for.\"",
+      "\"She's the oldest. She began the remembering.\"",
+      "\"So the rivers choose?\"",
+      "\"Not choice. Balance. You take too much, it answers. Not with anger. With memory.\"",
+      "\"Your brother knew. He saw it first.\""
+    ],
+    "lineCountExpectation": "preserved"
+  }
+}


### PR DESCRIPTION
## Phase
Phase 1 — Safe imports only

## What this PR does
Imports low-risk benchmark fixture files from `normalization/reconciliation-v1` into current mainline.

## Files included
- `tests/fixtures/benchmarks/behavioral-not-inventory.fixture.json`
- `tests/fixtures/benchmarks/i47-max-density.fixture.json`
- `tests/fixtures/benchmarks/ltrd-ch2-contrast.fixture.json`
- `tests/fixtures/benchmarks/ltrd-ch2-dialogue-stress.fixture.json`

## What this PR does NOT do
- No orchestrator changes
- No waveRegistry changes
- No CI workflow changes
- No CODEOWNERS changes
- No issue template changes
- No benchmark harness wiring
- No policy-as-code enforcement integration

## Why this is safe
These are fixture/data imports only. They do not change runtime behavior.

## Manuscripts
`manuscripts/let-the-river-decide-ch2.txt` — SKIPPED (repo data policy decision pending)