### PR TITLE
Reduce evaluation queue latency on submit

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -172,6 +172,24 @@ export async function POST(req: Request) {
       );
     }
 
+    const cronSecret = process.env.CRON_SECRET?.trim();
+    if (cronSecret) {
+      const workerTriggerUrl = new URL("/api/workers/process-evaluations", req.url);
+      void fetch(workerTriggerUrl.toString(), {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${cronSecret}`,
+        },
+      }).catch((triggerError: unknown) => {
+        const triggerMessage =
+          triggerError instanceof Error ? triggerError.message : String(triggerError);
+        console.warn(
+          "[evaluate] Best-effort worker trigger failed (cron will retry):",
+          triggerMessage
+        );
+      });
+    }
+
     // This return MUST be inside the POST function
     return Response.json(
       {

--- a/tests/api/evaluate-route-input-contract.test.ts
+++ b/tests/api/evaluate-route-input-contract.test.ts
@@ -16,11 +16,18 @@ jest.mock("@/lib/supabase/server", () => ({
 
 const mockCreateAdminClient = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
 const mockGetDevHeaderActor = getDevHeaderActor as jest.MockedFunction<typeof getDevHeaderActor>;
+const originalFetch = global.fetch;
 
 describe("POST /api/evaluate input contract", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetDevHeaderActor.mockReturnValue({ userId: "user-1", isAdmin: false });
+    delete process.env.CRON_SECRET;
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   test("returns 400 when both manuscript_id and manuscript_text are provided", async () => {
@@ -104,5 +111,81 @@ describe("POST /api/evaluate input contract", () => {
 
     expect(supabase.from).toHaveBeenCalledWith("manuscripts");
     expect(supabase.from).toHaveBeenCalledWith("evaluation_jobs");
+  });
+
+  test("returns 200 even when the best-effort worker trigger rejects", async () => {
+    process.env.CRON_SECRET = "cron-secret";
+    const fetchMock = jest.fn().mockRejectedValue(new Error("wake-up failed"));
+    global.fetch = fetchMock as typeof fetch;
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const insertMock = jest
+      .fn()
+      .mockImplementationOnce(() => ({
+        select: () => ({
+          single: async () => ({ data: { id: 654 }, error: null }),
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        select: () => ({
+          single: async () => ({
+            data: {
+              id: "job-trigger",
+              status: "queued",
+              phase: "phase_1",
+              phase_1_status: null,
+              policy_family: "standard",
+              voice_preservation_level: "balanced",
+              english_variant: "us",
+            },
+            error: null,
+          }),
+        }),
+      }));
+
+    const supabase = {
+      from: jest.fn(() => ({
+        insert: insertMock,
+      })),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    const req = new Request("https://preview.example.com/api/evaluate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        manuscript_text: "Trigger me maybe",
+        manuscript_title: "Wake the Worker",
+      }),
+    });
+
+    const response = await POST(req);
+    const json = (await response.json()) as {
+      ok: boolean;
+      job: { id: string; manuscript_id: number };
+    };
+
+    await Promise.resolve();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.job.id).toBe("job-trigger");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://preview.example.com/api/workers/process-evaluations",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer cron-secret",
+        },
+      }
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[evaluate] Best-effort worker trigger failed (cron will retry):",
+      "wake-up failed"
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/workers/process-evaluations",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/1 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- trigger the evaluation worker immediately after a job is inserted in `POST /api/evaluate`
- reduce the Vercel worker cron from every 5 minutes to every 1 minute as a fallback safety net
- add a focused route test proving the wake-up call is best-effort and does not block job creation if it fails

## Why
Queued jobs currently wait for cron to wake the worker, which adds avoidable dead time between submit and processing. This change keeps cron as the fallback while giving new jobs an immediate best-effort wake-up path.

## Notes
- the trigger uses the current request origin instead of a public site URL fallback
- the worker is called with `POST` and existing `CRON_SECRET` bearer auth
- atomic claiming via `claim_evaluation_jobs` remains the protection against duplicate processing when cron and the immediate trigger overlap

## Validation
- `CI=1 npm test -- --runInBand --runTestsByPath tests/api/evaluate-route-input-contract.test.ts`
