### PR TITLE
Item #6: Per-stage timestamps on evaluation_jobs (R4 observability)

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -160,6 +160,7 @@ export async function POST(req: Request) {
         policy_family: "standard",
         voice_preservation_level: "balanced",
         english_variant: "us",
+                queued_at: new Date().toISOString(), // Per-stage timestamp (R4 observability)
       })
       .select()
       .single();

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -967,6 +967,10 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
           last_heartbeat_at: now,
           heartbeat_at: now,
           updated_at: now,
+                      // Per-stage timestamps (R4 observability)
+            ...(phase === 'phase_1' ? { phase1_started_at: now } : {}),
+            ...(phase === 'phase_2' ? { phase2_started_at: now } : {}),
+                      ...(phase === 'phase_2' ? { phase1_completed_at: now } : {}), // phase_2 entry implies phase_1 done
         })
         .eq('id', jobId);
     };
@@ -1005,6 +1009,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
             completed_units: nextProgress.completed_units,
             progress: nextProgress,
             last_error: errorMessage,
+                        failed_at: now, // Per-stage timestamp (R4 observability)
             updated_at: now,
           })
           .eq('id', jobId);
@@ -1280,6 +1285,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         heartbeat_at: completionTime,
         last_error: null,
         updated_at: completionTime
+                  // Per-stage timestamps (R4 observability)
+          completed_at: completionTime,
+          phase2_completed_at: completionTime,
       })
       .eq('id', jobId);
     console.log(

--- a/supabase/migrations/20260416180000_add_stage_timestamps_evaluation_jobs.sql
+++ b/supabase/migrations/20260416180000_add_stage_timestamps_evaluation_jobs.sql
@@ -1,0 +1,49 @@
+-- Migration: Add per-stage timestamp columns to evaluation_jobs
+-- Date: 2026-04-16
+-- Purpose: R4 observability requirement — auditable stage-level timing
+-- for queued, phase 1 start/complete, phase 2 start/complete, and terminal states.
+-- Safe to run multiple times (IF NOT EXISTS guards).
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS queued_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS phase1_started_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS phase1_completed_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS phase2_started_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS phase2_completed_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ NULL;
+
+ALTER TABLE public.evaluation_jobs
+  ADD COLUMN IF NOT EXISTS failed_at TIMESTAMPTZ NULL;
+
+-- Backfill queued_at from created_at for existing rows where queued_at is null
+UPDATE public.evaluation_jobs
+  SET queued_at = created_at
+  WHERE queued_at IS NULL AND created_at IS NOT NULL;
+
+-- Backfill completed_at from updated_at for already-complete jobs
+UPDATE public.evaluation_jobs
+  SET completed_at = updated_at
+  WHERE completed_at IS NULL AND status = 'complete' AND updated_at IS NOT NULL;
+
+-- Backfill failed_at from updated_at for already-failed jobs
+UPDATE public.evaluation_jobs
+  SET failed_at = updated_at
+  WHERE failed_at IS NULL AND status = 'failed' AND updated_at IS NOT NULL;
+
+COMMENT ON COLUMN public.evaluation_jobs.queued_at IS 'Timestamp when job entered queued state (set at insert time)';
+COMMENT ON COLUMN public.evaluation_jobs.phase1_started_at IS 'Timestamp when phase 1 processing began';
+COMMENT ON COLUMN public.evaluation_jobs.phase1_completed_at IS 'Timestamp when phase 1 processing completed';
+COMMENT ON COLUMN public.evaluation_jobs.phase2_started_at IS 'Timestamp when phase 2 (artifact persistence) began';
+COMMENT ON COLUMN public.evaluation_jobs.phase2_completed_at IS 'Timestamp when phase 2 completed and job reached terminal state';
+COMMENT ON COLUMN public.evaluation_jobs.completed_at IS 'Timestamp when job reached complete terminal state';
+COMMENT ON COLUMN public.evaluation_jobs.failed_at IS 'Timestamp when job reached failed terminal state';


### PR DESCRIPTION
## Roadmap Item #6: Per-Stage Timestamps (R4 Observability)

### Problem
No auditable per-stage timing on `evaluation_jobs`. The only timestamps are `created_at`, `started_at`, and `updated_at` — not enough to diagnose where time is spent or prove stage transitions occurred.

### Changes

**1. Migration: `supabase/migrations/20260416180000_add_stage_timestamps_evaluation_jobs.sql`**
- Adds 7 nullable TIMESTAMPTZ columns: `queued_at`, `phase1_started_at`, `phase1_completed_at`, `phase2_started_at`, `phase2_completed_at`, `completed_at`, `failed_at`
- All use `IF NOT EXISTS` guards (safe to re-run)
- Backfills existing rows from `created_at`/`updated_at`
- Includes column comments for schema documentation

**2. `lib/evaluation/processor.ts` — Processor stage timestamps**
- `markRunning()`: writes `phase1_started_at` or `phase2_started_at` conditionally
- `markRunning()` with phase_2: also writes `phase1_completed_at` (phase_2 entry implies phase_1 done)
- `markFailed()`: writes `failed_at` as a top-level column (not just in progress JSON)
- Completion update: writes `completed_at` and `phase2_completed_at`

**3. `app/api/evaluate/route.ts` — Queue timestamp**
- Sets `queued_at: new Date().toISOString()` at job insert time

### Why this matters
- R4 certification requires auditable stage-level timing
- Enables future latency dashboards and SLA tracking
- Makes it possible to diagnose where time is spent in the pipeline
- Foundation for structured worker logging (Item #14)

### Gate Classification
- [x] Gate 6: Observability
- [x] Gate 2: State Machine Integrity (timestamps track state transitions)
- [x] Gate 9: Doctrine Traceability (auditable stage boundaries)