### PR TITLE
Item #8: Fail-closed governance + completion syntax fix (P1 trust)

### DIFF
--- a/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
+++ b/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
@@ -95,6 +95,17 @@ function makeSupabaseStub() {
           }),
         };
       }
+            if (table === "evaluation_artifacts") {
+        return {
+          select: () => {
+            const query = {
+              eq: () => query,
+              maybeSingle: async () => ({ data: { id: "artifact-canonical-pass" }, error: null }),
+            };
+            return query;
+          },
+        };
+      }
 
       throw new Error(`Unexpected table in canonical pipeline test stub: ${table}`);
     },

--- a/__tests__/lib/evaluation/processor.real-gate.test.ts
+++ b/__tests__/lib/evaluation/processor.real-gate.test.ts
@@ -160,6 +160,7 @@ function makeSupabaseStub() {
             }),
           }),
         };
+              }
               if (table === "evaluation_artifacts") {
         return {
           select: () => {
@@ -171,7 +172,6 @@ function makeSupabaseStub() {
             return query;
           },
         };
-      }
       }
       throw new Error(`Unexpected table in real-gate test stub: ${table}`);
     },

--- a/__tests__/lib/evaluation/processor.real-gate.test.ts
+++ b/__tests__/lib/evaluation/processor.real-gate.test.ts
@@ -132,6 +132,10 @@ function makeSupabaseStub() {
     user_id: "00000000-0000-0000-0000-000000000002",
   };
 
+    const artifactReadBack = {
+    id: "artifact-real-gate-pass",
+  };
+
   return {
     evaluationJobUpdates,
     from(table: string) {
@@ -156,6 +160,18 @@ function makeSupabaseStub() {
             }),
           }),
         };
+              if (table === "evaluation_artifacts") {
+        return {
+          select: () => {
+            const query = {
+              eq: () => query,
+              maybeSingle: async () => ({ data: artifactReadBack, error: null }),
+            };
+
+            return query;
+          },
+        };
+      }
       }
       throw new Error(`Unexpected table in real-gate test stub: ${table}`);
     },

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1252,6 +1252,20 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
       console.log(`[Processor] ${jobId}: EXIT upsertEvaluationArtifact id=${artifactId}`);
       console.log(`[Processor] Canonical artifact upserted: ${artifactId}`);
+
+          // Fail-closed read-back: verify artifact was actually persisted
+    const { data: readBackArtifact, error: readBackError } = await supabase
+      .from('evaluation_artifacts')
+      .select('id')
+      .eq('job_id', job.id)
+      .eq('manuscript_id', job.manuscript_id)
+      .eq('artifact_type', 'evaluation_result_v2')
+      .maybeSingle();
+    if (readBackError || !readBackArtifact) {
+      const readBackMsg = `Fail-closed: artifact read-back failed after upsert (${readBackError?.message ?? 'row not found'})`;
+      await markFailed(readBackMsg);
+      return { success: false, error: readBackMsg };
+    }
     } catch (artifactError) {
       const errorMsg = artifactError instanceof Error ? artifactError.message : String(artifactError);
       await markFailed(`Artifact persistence failed: ${errorMsg}`);
@@ -1284,7 +1298,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         last_heartbeat_at: completionTime,
         heartbeat_at: completionTime,
         last_error: null,
-        updated_at: completionTime
+        updated_at: completionTime,
                   // Per-stage timestamps (R4 observability)
           completed_at: completionTime,
           phase2_completed_at: completionTime,


### PR DESCRIPTION
## Roadmap Item #8: Fail-Closed Governance (P1 Trust)

### Problem
The completion update in `processor.ts` had a missing comma before `completed_at`, causing a syntax error. Additionally, after artifact upsert, there was no verification that the artifact was actually persisted — violating fail-closed governance requirements.

### Changes

**1. `lib/evaluation/processor.ts`**
- Fix missing comma before `completed_at: completionTime` in completion update object
- Add fail-closed read-back after `upsertEvaluationArtifact`: queries `evaluation_artifacts` to verify the row exists before marking the job complete
- If read-back fails, job is marked failed with explicit error message

### Why this matters
- Syntax error would cause runtime failures on every completion attempt
- Read-back ensures no silent data loss: if the artifact didn't persist, the job fails loudly
- Foundation for R4 certification trust chain (artifact existence proven, not assumed)

### Gate Classification
- [x] Gate 2: State Machine Integrity (fail-closed on write verification)
- [x] Gate 6: Observability (explicit error messages on read-back failure)
- [x] Gate 9: Doctrine Traceability (artifact existence proven before status transition)