### PR TITLE
feat(validity-gate): Item #8 — Finalizer criterion completeness gate

### DIFF
--- a/__tests__/lib/jobs/criterion-completeness.test.ts
+++ b/__tests__/lib/jobs/criterion-completeness.test.ts
@@ -1,0 +1,101 @@
+import { enforceCriterionCompleteness } from "../../../lib/jobs/invariants";
+import { InvariantViolation } from "../../../lib/jobs/invariants";
+import { CRITERIA_KEYS } from "../../../schemas/criteria-keys";
+import type { PassArtifact } from "../../../lib/jobs/finalize.types";
+
+// Helper to build a valid pass artifact with all 13 criteria
+function buildValidPass(passId: "pass1" | "pass2" | "pass3"): PassArtifact {
+  return {
+    id: `artifact-${passId}`,
+    job_id: "job-1",
+    pass_id: passId,
+    schema_version: "1.0.0",
+    manuscript_revision_id: "rev-1",
+    generated_at: new Date().toISOString(),
+    summary: "Test summary",
+    criteria: CRITERIA_KEYS.map((key) => ({
+      criterion_id: key,
+      score_0_10: 7,
+      rationale: `Rationale for ${key}`,
+      confidence_0_1: 0.8,
+      evidence: [
+        {
+          anchor_id: `anchor-${key}`,
+          source_type: "manuscript_chunk" as const,
+          source_ref: `chunk-${key}`,
+          start_offset: 0,
+          end_offset: 100,
+          excerpt: `Evidence for ${key}`,
+        },
+      ],
+      warnings: [],
+    })),
+    provenance: {
+      evaluator_version: "1.0.0",
+      prompt_pack_version: "1.0.0",
+      run_id: "run-1",
+    },
+    validations: {
+      schema_valid: true,
+      anchor_contract_valid: true,
+      evidence_nonempty: true,
+      orphan_reasoning_absent: true,
+    },
+  };
+}
+
+describe("enforceCriterionCompleteness", () => {
+  it("passes with all 13 criteria present and valid", () => {
+    const p1 = buildValidPass("pass1");
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).not.toThrow();
+  });
+
+  it("rejects pass missing a criterion", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria = p1.criteria.filter((c) => c.criterion_id !== "concept");
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(InvariantViolation);
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/missing criteria.*concept/);
+  });
+
+  it("rejects criterion with empty rationale", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria[0].rationale = "";
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/empty rationale/);
+  });
+
+  it("rejects criterion with no evidence", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria[0].evidence = [];
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/no evidence anchors/);
+  });
+
+  it("rejects criterion with out-of-range score", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria[0].score_0_10 = 11;
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/invalid score/);
+  });
+
+  it("uses CRITERION_COMPLETENESS_FAILED failure code", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria = [];
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    try {
+      enforceCriterionCompleteness(p1, p2, p3);
+      fail("Expected InvariantViolation");
+    } catch (e) {
+      expect(e).toBeInstanceOf(InvariantViolation);
+      expect((e as InvariantViolation).failureCode).toBe("CRITERION_COMPLETENESS_FAILED");
+    }
+  });
+});

--- a/__tests__/lib/jobs/criterion-completeness.test.ts
+++ b/__tests__/lib/jobs/criterion-completeness.test.ts
@@ -98,4 +98,32 @@ describe("enforceCriterionCompleteness", () => {
       expect((e as InvariantViolation).failureCode).toBe("CRITERION_COMPLETENESS_FAILED");
     }
   });
+
+  it("rejects duplicate criterion ids", () => {
+    const p1 = buildValidPass("pass1");
+    // Duplicate the first criterion
+    p1.criteria.push({ ...p1.criteria[0] });
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(InvariantViolation);
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/duplicate criterion id/);
+  });
+
+  it("rejects non-canonical criterion ids", () => {
+    const p1 = buildValidPass("pass1");
+    // Replace one criterion with an invented key
+    p1.criteria[0] = { ...p1.criteria[0], criterion_id: "fakeAxis" };
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(InvariantViolation);
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/non-canonical criterion id/);
+  });
+
+  it("rejects non-finite scores (NaN, Infinity)", () => {
+    const p1 = buildValidPass("pass1");
+    p1.criteria[0].score_0_10 = NaN;
+    const p2 = buildValidPass("pass2");
+    const p3 = buildValidPass("pass3");
+    expect(() => enforceCriterionCompleteness(p1, p2, p3)).toThrow(/invalid score/);
+  });
 });

--- a/lib/jobs/failures.ts
+++ b/lib/jobs/failures.ts
@@ -3,7 +3,6 @@
  * Source of truth for retryability decisions.
  * EVALUATION_GATE_REJECTED is non-transient: never retry.
  */
-
 export const FAILURE_CODES = [
   // Transient / retriable
   'TIMEOUT',
@@ -26,6 +25,7 @@ export const FAILURE_CODES = [
   'VALIDATION_ERROR',
   'CANONICAL_ARTIFACT_WRITE_FAILED',
   'SUMMARY_PROJECTION_FAILED',
+  'CRITERION_COMPLETENESS_FAILED',
 ] as const;
 
 export type FailureCode = typeof FAILURE_CODES[number];
@@ -43,6 +43,7 @@ const NON_TRANSIENT_CODES = new Set<FailureCode>([
   'VALIDATION_ERROR',
   'CANONICAL_ARTIFACT_WRITE_FAILED',
   'SUMMARY_PROJECTION_FAILED',
+  'CRITERION_COMPLETENESS_FAILED',
 ]);
 
 export function assertValidFailureCode(raw: string): asserts raw is FailureCode {

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -1,20 +1,19 @@
 /**
  * Finalizer — RevisionGrade Phase 1
- * 
+ *
  * The sole truth gate between execution and canonical artifact publication.
- * 
+ *
  * Rules:
  * - No code path sets job.status = "complete" outside this module
  * - No report renders without Finalizer-approved canonical artifact
  * - No missing pass artifact tolerated
  * - No partial-complete states
  * - All decisions reconstructable from logs and persisted state
- * 
+ *
  * Architecture:
  * Layer 1 — Pure domain logic (validate, enforce, build)
  * Layer 2 — Side effects (fetch, persist, update)
  */
-
 import type {
   EvaluationJob,
   PassArtifact,
@@ -33,6 +32,7 @@ import {
   assertFinalizerAuthority,
   assertRequiredArtifactsPresent,
   enforcePassSeparation,
+  enforceCriterionCompleteness,
   enforceAnchorIntegrity,
   enforceA6Credibility,
   assertPreCompletionInvariants,
@@ -42,7 +42,6 @@ import {
 export const FINALIZER_VERSION = "1.0.0";
 
 // === Storage Interface (injected) ===
-
 export interface FinalizerStorage {
   getJob(jobId: string): Promise<EvaluationJob | null>;
   getPassArtifact(artifactId: string): Promise<PassArtifact | null>;
@@ -208,6 +207,9 @@ export async function finalizeJob(
 
     // Step 5: Pass separation enforcement
     enforcePassSeparation(pass1, pass2, pass3, convergence);
+
+    // Step 5.5: Criterion completeness gate (Item #8)
+    enforceCriterionCompleteness(pass1, pass2, pass3);
 
     // Step 6: Anchor integrity
     enforceAnchorIntegrity(pass1, pass2, pass3, convergence);

--- a/lib/jobs/invariants.ts
+++ b/lib/jobs/invariants.ts
@@ -1,10 +1,9 @@
 /**
  * Runtime Invariant Checks — RevisionGrade Phase 1
- * 
+ *
  * These invariants MUST block execution. They are not warnings.
  * Violation = immediate failure with classified error.
  */
-
 import type {
   EvaluationJob,
   PassArtifact,
@@ -12,6 +11,7 @@ import type {
   CanonicalEvaluationArtifact,
 } from "./finalize.types";
 import type { FailureCode } from "./failures";
+import { CRITERIA_KEYS } from "../../schemas/criteria-keys";
 
 export class InvariantViolation extends Error {
   constructor(
@@ -109,6 +109,61 @@ export function enforcePassSeparation(
       "PASS_CONVERGENCE_FAILURE",
       `Convergence inputs do not match loaded pass artifacts`,
     );
+  }
+}
+
+// === Criterion Completeness (Item #8 Validity Gate) ===
+
+export function enforceCriterionCompleteness(
+  pass1: PassArtifact,
+  pass2: PassArtifact,
+  pass3: PassArtifact,
+): void {
+  const requiredKeys = new Set<string>(CRITERIA_KEYS);
+  const allArtifacts = [
+    { label: "pass1", artifact: pass1 },
+    { label: "pass2", artifact: pass2 },
+    { label: "pass3", artifact: pass3 },
+  ];
+
+  for (const { label, artifact } of allArtifacts) {
+    const presentKeys = new Set(artifact.criteria.map((c) => c.criterion_id));
+
+    // Check all 13 criteria are present
+    const missing: string[] = [];
+    for (const key of requiredKeys) {
+      if (!presentKeys.has(key)) {
+        missing.push(key);
+      }
+    }
+    if (missing.length > 0) {
+      throw new InvariantViolation(
+        "CRITERION_COMPLETENESS_FAILED",
+        `${label}: missing criteria [${missing.join(", ")}]`,
+      );
+    }
+
+    // Check each criterion has score, rationale, and evidence
+    for (const criterion of artifact.criteria) {
+      if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+        throw new InvariantViolation(
+          "CRITERION_COMPLETENESS_FAILED",
+          `${label} criterion ${criterion.criterion_id}: invalid score (${criterion.score_0_10})`,
+        );
+      }
+      if (!criterion.rationale || criterion.rationale.trim().length === 0) {
+        throw new InvariantViolation(
+          "CRITERION_COMPLETENESS_FAILED",
+          `${label} criterion ${criterion.criterion_id}: empty rationale`,
+        );
+      }
+      if (!criterion.evidence || criterion.evidence.length === 0) {
+        throw new InvariantViolation(
+          "CRITERION_COMPLETENESS_FAILED",
+          `${label} criterion ${criterion.criterion_id}: no evidence anchors`,
+        );
+      }
+    }
   }
 }
 

--- a/lib/jobs/invariants.ts
+++ b/lib/jobs/invariants.ts
@@ -127,12 +127,28 @@ export function enforceCriterionCompleteness(
   ];
 
   for (const { label, artifact } of allArtifacts) {
-    const presentKeys = new Set(artifact.criteria.map((c) => c.criterion_id));
+    // Check for non-canonical or duplicate criterion IDs
+    const seen = new Set<string>();
+    for (const criterion of artifact.criteria) {
+      if (!requiredKeys.has(criterion.criterion_id)) {
+        throw new InvariantViolation(
+          "CRITERION_COMPLETENESS_FAILED",
+          `${label}: non-canonical criterion id "${criterion.criterion_id}"`,
+        );
+      }
+      if (seen.has(criterion.criterion_id)) {
+        throw new InvariantViolation(
+          "CRITERION_COMPLETENESS_FAILED",
+          `${label}: duplicate criterion id "${criterion.criterion_id}"`,
+        );
+      }
+      seen.add(criterion.criterion_id);
+    }
 
-    // Check all 13 criteria are present
+    // Check all 13 criteria are present (exactly once, after uniqueness pass)
     const missing: string[] = [];
     for (const key of requiredKeys) {
-      if (!presentKeys.has(key)) {
+      if (!seen.has(key)) {
         missing.push(key);
       }
     }
@@ -145,7 +161,12 @@ export function enforceCriterionCompleteness(
 
     // Check each criterion has score, rationale, and evidence
     for (const criterion of artifact.criteria) {
-      if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+      if (
+        typeof criterion.score_0_10 !== "number" ||
+        !Number.isFinite(criterion.score_0_10) ||
+        criterion.score_0_10 < 0 ||
+        criterion.score_0_10 > 10
+      ) {
         throw new InvariantViolation(
           "CRITERION_COMPLETENESS_FAILED",
           `${label} criterion ${criterion.criterion_id}: invalid score (${criterion.score_0_10})`,

--- a/tests/jobs/finalize.persistence.test.ts
+++ b/tests/jobs/finalize.persistence.test.ts
@@ -5,6 +5,7 @@ import type {
   EvaluationJob,
   PassArtifact,
 } from "@/lib/jobs/finalize.types";
+import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 
 function makePass(passId: "pass1" | "pass2" | "pass3", id: string): PassArtifact {
   return {
@@ -15,25 +16,23 @@ function makePass(passId: "pass1" | "pass2" | "pass3", id: string): PassArtifact
     manuscript_revision_id: "rev-1",
     generated_at: new Date().toISOString(),
     summary: `${passId} summary`,
-    criteria: [
-      {
-        criterion_id: "sceneConstruction",
-        score_0_10: 8,
-        rationale: "Supported by evidence.",
-        confidence_0_1: 0.8,
-        evidence: [
-          {
-            anchor_id: `${id}-a1`,
-            source_type: "manuscript_chunk",
-            source_ref: "chunk-1",
-            start_offset: 10,
-            end_offset: 25,
-            excerpt: "Example excerpt",
-          },
-        ],
-        warnings: [],
-      },
-    ],
+    criteria: CRITERIA_KEYS.map((key, idx) => ({
+      criterion_id: key,
+      score_0_10: 7,
+      rationale: `Rationale for ${key} in ${passId}.`,
+      confidence_0_1: 0.8,
+      evidence: [
+        {
+          anchor_id: `${id}-a${idx + 1}`,
+          source_type: "manuscript_chunk" as const,
+          source_ref: `chunk-${idx + 1}`,
+          start_offset: 10,
+          end_offset: 25,
+          excerpt: `Evidence for ${key}`,
+        },
+      ],
+      warnings: [],
+    })),
     provenance: {
       evaluator_version: "eval-v1",
       prompt_pack_version: "pack-v1",


### PR DESCRIPTION
## Roadmap Item #8 — Finalizer Criterion Completeness Gate

### What
Adds a fail-closed validity gate (`enforceCriterionCompleteness`) to the finalizer pipeline that verifies every pass artifact contains all 13 canonical criteria with valid score, rationale, and evidence before allowing canonical artifact publication.

### Why
Without this gate, a pass artifact missing criteria (e.g., AI dropped `marketability`) would silently produce an incomplete canonical artifact. This is a certification blocker — wrong output is worse than no output.

### Changes
- **`lib/jobs/failures.ts`**: Add `CRITERION_COMPLETENESS_FAILED` failure code (non-transient/terminal)
- **`lib/jobs/invariants.ts`**: Add `enforceCriterionCompleteness()` invariant importing `CRITERIA_KEYS` from canonical registry. Checks:
  - All 13 criteria present in each pass (keyed against `schemas/criteria-keys.ts`)
  - Score in valid range (0–10)
  - Non-empty rationale
  - At least one evidence anchor per criterion
- **`lib/jobs/finalize.ts`**: Wire new invariant at Step 5.5 (after pass separation, before anchor integrity)
- **`__tests__/lib/jobs/criterion-completeness.test.ts`**: 6 test cases covering happy path + missing criteria + empty rationale + no evidence + invalid score + failure code assertion

### Gate Classification
- [x] Gate 8: Regression Safety
- [x] Gate 10: Canon Compliance
- [x] Gate 11: Finalizer Authority (hard stop)
- [x] Gate 12: Pass Artifact Integrity

### Scope
Governance/validity only. No UI, no prompt, no confidence changes.