### PR TITLE
Feat/fixture canon guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -78,4 +78,15 @@ Describe how to revert safely.
 
 ## Follow-ups
 
+
+## Blast-Radius Check (Required for invariant-tightening PRs)
+
+<!-- Fill this section if this PR adds or tightens an enforce*/assert* invariant -->
+
+- [ ] Shared valid fixtures still satisfy the new invariant
+- [ ] Success-path tests using pass artifacts still use canon-complete fixtures
+- [ ] No local minimal fixture is pretending to be a valid release-path artifact
+- [ ] PassArtifact shape, CRITERIA_KEYS, and fixture builders still align (triangle check)
+- [ ] At least one downstream integration/success-path suite was re-run
+- [ ] Fixture Canon Guard CI job passes
 List anything intentionally deferred.

--- a/.github/workflows/fixture-guard.yml
+++ b/.github/workflows/fixture-guard.yml
@@ -1,0 +1,39 @@
+name: Fixture Canon Guard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '__tests__/**'
+      - 'lib/jobs/**'
+      - 'schemas/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '__tests__/**'
+      - 'lib/jobs/**'
+      - 'schemas/**'
+
+jobs:
+  fixture-canon-guard:
+    name: Fixture Canon Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run fixture canon guard tests
+        run: npx jest --testPathPattern='fixture-canon-guard' --runInBand --verbose
+
+  fixture-guard-gate:
+    name: Fixture Guard Gate (must pass)
+    needs: [fixture-canon-guard]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'All fixture canon guard checks passed'

--- a/__tests__/guards/fixture-canon-guard.test.ts
+++ b/__tests__/guards/fixture-canon-guard.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Fixture Canon Guard — RevisionGrade
+ *
+ * Purpose: Prove that shared "valid" fixtures are actually valid
+ * under current doctrine. If canon changes and the fixture builder
+ * drifts, this fails immediately.
+ *
+ * This suite is the real tripwire. It runs in CI on every PR.
+ */
+import { buildValidPassArtifact, buildValidConvergenceArtifact } from "../helpers/buildValidPassArtifact";
+import { assertCanonCompletePassArtifact } from "../helpers/assertCanonCompletePassArtifact";
+import { enforceCriterionCompleteness } from "../../lib/jobs/invariants";
+import { enforcePassSeparation } from "../../lib/jobs/invariants";
+import { enforceAnchorIntegrity } from "../../lib/jobs/invariants";
+import { enforceA6Credibility } from "../../lib/jobs/invariants";
+import { CRITERIA_KEYS } from "../../schemas/criteria-keys";
+
+describe("fixture canon guard", () => {
+  const p1 = buildValidPassArtifact("pass1");
+  const p2 = buildValidPassArtifact("pass2");
+  const p3 = buildValidPassArtifact("pass3");
+  const convergence = buildValidConvergenceArtifact(p1.id, p2.id, p3.id);
+
+  describe("shared fixture builder produces canon-complete artifacts", () => {
+    it("pass1 fixture passes assertCanonCompletePassArtifact", () => {
+      expect(() => assertCanonCompletePassArtifact(p1)).not.toThrow();
+    });
+
+    it("pass2 fixture passes assertCanonCompletePassArtifact", () => {
+      expect(() => assertCanonCompletePassArtifact(p2)).not.toThrow();
+    });
+
+    it("pass3 fixture passes assertCanonCompletePassArtifact", () => {
+      expect(() => assertCanonCompletePassArtifact(p3)).not.toThrow();
+    });
+  });
+
+  describe("shared fixtures satisfy all current invariants", () => {
+    it("satisfies enforceCriterionCompleteness", () => {
+      expect(() => enforceCriterionCompleteness(p1, p2, p3)).not.toThrow();
+    });
+
+    it("satisfies enforcePassSeparation", () => {
+      expect(() => enforcePassSeparation(p1, p2, p3, convergence)).not.toThrow();
+    });
+
+    it("satisfies enforceAnchorIntegrity", () => {
+      expect(() => enforceAnchorIntegrity(p1, p2, p3, convergence)).not.toThrow();
+    });
+
+    it("satisfies enforceA6Credibility", () => {
+      expect(() => enforceA6Credibility(p1, p2, p3, convergence)).not.toThrow();
+    });
+  });
+
+  describe("fixture builder aligns with CRITERIA_KEYS canon", () => {
+    it("produces exactly 13 criteria", () => {
+      expect(p1.criteria.length).toBe(CRITERIA_KEYS.length);
+      expect(p1.criteria.length).toBe(13);
+    });
+
+    it("every criterion_id matches a CRITERIA_KEYS entry", () => {
+      const keys = new Set<string>(CRITERIA_KEYS);
+      for (const c of p1.criteria) {
+        expect(keys.has(c.criterion_id)).toBe(true);
+      }
+    });
+
+    it("no duplicate criterion_ids", () => {
+      const ids = p1.criteria.map((c) => c.criterion_id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  describe("overrides do not break canon compliance", () => {
+    it("overriding summary still passes canon check", () => {
+      const custom = buildValidPassArtifact("pass1", { summary: "Custom summary" });
+      expect(() => assertCanonCompletePassArtifact(custom)).not.toThrow();
+    });
+
+    it("overriding job_id still passes canon check", () => {
+      const custom = buildValidPassArtifact("pass1", { job_id: "custom-job" });
+      expect(() => assertCanonCompletePassArtifact(custom)).not.toThrow();
+    });
+  });
+});

--- a/__tests__/helpers/assertCanonCompletePassArtifact.ts
+++ b/__tests__/helpers/assertCanonCompletePassArtifact.ts
@@ -1,0 +1,48 @@
+/**
+ * Canon Drift Assertion Helper — RevisionGrade
+ *
+ * Use inside fixture tests and success-path tests to verify that a
+ * PassArtifact contains all canonical criteria from CRITERIA_KEYS.
+ *
+ * This catches the exact mismatch where a fixture builder drifts
+ * below canon (e.g., uses 1 criterion instead of 13).
+ */
+import { CRITERIA_KEYS } from "../../schemas/criteria-keys";
+import type { PassArtifact } from "../../lib/jobs/finalize.types";
+
+export function assertCanonCompletePassArtifact(artifact: PassArtifact): void {
+  const required = new Set<string>(CRITERIA_KEYS);
+  const actual = artifact.criteria.map((c) => c.criterion_id);
+  const unique = new Set(actual);
+
+  if (unique.size !== CRITERIA_KEYS.length) {
+    throw new Error(
+      `Expected ${CRITERIA_KEYS.length} unique criteria, got ${unique.size}`,
+    );
+  }
+
+  for (const key of required) {
+    if (!unique.has(key)) {
+      throw new Error(`Missing canonical criterion: ${key}`);
+    }
+  }
+
+  // Validate each criterion has required fields
+  for (const criterion of artifact.criteria) {
+    if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+      throw new Error(
+        `Criterion ${criterion.criterion_id}: invalid score (${criterion.score_0_10})`,
+      );
+    }
+    if (!criterion.rationale || criterion.rationale.trim().length === 0) {
+      throw new Error(
+        `Criterion ${criterion.criterion_id}: empty rationale`,
+      );
+    }
+    if (!criterion.evidence || criterion.evidence.length === 0) {
+      throw new Error(
+        `Criterion ${criterion.criterion_id}: no evidence anchors`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Fixture-Canon Guardrail

Turns the blast-radius review discipline into CI enforcement.

### Problem
When a stricter invariant (enforce*/assert*) lands, old "minimal fake" test fixtures silently become invalid. This causes downstream test failures that are discovered late.

### Solution
A three-layer guardrail system:

**1. Shared Canonical Fixture Builder** (`__tests__/helpers/buildValidPassArtifact.ts`)
- Single source of truth for valid PassArtifact and ConvergenceArtifact fixtures
- Generated from `CRITERIA_KEYS` (canon), not memory
- Supports overrides without breaking canon compliance
- If an invariant tightens, the fix belongs HERE

**2. Canon Drift Assertion Helper** (`__tests__/helpers/assertCanonCompletePassArtifact.ts`)
- Validates any PassArtifact has all 13 criteria with score/rationale/evidence
- Use inside fixture tests and success-path tests

**3. Fixture Canon Guard Test Suite** (`__tests__/guards/fixture-canon-guard.test.ts`)
- 12 tests proving shared fixtures satisfy ALL current invariants
- Validates against: enforceCriterionCompleteness, enforcePassSeparation, enforceAnchorIntegrity, enforceA6Credibility
- Tests CRITERIA_KEYS alignment (count, keys, no duplicates)
- Tests that overrides preserve canon compliance

**4. CI Workflow** (`.github/workflows/fixture-guard.yml`)
- Runs on every PR touching `__tests__/`, `lib/jobs/`, or `schemas/`
- Dedicated Fixture Canon Guard job

**5. PR Template Update** (`.github/pull_request_template.md`)
- New Blast-Radius Check section for invariant-tightening PRs
- Triangle check: PassArtifact shape + CRITERIA_KEYS + fixture builders

### One-Line Principle
> Any test fixture that claims to represent a valid canonical pass artifact must be generated from canon, not memory.

### Gate Classification
- [x] Gate 8: Regression Safety
- [x] Gate 10: Canon Compliance

### Scope
Test infrastructure and CI only. No runtime changes.