### PR TITLE
fix(fixtures): tighten canon guard assertions

### DIFF
--- a/__tests__/guards/fixture-canon-guard.test.ts
+++ b/__tests__/guards/fixture-canon-guard.test.ts
@@ -70,6 +70,10 @@ describe("fixture canon guard", () => {
       const ids = p1.criteria.map((c) => c.criterion_id);
       expect(new Set(ids).size).toBe(ids.length);
     });
+
+    it("CRITERIA_KEYS itself has no duplicates", () => {
+      expect(new Set(CRITERIA_KEYS).size).toBe(CRITERIA_KEYS.length);
+    });
   });
 
   describe("overrides do not break canon compliance", () => {
@@ -81,6 +85,30 @@ describe("fixture canon guard", () => {
     it("overriding job_id still passes canon check", () => {
       const custom = buildValidPassArtifact("pass1", { job_id: "custom-job" });
       expect(() => assertCanonCompletePassArtifact(custom)).not.toThrow();
+    });
+  });
+
+  describe("canon assertion helper rejects illegal fixture states", () => {
+    it("rejects extra criteria entries even if unique keys still cover canon", () => {
+      const custom = buildValidPassArtifact("pass1");
+      custom.criteria.push({
+        ...custom.criteria[0],
+        evidence: [...custom.criteria[0].evidence],
+      });
+
+      expect(() => assertCanonCompletePassArtifact(custom)).toThrow(
+        /Expected exactly 13 criteria entries, got 14/,
+      );
+    });
+
+    it("rejects non-finite criterion scores", () => {
+      const custom = buildValidPassArtifact("pass1");
+      custom.criteria[0] = {
+        ...custom.criteria[0],
+        score_0_10: Number.NaN,
+      };
+
+      expect(() => assertCanonCompletePassArtifact(custom)).toThrow(/invalid score/);
     });
   });
 });

--- a/__tests__/helpers/assertCanonCompletePassArtifact.ts
+++ b/__tests__/helpers/assertCanonCompletePassArtifact.ts
@@ -15,6 +15,12 @@ export function assertCanonCompletePassArtifact(artifact: PassArtifact): void {
   const actual = artifact.criteria.map((c) => c.criterion_id);
   const unique = new Set(actual);
 
+  if (actual.length !== CRITERIA_KEYS.length) {
+    throw new Error(
+      `Expected exactly ${CRITERIA_KEYS.length} criteria entries, got ${actual.length}`,
+    );
+  }
+
   if (unique.size !== CRITERIA_KEYS.length) {
     throw new Error(
       `Expected ${CRITERIA_KEYS.length} unique criteria, got ${unique.size}`,
@@ -29,7 +35,12 @@ export function assertCanonCompletePassArtifact(artifact: PassArtifact): void {
 
   // Validate each criterion has required fields
   for (const criterion of artifact.criteria) {
-    if (typeof criterion.score_0_10 !== "number" || criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+    if (
+      typeof criterion.score_0_10 !== "number"
+      || !Number.isFinite(criterion.score_0_10)
+      || criterion.score_0_10 < 0
+      || criterion.score_0_10 > 10
+    ) {
       throw new Error(
         `Criterion ${criterion.criterion_id}: invalid score (${criterion.score_0_10})`,
       );


### PR DESCRIPTION
This follow-up tightens the merged fixture canon guard helper from PR #149.

### Why
The merged helper correctly verified canonical key coverage, but it still allowed two illegal states:
- extra duplicate criteria entries as long as the unique-key set still matched canon
- non-finite scores such as `NaN` or `Infinity`

### What changed
- require `artifact.criteria.length === CRITERIA_KEYS.length`
- continue enforcing unique canonical keys
- reject non-finite `score_0_10` values with `Number.isFinite(...)`
- add regression tests for:
  - extra duplicate criterion entry (14 entries total)
  - non-finite score rejection
  - duplicate detection on `CRITERIA_KEYS` itself

### Validation
- `__tests__/guards/fixture-canon-guard.test.ts`
- `__tests__/lib/jobs/criterion-completeness.test.ts`
- `tests/jobs/finalize.persistence.test.ts`
- local result: 32 tests passed

This is test infrastructure only; no runtime behavior is changed.