### PR TITLE
refactor(evaluation): route live job writes through canonical status contract (#18.5)

### DIFF
--- a/docs/governance/STATUS_ENFORCEMENT_18_5_PLAN.md
+++ b/docs/governance/STATUS_ENFORCEMENT_18_5_PLAN.md
@@ -1,0 +1,172 @@
+# Item #18.5 — Runtime Status Contract Wiring
+
+## Purpose
+
+Wire live evaluation job writes to the canonical status contract introduced in PR #151.
+
+This is an execution PR, not a doctrine PR.
+
+## Scope
+
+Enforce three runtime rules:
+
+1. lifecycle writes must go through `normalizeEvaluationJobStatus(...)`
+2. lifecycle transitions must go through one canonical validator
+3. validity must be written separately and never inferred from lifecycle
+
+## Canonical contracts
+
+### Lifecycle status
+`queued | running | complete | failed`
+
+### Validity status
+`pending | valid | invalid | quarantined`
+
+Definitions:
+- `pending` — not yet adjudicated
+- `valid` — passes release criteria, safe to surface
+- `invalid` — adjudicated and blocked
+- `quarantined` — held back due to integrity/trust anomaly; distinct from invalid
+
+## Canonical ownership
+
+Before rewiring, confirm the single source of truth for:
+
+- `EvaluationJobStatus`
+- `assertValidJobStatusTransition(...)`
+
+Do **not** allow parallel owners in:
+- `lib/evaluation/status.ts`
+- `lib/jobs/types.ts`
+- `lib/jobs/transitions.ts`
+
+Rule:
+- if `lib/evaluation/status.ts` is the canonical owner, downstream code imports from there
+- if `lib/jobs/*` already owns lifecycle truth, `lib/evaluation/status.ts` must delegate or re-export
+
+There must be exactly one canonical lifecycle type owner and one canonical transition validator.
+
+## Allowed lifecycle transitions
+
+Only these transitions are valid:
+
+- `queued -> running`
+- `queued -> failed`
+- `running -> complete`
+- `running -> failed`
+
+Blocked examples:
+- `queued -> complete`
+- `complete -> running`
+- `failed -> complete`
+
+## Write hub map
+
+### Enforced hub
+- `lib/jobs/jobStore.supabase.ts`
+
+This is the primary write surface for `evaluation_jobs.status` and, when present, `validity_status`.
+
+### Verification-only touch points
+- `claimJob.ts`
+- `processor.ts`
+- `finalize.ts`
+
+These files should be checked only to ensure they do not bypass the store or persist raw lifecycle values directly.
+
+## File-by-file plan
+
+### 1) `lib/jobs/jobStore.supabase.ts`
+Primary work happens here.
+
+Required changes:
+- route every lifecycle write through `normalizeEvaluationJobStatus(...)`
+- validate every lifecycle transition through `assertValidJobStatusTransition(from, to)` before persistence
+- keep validity writes explicit and separate
+- do not infer validity from lifecycle
+- do not introduce new lifecycle values
+
+### 2) `claimJob.ts`
+Check caller behavior only.
+
+Confirm:
+- claim path uses the store
+- persisted transition is `queued -> running`
+- no raw status writes bypass the hub
+
+### 3) `processor.ts`
+Check processing/failure paths only.
+
+Confirm:
+- success path ends as `running -> complete`
+- failure path ends as `running -> failed`
+- no raw status persistence bypasses the hub
+- no stage-specific lifecycle states are introduced
+
+### 4) `finalize.ts`
+Check validity handling only.
+
+Confirm:
+- validity is written explicitly, not inferred
+- valid completion can write:
+  - `status='complete'`
+  - `validity_status='valid'`
+- invalid completion can write:
+  - `status='complete'`
+  - `validity_status='invalid'`
+- quarantined completion can write:
+  - `status='complete'`
+  - `validity_status='quarantined'`
+
+## Non-goals
+
+This PR does **not** do any of the following:
+
+- no DB migration
+- no `validity_status` backfill
+- no DB CHECK constraints
+- no new lifecycle states
+- no inferred validity
+- no UI cleanup
+- no progress-model changes
+
+Those belong to #18.6 or later work.
+
+## Acceptance criteria
+
+18.5 is done when:
+
+- no raw lifecycle writes bypass the canonical normalizer
+- no lifecycle transition is persisted without validator approval
+- validity writes are explicit and separate
+- retry/failure semantics still work under the 4-state lifecycle
+- no new lifecycle vocabulary appears in runtime code
+
+## Test checklist
+
+Before merge, confirm:
+
+### Unit / targeted
+- canonical status tests still pass
+- transition guard tests still pass
+
+### Runtime behavior
+- `queued -> running`
+- `running -> complete`
+- `running -> failed`
+
+### Blocked transitions
+- `queued -> complete` is blocked
+- `complete -> running` is blocked
+- `failed -> complete` is blocked
+
+### Validity separation
+- `status='complete'`, `validity_status='valid'`
+- `status='complete'`, `validity_status='invalid'`
+- `status='complete'`, `validity_status='quarantined'`
+
+## Merge note
+
+Keep #18.5 surgical.
+
+If a change does not directly support runtime enforcement of the canonical lifecycle/validity contract, it belongs in a different PR.

--- a/lib/evaluation/status.ts
+++ b/lib/evaluation/status.ts
@@ -5,16 +5,19 @@
 // Validity status: is the completed evaluation releasable/trustworthy?
 // These are NOT interchangeable.
 
+import { isValidTransition } from "../jobs/transitions";
+import { JOB_STATUS, type JobStatus } from "../jobs/types";
+
 // --- Lifecycle ---
 
 export const EVALUATION_JOB_STATUSES = [
-  "queued",
-  "running",
-  "complete",
-  "failed",
+  JOB_STATUS.QUEUED,
+  JOB_STATUS.RUNNING,
+  JOB_STATUS.COMPLETE,
+  JOB_STATUS.FAILED,
 ] as const;
 
-export type EvaluationJobStatus = (typeof EVALUATION_JOB_STATUSES)[number];
+export type EvaluationJobStatus = JobStatus;
 
 // --- Validity / Release ---
 
@@ -60,20 +63,11 @@ export function normalizeEvaluationValidityStatus(
   return normalized as EvaluationValidityStatus;
 }
 
-// --- Transition guard ---
-
-const ALLOWED_TRANSITIONS: Record<EvaluationJobStatus, EvaluationJobStatus[]> = {
-  queued: ["running", "failed"],
-  running: ["complete", "failed"],
-  complete: [],
-  failed: [],
-};
-
 export function assertValidJobStatusTransition(
   from: EvaluationJobStatus,
   to: EvaluationJobStatus,
 ): void {
-  if (!ALLOWED_TRANSITIONS[from].includes(to)) {
+  if (!isValidTransition(from, to)) {
     throw new Error(
       `Invalid evaluation job status transition: ${from} -> ${to}`,
     );

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -1,6 +1,9 @@
 import { createAdminClient } from "../supabase/admin";
-import { assertValidTransition, isValidTransition } from "./transitions";
 import { validateProgressForPhase } from "./validation";
+import {
+  assertValidJobStatusTransition,
+  normalizeEvaluationJobStatus,
+} from "../evaluation/status";
 import {
   migrateProgressPhaseToCanonical,
   migrateProgressStageToPhaseStatus,
@@ -85,6 +88,16 @@ function assertCanonicalPhaseStatusValue(value: string | null | undefined): void
   assertCanonicalStatusValue(value);
 }
 
+function normalizeLifecycleStatus(value: unknown): JobStatus {
+  return normalizeEvaluationJobStatus(value) as JobStatus;
+}
+
+function assertAndNormalizeLifecycleTransition(from: JobStatus, to: unknown): JobStatus {
+  const next = normalizeLifecycleStatus(to);
+  assertValidJobStatusTransition(from, next);
+  return next;
+}
+
 function validateProgressWrite(progress: Record<string, unknown>): void {
   validateProgressSchema(progress);
   if ("phase" in progress && typeof progress.phase === "string") {
@@ -139,10 +152,10 @@ export async function createJob(input: {
     manuscript_id: manuscriptId,
     user_id: input.user_id,
     job_type: JOB_TYPE_TO_DB[input.job_type] ?? input.job_type,
-    status: "queued" as JobStatus,
+    status: normalizeLifecycleStatus(JOB_STATUS.QUEUED),
     progress: {
       phase: PHASES.PHASE_1,
-      phase_status: "queued", // CANON: aligned with JobStatus
+      phase_status: JOB_STATUS.QUEUED, // CANON: aligned with JobStatus
       message: "Job created",
     },
     // keep phase/phase_status only in progress JSON for consistency
@@ -196,11 +209,16 @@ export async function getJob(id: string): Promise<Job | null> {
       job.progress,
     );
 
+    const failedStatus = assertAndNormalizeLifecycleTransition(
+      job.status,
+      JOB_STATUS.FAILED,
+    );
+
     // Mark job as failed and clear lease (best-effort)
     const { error: updateError } = await supabase
       .from("evaluation_jobs")
       .update({
-        status: JOB_STATUS.FAILED,
+        status: failedStatus,
         progress: {
           ...job.progress,
           error_code: validationErr,
@@ -244,17 +262,17 @@ export async function updateJob(
   const existing = await getJob(id);
   if (!existing) return null;
 
+  let nextStatus: JobStatus | null = null;
   if (updates.status) {
-    assertCanonicalStatusValue(updates.status);
-    assertValidTransition(existing, updates.status as JobStatus);
+    nextStatus = assertAndNormalizeLifecycleTransition(existing.status, updates.status);
   }
 
   const payload: Record<string, unknown> = {
     updated_at: new Date().toISOString(),
   };
 
-  if (updates.status) {
-    payload.status = updates.status;
+  if (nextStatus) {
+    payload.status = nextStatus;
   }
 
   // Always merge progress to preserve existing fields
@@ -294,14 +312,11 @@ export async function safeUpdateJobStatus(
   const job = await getJob(id);
   if (!job) return null;
 
-  if (!isValidTransition(job.status, nextStatus)) {
-    const err = `Invalid status transition: ${job.status} -> ${nextStatus} (reason: ${reason})`;
-    console.error(`[InvalidTransition] job_id=${id} ${err}`);
-    throw new Error(err);
-  }
+  const normalizedNext = assertAndNormalizeLifecycleTransition(job.status, nextStatus);
+  console.log(`[JobStatusUpdate] job_id=${id} ${job.status} -> ${normalizedNext} reason=${reason}`);
 
   const progress = extraProgress ? { ...job.progress, ...extraProgress } : job.progress;
-  return updateJob(id, { status: nextStatus, progress });
+  return updateJob(id, { status: normalizedNext, progress });
 }
 
 /**
@@ -391,13 +406,17 @@ export async function acquireLeaseForPhase2(
 
     if (deadLease) {
       const nowIso = new Date().toISOString();
+      const failedStatus = assertAndNormalizeLifecycleTransition(
+        existing.status,
+        JOB_STATUS.FAILED,
+      );
       const errorMessage =
         "Lease expired with no heartbeat; marking job failed to prevent stuck running state";
 
       const { data: failedRow, error: failError } = await supabase
         .from("evaluation_jobs")
         .update({
-          status: JOB_STATUS.FAILED,
+          status: failedStatus,
           last_error: errorMessage,
           failure_envelope: {
             error_code: "LEASE_EXPIRED",
@@ -546,6 +565,11 @@ export async function setJobFailed(
   const attemptCount = jobRow.attempt_count ?? 0;
   const maxAttempts = jobRow.max_attempts ?? 3;
   const nextAttempt = attemptCount + 1;
+
+  const failedStatus = assertAndNormalizeLifecycleTransition(
+    job.status,
+    JOB_STATUS.FAILED,
+  );
   
   // Determine if we should retry or permanently fail
   const shouldRetry = errorEnvelope.retryable && nextAttempt <= maxAttempts;
@@ -573,23 +597,23 @@ export async function setJobFailed(
     
     updatePayload = {
       ...updatePayload,
-      status: JOB_STATUS.QUEUED,
+      status: failedStatus,
       next_attempt_at: nextAttemptAt,
       progress: {
         ...job.progress,
-        phase_status: 'queued',
-        message: `Retry scheduled (attempt ${nextAttempt}/${maxAttempts})`,
+        phase_status: JOB_STATUS.FAILED,
+        message: `Retry eligible (attempt ${nextAttempt}/${maxAttempts}); awaiting explicit requeue`,
       },
     };
   } else {
     // Permanently failed (either non-retryable or exhausted attempts)
     updatePayload = {
       ...updatePayload,
-      status: JOB_STATUS.FAILED,
+      status: failedStatus,
       failed_at: now,
       progress: {
         ...job.progress,
-        phase_status: 'failed',
+        phase_status: JOB_STATUS.FAILED,
         finished_at: now,
         message: errorEnvelope.retryable
           ? `Max retries exhausted (${maxAttempts})`

--- a/tests/failures/apply-failure-classification-paths.test.ts
+++ b/tests/failures/apply-failure-classification-paths.test.ts
@@ -214,15 +214,17 @@ describe("Phase 2.4.c — apply-path failure classification proof", () => {
       // 4) Read via jobs store path and verify surfaced failure_code
       const job = await jobStoreSupabase.getJob("job-1");
       expect(job).toBeTruthy();
-      expect(job?.status).toBe(retryable ? "queued" : "failed");
+      expect(job?.status).toBe("failed");
       expect(job?.failure_code).toBe(code);
       expect(job?.last_error).toContain(messageFragment);
 
       // 5) Specific status behavior check for retryable vs non-retryable
       if (code === RevisionFailureCode.PARSE_ERROR) {
-        expect(updatePayload.status).toBe("queued");
+        expect(updatePayload.status).toBe("failed");
+        expect(updatePayload.next_attempt_at).toBe("2026-03-19T00:10:00.000Z");
       } else {
         expect(updatePayload.status).toBe("failed");
+        expect(updatePayload.next_attempt_at).toBeUndefined();
       }
     },
   );


### PR DESCRIPTION
## Summary
Integrates the canonical status foundation from #151 into live evaluation job write paths.

This PR wires runtime persistence to enforce:
1. lifecycle writes go through `normalizeEvaluationJobStatus(...)`
2. lifecycle transitions go through a single canonical validator
3. validity remains separate (no lifecycle inference introduced)

## Key changes
- `lib/evaluation/status.ts`
  - lifecycle statuses now derive from `lib/jobs/types.ts` (`JOB_STATUS`)
  - transition guard delegates to centralized `isValidTransition` from `lib/jobs/transitions.ts`
- `lib/jobs/jobStore.supabase.ts`
  - added `normalizeLifecycleStatus(...)` and `assertAndNormalizeLifecycleTransition(...)`
  - all lifecycle status writes in this hub now normalize + validate transitions before persistence
  - retryable failure path keeps 4-state lifecycle (`failed`) and uses `next_attempt_at` metadata
- `tests/failures/apply-failure-classification-paths.test.ts`
  - updated expectations for retryable classification under strict lifecycle enforcement

## Non-goals
- no DB migration/backfill/check constraints (belongs to #18.6)
- no new lifecycle states
- no inferred validity from lifecycle

## Validation run
- `npx jest __tests__/lib/evaluation/status.test.ts tests/failures/apply-failure-classification-paths.test.ts __tests__/lib/jobs/jobStore.phase2-lease-hardening.test.ts tests/jobs/finalize.test.ts --no-coverage`
  - 4 suites passed, 30 tests passed
- `npx jest tests/claim-invariants.test.ts --no-coverage`
  - suite skipped in this environment
