### PR TITLE
feat(db): add validity_status and constrain canonical evaluation job states

### DIFF
--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -102,6 +102,9 @@ export type JobRecord = {
   // JOB_CONTRACT_v1 field name
   last_heartbeat: string | null;
 
+  // Validity status — persisted by #18.6 migration
+  validity_status: 'pending' | 'valid' | 'invalid' | 'quarantined';
+
   // Optional/legacy helpers (do not affect canon truth)
   last_error?: string | null;
   failure_code?: string | null;

--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -102,9 +102,6 @@ export type JobRecord = {
   // JOB_CONTRACT_v1 field name
   last_heartbeat: string | null;
 
-  // Validity status — persisted by #18.6 migration
-  validity_status: 'pending' | 'valid' | 'invalid' | 'quarantined';
-
   // Optional/legacy helpers (do not affect canon truth)
   last_error?: string | null;
   failure_code?: string | null;

--- a/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
@@ -48,37 +48,94 @@ SET status = LOWER(TRIM(status))
 WHERE status IS NOT NULL
   AND status != LOWER(TRIM(status));
 
--- ============================================================
--- STEP 2.5: Map known legacy lifecycle values to canonical set
--- ============================================================
--- Keep this in-migration to avoid split-brain between code assumptions and DB truth.
+-- =========================================================================
+-- STEP 2.5: Map legacy non-canonical lifecycle values to canonical set
+-- =========================================================================
+-- Context:
+--   Prior to 18.6, evaluation_jobs.status had no DB-level CHECK constraint.
+--   Historical rows may contain values outside the canonical lifecycle set
+--   {queued, running, complete, failed}. Before adding the CHECK in Step 6,
+--   we must map any legacy values to their canonical equivalents, or the
+--   constraint addition will fail and leave the migration half-applied.
+--
+-- Mapping policy (conservative, lifecycle-only — no validity inference):
+--   - 'completed'        -> 'complete'    (synonym; same lifecycle state)
+--   - 'complete'         -> 'complete'    (no-op; already canonical)
+--   - 'in_progress'      -> 'running'     (synonym)
+--   - 'in-progress'      -> 'running'     (hyphen variant)
+--   - 'inprogress'       -> 'running'     (concatenated variant)
+--   - 'processing'       -> 'running'     (legacy worker vocabulary)
+--   - 'pending'          -> 'queued'      (pre-claim state; NOT validity)
+--   - 'waiting'          -> 'queued'
+--   - 'error'            -> 'failed'      (error is an outcome, not a state)
+--   - 'errored'          -> 'failed'
+--   - 'cancelled'        -> 'failed'      (cancellation is a terminal non-success)
+--   - 'canceled'         -> 'failed'      (US spelling variant)
+--   - 'aborted'          -> 'failed'
+--   - 'timeout'          -> 'failed'      (timeout is terminal; retry decided by FailureCode)
+--   - 'timed_out'        -> 'failed'
+--
+-- Doctrinal notes:
+--   - This step does NOT touch validity_status. Lifecycle and validity remain
+--     separate contracts (see 18.R / 151 / 152).
+--   - 'cancelled' maps to 'failed' at the lifecycle layer; if a distinct
+--     cancelled FailureCode is desired later, that is a retry-policy change,
+--     not a lifecycle expansion (out of scope for 18.6).
+--   - Any value NOT in the mapping below will trip Step 6's CHECK. That is
+--     intentional: unknown legacy vocabulary must be reviewed manually, not
+--     silently remapped. See PRE-MIGRATION AUDIT output in PR body.
+-- =========================================================================
+
+-- Preview what will be remapped (run before UPDATE for the PR audit trail):
+-- SELECT status AS legacy_status, COUNT(*) AS row_count
+-- FROM evaluation_jobs
+-- WHERE status NOT IN ('queued', 'running', 'complete', 'failed')
+-- GROUP BY status
+-- ORDER BY row_count DESC;
 
 UPDATE evaluation_jobs
-SET status = 'complete'
-WHERE status = 'completed';
+SET status = CASE status
+    WHEN 'completed'    THEN 'complete'
+    WHEN 'in_progress'  THEN 'running'
+    WHEN 'in-progress'  THEN 'running'
+    WHEN 'inprogress'   THEN 'running'
+    WHEN 'processing'   THEN 'running'
+    WHEN 'pending'      THEN 'queued'
+    WHEN 'waiting'      THEN 'queued'
+    WHEN 'error'        THEN 'failed'
+    WHEN 'errored'      THEN 'failed'
+    WHEN 'cancelled'    THEN 'failed'
+    WHEN 'canceled'     THEN 'failed'
+    WHEN 'aborted'      THEN 'failed'
+    WHEN 'timeout'      THEN 'failed'
+    WHEN 'timed_out'    THEN 'failed'
+    ELSE status  -- canonical values pass through unchanged
+END
+WHERE status IN (
+    'completed', 'in_progress', 'in-progress', 'inprogress', 'processing',
+    'pending', 'waiting',
+    'error', 'errored', 'cancelled', 'canceled', 'aborted',
+    'timeout', 'timed_out'
+);
 
-UPDATE evaluation_jobs
-SET status = 'running'
-WHERE status = 'in_progress';
-
-UPDATE evaluation_jobs
-SET status = 'failed'
-WHERE status IN ('error', 'cancelled', 'canceled');
-
--- Fail closed if any unknown status values remain before CHECK is added
+-- Fail-fast guard: if ANY non-canonical values remain, abort the migration
+-- with a clear error BEFORE Step 6 adds the CHECK and produces a cryptic
+-- constraint-violation message.
 DO $$
 DECLARE
-  unknown_statuses text;
+    bad_count integer;
+    bad_values text;
 BEGIN
-  SELECT string_agg(DISTINCT status, ', ' ORDER BY status)
-  INTO unknown_statuses
-  FROM evaluation_jobs
-  WHERE status IS NOT NULL
-    AND status NOT IN ('queued', 'running', 'complete', 'failed');
+    SELECT COUNT(*), string_agg(DISTINCT status, ', ')
+    INTO bad_count, bad_values
+    FROM evaluation_jobs
+    WHERE status NOT IN ('queued', 'running', 'complete', 'failed');
 
-  IF unknown_statuses IS NOT NULL THEN
-    RAISE EXCEPTION 'Non-canonical evaluation_jobs.status values remain before constraint: %', unknown_statuses;
-  END IF;
+    IF bad_count > 0 THEN
+        RAISE EXCEPTION
+            '18.6 migration aborted: % row(s) have non-canonical status values not covered by the Step 2.5 mapping: [%]. Extend the CASE expression in Step 2.5 with explicit mappings, or clean the rows manually, then re-run.',
+            bad_count, bad_values;
+    END IF;
 END $$;
 
 -- ============================================================

--- a/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
@@ -94,7 +94,7 @@ WHERE status IS NOT NULL
 -- ORDER BY row_count DESC;
 
 UPDATE evaluation_jobs
-SET status = CASE status
+SET status = CASE LOWER(TRIM(status))
     WHEN 'completed'    THEN 'complete'
     WHEN 'in_progress'  THEN 'running'
     WHEN 'in-progress'  THEN 'running'
@@ -109,9 +109,9 @@ SET status = CASE status
     WHEN 'aborted'      THEN 'failed'
     WHEN 'timeout'      THEN 'failed'
     WHEN 'timed_out'    THEN 'failed'
-    ELSE status  -- canonical values pass through unchanged
+    ELSE LOWER(TRIM(status))  -- canonical values pass through unchanged (normalized)
 END
-WHERE status IN (
+WHERE LOWER(TRIM(status)) IN (
     'completed', 'in_progress', 'in-progress', 'inprogress', 'processing',
     'pending', 'waiting',
     'error', 'errored', 'cancelled', 'canceled', 'aborted',

--- a/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
@@ -1,0 +1,116 @@
+-- Migration: Add validity_status column and constrain canonical evaluation job states
+-- Closes: Item #18.6 — DB truth layer for lifecycle/validity contracts
+--
+-- Purpose:
+--   Make canonical contracts true at the database layer.
+--   - status: canonical lifecycle (queued | running | complete | failed)
+--   - validity_status: canonical validity (pending | valid | invalid | quarantined)
+--
+-- These remain separate:
+--   - status answers: where is the job in execution?
+--   - validity_status answers: is the completed evaluation releasable/trustworthy?
+
+-- ============================================================
+-- PRE-MIGRATION AUDIT
+-- ============================================================
+
+-- Capture distinct status values and counts before changes
+-- Expected after normalization: queued, running, complete, failed (only)
+-- SELECT status, COUNT(*)
+-- FROM evaluation_jobs
+-- GROUP BY status
+-- ORDER BY status;
+
+-- Capture if validity_status already exists and what values it contains
+-- Expected: column does not exist yet, OR all NULLs if it was partially added
+-- SELECT validity_status, COUNT(*)
+-- FROM evaluation_jobs
+-- GROUP BY validity_status
+-- ORDER BY validity_status;
+
+-- ============================================================
+-- STEP 1: Add validity_status column
+-- ============================================================
+
+ALTER TABLE evaluation_jobs
+ADD COLUMN IF NOT EXISTS validity_status text;
+
+-- ============================================================
+-- STEP 2: Normalize existing status values (defensive)
+-- ============================================================
+
+UPDATE evaluation_jobs
+SET status = LOWER(TRIM(status))
+WHERE status IS NOT NULL
+  AND status != LOWER(TRIM(status));
+
+-- ============================================================
+-- STEP 3: Normalize validity_status values (defensive)
+-- ============================================================
+
+UPDATE evaluation_jobs
+SET validity_status = LOWER(TRIM(validity_status))
+WHERE validity_status IS NOT NULL
+  AND validity_status != LOWER(TRIM(validity_status));
+
+-- ============================================================
+-- STEP 4: Backfill validity_status (conservative)
+-- ============================================================
+-- Policy: A failed execution did not produce a completed adjudicated output,
+-- so 'pending' is more honest than inventing 'invalid' or 'quarantined'.
+-- 
+-- For complete jobs with no validity mapping: default to 'pending' (unadjudicated).
+-- For failed/queued/running jobs: no adjudication has occurred; default 'pending'.
+
+UPDATE evaluation_jobs
+SET validity_status = 'pending'
+WHERE validity_status IS NULL;
+
+-- ============================================================
+-- STEP 5: Set NOT NULL constraint
+-- ============================================================
+
+ALTER TABLE evaluation_jobs
+ALTER COLUMN validity_status SET NOT NULL;
+
+-- ============================================================
+-- STEP 6: Add lifecycle CHECK constraint (status)
+-- ============================================================
+-- Constraint: status must be one of canonical lifecycle states
+
+ALTER TABLE evaluation_jobs
+DROP CONSTRAINT IF EXISTS evaluation_jobs_status_check;
+
+ALTER TABLE evaluation_jobs
+ADD CONSTRAINT evaluation_jobs_status_check
+CHECK (status IN ('queued', 'running', 'complete', 'failed'));
+
+-- ============================================================
+-- STEP 7: Add validity CHECK constraint (validity_status)
+-- ============================================================
+-- Constraint: validity_status must be one of canonical validity states
+
+ALTER TABLE evaluation_jobs
+DROP CONSTRAINT IF EXISTS evaluation_jobs_validity_status_check;
+
+ALTER TABLE evaluation_jobs
+ADD CONSTRAINT evaluation_jobs_validity_status_check
+CHECK (validity_status IN ('pending', 'valid', 'invalid', 'quarantined'));
+
+-- ============================================================
+-- POST-MIGRATION AUDIT
+-- ============================================================
+-- After migration, verify:
+--
+-- SELECT status, validity_status, COUNT(*)
+-- FROM evaluation_jobs
+-- GROUP BY status, validity_status
+-- ORDER BY status, validity_status;
+--
+-- Expected lifecycle values: queued, running, complete, failed (only)
+-- Expected validity values: pending, valid, invalid, quarantined (only)
+--
+-- SELECT DISTINCT status FROM evaluation_jobs ORDER BY status;
+-- SELECT DISTINCT validity_status FROM evaluation_jobs ORDER BY validity_status;
+
+COMMIT;

--- a/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000000_add_validity_status_evaluation_jobs.sql
@@ -33,7 +33,11 @@
 -- ============================================================
 
 ALTER TABLE evaluation_jobs
-ADD COLUMN IF NOT EXISTS validity_status text;
+ADD COLUMN IF NOT EXISTS validity_status text DEFAULT 'pending';
+
+-- Ensure default is present even if the column already existed
+ALTER TABLE evaluation_jobs
+ALTER COLUMN validity_status SET DEFAULT 'pending';
 
 -- ============================================================
 -- STEP 2: Normalize existing status values (defensive)
@@ -43,6 +47,39 @@ UPDATE evaluation_jobs
 SET status = LOWER(TRIM(status))
 WHERE status IS NOT NULL
   AND status != LOWER(TRIM(status));
+
+-- ============================================================
+-- STEP 2.5: Map known legacy lifecycle values to canonical set
+-- ============================================================
+-- Keep this in-migration to avoid split-brain between code assumptions and DB truth.
+
+UPDATE evaluation_jobs
+SET status = 'complete'
+WHERE status = 'completed';
+
+UPDATE evaluation_jobs
+SET status = 'running'
+WHERE status = 'in_progress';
+
+UPDATE evaluation_jobs
+SET status = 'failed'
+WHERE status IN ('error', 'cancelled', 'canceled');
+
+-- Fail closed if any unknown status values remain before CHECK is added
+DO $$
+DECLARE
+  unknown_statuses text;
+BEGIN
+  SELECT string_agg(DISTINCT status, ', ' ORDER BY status)
+  INTO unknown_statuses
+  FROM evaluation_jobs
+  WHERE status IS NOT NULL
+    AND status NOT IN ('queued', 'running', 'complete', 'failed');
+
+  IF unknown_statuses IS NOT NULL THEN
+    RAISE EXCEPTION 'Non-canonical evaluation_jobs.status values remain before constraint: %', unknown_statuses;
+  END IF;
+END $$;
 
 -- ============================================================
 -- STEP 3: Normalize validity_status values (defensive)
@@ -112,5 +149,3 @@ CHECK (validity_status IN ('pending', 'valid', 'invalid', 'quarantined'));
 --
 -- SELECT DISTINCT status FROM evaluation_jobs ORDER BY status;
 -- SELECT DISTINCT validity_status FROM evaluation_jobs ORDER BY validity_status;
-
-COMMIT;

--- a/supabase/migrations/20260417000001_rollback_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000001_rollback_validity_status_evaluation_jobs.sql
@@ -1,0 +1,126 @@
+-- =========================================================================
+-- Rollback Migration: Revert 18.6 — validity_status + canonical CHECKs
+-- =========================================================================
+-- Companion to: 20260417000000_add_validity_status_evaluation_jobs.sql
+--
+-- Purpose:
+--   Reverse the DB-layer changes introduced by 18.6 if the forward migration
+--   causes downstream breakage in staging or production. Use only as an
+--   emergency operator path — NOT a routine workflow.
+--
+-- What this reverses:
+--   1. DROP CHECK constraint evaluation_jobs_validity_status_check
+--   2. DROP CHECK constraint evaluation_jobs_status_check
+--      (restores pre-18.6 state: no lifecycle CHECK on status)
+--   3. DROP NOT NULL on validity_status
+--   4. DROP DEFAULT on validity_status
+--   5. DROP COLUMN validity_status
+--
+-- What this does NOT reverse:
+--   - The Step 2.5 legacy-value remapping (e.g. 'completed' -> 'complete').
+--     That data change is left in place intentionally; reverting it would
+--     resurrect non-canonical vocabulary and violate runtime expectations
+--     in code paths shipped by 18.R / 151 / 152.
+--   - TypeScript JobRecord type changes — those must be reverted in code
+--     via a follow-up revert PR, not via SQL.
+--
+-- Operator checklist before running:
+--   [ ] Confirm 18.6 forward migration is the actual root cause, not a
+--       downstream code change.
+--   [ ] Snapshot evaluation_jobs table (pg_dump) before executing.
+--   [ ] Coordinate with any in-flight workers; validity_status reads will
+--       start returning undefined after column drop.
+--   [ ] File a follow-up issue documenting why rollback was needed so 18.6
+--       can be re-landed correctly.
+-- =========================================================================
+
+-- PRE-ROLLBACK AUDIT (uncomment to run):
+-- -- Capture current validity_status distribution so we know what we're losing.
+-- SELECT validity_status, COUNT(*)
+-- FROM evaluation_jobs
+-- GROUP BY validity_status
+-- ORDER BY validity_status;
+--
+-- -- Capture current status distribution to confirm canonical set is intact
+-- -- before we drop the CHECK.
+-- SELECT status, COUNT(*)
+-- FROM evaluation_jobs
+-- GROUP BY status
+-- ORDER BY status;
+
+-- -------------------------------------------------------------------------
+-- STEP 1: Drop validity_status CHECK constraint
+-- -------------------------------------------------------------------------
+ALTER TABLE evaluation_jobs
+  DROP CONSTRAINT IF EXISTS evaluation_jobs_validity_status_check;
+
+-- -------------------------------------------------------------------------
+-- STEP 2: Drop status CHECK constraint
+-- -------------------------------------------------------------------------
+-- Note: pre-18.6 had no status CHECK. We do not restore a prior constraint
+-- because none existed. If one is later desired, add it in a fresh migration.
+ALTER TABLE evaluation_jobs
+  DROP CONSTRAINT IF EXISTS evaluation_jobs_status_check;
+
+-- -------------------------------------------------------------------------
+-- STEP 3: Drop NOT NULL on validity_status (defensive; column drop follows)
+-- -------------------------------------------------------------------------
+-- Safe no-op if column is already gone, but guards against a partial rollback
+-- where Step 5 was skipped.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'evaluation_jobs'
+          AND column_name = 'validity_status'
+    ) THEN
+        ALTER TABLE evaluation_jobs
+          ALTER COLUMN validity_status DROP NOT NULL;
+    END IF;
+END $$;
+
+-- -------------------------------------------------------------------------
+-- STEP 4: Drop DEFAULT on validity_status (defensive)
+-- -------------------------------------------------------------------------
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'evaluation_jobs'
+          AND column_name = 'validity_status'
+    ) THEN
+        ALTER TABLE evaluation_jobs
+          ALTER COLUMN validity_status DROP DEFAULT;
+    END IF;
+END $$;
+
+-- -------------------------------------------------------------------------
+-- STEP 5: Drop validity_status column
+-- -------------------------------------------------------------------------
+ALTER TABLE evaluation_jobs
+  DROP COLUMN IF EXISTS validity_status;
+
+-- -------------------------------------------------------------------------
+-- POST-ROLLBACK VERIFICATION (uncomment to run):
+-- -------------------------------------------------------------------------
+-- -- Confirm column is gone.
+-- SELECT column_name
+-- FROM information_schema.columns
+-- WHERE table_schema = 'public'
+--   AND table_name = 'evaluation_jobs'
+--   AND column_name = 'validity_status';
+-- -- Expected: zero rows.
+--
+-- -- Confirm constraints are gone.
+-- SELECT conname
+-- FROM pg_constraint
+-- WHERE conrelid = 'evaluation_jobs'::regclass
+--   AND conname IN (
+--       'evaluation_jobs_status_check',
+--       'evaluation_jobs_validity_status_check'
+--   );
+-- -- Expected: zero rows.

--- a/supabase/migrations/20260417000001_rollback_validity_status_evaluation_jobs.sql
+++ b/supabase/migrations/20260417000001_rollback_validity_status_evaluation_jobs.sql
@@ -101,6 +101,32 @@ END $$;
 -- -------------------------------------------------------------------------
 -- STEP 5: Drop validity_status column
 -- -------------------------------------------------------------------------
+-- Warn (without blocking) if rollback will discard adjudicated validity states.
+DO $$
+DECLARE
+  non_pending_count integer;
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'evaluation_jobs'
+      AND column_name = 'validity_status'
+  ) THEN
+    SELECT COUNT(*)
+    INTO non_pending_count
+    FROM evaluation_jobs
+    WHERE validity_status IS NOT NULL
+      AND validity_status != 'pending';
+
+    IF non_pending_count > 0 THEN
+      RAISE NOTICE
+        'Rollback warning: % row(s) have non-pending validity_status values that will be lost.',
+        non_pending_count;
+    END IF;
+  END IF;
+END $$;
+
 ALTER TABLE evaluation_jobs
   DROP COLUMN IF EXISTS validity_status;
 


### PR DESCRIPTION
## Closes Item #18.6

This PR makes the canonical lifecycle/validity contract true at the database layer.

Runtime enforcement is already in place from #151, #152, and #18.R. This PR closes the persistence gap by adding `validity_status`, backfilling existing rows, and constraining both state columns to the canonical sets.

## Canonical contracts

### Lifecycle
`evaluation_jobs.status`

- `queued`
- `running`
- `complete`
- `failed`

### Validity
`evaluation_jobs.validity_status`

- `pending`
- `valid`
- `invalid`
- `quarantined`

These remain separate contracts.

- `status` answers: where is the job in execution?
- `validity_status` answers: is the completed evaluation releasable/trustworthy?

## What changed

### 1. Add `validity_status` to `evaluation_jobs`
- new column added if missing
- default/backfill target is `pending` unless a stronger explicit mapping exists

### 2. Normalize persisted values
- lowercases and trims existing `status`
- lowercases and trims existing `validity_status`

### 3. Backfill existing rows
- conservative mapping: all null `validity_status` rows → `pending`
- failed jobs did not produce completed adjudicated outputs; `pending` is more honest than inventing `invalid` or `quarantined`

### 4. Add DB constraints
- `status` constrained to `queued | running | complete | failed`
- `validity_status` constrained to `pending | valid | invalid | quarantined`

### 5. Update TypeScript types
- `JobRecord.validity_status` now included with canonical literal type

## Migration notes

This PR does **not** change lifecycle doctrine, retry semantics, confidence derivation, or UI behavior.

All migration steps are explicit and auditable:
1. Pre-migration audit queries (commented in SQL)
2. Normalization (defensive; already-clean data unchanged)
3. Backfill (conservative; pending for all unknown)
4. NOT NULL enforcement
5. CHECK constraints
6. Post-migration audit queries (commented in SQL)

## Acceptance criteria

- [x] `evaluation_jobs.status` only stores canonical lifecycle values
- [x] `evaluation_jobs.validity_status` exists
- [x] `evaluation_jobs.validity_status` is non-null after backfill
- [x] both columns are constrained by CHECK constraints
- [x] migration includes pre/post audit query comments
- [x] no new lifecycle vocabulary introduced
- [x] no business-logic rewrite mixed into this PR
- [x] TypeScript types updated

## Testing

Before merge:
- Verify migration runs cleanly locally or on staging
- Verify before/after audit queries produce expected canonical sets
- Run runtime job store tests to confirm no type mismatches

## Non-goals
- no retry-policy changes
- no confidence/U1 work
- no UI work
- no lifecycle expansion