### PR TITLE
fix(jobs): restore validity_status to type layer and reconcile evaluation_jobs access sites

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -155,6 +155,7 @@ export async function POST(req: Request) {
         manuscript_id: manuscriptId,
         user_id: userId,
         job_type: "full_evaluation",
+        validity_status: "pending",
         phase: PHASES.PHASE_1,
         phase_status: "queued",
         policy_family: "standard",

--- a/lib/jobs/jobStore.memory.ts
+++ b/lib/jobs/jobStore.memory.ts
@@ -65,6 +65,7 @@ export function createJob(input: { manuscript_id: string; job_type: JobType; use
     manuscript_id: input.manuscript_id, // Keep as-is for test compatibility (string or number)
     job_type: input.job_type,
     status: "queued",
+    validity_status: "pending",
     progress: {
       // CANON: phase + phase_status are the stored state machine keys
       // phase: phase_0 | phase_1 | phase_2

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -3,6 +3,7 @@ import { validateProgressForPhase } from "./validation";
 import {
   assertValidJobStatusTransition,
   normalizeEvaluationJobStatus,
+  normalizeEvaluationValidityStatus,
 } from "../evaluation/status";
 import {
   migrateProgressPhaseToCanonical,
@@ -13,7 +14,7 @@ import { Job, JobStatus, JobType, PHASES, Phase, JOB_STATUS, JobProgress } from 
 import { getLeaseTimeoutSeconds } from "./config";
 
 const JOB_SELECT_FIELDS =
-  "id, manuscript_id, user_id, job_type, status, progress, created_at, updated_at, last_heartbeat, last_error, failure_envelope, manuscripts(user_id)";
+  "id, manuscript_id, user_id, job_type, status, validity_status, progress, created_at, updated_at, last_heartbeat, last_error, failure_envelope, manuscripts(user_id)";
 
 // Lazy-initialized Supabase client - null-safe for CI/build environments
 let _supabase: ReturnType<typeof createAdminClient> | undefined;
@@ -153,6 +154,7 @@ export async function createJob(input: {
     user_id: input.user_id,
     job_type: JOB_TYPE_TO_DB[input.job_type] ?? input.job_type,
     status: normalizeLifecycleStatus(JOB_STATUS.QUEUED),
+    validity_status: normalizeEvaluationValidityStatus("pending"),
     progress: {
       phase: PHASES.PHASE_1,
       phase_status: JOB_STATUS.QUEUED, // CANON: aligned with JobStatus
@@ -691,6 +693,7 @@ function mapDbRowToJob(row: any): Job {
     manuscript_id: Number(row.manuscript_id), // BigInt from DB → number
     job_type: JOB_TYPE_FROM_DB[row.job_type] ?? row.job_type,
     status: row.status,
+    validity_status: normalizeEvaluationValidityStatus(row.validity_status ?? "pending"),
     progress: completeProgress,
     created_at: row.created_at,
     updated_at: row.updated_at,

--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -86,6 +86,12 @@ export type JobProgress = {
   [k: string]: unknown;
 };
 
+/**
+ * #18.6 canonical validity contract at type layer.
+ * Keep aligned with lib/evaluation/status.ts and DB CHECK constraint.
+ */
+export type JobValidityStatus = "pending" | "valid" | "invalid" | "quarantined";
+
 export type JobRecord = {
   id: string; // uuid
   user_id: string; // ownership: x-user-id from request header
@@ -101,6 +107,9 @@ export type JobRecord = {
 
   // JOB_CONTRACT_v1 field name
   last_heartbeat: string | null;
+
+  // #18.6b: restore DB/type coherence for validity_status (NOT NULL in DB)
+  validity_status: JobValidityStatus;
 
   // Optional/legacy helpers (do not affect canon truth)
   last_error?: string | null;


### PR DESCRIPTION
## Follow-up to #18.6 (type/schema coherence)

This PR reconciles the TypeScript job model with the DB truth established by #18.6.

After #18.6 merged, `evaluation_jobs.validity_status` became `NOT NULL DEFAULT 'pending'`, but `JobRecord` no longer exposed the field. That created a DB/type split-brain where writes could rely on DB defaults while the type layer omitted the canonical column.

## What changed

- Restored `validity_status` in `JobRecord` as canonical union:
  - `'pending' | 'valid' | 'invalid' | 'quarantined'`
- Updated Supabase job store read model:
  - include `validity_status` in `JOB_SELECT_FIELDS`
  - map row `validity_status` through canonical normalizer
- Updated job creation write paths to set explicit `validity_status: 'pending'`:
  - `lib/jobs/jobStore.supabase.ts` (`createJob` payload)
  - `app/api/evaluate/route.ts` direct insert payload
- Aligned in-memory store job shape with canonical validity contract:
  - `lib/jobs/jobStore.memory.ts` create path now sets `validity_status: 'pending'`

## Scope and intent

- **Type-contract reconciliation only**
- No lifecycle or retry semantics changes
- No confidence/U1 behavior introduced
- No intended runtime behavior change beyond removing DB/type ambiguity

## Verification

- `tests/jobs/` passed locally (`43 passed, 0 failed`)
- No diagnostics errors in touched files

## Why now

This closes the post-#18.6 gap so U1 can build on a coherent schema/type base without hidden reliance on DB defaults.