### PR TITLE
fix(jobs): narrow createJob insert result before data.id access

### DIFF
--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -147,6 +147,16 @@ function validateProgressWrite(progress: Record<string, unknown>): void {
   }
 }
 
+function hasObjectId(value: unknown): value is { id: string | number } & Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    (typeof (value as { id?: unknown }).id === "string" ||
+      typeof (value as { id?: unknown }).id === "number")
+  );
+}
+
 export async function createJob(input: {
   manuscript_id: string;
   user_id: string;
@@ -222,8 +232,12 @@ export async function createJob(input: {
     throw new Error(`Failed to create job: ${error.message}`);
   }
 
+  if (!hasObjectId(data)) {
+    throw new Error("Failed to create job: insert/select did not return a typed row with id");
+  }
+
   console.log("EvaluationJobCreated", {
-    job_id: data.id,
+    job_id: String(data.id),
     job_type: input.job_type,
     timestamp: now,
   });


### PR DESCRIPTION
## Summary

Fixes the compile-time type failure reported in #159 for `lib/jobs/jobStore.supabase.ts`:

- add a narrow type guard for Supabase insert/select row shape (`hasObjectId`)
- validate insert result row before touching `data.id` in `createJob()`
- log `job_id` via `String(data.id)` after guard

## Why

Main branch failure evidence (run `24583476132`) showed:

- `Type error: Property 'id' does not exist on type 'GenericStringError'`
- location: `lib/jobs/jobStore.supabase.ts:226`

This PR addresses that exact typed access path without broad scope changes.

## Scope

- one file changed (`lib/jobs/jobStore.supabase.ts`)
- no DB schema changes
- no U1.1 wiring
- no behavior expansion

## Validation

- `npx tsc --noEmit` passes locally
- full `npm run build` is still blocked by an unrelated production config guard (`EVAL_OPENAI_TIMEOUT_MS` vs `EVAL_PASS_TIMEOUT_MS`), not by this type issue

Refs: #159