### PR TITLE
chore(ci): move GitHub Actions JS runtime to Node24-compatible versions

### DIFF
--- a/.github/workflows/canon.yml
+++ b/.github/workflows/canon.yml
@@ -9,6 +9,6 @@ jobs:
   canon:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Canon Guard
         run: bash ./scripts/canon-guard.sh

--- a/.github/workflows/ci-staging-tests.yml
+++ b/.github/workflows/ci-staging-tests.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -45,8 +45,8 @@ jobs:
     env:
       CANON_VERSION: v1
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci
@@ -70,8 +70,8 @@ jobs:
       USE_SUPABASE_JOBS: "true"
       TEST_MODE: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci

--- a/.github/workflows/fixture-guard.yml
+++ b/.github/workflows/fixture-guard.yml
@@ -19,9 +19,9 @@ jobs:
     name: Fixture Canon Guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/flow1-proof-pack.yml
+++ b/.github/workflows/flow1-proof-pack.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Known: GitHub git service occasionally emits transient "RPC failed; HTTP 404" or
-      # "expected 'packfile'" during checkout. actions/checkout@v4 has built-in retry logic
+      # "expected 'packfile'" during checkout. actions/checkout@v5 has built-in retry logic
       # that recovers. The annotation is informational (shows retry worked), not a failure.
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -101,7 +101,7 @@ jobs:
           echo "Known transient infra flakes:"
           echo "  - GitHub git fetch may emit 'RPC failed; HTTP 404' or 'expected packfile'"
           echo "  - These are GitHub infrastructure issues, not code issues"
-          echo "  - actions/checkout@v4.2.0 has built-in retry logic that recovers"
+          echo "  - actions/checkout@v5 has built-in retry logic that recovers"
           echo "  - Red annotations are informational (show retry worked)"
           echo ""
           echo "Gate status: Green (all functional checks passed)"

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -21,8 +21,8 @@ jobs:
     name: Governance Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci
@@ -39,8 +39,8 @@ jobs:
     name: Governance Coverage Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci
@@ -55,8 +55,8 @@ jobs:
     name: Canon Governance Guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci
@@ -73,8 +73,8 @@ jobs:
     name: Phase Integrity Guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - run: npm ci

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -142,14 +142,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Debug Supabase URL
         run: |
           echo "NEXT_PUBLIC_SUPABASE_URL: '${NEXT_PUBLIC_SUPABASE_URL}'"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"
@@ -359,10 +359,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/phase1-evidence.yml
+++ b/.github/workflows/phase1-evidence.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/phase2c-evidence.yml
+++ b/.github/workflows/phase2c-evidence.yml
@@ -29,10 +29,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/phase2d-evidence.yml
+++ b/.github/workflows/phase2d-evidence.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/phase2e-anchor-guard.yml
+++ b/.github/workflows/phase2e-anchor-guard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify anchors in PHASE2E_STATUS.md
         shell: bash

--- a/.github/workflows/phase2e-evidence.yml
+++ b/.github/workflows/phase2e-evidence.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Verify required secrets are present (no values printed)
         env:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1  # Shallow clone (faster, sufficient for full-repo scan)
       


### PR DESCRIPTION
Updates workflow action versions to remove Node.js 20 deprecation warnings from GitHub-hosted runners.

### Changes
- `actions/checkout`: v4/v4.2.0 -> v5
- `actions/setup-node`: v4 -> v5
- Scope: workflow metadata only (no app/runtime code changes)

### Why
GitHub Actions has announced Node 20 deprecation for JavaScript actions. This PR moves the repository to Node24-compatible action versions ahead of enforcement dates.

### Validation
- No remaining `actions/checkout@v4` / `actions/setup-node@v4` references under `.github/workflows`
- Workflow files report no editor diagnostics in this session