### PR TITLE
fix(jobs): align Phase 2 trigger CAS with Phase 1 handoff reality

### DIFF
--- a/__tests__/lib/evaluation/architecture-invariants.test.ts
+++ b/__tests__/lib/evaluation/architecture-invariants.test.ts
@@ -62,7 +62,7 @@ describe("evaluation architecture invariants", () => {
       // Non-force updates must use CAS predicates (no loose update-by-id)
       expect(code).toContain('.eq("status", "running")');
       expect(code).toContain('.eq("phase", "phase_1")');
-      expect(code).toContain('.eq("phase_status", "complete")');
+      expect(code).not.toContain('.eq("phase_status", "complete")');
       expect(code).toContain("canonical_pipeline_queued");
       expect(code).toContain("status: 202");
     }

--- a/app/api/admin/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/admin/jobs/[jobId]/run-phase2/route.ts
@@ -76,8 +76,7 @@ export async function POST(
     if (!force) {
       updateQuery = updateQuery
         .eq("status", "running")
-        .eq("phase", "phase_1")
-        .eq("phase_status", "complete");
+        .eq("phase", "phase_1");
     }
 
     const { data: updatedRows, error: updateError } = await updateQuery;

--- a/app/api/jobs/[jobId]/run-phase2/route.ts
+++ b/app/api/jobs/[jobId]/run-phase2/route.ts
@@ -77,8 +77,7 @@ export async function POST(req: NextRequest, ctx: { params: Params }) {
   if (!force) {
     updateQuery = updateQuery
       .eq("status", "running")
-      .eq("phase", "phase_1")
-      .eq("phase_status", "complete");
+      .eq("phase", "phase_1");
   }
 
   const { data, error } = await updateQuery;


### PR DESCRIPTION
## Summary
Fixes a false-409 handoff failure in both Phase 2 trigger routes.

## Root cause
The routes validated Phase 1 completion from `progress.phase_status === "complete"`, but the atomic update predicate required top-level `phase_status === "complete"`.
In live runs, top-level `phase_status` remained `"triggered"` while progress was complete, so CAS update matched 0 rows and returned:

`Phase 2 trigger lost race or job state changed before update.`

## Changes
- `app/api/jobs/[jobId]/run-phase2/route.ts`
  - Remove non-force CAS predicate `.eq("phase_status", "complete")`
- `app/api/admin/jobs/[jobId]/run-phase2/route.ts`
  - Remove non-force CAS predicate `.eq("phase_status", "complete")`
- `__tests__/lib/evaluation/architecture-invariants.test.ts`
  - Update invariant to assert that stale top-level `phase_status=complete` CAS is not required.

## Validation
- ✅ `npm test -- __tests__/lib/evaluation/architecture-invariants.test.ts --runInBand`
- ✅ Live proof rerun: `node scripts/evidence-phase2-handoff-proof.mjs`
  - Before fix: `phase2_trigger=409`, no terminal state reached.
  - After fix: `phase2_trigger=202`, worker claims/processes job (`claimed:1, processed:1`).
  - Terminal reached in Phase 2 (`failed` due manuscript min-length gate), proving handoff path itself now works.

## Notes
This PR does not relax governance/state machine semantics; it aligns CAS with the canonical handoff signal already validated in `progress.*`.