### PR TITLE
chore(failures): tighten classifyError pattern precision (#154)

### DIFF
--- a/lib/jobs/failures.ts
+++ b/lib/jobs/failures.ts
@@ -75,36 +75,45 @@ export const isRetryableFailure = isTransientFailure;
  * Used to route errors through the canonical taxonomy rather than
  * ad-hoc message-string heuristics.
  *
- * Retryable (transient) matches are tried first; non-retryable patterns
- * take precedence if they match — fail closed wins.
+ * Non-retryable (terminal) patterns are checked first (fail-closed),
+ * then retryable (transient) patterns.
  */
 export function classifyError(error: Error): FailureCode {
   const msg = error.message.toLowerCase();
+  const hasAny = (...phrases: string[]) => phrases.some((p) => msg.includes(p));
 
   // Non-retryable patterns (checked first — fail-closed wins)
-  if (msg.includes('state transition') || msg.includes('illegal transition'))
+  if (hasAny('state transition', 'illegal transition'))
     return 'STATE_TRANSITION_INVALID';
-  if (msg.includes('anchor contract'))         return 'ANCHOR_CONTRACT_VIOLATION';
-  if (msg.includes('governance'))              return 'GOVERNANCE_BLOCK';
-  if (msg.includes('convergence'))             return 'PASS_CONVERGENCE_FAILURE';
-  if (msg.includes('missing pass artifact') || msg.includes('pass artifact'))
+  if (hasAny('anchor contract'))               return 'ANCHOR_CONTRACT_VIOLATION';
+  if (
+    hasAny('governance block', 'governance gate', 'governance enforcement failed') ||
+    (msg.includes('governance') && msg.includes('block'))
+  )
+    return 'GOVERNANCE_BLOCK';
+  if (hasAny('pass_convergence_failure', 'pass convergence failure', 'pass convergence check failed', 'convergence artifact', 'convergence inputs do not match'))
+    return 'PASS_CONVERGENCE_FAILURE';
+  if (hasAny('missing pass artifact', 'pass artifact missing'))
     return 'MISSING_PASS_ARTIFACT';
-  if (msg.includes('criterion completeness'))  return 'CRITERION_COMPLETENESS_FAILED';
-  if (msg.includes('canonical artifact'))      return 'CANONICAL_ARTIFACT_WRITE_FAILED';
-  if (msg.includes('summary projection'))      return 'SUMMARY_PROJECTION_FAILED';
-  if (msg.includes('invalid api key') || msg.includes('authentication'))
+  if (hasAny('criterion completeness'))        return 'CRITERION_COMPLETENESS_FAILED';
+  if (hasAny('canonical artifact'))            return 'CANONICAL_ARTIFACT_WRITE_FAILED';
+  if (hasAny('summary projection'))            return 'SUMMARY_PROJECTION_FAILED';
+  if (hasAny('schema validation failed', 'schema_validation_failed'))
+    return 'SCHEMA_VALIDATION_FAILED';
+  if (hasAny('schema error', 'schema violation'))
+    return 'SCHEMA_ERROR';
+  if (hasAny('validation error'))              return 'VALIDATION_ERROR';
+  if (hasAny('invalid api key', 'authentication'))
     return 'INVALID_INPUT';
-  if (msg.includes('schema'))                  return 'SCHEMA_ERROR';
-  if (msg.includes('validation'))              return 'VALIDATION_ERROR';
-  if (msg.includes('invalid input') || msg.includes('malformed'))
+  if (hasAny('invalid input', 'malformed'))
     return 'INVALID_INPUT';
 
   // Retryable (transient) patterns
-  if (msg.includes('rate limit') || msg.includes('429'))  return 'RATE_LIMITED';
-  if (msg.includes('timeout'))                            return 'TIMEOUT';
-  if (msg.includes('network') || msg.includes('econnreset') || msg.includes('econnrefused'))
+  if (hasAny('rate limit', '429'))                        return 'RATE_LIMITED';
+  if (hasAny('timeout'))                                  return 'TIMEOUT';
+  if (hasAny('network', 'econnreset', 'econnrefused'))
     return 'UPSTREAM_ERROR';
-  if (msg.includes('lease expired'))                      return 'LEASE_EXPIRED';
+  if (hasAny('lease expired'))                            return 'LEASE_EXPIRED';
 
   // Default to INTERNAL_ERROR (transient) — unknown failures get one retry chance
   return 'INTERNAL_ERROR';

--- a/tests/jobs/failures.test.ts
+++ b/tests/jobs/failures.test.ts
@@ -108,6 +108,20 @@ describe('failure taxonomy', () => {
       expect(isNonTransientFailure(classifyError(new Error('pass convergence check failed')))).toBe(true);
     });
 
+    test('schema validation failures map to SCHEMA_VALIDATION_FAILED before generic schema buckets', () => {
+      expect(classifyError(new Error('schema validation failed: missing required field'))).toBe('SCHEMA_VALIDATION_FAILED');
+      expect(classifyError(new Error('SCHEMA_VALIDATION_FAILED invariant breach'))).toBe('SCHEMA_VALIDATION_FAILED');
+      expect(classifyError(new Error('schema error while decoding payload'))).toBe('SCHEMA_ERROR');
+    });
+
+    test('convergence classification is specific and does not trigger on non-failure mentions', () => {
+      expect(classifyError(new Error('pass convergence failure: unresolved contradiction'))).toBe('PASS_CONVERGENCE_FAILURE');
+      expect(classifyError(new Error('convergence artifact not found'))).toBe('PASS_CONVERGENCE_FAILURE');
+
+      // Informational language containing "convergence" must not be auto-classified as a deterministic failure.
+      expect(classifyError(new Error('convergence report generated successfully'))).toBe('INTERNAL_ERROR');
+    });
+
     test('unknown errors default to INTERNAL_ERROR (transient) — one retry chance', () => {
       const code = classifyError(new Error('something completely unexpected happened'));
       expect(code).toBe('INTERNAL_ERROR');


### PR DESCRIPTION
Resolves #154 by tightening `classifyError()` ordering/docs and ambiguous pattern matching.

## What changed
- Updated `classifyError()` doc to match actual fail-closed precedence:
  - non-retryable first
  - retryable second
- Reduced broad keyword matching ambiguity:
  - added explicit `SCHEMA_VALIDATION_FAILED` mapping before generic schema buckets
  - narrowed convergence mapping to failure-specific phrases (still preserving existing expected variants)
  - tightened governance mapping while retaining backward-compatible phrase handling
- Added regression coverage in `tests/jobs/failures.test.ts`:
  - schema-validation vs schema-error disambiguation
  - convergence mention that is informational (non-failure) no longer misclassifies

## Validation
- `npm test -- tests/jobs/failures.test.ts --runInBand`

## Why
Keeps canonical failure taxonomy accurate and avoids silent misclassification drift from broad message heuristics.