### PR TITLE
test(finalizer): align finalize confidence suite with Jest runner

### DIFF
--- a/lib/jobs/__tests__/finalize.confidence.test.ts
+++ b/lib/jobs/__tests__/finalize.confidence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "@jest/globals";
 import { buildConfidenceInputs, buildCanonicalArtifact } from "../finalize";
 import type {
   PassArtifact,


### PR DESCRIPTION
Dedicated tiny fix for the recurring CI blocker in `lib/jobs/__tests__/finalize.confidence.test.ts`.

## Change
- Replace `vitest` test import with `@jest/globals` in the finalize confidence test suite.

## Why
The repository test pipeline runs this suite under Jest. Importing Vitest in this file causes a hard runtime failure:
- `Vitest cannot be imported in a CommonJS module using require()`

This one-line runner alignment prevents unrelated PRs (including Item #8 / U2 / U3 work) from failing on the same check.

## Scope
- One file
- One-line import change
- No test-runner split, no behavior changes outside runner compatibility

## Local validation
- `npm test -- lib/jobs/__tests__/finalize.confidence.test.ts --runInBand` (passes)