### PR TITLE
finalizer: enforce Item #8 fail-closed validity gate

### DIFF
--- a/lib/jobs/__tests__/finalize.confidence.test.ts
+++ b/lib/jobs/__tests__/finalize.confidence.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "@jest/globals";
-import { buildConfidenceInputs, buildCanonicalArtifact } from "../finalize";
+import {
+  buildConfidenceInputs,
+  buildCanonicalArtifact,
+  deriveValidityStatus,
+} from "../finalize";
+import { CONFIDENCE_DERIVATION_VERSION } from "../../governance/confidenceDerivation";
 import type {
   PassArtifact,
   ConvergenceArtifact,
@@ -176,7 +181,9 @@ describe("buildCanonicalArtifact confidence wiring", () => {
     expect(canonical.governance.confidence_label).toBeDefined();
     expect(["high", "medium", "low", "withheld"]).toContain(canonical.governance.confidence_label);
     expect(Array.isArray(canonical.governance.confidence_reasons)).toBe(true);
-    expect(canonical.governance.confidence_derivation_version).toBe("1.0.0");
+    expect(canonical.governance.confidence_derivation_version).toBe(
+      CONFIDENCE_DERIVATION_VERSION,
+    );
   });
 
   it("degraded signals: confidence_label reflects lower confidence", () => {
@@ -193,5 +200,45 @@ describe("buildCanonicalArtifact confidence wiring", () => {
     // With material disagreement + partial evidence, should not be "high"
     expect(canonical.governance.confidence_label).not.toBe("high");
     expect(canonical.governance.confidence_reasons!.length).toBeGreaterThan(0);
+  });
+});
+
+describe("deriveValidityStatus", () => {
+  it("returns valid when canonical governance gates are all true", () => {
+    const job = makeJob();
+    const pass1 = makePassArtifact("pass1");
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+
+    expect(deriveValidityStatus(canonical)).toBe("valid");
+  });
+
+  it("returns quarantined when transparency is false", () => {
+    const job = makeJob();
+    const pass1 = makePassArtifact("pass1");
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+    canonical.governance.transparency_passed = false;
+
+    expect(deriveValidityStatus(canonical)).toBe("quarantined");
+  });
+
+  it("returns invalid when canonical_ready is false without quarantine signals", () => {
+    const job = makeJob();
+    const pass1 = makePassArtifact("pass1");
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+    canonical.governance.canonical_ready = false;
+
+    expect(deriveValidityStatus(canonical)).toBe("invalid");
   });
 });

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -39,6 +39,7 @@ import {
 } from "./invariants";
 import {
   deriveConfidence,
+  CONFIDENCE_DERIVATION_VERSION,
   type ConfidenceInputs,
 } from "../governance/confidenceDerivation";
 
@@ -55,6 +56,8 @@ export interface FinalizerStorage {
   ): Promise<PersistCanonicalAndSummaryAndCompleteResult>;
   markJobFailed(args: MarkJobFailedArgs): Promise<void>;
 }
+
+type FinalizerDerivedValidityStatus = "valid" | "invalid" | "quarantined";
 
 // === U1.1: Build ConfidenceInputs from finalizer scope ===
 export function buildConfidenceInputs(args: {
@@ -191,7 +194,7 @@ export function buildCanonicalArtifact(args: {
       // U1.1 wiring
       confidence_label: confidenceResult.confidence,
       confidence_reasons: confidenceResult.reasons,
-      confidence_derivation_version: "1.0.0",
+      confidence_derivation_version: CONFIDENCE_DERIVATION_VERSION,
     },
     eligibility: {
       structural_pass: avgScore >= 50,
@@ -207,6 +210,24 @@ export function buildCanonicalArtifact(args: {
       finalizer_version: FINALIZER_VERSION,
     },
   };
+}
+
+export function deriveValidityStatus(
+  canonical: CanonicalEvaluationArtifact,
+): FinalizerDerivedValidityStatus {
+  if (!canonical.governance.transparency_passed) {
+    return "quarantined";
+  }
+
+  if (!canonical.governance.anchor_contract_passed) {
+    return "quarantined";
+  }
+
+  if (!canonical.governance.canonical_ready) {
+    return "invalid";
+  }
+
+  return "valid";
 }
 
 export function buildReportSummaryProjection(
@@ -235,16 +256,31 @@ export function buildReportSummaryProjection(
 }
 
 function validateCanonicalArtifact(canonical: CanonicalEvaluationArtifact): void {
-  if (!canonical.governance.canonical_ready) {
-    throw new InvariantViolation(
-      "SCHEMA_ERROR",
-      `Canonical artifact not marked as ready`,
-    );
-  }
   if (!canonical.schema_version) {
     throw new InvariantViolation(
       "SCHEMA_ERROR",
       `Canonical artifact missing schema_version`,
+    );
+  }
+
+  if (!canonical.governance.transparency_passed) {
+    throw new InvariantViolation(
+      "GOVERNANCE_BLOCK",
+      "Canonical artifact failed transparency gate",
+    );
+  }
+
+  if (!canonical.governance.anchor_contract_passed) {
+    throw new InvariantViolation(
+      "ANCHOR_CONTRACT_VIOLATION",
+      "Canonical artifact failed anchor contract gate",
+    );
+  }
+
+  if (!canonical.governance.canonical_ready) {
+    throw new InvariantViolation(
+      "SCHEMA_ERROR",
+      "Canonical artifact not marked as ready",
     );
   }
 }
@@ -300,6 +336,15 @@ export async function finalizeJob(
 
     // Step 9: Validate canonical artifact
     validateCanonicalArtifact(canonical);
+
+    // Step 9.5: Derive validity and fail closed if canonical output is not releasable
+    const validityStatus = deriveValidityStatus(canonical);
+    if (validityStatus !== "valid") {
+      throw new InvariantViolation(
+        "GOVERNANCE_BLOCK",
+        `Finalizer validity gate blocked completion with validity_status='${validityStatus}'`,
+      );
+    }
 
     // Step 10: Build summary projection candidate (IDs finalized in write authority)
     const summaryCandidate = buildReportSummaryProjection(job, canonical, "pending");

--- a/tests/jobs/finalize.test.ts
+++ b/tests/jobs/finalize.test.ts
@@ -270,4 +270,32 @@ describe('finalizeJob', () => {
       expect(result.failure_code).toBe('GOVERNANCE_BLOCK');
     }
   });
+
+  test('fails closed before completion write when validity gate is non-valid', async () => {
+    const storage = makeStorage();
+    storage.getConvergenceArtifact.mockResolvedValueOnce({
+      ...makeConvergence(),
+      validations: {
+        ...makeConvergence().validations,
+        anchor_contract_valid: false,
+      },
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.failure_code).toBe('ANCHOR_CONTRACT_VIOLATION');
+    }
+    expect(storage.persistCanonicalAndSummaryAndCompleteJob).not.toHaveBeenCalled();
+    expect(storage.markJobFailed).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- tighten canonical validation to explicitly block transparency and anchor-contract failures
- add deriveValidityStatus() in finalizer domain logic (valid | invalid | quarantined)
- enforce Step 9.5 fail-closed gate: block completion writes when derived validity is not valid
- align confidence derivation version wiring to CONFIDENCE_DERIVATION_VERSION

## Tests
- targeted Jest run:
  - lib/jobs/__tests__/finalize.confidence.test.ts
  - tests/jobs/finalize.test.ts

## Notes
- scope is intentionally narrow and does not alter DB RPC shape
- completion authority remains atomic and unchanged
