### PR TITLE
read-gate: fail-closed evaluation/report release by lifecycle+validity

### DIFF
--- a/app/api/jobs/[jobId]/evaluation-result/route.ts
+++ b/app/api/jobs/[jobId]/evaluation-result/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { canReleaseEvaluationRead } from '@/lib/jobs/readReleaseGate';
 import { 
   EvaluationResultV1, 
   isEvaluationResultV1, 
@@ -28,7 +29,7 @@ export async function GET(
     // Fetch job with evaluation result
     const { data: job, error } = await supabase
       .from('evaluation_jobs')
-      .select('id, manuscript_id, status, evaluation_result, evaluation_result_version, created_at, updated_at')
+      .select('id, manuscript_id, status, validity_status, evaluation_result, evaluation_result_version, created_at, updated_at')
       .eq('id', jobId)
       .single();
 
@@ -39,14 +40,15 @@ export async function GET(
       );
     }
 
-    // Check if evaluation result exists
-    if (!job.evaluation_result) {
+    // #168 fail-closed read gate: release only complete + valid jobs with result payload.
+    if (!canReleaseEvaluationRead(job) || !job.evaluation_result) {
       return NextResponse.json(
         { 
-          error: 'Evaluation not complete',
+          error: 'Evaluation not releasable',
           job: {
             id: job.id,
             status: job.status,
+            validity_status: job.validity_status,
             created_at: job.created_at,
           }
         },
@@ -82,6 +84,7 @@ export async function GET(
       job_id: job.id,
       manuscript_id: job.manuscript_id,
       status: job.status,
+      validity_status: job.validity_status,
       result,
       result_version: job.evaluation_result_version,
       created_at: job.created_at,

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -3,6 +3,7 @@ import { unstable_noStore as noStore } from 'next/cache';
 import { notFound } from 'next/navigation';
 import { createClient as createSSRClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { canReleaseEvaluationRead } from '@/lib/jobs/readReleaseGate';
 import { EvaluationResultV1, isEvaluationResultV1, hasD2TransparencyFields } from '@/schemas/evaluation-result-v1';
 import AgentTrustHeader from '@/components/reports/AgentTrustHeader';
 import { scanObjectForForbiddenMarketClaims } from '@/lib/release/forbiddenMarketClaims';
@@ -28,13 +29,14 @@ async function getEvaluationResult(jobId: string, userId: string): Promise<Evalu
     .select(`
       evaluation_result,
       status,
+      validity_status,
       manuscripts!inner(user_id)
     `)
     .eq('id', jobId)
     .eq('manuscripts.user_id', userId)
     .single();
 
-  if (error || !job || !job.evaluation_result) {
+  if (error || !job || !canReleaseEvaluationRead(job) || !job.evaluation_result) {
     return null;
   }
 

--- a/lib/jobs/readReleaseGate.ts
+++ b/lib/jobs/readReleaseGate.ts
@@ -1,0 +1,17 @@
+import {
+  normalizeEvaluationJobStatus,
+  normalizeEvaluationValidityStatus,
+} from "@/lib/evaluation/status";
+
+export function canReleaseEvaluationRead(input: {
+  status: unknown;
+  validity_status: unknown;
+}): boolean {
+  try {
+    const status = normalizeEvaluationJobStatus(input.status);
+    const validityStatus = normalizeEvaluationValidityStatus(input.validity_status);
+    return status === "complete" && validityStatus === "valid";
+  } catch {
+    return false;
+  }
+}

--- a/tests/api/evaluation-result-route-gating.test.ts
+++ b/tests/api/evaluation-result-route-gating.test.ts
@@ -1,0 +1,122 @@
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/jobs/[jobId]/evaluation-result/route";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/schemas/evaluation-result-v1", () => ({
+  isEvaluationResultV1: jest.fn(() => true),
+  validateEvaluationResult: jest.fn(() => ({ valid: true, errors: [] })),
+}));
+
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
+
+function makeRequest(): NextRequest {
+  return new NextRequest("https://localhost:3000/api/jobs/11111111-1111-1111-1111-111111111111/evaluation-result", {
+    method: "GET",
+  });
+}
+
+describe("GET /api/jobs/[jobId]/evaluation-result release gate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns 404 when job is complete but validity_status is invalid", async () => {
+    const supabase = {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            single: jest.fn(async () => ({
+              data: {
+                id: "11111111-1111-1111-1111-111111111111",
+                manuscript_id: 42,
+                status: "complete",
+                validity_status: "invalid",
+                evaluation_result: { arbitrary: true },
+                evaluation_result_version: "v1",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+              },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    const response = await GET(makeRequest(), {
+      params: Promise.resolve({ jobId: "11111111-1111-1111-1111-111111111111" }),
+    });
+
+    const json = (await response.json()) as { error: string };
+    expect(response.status).toBe(404);
+    expect(json.error).toBe("Evaluation not releasable");
+  });
+
+  test("returns 200 when job is complete + valid and payload is schema-valid", async () => {
+    const supabase = {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            single: jest.fn(async () => ({
+              data: {
+                id: "11111111-1111-1111-1111-111111111111",
+                manuscript_id: 42,
+                status: "complete",
+                validity_status: "valid",
+                evaluation_result: {
+                  schema_version: "evaluation_result_v1",
+                  ids: {
+                    evaluation_run_id: "run-1",
+                    job_id: "11111111-1111-1111-1111-111111111111",
+                    manuscript_id: 42,
+                    user_id: "user-1",
+                  },
+                  generated_at: new Date().toISOString(),
+                  engine: { model: "gpt-5", provider: "openai", prompt_version: "p1" },
+                  overview: {
+                    verdict: "pass",
+                    overall_score_0_100: 82,
+                    one_paragraph_summary: "Good manuscript quality.",
+                    top_3_strengths: ["voice", "pacing", "structure"],
+                    top_3_risks: ["stakes", "clarity", "ending"],
+                  },
+                  criteria: [],
+                  recommendations: { quick_wins: [], strategic_revisions: [] },
+                  metrics: { manuscript: {}, processing: {} },
+                  artifacts: [],
+                  governance: {
+                    confidence: 0.84,
+                    warnings: [],
+                    limitations: [],
+                    policy_family: "standard",
+                  },
+                },
+                evaluation_result_version: "v1",
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+              },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    const response = await GET(makeRequest(), {
+      params: Promise.resolve({ jobId: "11111111-1111-1111-1111-111111111111" }),
+    });
+    const json = (await response.json()) as { status: string; validity_status: string };
+
+    expect(response.status).toBe(200);
+    expect(json.status).toBe("complete");
+    expect(json.validity_status).toBe("valid");
+  });
+});

--- a/tests/jobs/read-release-gate.test.ts
+++ b/tests/jobs/read-release-gate.test.ts
@@ -1,0 +1,46 @@
+import { canReleaseEvaluationRead } from "@/lib/jobs/readReleaseGate";
+
+describe("canReleaseEvaluationRead", () => {
+  test("returns true only for complete + valid", () => {
+    expect(
+      canReleaseEvaluationRead({
+        status: "complete",
+        validity_status: "valid",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for complete + invalid", () => {
+    expect(
+      canReleaseEvaluationRead({
+        status: "complete",
+        validity_status: "invalid",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for running + valid", () => {
+    expect(
+      canReleaseEvaluationRead({
+        status: "running",
+        validity_status: "valid",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false for malformed statuses (fail-closed)", () => {
+    expect(
+      canReleaseEvaluationRead({
+        status: "completed",
+        validity_status: "valid",
+      }),
+    ).toBe(false);
+
+    expect(
+      canReleaseEvaluationRead({
+        status: "complete",
+        validity_status: "approved",
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared fail-closed read-release gate helper in `lib/jobs/readReleaseGate.ts`
- enforce release gate in API read surface: `app/api/jobs/[jobId]/evaluation-result/route.ts`
- enforce release gate in report page surface: `app/reports/[jobId]/page.tsx`
- gate contract is strict: release only when `status='complete'` and `validity_status='valid'`

## Tests
- `tests/jobs/read-release-gate.test.ts`
- `tests/api/evaluation-result-route-gating.test.ts`

## Notes
- keeps governance doctrine: no inferred/simulated progress; read persisted canonical state only
- behavior is fail-closed for any non-canonical or missing release state

Closes #168
