### PR TITLE
finalizer: explicit invalid-state contract for Item #8

### DIFF
--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -19,11 +19,16 @@ import type {
   PassArtifact,
   ConvergenceArtifact,
   CanonicalEvaluationArtifact,
+  CanonicalValidationIssue,
+  CanonicalValidityStatus,
   ReportSummaryProjection,
   FinalizeJobInput,
   FinalizeJobResult,
   PersistCanonicalAndSummaryAndCompleteArgs,
   PersistCanonicalAndSummaryAndCompleteResult,
+  PersistInvalidCanonicalArgs,
+  PersistInvalidCanonicalResult,
+  MarkJobInvalidArgs,
   MarkJobFailedArgs,
 } from "./finalize.types";
 import type { FailureCode } from "./failures";
@@ -42,6 +47,7 @@ import {
   CONFIDENCE_DERIVATION_VERSION,
   type ConfidenceInputs,
 } from "../governance/confidenceDerivation";
+import { CRITERIA_KEYS } from "../../schemas/criteria-keys";
 
 // === Finalizer Version ===
 export const FINALIZER_VERSION = "1.0.0";
@@ -54,10 +60,12 @@ export interface FinalizerStorage {
   persistCanonicalAndSummaryAndCompleteJob(
     args: PersistCanonicalAndSummaryAndCompleteArgs,
   ): Promise<PersistCanonicalAndSummaryAndCompleteResult>;
+  persistInvalidCanonicalArtifact(
+    args: PersistInvalidCanonicalArgs,
+  ): Promise<PersistInvalidCanonicalResult>;
+  markJobInvalid(args: MarkJobInvalidArgs): Promise<void>;
   markJobFailed(args: MarkJobFailedArgs): Promise<void>;
 }
-
-type FinalizerDerivedValidityStatus = "valid" | "invalid" | "quarantined";
 
 // === U1.1: Build ConfidenceInputs from finalizer scope ===
 export function buildConfidenceInputs(args: {
@@ -191,6 +199,9 @@ export function buildCanonicalArtifact(args: {
         convergence.validations.pass_separation_preserved &&
         convergence.validations.all_required_passes_present &&
         convergence.validations.anchor_contract_valid,
+      validity_status: "valid",
+      validation_issues: [],
+      release_blocked: false,
       // U1.1 wiring
       confidence_label: confidenceResult.confidence,
       confidence_reasons: confidenceResult.reasons,
@@ -213,21 +224,9 @@ export function buildCanonicalArtifact(args: {
 }
 
 export function deriveValidityStatus(
-  canonical: CanonicalEvaluationArtifact,
-): FinalizerDerivedValidityStatus {
-  if (!canonical.governance.transparency_passed) {
-    return "quarantined";
-  }
-
-  if (!canonical.governance.anchor_contract_passed) {
-    return "quarantined";
-  }
-
-  if (!canonical.governance.canonical_ready) {
-    return "invalid";
-  }
-
-  return "valid";
+  issues: CanonicalValidationIssue[],
+): CanonicalValidityStatus {
+  return issues.length === 0 ? "valid" : "invalid";
 }
 
 export function buildReportSummaryProjection(
@@ -255,34 +254,91 @@ export function buildReportSummaryProjection(
   };
 }
 
-function validateCanonicalArtifact(canonical: CanonicalEvaluationArtifact): void {
+export function validateCanonicalArtifact(
+  canonical: CanonicalEvaluationArtifact,
+): CanonicalValidationIssue[] {
+  const issues: CanonicalValidationIssue[] = [];
+  const requiredKeys = new Set<string>(CRITERIA_KEYS);
+  const seen = new Set<string>();
+
   if (!canonical.schema_version) {
-    throw new InvariantViolation(
-      "SCHEMA_ERROR",
-      `Canonical artifact missing schema_version`,
-    );
-  }
-
-  if (!canonical.governance.transparency_passed) {
-    throw new InvariantViolation(
-      "GOVERNANCE_BLOCK",
-      "Canonical artifact failed transparency gate",
-    );
-  }
-
-  if (!canonical.governance.anchor_contract_passed) {
-    throw new InvariantViolation(
-      "ANCHOR_CONTRACT_VIOLATION",
-      "Canonical artifact failed anchor contract gate",
-    );
+    issues.push({
+      criterion_id: "__artifact__",
+      code: "NON_CANONICAL_CRITERION",
+      detail: "Canonical artifact missing schema_version",
+    });
   }
 
   if (!canonical.governance.canonical_ready) {
-    throw new InvariantViolation(
-      "SCHEMA_ERROR",
-      "Canonical artifact not marked as ready",
-    );
+    issues.push({
+      criterion_id: "__artifact__",
+      code: "NON_CANONICAL_CRITERION",
+      detail: "Canonical artifact not marked canonical_ready",
+    });
   }
+
+  for (const criterion of canonical.criteria) {
+    if (!requiredKeys.has(criterion.criterion_id)) {
+      issues.push({
+        criterion_id: criterion.criterion_id,
+        code: "NON_CANONICAL_CRITERION",
+        detail: `Non-canonical criterion id \"${criterion.criterion_id}\"`,
+      });
+      continue;
+    }
+
+    if (seen.has(criterion.criterion_id)) {
+      issues.push({
+        criterion_id: criterion.criterion_id,
+        code: "DUPLICATE_CRITERION",
+        detail: `Duplicate criterion \"${criterion.criterion_id}\"`,
+      });
+      continue;
+    }
+
+    seen.add(criterion.criterion_id);
+
+    if (
+      typeof criterion.score_0_10 !== "number" ||
+      !Number.isFinite(criterion.score_0_10) ||
+      criterion.score_0_10 < 0 ||
+      criterion.score_0_10 > 10
+    ) {
+      issues.push({
+        criterion_id: criterion.criterion_id,
+        code: "INVALID_SCORE",
+        detail: `Invalid score (${criterion.score_0_10})`,
+      });
+    }
+
+    if (!criterion.rationale || criterion.rationale.trim().length === 0) {
+      issues.push({
+        criterion_id: criterion.criterion_id,
+        code: "MISSING_REASONING",
+        detail: "Reasoning/rationale is empty",
+      });
+    }
+
+    if (!criterion.evidence || criterion.evidence.length === 0) {
+      issues.push({
+        criterion_id: criterion.criterion_id,
+        code: "MISSING_EVIDENCE",
+        detail: "Evidence anchors are empty",
+      });
+    }
+  }
+
+  for (const key of requiredKeys) {
+    if (!seen.has(key)) {
+      issues.push({
+        criterion_id: key,
+        code: "MISSING_CRITERION",
+        detail: `Missing canonical criterion \"${key}\"`,
+      });
+    }
+  }
+
+  return issues;
 }
 
 // === Layer 2: Side Effects (Finalizer Entry Point) ===
@@ -292,6 +348,7 @@ export async function finalizeJob(
   storage: FinalizerStorage,
 ): Promise<FinalizeJobResult> {
   let failureWriteAuthorized = false;
+  let criterionCompletenessViolation: InvariantViolation | null = null;
 
   try {
     // Step 1: Acquire and verify authority
@@ -323,27 +380,83 @@ export async function finalizeJob(
     enforcePassSeparation(pass1, pass2, pass3, convergence);
 
     // Step 5.5: Criterion completeness gate (Item #8)
-    enforceCriterionCompleteness(pass1, pass2, pass3);
+    try {
+      enforceCriterionCompleteness(pass1, pass2, pass3);
+    } catch (error) {
+      if (
+        error instanceof InvariantViolation
+        && error.failureCode === "CRITERION_COMPLETENESS_FAILED"
+      ) {
+        criterionCompletenessViolation = error;
+      } else {
+        throw error;
+      }
+    }
 
     // Step 6: Anchor integrity
-    enforceAnchorIntegrity(pass1, pass2, pass3, convergence);
+    if (!criterionCompletenessViolation) {
+      enforceAnchorIntegrity(pass1, pass2, pass3, convergence);
+    }
 
     // Step 7: A6 credibility
-    enforceA6Credibility(pass1, pass2, pass3, convergence);
+    if (!criterionCompletenessViolation) {
+      enforceA6Credibility(pass1, pass2, pass3, convergence);
+    }
 
     // Step 8: Build canonical artifact (includes U1.1 confidence derivation)
     const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
 
     // Step 9: Validate canonical artifact
-    validateCanonicalArtifact(canonical);
+    const validationIssues = validateCanonicalArtifact(canonical);
+    if (criterionCompletenessViolation) {
+      validationIssues.push({
+        criterion_id: "__artifact__",
+        code: "MISSING_CRITERION",
+        detail: criterionCompletenessViolation.message,
+      });
+    }
 
-    // Step 9.5: Derive validity and fail closed if canonical output is not releasable
-    const validityStatus = deriveValidityStatus(canonical);
-    if (validityStatus !== "valid") {
-      throw new InvariantViolation(
-        "GOVERNANCE_BLOCK",
-        `Finalizer validity gate blocked completion with validity_status='${validityStatus}'`,
-      );
+    // Step 9.5: Derive validity and route invalid outputs to blocked-release path
+    const validityStatus = deriveValidityStatus(validationIssues);
+    canonical.governance.validity_status = validityStatus;
+    canonical.governance.validation_issues = validationIssues;
+    canonical.governance.release_blocked = validityStatus === "invalid";
+
+    if (validityStatus === "invalid") {
+      canonical.overview.overall_score_0_100 = 0;
+      canonical.overview.verdict = "Invalid";
+      canonical.eligibility = {
+        structural_pass: false,
+        refinement_unlocked: false,
+        wave_unlocked: false,
+        submission_packaging_unlocked: false,
+        reason: "Evaluation invalid: canonical completeness contract failed",
+      };
+      canonical.governance.confidence_label = "withheld";
+
+      const invalidWrite = await storage.persistInvalidCanonicalArtifact({
+        job,
+        worker_id: input.worker_id,
+        canonical,
+      });
+
+      await storage.markJobInvalid({
+        job_id: job.id,
+        worker_id: input.worker_id,
+        canonical_artifact_id: invalidWrite.canonical_artifact_id,
+        last_error: `Canonical validation failed: ${validationIssues
+          .map((issue) => `${issue.criterion_id}:${issue.code}`)
+          .join(", ")}`,
+      });
+
+      return {
+        ok: false,
+        job_id: job.id,
+        canonical_artifact_id: invalidWrite.canonical_artifact_id,
+        final_status: "invalid",
+        reason: "Canonical validation failed",
+        validation_issues: validationIssues,
+      };
     }
 
     // Step 10: Build summary projection candidate (IDs finalized in write authority)

--- a/lib/jobs/finalize.types.ts
+++ b/lib/jobs/finalize.types.ts
@@ -102,6 +102,22 @@ export interface EligibilityBlock {
   reason: string | null;
 }
 
+export type CanonicalValidityStatus = "valid" | "invalid";
+
+export type CanonicalValidationIssueCode =
+  | "MISSING_CRITERION"
+  | "INVALID_SCORE"
+  | "MISSING_REASONING"
+  | "MISSING_EVIDENCE"
+  | "NON_CANONICAL_CRITERION"
+  | "DUPLICATE_CRITERION";
+
+export interface CanonicalValidationIssue {
+  criterion_id: string;
+  code: CanonicalValidationIssueCode;
+  detail: string;
+}
+
 export interface CanonicalEvaluationArtifact {
   id: string;
   job_id: string;
@@ -128,6 +144,9 @@ export interface CanonicalEvaluationArtifact {
     transparency_passed: boolean;
     anchor_contract_passed: boolean;
     canonical_ready: boolean;
+    validity_status: CanonicalValidityStatus;
+    validation_issues: CanonicalValidationIssue[];
+    release_blocked: boolean;
     // U1.1 — confidence derivation wiring (see lib/governance/confidenceDerivation.ts)
     confidence_label?: "high" | "medium" | "low" | "withheld";
     confidence_reasons?: string[];
@@ -183,6 +202,14 @@ export type FinalizeJobResult =
   | {
       ok: false;
       job_id: string;
+      canonical_artifact_id: string;
+      final_status: "invalid";
+      reason: string;
+      validation_issues: CanonicalValidationIssue[];
+    }
+  | {
+      ok: false;
+      job_id: string;
       failure_code: FailureCode;
       final_status: "failed";
       reason: string;
@@ -198,6 +225,23 @@ export interface PersistCanonicalAndSummaryAndCompleteArgs {
 export interface PersistCanonicalAndSummaryAndCompleteResult {
   canonical_artifact_id: string;
   summary_artifact_id: string;
+}
+
+export interface PersistInvalidCanonicalArgs {
+  job: EvaluationJob;
+  worker_id: string;
+  canonical: CanonicalEvaluationArtifact;
+}
+
+export interface PersistInvalidCanonicalResult {
+  canonical_artifact_id: string;
+}
+
+export interface MarkJobInvalidArgs {
+  job_id: string;
+  worker_id: string;
+  canonical_artifact_id: string;
+  last_error: string;
 }
 
 export interface MarkJobFailedArgs {

--- a/lib/jobs/store.finalizer.ts
+++ b/lib/jobs/store.finalizer.ts
@@ -6,7 +6,10 @@ import type {
   ConvergenceArtifact,
   EvaluationJob,
   JobAuditEvent,
+  MarkJobInvalidArgs,
   MarkJobFailedArgs,
+  PersistInvalidCanonicalArgs,
+  PersistInvalidCanonicalResult,
   PassArtifact,
   PersistCanonicalAndSummaryAndCompleteArgs,
   PersistCanonicalAndSummaryAndCompleteResult,
@@ -31,6 +34,7 @@ const FINALIZER_JOB_SELECT_FIELDS = [
 
 const ARTIFACT_SELECT_FIELDS = "id, job_id, artifact_type, content";
 const FINALIZER_CANONICAL_ARTIFACT_TYPE = "evaluation_result_v1";
+const FINALIZER_CANONICAL_INVALID_ARTIFACT_TYPE = "evaluation_result_v1_invalid";
 const FINALIZER_SUMMARY_ARTIFACT_TYPE = "one_page_summary";
 
 type SupabaseLike = NonNullable<ReturnType<typeof createAdminClient>>;
@@ -311,6 +315,56 @@ export async function persistCanonicalAndSummaryAndCompleteJob(
   return requireCompletionIds(data);
 }
 
+export async function persistInvalidCanonicalArtifact(
+  args: PersistInvalidCanonicalArgs,
+): Promise<PersistInvalidCanonicalResult> {
+  const canonicalContent: CanonicalEvaluationArtifact = {
+    ...args.canonical,
+    job_id: args.job.id,
+  };
+
+  const { data: jobRow, error: jobLookupError } = await supabase
+    .from("evaluation_jobs")
+    .select("manuscript_id")
+    .eq("id", args.job.id)
+    .single();
+
+  if (jobLookupError || !jobRow || typeof jobRow.manuscript_id !== "number") {
+    throw new Error(
+      `[FINALIZER-STORE] Invalid canonical persistence failed manuscript lookup for job ${args.job.id}: ${jobLookupError?.message ?? "missing manuscript_id"}`,
+    );
+  }
+
+  const { data, error } = await supabase
+    .from("evaluation_artifacts")
+    .insert({
+      job_id: args.job.id,
+      manuscript_id: jobRow.manuscript_id,
+      artifact_type: FINALIZER_CANONICAL_INVALID_ARTIFACT_TYPE,
+      artifact_version: "v1",
+      content: canonicalContent,
+      source_phase: "finalizer",
+      source_hash: null,
+      updated_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(
+      `[FINALIZER-STORE] Invalid canonical persistence failed for job ${args.job.id}: ${error.message}`,
+    );
+  }
+
+  if (!data || typeof data.id !== "string" || data.id.length === 0) {
+    throw new Error(
+      `[FINALIZER-STORE] Invalid canonical persistence missing id for job ${args.job.id}`,
+    );
+  }
+
+  return { canonical_artifact_id: data.id };
+}
+
 export async function getPassArtifactById(artifactId: string): Promise<PassArtifact> {
   const row = await getArtifactRowById(artifactId);
   const payload = readArtifactPayload(row);
@@ -367,6 +421,51 @@ export async function markJobFailed(args: MarkJobFailedArgs): Promise<void> {
   if (error) {
     throw new Error(
       `[FINALIZER-STORE] Failed to mark job failed for ${args.job_id}: ${error.message}`,
+    );
+  }
+}
+
+export async function markJobInvalid(args: MarkJobInvalidArgs): Promise<void> {
+  const job = await getJobForFinalization(args.job_id);
+
+  if (job.status !== "running") {
+    throw new Error(
+      `[FINALIZER-STORE] Cannot mark job invalid from status ${job.status}`,
+    );
+  }
+
+  if (job.claimed_by !== args.worker_id) {
+    throw new Error(
+      `[FINALIZER-STORE] Cannot mark job invalid: claim mismatch expected ${args.worker_id} got ${job.claimed_by}`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  const progress = {
+    phase: "finalizer",
+    phase_status: "complete",
+    canonical_artifact_id: args.canonical_artifact_id,
+    summary_artifact_id: null,
+    terminal_at: now,
+    lease_id: null,
+    lease_expires_at: null,
+  };
+
+  const { error } = await supabase
+    .from("evaluation_jobs")
+    .update({
+      status: "complete",
+      validity_status: "invalid",
+      progress,
+      last_error: args.last_error,
+      updated_at: now,
+    })
+    .eq("id", args.job_id)
+    .eq("status", "running");
+
+  if (error) {
+    throw new Error(
+      `[FINALIZER-STORE] Failed to mark job invalid for ${args.job_id}: ${error.message}`,
     );
   }
 }

--- a/lib/jobs/store.ts
+++ b/lib/jobs/store.ts
@@ -3,6 +3,7 @@ import { JOB_STATUS, PHASES } from "./types";
 import type {
   CanonicalEvaluationArtifact,
   EvaluationJob,
+  PersistInvalidCanonicalResult,
   PersistCanonicalAndSummaryAndCompleteResult,
   ReportSummaryProjection,
 } from "./finalize.types";
@@ -91,6 +92,19 @@ export type MarkFinalizerJobFailedArgs = {
   last_error: string;
 };
 
+export type PersistInvalidCanonicalArtifactArgs = {
+  job: EvaluationJob;
+  worker_id: string;
+  canonical: CanonicalEvaluationArtifact;
+};
+
+export type MarkFinalizerJobInvalidArgs = {
+  job_id: string;
+  worker_id: string;
+  canonical_artifact_id: string;
+  last_error: string;
+};
+
 let _finalizerStoreModule: any = null;
 
 const loadFinalizerStore = async () => {
@@ -124,6 +138,32 @@ export async function markJobFailed(
 
   const store = await loadFinalizerStore();
   return store.markJobFailed(args);
+}
+
+export async function persistInvalidCanonicalArtifact(
+  args: PersistInvalidCanonicalArtifactArgs,
+): Promise<PersistInvalidCanonicalResult> {
+  if (!USE_SUPABASE) {
+    throw new Error(
+      "[FINALIZER-STORE] invalid canonical persistence unavailable without Supabase backing",
+    );
+  }
+
+  const store = await loadFinalizerStore();
+  return store.persistInvalidCanonicalArtifact(args);
+}
+
+export async function markJobInvalid(
+  args: MarkFinalizerJobInvalidArgs,
+): Promise<void> {
+  if (!USE_SUPABASE) {
+    throw new Error(
+      "[FINALIZER-STORE] markJobInvalid unavailable without Supabase backing",
+    );
+  }
+
+  const store = await loadFinalizerStore();
+  return store.markJobInvalid(args);
 }
 
 export function canRunPhase(

--- a/tests/jobs/finalize.persistence.test.ts
+++ b/tests/jobs/finalize.persistence.test.ts
@@ -58,25 +58,23 @@ function makeConvergence(): ConvergenceArtifact {
       pass2_artifact_id: "p2",
       pass3_artifact_id: "p3",
     },
-    merged_criteria: [
-      {
-        criterion_id: "sceneConstruction",
-        score_0_10: 8,
-        rationale: "Merged rationale.",
-        confidence_0_1: 0.85,
-        evidence: [
-          {
-            anchor_id: "conv-a1",
-            source_type: "manuscript_chunk",
-            source_ref: "chunk-1",
-            start_offset: 10,
-            end_offset: 25,
-            excerpt: "Merged excerpt",
-          },
-        ],
-        warnings: [],
-      },
-    ],
+    merged_criteria: CRITERIA_KEYS.map((key, idx) => ({
+      criterion_id: key,
+      score_0_10: 8,
+      rationale: "Merged rationale.",
+      confidence_0_1: 0.85,
+      evidence: [
+        {
+          anchor_id: `conv-a${idx + 1}`,
+          source_type: "manuscript_chunk",
+          source_ref: "chunk-1",
+          start_offset: 10,
+          end_offset: 25,
+          excerpt: "Merged excerpt",
+        },
+      ],
+      warnings: [],
+    })),
     overview_summary: "Overall convergence summary.",
     convergence_notes: [],
     conflicts_detected: [],
@@ -137,6 +135,10 @@ function makeStorage(
     persistCanonicalAndSummaryAndCompleteJob:
       completionImpl
       ?? jest.fn(async () => ({ canonical_artifact_id: "canon-1", summary_artifact_id: "sum-1" })),
+    persistInvalidCanonicalArtifact: jest.fn(async () => ({
+      canonical_artifact_id: "canon-invalid-1",
+    })),
+    markJobInvalid: jest.fn(async () => undefined),
     markJobFailed: jest.fn(async () => undefined),
   };
 }

--- a/tests/jobs/finalize.test.ts
+++ b/tests/jobs/finalize.test.ts
@@ -63,25 +63,23 @@ function makeConvergence(): ConvergenceArtifact {
       pass2_artifact_id: 'p2',
       pass3_artifact_id: 'p3',
     },
-    merged_criteria: [
-      {
-        criterion_id: 'structure',
-        score_0_10: 8,
-        rationale: 'Merged rationale.',
-        confidence_0_1: 0.85,
-        evidence: [
-          {
-            anchor_id: 'conv-a1',
-            source_type: 'manuscript_chunk',
-            source_ref: 'chunk-1',
-            start_offset: 10,
-            end_offset: 25,
-            excerpt: 'Merged excerpt',
-          },
-        ],
-        warnings: [],
-      },
-    ],
+    merged_criteria: CANONICAL_CRITERION_IDS.map((criterion_id, i) => ({
+      criterion_id,
+      score_0_10: 8,
+      rationale: 'Merged rationale.',
+      confidence_0_1: 0.85,
+      evidence: [
+        {
+          anchor_id: `conv-a${i + 1}`,
+          source_type: 'manuscript_chunk',
+          source_ref: 'chunk-1',
+          start_offset: 10,
+          end_offset: 25,
+          excerpt: 'Merged excerpt',
+        },
+      ],
+      warnings: [],
+    })),
     overview_summary: 'Overall convergence summary.',
     convergence_notes: [],
     conflicts_detected: [],
@@ -140,6 +138,10 @@ function makeStorage(): jest.Mocked<FinalizerStorage> {
       canonical_artifact_id: 'canon-1',
       summary_artifact_id: 'summary-1',
     })),
+    persistInvalidCanonicalArtifact: jest.fn(async () => ({
+      canonical_artifact_id: 'canon-invalid-1',
+    })),
+    markJobInvalid: jest.fn(async () => undefined),
     markJobFailed: jest.fn(async () => undefined),
   };
 }
@@ -293,9 +295,45 @@ describe('finalizeJob', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok === false) {
-      expect(result.failure_code).toBe('ANCHOR_CONTRACT_VIOLATION');
+      expect(result.final_status).toBe('invalid');
+      expect(result.reason).toBe('Canonical validation failed');
+      expect(
+        result.validation_issues.some(
+          (issue) => issue.criterion_id === '__artifact__' && issue.code === 'NON_CANONICAL_CRITERION',
+        ),
+      ).toBe(true);
     }
     expect(storage.persistCanonicalAndSummaryAndCompleteJob).not.toHaveBeenCalled();
-    expect(storage.markJobFailed).toHaveBeenCalledTimes(1);
+    expect(storage.persistInvalidCanonicalArtifact).toHaveBeenCalledTimes(1);
+    expect(storage.markJobInvalid).toHaveBeenCalledTimes(1);
+    expect(storage.markJobFailed).not.toHaveBeenCalled();
+  });
+
+  test('returns explicit invalid outcome and blocks release when canonical criteria are incomplete', async () => {
+    const storage = makeStorage();
+    storage.getConvergenceArtifact.mockResolvedValueOnce({
+      ...makeConvergence(),
+      merged_criteria: makeConvergence().merged_criteria.slice(0, 12),
+    });
+
+    const result = await finalizeJob(
+      {
+        job_id: 'job-1',
+        worker_id: 'worker-1',
+        expected_status: 'running',
+        expected_phase: 'finalizer',
+      },
+      storage,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.final_status).toBe('invalid');
+      expect(result.validation_issues.some((issue) => issue.code === 'MISSING_CRITERION')).toBe(true);
+    }
+    expect(storage.persistInvalidCanonicalArtifact).toHaveBeenCalledTimes(1);
+    expect(storage.markJobInvalid).toHaveBeenCalledTimes(1);
+    expect(storage.persistCanonicalAndSummaryAndCompleteJob).not.toHaveBeenCalled();
+    expect(storage.markJobFailed).not.toHaveBeenCalled();
   });
 });

--- a/tests/jobs/store.finalizer.test.ts
+++ b/tests/jobs/store.finalizer.test.ts
@@ -135,6 +135,9 @@ function makeCanonicalArtifact(): CanonicalEvaluationArtifact {
       transparency_passed: true,
       anchor_contract_passed: true,
       canonical_ready: true,
+      validity_status: "valid",
+      validation_issues: [],
+      release_blocked: false,
     },
     eligibility: {
       structural_pass: true,


### PR DESCRIPTION
## Summary
- promote finalizer criterion completeness outcomes into an explicit `invalid` contract instead of generic `failed`
- add canonical validation metadata to artifact governance:
  - `validity_status`
  - `validation_issues`
  - `release_blocked`
- add invalid persistence path and status write authority:
  - `persistInvalidCanonicalArtifact(...)`
  - `markJobInvalid(...)`
- keep complete path unchanged for valid artifacts
- replace hardcoded confidence version with `CONFIDENCE_DERIVATION_VERSION`

## Behavior
- canonical validation failures now persist invalid artifact, block summary/release, and return:
  - `ok: false`
  - `final_status: "invalid"`
  - `validation_issues[]`
- non-validity runtime/invariant failures still route to `final_status: "failed"`

## Tests
- `tests/jobs/finalize.test.ts`
- `tests/jobs/finalize.persistence.test.ts`
- `tests/jobs/store.finalizer.test.ts`

All targeted suites pass locally.
