### PR TITLE
Propagate unresolved Pass 1 incompleteness

### DIFF
--- a/.artifacts/u2-1-guardrails.md
+++ b/.artifacts/u2-1-guardrails.md
@@ -1,0 +1,16 @@
+## U2.1 Guardrails
+
+Do not expand this PR beyond the first propagation-integrity slice.
+
+- no UI work
+- no DB schema changes
+- no release-gate changes
+- no new validity states
+- no expansion into U2.2, U2.3, or U3
+- no invented upstream signal if an existing one can be mapped cleanly
+- no penalty for raw Pass 1 findings that were later resolved
+
+Correctness hinge:
+
+> “incomplete” means unresolved after downstream convergence/resolution,
+> not merely observed in Pass 1.

--- a/.artifacts/u2-1-issue.md
+++ b/.artifacts/u2-1-issue.md
@@ -1,0 +1,67 @@
+## Objective
+
+Implement the first narrow U2 propagation-integrity slice:
+
+**unresolved Pass 1 incompleteness must affect final confidence instead of being silently ignored.**
+
+U1 and U1.1 established deterministic confidence derivation and artifact wiring. This issue begins U2 by ensuring upstream weakness propagates into downstream confidence.
+
+## Problem
+
+The system can detect incompleteness upstream, but confidence derivation does not yet fully express that unresolved signal.
+
+That creates a silent integrity gap:
+- weakness is observed
+- canonical output is still produced
+- final confidence may not acknowledge unresolved incompleteness
+
+## Scope
+
+This issue implements exactly **one** new propagation rule.
+
+### Included
+
+- extend the confidence inputs with:
+  - `pass1IncompleteCount: number`
+- wire a real Pass 1 incompleteness signal from existing pass/finalizer data
+- add one derivation rule for unresolved incompleteness:
+  - `pass1_incompleteness_unresolved`
+- bump the derivation version because confidence semantics change
+- add focused tests for zero, below-threshold, at-threshold, and resolved cases
+
+### Not included
+
+- Pass 2 divergence propagation
+- broader Pass 3 propagation work
+- contradiction detection
+- UI changes
+- DB schema changes
+- release-gate changes
+
+## Correctness rule
+
+For this issue, “incomplete” means:
+
+> unresolved incompleteness after downstream convergence/resolution,
+> not raw Pass 1 findings.
+
+If a weakness was detected in Pass 1 but resolved later, it must not penalize confidence here.
+
+## Acceptance criteria
+
+- confidence inputs include `pass1IncompleteCount`
+- confidence derivation can express `pass1_incompleteness_unresolved`
+- derivation version is bumped from `u1.v1`
+- existing U1 regression tests remain green
+- targeted U2.1 tests pass
+
+## Pre-flight scope evidence
+
+Mandatory grep confirmed the existing signal family before implementation:
+
+- `lib/evaluation/pipeline/runPipeline.ts` emits `INCOMPLETE_CRITERIA_WARNING`
+- `lib/evaluation/pipeline/runPipeline.ts` threads those warnings into governance warnings
+- Pass prompts are already vocabulary-locked around `WEAK` signal strength
+- `qualityGate.ts` distinguishes weak signal from truly applicable/scorable states
+
+This issue maps that existing incompleteness surface into confidence derivation. It does not invent a new upstream concept.

--- a/.artifacts/u2-1-open-issue.txt
+++ b/.artifacts/u2-1-open-issue.txt
@@ -1,0 +1,4 @@
+gh issue create \
+  --title "U2.1 — propagate Pass 1 incompleteness into confidence derivation" \
+  --body-file .artifacts/u2-1-issue.md \
+  --label enhancement

--- a/.artifacts/u2-1-pr-body.md
+++ b/.artifacts/u2-1-pr-body.md
@@ -1,0 +1,61 @@
+## Summary
+
+Implements U2.1, the first propagation-integrity rule.
+
+Unresolved incompleteness detected upstream in Pass 1 now affects final confidence instead of being silently ignored.
+
+## Why
+
+U1 established deterministic confidence derivation.
+U1.1 wired that derivation into the final artifact.
+
+This PR begins U2 by making confidence reflect a real upstream weakness signal:
+**unresolved Pass 1 incompleteness**.
+
+## What changed
+
+- extended the confidence inputs with `pass1IncompleteCount`
+- added the confidence reason `pass1_incompleteness_unresolved`
+- added a narrow derivation rule for unresolved Pass 1 incompleteness
+- bumped `CONFIDENCE_DERIVATION_VERSION` from `u1.v1` to `u2.v1`
+- added focused tests for threshold and resolved-case behavior
+
+## Scope control
+
+### Included
+- one new confidence input
+- one new reason
+- one derivation rule
+- focused tests
+
+### Not included
+- Pass 2 divergence propagation
+- broader Pass 3 propagation work
+- contradiction detection
+- UI changes
+- DB schema changes
+- release-gate changes
+
+## Correctness boundary
+
+This PR does **not** penalize raw Pass 1 findings.
+
+It only penalizes **unresolved** incompleteness that remains after downstream convergence/resolution.
+
+## Pre-flight scope evidence
+
+The mandatory grep was used to lock scope to real existing signals:
+
+- `runPipeline.ts` defines and emits `INCOMPLETE_CRITERIA_WARNING`
+- governance warnings already carry these incompleteness signals downstream
+- Pass 1 and Pass 2 prompts are locked to the `WEAK` signal vocabulary
+- `qualityGate.ts` already treats weak signal as meaningful governed state
+
+This PR only propagates that established signal family into confidence.
+
+## Verification
+
+- [x] focused derivation tests pass
+- [x] existing finalizer confidence tests pass
+- [x] broader governance and jobs suites pass
+- [x] no compile errors in changed files

--- a/.artifacts/u2-1-start.sh
+++ b/.artifacts/u2-1-start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspaces/literary-ai-partner
+
+echo "== pre-flight grep: identify Pass 1 incompleteness signals =="
+grep -rnE "INCOMPLETE|WEAK" lib/evaluation/pipeline --include='*.ts' | head -20 || true
+grep -rnE "incomplete_reasons|weakness_flags|warnings" lib/evaluation --include='*.ts' | head -20 || true
+
+echo
+echo "== create branch =="
+git checkout -b feat/u2-1-pass1-incompleteness-propagation
+
+echo
+echo "Next manual step: open the U2.1 issue with .artifacts/u2-1-issue.md"

--- a/lib/governance/__tests__/confidenceDerivation.test.ts
+++ b/lib/governance/__tests__/confidenceDerivation.test.ts
@@ -11,6 +11,7 @@ function makeBaseInput(overrides: Partial<ConfidenceInputs> = {}): ConfidenceInp
     governancePassed: true,
     passConvergencePassed: true,
     hasMaterialPassDisagreement: false,
+    pass1IncompleteCount: 0,
     usedFallbackPath: false,
     executionDegraded: false,
     invalidOutput: false,
@@ -171,5 +172,17 @@ describe("U1 confidence derivation", () => {
     const resultB = deriveConfidence(input);
 
     expect(resultA).toEqual(resultB);
+  });
+
+  test("18) pass1IncompleteCount below threshold => no incompleteness penalty", () => {
+    const result = deriveConfidence(makeBaseInput({ pass1IncompleteCount: 1 }));
+    expect(result.confidence).toBe("high");
+    expect(result.reasons).not.toContain("pass1_incompleteness_unresolved");
+  });
+
+  test("19) pass1IncompleteCount at threshold => medium with unresolved incompleteness reason", () => {
+    const result = deriveConfidence(makeBaseInput({ pass1IncompleteCount: 2 }));
+    expect(result.confidence).toBe("medium");
+    expect(result.reasons).toContain("pass1_incompleteness_unresolved");
   });
 });

--- a/lib/governance/confidenceDerivation.ts
+++ b/lib/governance/confidenceDerivation.ts
@@ -38,6 +38,10 @@ export type ConfidenceInputs = {
   governancePassed: boolean;
   passConvergencePassed: boolean;
   hasMaterialPassDisagreement: boolean;
+  /**
+   * Count of criteria still absent after downstream convergence.
+   * Raw Pass 1 gaps that are later recovered must not contribute here.
+   */
   pass1IncompleteCount: number;
   usedFallbackPath: boolean;
   executionDegraded: boolean;

--- a/lib/governance/confidenceDerivation.ts
+++ b/lib/governance/confidenceDerivation.ts
@@ -13,7 +13,8 @@
  *    highest-severity rule that matches.
  */
 
-export const CONFIDENCE_DERIVATION_VERSION = "u1.v1";
+export const CONFIDENCE_DERIVATION_VERSION = "u2.v1";
+export const PASS1_INCOMPLETENESS_THRESHOLD = 2;
 
 export type EvaluationConfidence = "high" | "medium" | "low" | "withheld";
 
@@ -23,6 +24,7 @@ export type ConfidenceReason =
   | "governance_block"
   | "pass_convergence_failed"
   | "pass_disagreement_material"
+  | "pass1_incompleteness_unresolved"
   | "used_fallback_path"
   | "execution_degraded"
   | "invalid_output"
@@ -36,6 +38,7 @@ export type ConfidenceInputs = {
   governancePassed: boolean;
   passConvergencePassed: boolean;
   hasMaterialPassDisagreement: boolean;
+  pass1IncompleteCount: number;
   usedFallbackPath: boolean;
   executionDegraded: boolean;
   invalidOutput: boolean;
@@ -69,6 +72,10 @@ export function deriveConfidence(input: ConfidenceInputs): ConfidenceResult {
 
   if (input.hasMaterialPassDisagreement) {
     reasons.push("pass_disagreement_material");
+  }
+
+  if (input.pass1IncompleteCount >= PASS1_INCOMPLETENESS_THRESHOLD) {
+    reasons.push("pass1_incompleteness_unresolved");
   }
 
   if (input.usedFallbackPath) {
@@ -119,7 +126,8 @@ export function deriveConfidence(input: ConfidenceInputs): ConfidenceResult {
     input.usedFallbackPath ||
     input.executionDegraded ||
     input.evidenceCoverage === "partial" ||
-    !input.passConvergencePassed
+    !input.passConvergencePassed ||
+    input.pass1IncompleteCount >= PASS1_INCOMPLETENESS_THRESHOLD
   ) {
     return { confidence: "medium", reasons };
   }

--- a/lib/jobs/__tests__/finalize.confidence.test.ts
+++ b/lib/jobs/__tests__/finalize.confidence.test.ts
@@ -32,7 +32,10 @@ function makeCriterion(overrides: Partial<{ criterion_id: string; score_0_10: nu
   };
 }
 
-function makePassArtifact(passId: "pass1" | "pass2" | "pass3", criteria = [makeCriterion()]): PassArtifact {
+function makePassArtifact(
+  passId: "pass1" | "pass2" | "pass3",
+  criteria = CRITERIA_KEYS.map((criterionId) => makeCriterion({ criterion_id: criterionId })),
+): PassArtifact {
   return {
     id: `${passId}-artifact-id`,
     job_id: "job-1",
@@ -67,7 +70,7 @@ function makeConvergenceArtifact(overrides: Partial<ConvergenceArtifact> = {}): 
       pass2_artifact_id: "pass2-artifact-id",
       pass3_artifact_id: "pass3-artifact-id",
     },
-    merged_criteria: [makeCriterion()],
+    merged_criteria: CRITERIA_KEYS.map((criterionId) => makeCriterion({ criterion_id: criterionId })),
     overview_summary: "test overview",
     convergence_notes: [],
     conflicts_detected: [],
@@ -124,6 +127,7 @@ describe("buildConfidenceInputs", () => {
     expect(inputs.governancePassed).toBe(true);
     expect(inputs.passConvergencePassed).toBe(true);
     expect(inputs.hasMaterialPassDisagreement).toBe(false);
+    expect(inputs.pass1IncompleteCount).toBe(0);
     expect(inputs.evidenceCoverage).toBe("strong");
     expect(inputs.usedFallbackPath).toBe(false);
     expect(inputs.executionDegraded).toBe(false);
@@ -166,6 +170,24 @@ describe("buildConfidenceInputs", () => {
     const inputs = buildConfidenceInputs({ pass1, pass2, pass3, convergence });
 
     expect(inputs.evidenceCoverage).toBe("partial");
+  });
+
+  it("resolved incompleteness: missing pass1 criteria fully recovered in convergence => no penalty signal", () => {
+    const pass1 = makePassArtifact("pass1", [
+      makeCriterion({ criterion_id: CRITERIA_KEYS[0] }),
+      makeCriterion({ criterion_id: CRITERIA_KEYS[1] }),
+    ]);
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact({
+      merged_criteria: CRITERIA_KEYS.map((criterionId) =>
+        makeCriterion({ criterion_id: criterionId }),
+      ),
+    });
+
+    const inputs = buildConfidenceInputs({ pass1, pass2, pass3, convergence });
+
+    expect(inputs.pass1IncompleteCount).toBe(0);
   });
 });
 

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -107,6 +107,19 @@ export function buildConfidenceInputs(args: {
     return Math.max(...scores) - Math.min(...scores) > 3;
   });
 
+  // U2.1: unresolved Pass 1 incompleteness after downstream convergence.
+  // We count only criteria still absent from the convergence artifact, not raw Pass 1 gaps
+  // that were later recovered/resolved downstream.
+  const pass1CriterionIds = new Set(pass1.criteria.map((c) => c.criterion_id));
+  const convergenceCriterionIds = new Set(
+    convergence.merged_criteria.map((c) => c.criterion_id),
+  );
+  const pass1IncompleteCount = CRITERIA_KEYS.filter(
+    (criterionId) =>
+      !pass1CriterionIds.has(criterionId) &&
+      !convergenceCriterionIds.has(criterionId),
+  ).length;
+
   // Evidence coverage: strong if all passes report evidence_nonempty, partial if mixed
   const evidenceFlags = [pass1, pass2, pass3].map((p) => p.validations.evidence_nonempty);
   const evidenceCoverage: ConfidenceInputs["evidenceCoverage"] =
@@ -122,6 +135,7 @@ export function buildConfidenceInputs(args: {
     governancePassed,
     passConvergencePassed,
     hasMaterialPassDisagreement,
+    pass1IncompleteCount,
     usedFallbackPath: false,
     executionDegraded: false,
     invalidOutput: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "jest-environment-jsdom": "^30.2.0",
         "pg": "^8.18.0",
         "postcss": "^8.5.3",
-        "supabase": "^2.72.8",
         "tailwindcss": "^3.4.17",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.21.0",
@@ -172,6 +171,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -782,6 +782,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -805,30 +806,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2052,19 +2032,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -4856,6 +4823,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.10.0.tgz",
       "integrity": "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -4954,6 +4922,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
       "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.95.3",
         "@supabase/functions-js": "2.95.3",
@@ -5006,7 +4975,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5027,7 +4995,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5041,7 +5008,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -5052,7 +5018,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5067,8 +5032,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -5114,8 +5078,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5396,6 +5359,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5407,6 +5371,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6294,6 +6259,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6878,37 +6844,6 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
-    "node_modules/bin-links": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
-      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "read-cmd-shim": "^6.0.0",
-        "write-file-atomic": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/bin-links/node_modules/write-file-atomic": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
-      "integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6969,6 +6904,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7231,16 +7167,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -7344,16 +7270,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cmd-shim": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
-      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/cmdk": {
@@ -7537,7 +7453,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -7667,16 +7584,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -7750,6 +7657,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7959,8 +7867,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8026,7 +7933,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8388,6 +8296,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8570,6 +8479,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9239,40 +9149,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9423,19 +9299,6 @@
       },
       "engines": {
         "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -11414,6 +11277,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11443,6 +11307,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -11994,7 +11859,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12774,19 +12638,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -13042,16 +12893,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -13526,6 +13367,7 @@
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -13751,6 +13593,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13969,16 +13812,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -14085,6 +13918,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14111,6 +13945,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14124,6 +13959,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -14341,16 +14177,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/read-cmd-shim": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
-      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -14414,7 +14240,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -15544,69 +15371,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/supabase": {
-      "version": "2.90.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.90.0.tgz",
-      "integrity": "sha512-1CQAmrARl8oGsKKGl4LhF64qkPmdSMqw77EIhAdx/O5bly1CfnoXHwccGUiBImqlXHwQ3SvYZs8WMRm52V7VEQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bin-links": "^6.0.0",
-        "https-proxy-agent": "^9.0.0",
-        "node-fetch": "^3.3.2",
-        "tar": "7.5.13"
-      },
-      "bin": {
-        "supabase": "bin/supabase"
-      },
-      "engines": {
-        "npm": ">=8"
-      }
-    },
-    "node_modules/supabase/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/supabase/node_modules/https-proxy-agent": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
-      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/supabase/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15670,6 +15434,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15737,33 +15502,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/test-exclude": {
@@ -15931,6 +15669,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16089,6 +15828,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -16598,6 +16338,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17278,6 +17019,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "jest-environment-jsdom": "^30.2.0",
     "pg": "^8.18.0",
     "postcss": "^8.5.3",
-    "supabase": "^2.72.8",
     "tailwindcss": "^3.4.17",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary
Implements U2.1, the first propagation-integrity slice for confidence derivation.

This change makes unresolved Pass 1 incompleteness affect final confidence instead of being silently ignored.

## What changed
- added a new confidence input for unresolved Pass 1 incompleteness
- added the reason pass1_incompleteness_unresolved
- bumped the derivation version from u1.v1 to u2.v1
- added focused regression coverage for threshold and resolved-case behavior
- staged matching issue and PR artifacts under .artifacts/

## Verification
- focused derivation and finalizer tests passed
- broader governance and jobs suites passed: 14 suites, 151 tests

Closes #177