### PR TITLE
feat(u2.1-pre): structured Pass 1 warning propagation contract

### DIFF
--- a/lib/jobs/__tests__/finalize.warning-propagation.test.ts
+++ b/lib/jobs/__tests__/finalize.warning-propagation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "@jest/globals";
+import { countPass1UnresolvedWarnings } from "../finalize";
+import type {
+  ConvergenceArtifact,
+  CriterionAssessment,
+  EvaluationJob,
+  PassArtifact,
+} from "../finalize.types";
+
+function makeCriterion(overrides: Partial<CriterionAssessment> = {}): CriterionAssessment {
+  return {
+    criterion_id: overrides.criterion_id ?? "openingHook",
+    score_0_10: overrides.score_0_10 ?? 7,
+    rationale: overrides.rationale ?? "Rationale",
+    confidence_0_1: overrides.confidence_0_1 ?? 0.8,
+    evidence: overrides.evidence ?? [
+      {
+        anchor_id: "a1",
+        source_type: "manuscript_chunk",
+        source_ref: "chunk-1",
+        start_offset: 0,
+        end_offset: 42,
+        excerpt: "Excerpt",
+      },
+    ],
+    warnings: overrides.warnings ?? [],
+    quality_warnings: overrides.quality_warnings ?? [],
+    propagated_warnings: overrides.propagated_warnings ?? [],
+  };
+}
+
+function makePassArtifact(criteria: CriterionAssessment[]): PassArtifact {
+  return {
+    id: "pass1-artifact",
+    job_id: "job-1",
+    pass_id: "pass1",
+    schema_version: "1.0.0",
+    manuscript_revision_id: "rev-1",
+    generated_at: new Date().toISOString(),
+    summary: "summary",
+    criteria,
+    provenance: {
+      evaluator_version: "eval-v1",
+      prompt_pack_version: "pack-v1",
+      run_id: "run-1",
+    },
+    validations: {
+      schema_valid: true,
+      anchor_contract_valid: true,
+      evidence_nonempty: true,
+      orphan_reasoning_absent: true,
+    },
+  };
+}
+
+function makeConvergenceArtifact(criteria: CriterionAssessment[]): ConvergenceArtifact {
+  return {
+    id: "conv-1",
+    job_id: "job-1",
+    schema_version: "1.0.0",
+    generated_at: new Date().toISOString(),
+    inputs: {
+      pass1_artifact_id: "pass1-artifact",
+      pass2_artifact_id: "pass2-artifact",
+      pass3_artifact_id: "pass3-artifact",
+    },
+    merged_criteria: criteria,
+    overview_summary: "overview",
+    convergence_notes: [],
+    conflicts_detected: [],
+    conflicts_resolved: [],
+    validations: {
+      schema_valid: true,
+      pass_separation_preserved: true,
+      all_required_passes_present: true,
+      anchor_contract_valid: true,
+    },
+  };
+}
+
+describe("countPass1UnresolvedWarnings", () => {
+  it("counts unresolved pass1 quality_warnings from structured pass state", () => {
+    const pass1 = makePassArtifact([
+      makeCriterion({
+        quality_warnings: [
+          {
+            warning_code: "pass1_incomplete_evidence",
+            message: "Needs more evidence",
+            source_pass: "pass1",
+            resolution_status: "unresolved",
+          },
+          {
+            warning_code: "pass1_soft_warning",
+            message: "Already handled",
+            source_pass: "pass1",
+            resolution_status: "resolved",
+          },
+        ],
+      }),
+    ]);
+
+    const result = countPass1UnresolvedWarnings({ pass1 });
+
+    expect(result.pass1_unresolved_warning_count).toBe(1);
+    expect(result.used_fallback).toBe(false);
+  });
+
+  it("counts unresolved propagated_warnings from convergence state without counting pass2", () => {
+    const pass1 = makePassArtifact([makeCriterion()]);
+    const convergence = makeConvergenceArtifact([
+      makeCriterion({
+        propagated_warnings: [
+          {
+            warning_code: "pass1_missing_anchor",
+            message: "Missing anchor",
+            source_pass: "pass1",
+            resolution_status: "unresolved",
+          },
+          {
+            warning_code: "pass2_style_note",
+            message: "Pass 2 warning should not count",
+            source_pass: "pass2",
+            resolution_status: "unresolved",
+          },
+          {
+            warning_code: "pass1_resolved_warning",
+            message: "Resolved warning should not count",
+            source_pass: "pass1",
+            resolution_status: "resolved",
+          },
+        ],
+      }),
+    ]);
+
+    const result = countPass1UnresolvedWarnings({ pass1, convergence });
+
+    expect(result.pass1_unresolved_warning_count).toBe(1);
+    expect(result.used_fallback).toBe(false);
+  });
+
+  it("falls back to legacy warnings strings only when structured warning state is absent", () => {
+    const pass1 = makePassArtifact([
+      makeCriterion({ warnings: ["legacy-warning-1", "legacy-warning-2"] }),
+    ]);
+
+    const result = countPass1UnresolvedWarnings({ pass1 });
+
+    expect(result.pass1_unresolved_warning_count).toBe(2);
+    expect(result.used_fallback).toBe(true);
+  });
+});

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -30,6 +30,7 @@ import type {
   PersistInvalidCanonicalResult,
   MarkJobInvalidArgs,
   MarkJobFailedArgs,
+  Pass1WarningSummary,
 } from "./finalize.types";
 import type { FailureCode } from "./failures";
 import {
@@ -127,6 +128,59 @@ export function buildConfidenceInputs(args: {
     invalidOutput: false,
     quarantinedOutput: false,
     evidenceCoverage,
+  };
+}
+
+export function countPass1UnresolvedWarnings(args: {
+  pass1: PassArtifact;
+  convergence?: ConvergenceArtifact;
+}): Pass1WarningSummary {
+  const { pass1, convergence } = args;
+
+  const structuredWarnings = [
+    ...pass1.criteria.flatMap((criterion) => [
+      ...(criterion.quality_warnings ?? []).map((warning) => ({
+        criterion_id: criterion.criterion_id,
+        ...warning,
+      })),
+      ...(criterion.propagated_warnings ?? []).map((warning) => ({
+        criterion_id: criterion.criterion_id,
+        ...warning,
+      })),
+    ]),
+    ...(convergence?.merged_criteria ?? []).flatMap((criterion) => [
+      ...(criterion.quality_warnings ?? []).map((warning) => ({
+        criterion_id: criterion.criterion_id,
+        ...warning,
+      })),
+      ...(criterion.propagated_warnings ?? []).map((warning) => ({
+        criterion_id: criterion.criterion_id,
+        ...warning,
+      })),
+    ]),
+  ];
+
+  if (structuredWarnings.length > 0) {
+    const unresolvedPass1Warnings = new Set(
+      structuredWarnings
+        .filter(
+          (warning) => warning.source_pass === "pass1" && warning.resolution_status === "unresolved",
+        )
+        .map((warning) => `${warning.criterion_id}::${warning.warning_code}`),
+    );
+
+    return {
+      pass1_unresolved_warning_count: unresolvedPass1Warnings.size,
+      used_fallback: false,
+    };
+  }
+
+  return {
+    pass1_unresolved_warning_count: pass1.criteria.reduce(
+      (total, criterion) => total + criterion.warnings.length,
+      0,
+    ),
+    used_fallback: true,
   };
 }
 

--- a/lib/jobs/finalize.types.ts
+++ b/lib/jobs/finalize.types.ts
@@ -34,6 +34,24 @@ export interface EvidenceAnchor {
   excerpt: string | null;
 }
 
+export type WarningResolutionStatus = "unresolved" | "resolved";
+
+export type CriterionWarningCode =
+  | "pass1_incomplete"
+  | "pass1_incomplete_evidence"
+  | "pass1_missing_anchor"
+  | "pass1_missing_evidence"
+  | "pass1_conflict_requires_review"
+  | (string & {});
+
+export interface CriterionWarning {
+  warning_code: CriterionWarningCode;
+  message: string;
+  source_pass: PassId;
+  resolution_status: WarningResolutionStatus;
+  used_fallback?: boolean;
+}
+
 export interface CriterionAssessment {
   criterion_id: string;
   score_0_10: number;
@@ -41,6 +59,8 @@ export interface CriterionAssessment {
   confidence_0_1: number;
   evidence: EvidenceAnchor[];
   warnings: string[];
+  quality_warnings?: CriterionWarning[];
+  propagated_warnings?: CriterionWarning[];
 }
 
 // === Pass Artifact ===
@@ -90,6 +110,11 @@ export interface ConvergenceArtifact {
     all_required_passes_present: boolean;
     anchor_contract_valid: boolean;
   };
+}
+
+export interface Pass1WarningSummary {
+  pass1_unresolved_warning_count: number;
+  used_fallback: boolean;
 }
 
 // === Canonical Evaluation Artifact ===


### PR DESCRIPTION
Introduces the typed warning propagation seam between Pass 1 / Convergence and the Finalizer. Contract-only; consumers come in U2.1-final.

**Why:**
- Finalizer currently infers Pass 1 incompleteness from unstructured `warnings: string[]` via regex-style interpretation
- This PR establishes the structured producer/convergence seam: typed warning codes, explicit resolution status, and an unresolved-warning count contract
- U2.1-final will then consume this seam and remove the legacy-primary path

**Scope (contract only):**
- [lib/jobs/finalize.types.ts](lib/jobs/finalize.types.ts) — structured warning contract types and snake_case fields on artifact criterion shapes
- [lib/jobs/finalize.ts](lib/jobs/finalize.ts) — pure `countPass1UnresolvedWarnings` helper with legacy fallback bridge
- [lib/jobs/__tests__/finalize.warning-propagation.test.ts](lib/jobs/__tests__/finalize.warning-propagation.test.ts) — 3 focused seam tests
- No finalizer persistence changes
- No confidence derivation changes
- No regex-primary removal

**Casing source of truth:**
- [lib/jobs/finalize.types.ts](lib/jobs/finalize.types.ts) remains the authority
- New fields match repo-native snake_case: `quality_warnings`, `propagated_warnings`, `resolution_status`, `pass1_unresolved_warning_count`, `used_fallback`

**Verification:**
- `npm test -- --runInBand lib/jobs/__tests__/finalize.warning-propagation.test.ts lib/jobs/__tests__/finalize.confidence.test.ts tests/jobs/finalize.persistence.test.ts`
- Result: 3 suites passed, 19 tests passed, 0 failures

**Follow-up (U2.1-final):**
- Finalizer consumption of the new seam
- Removal of the legacy-primary warning fallback path
- Any downstream rename/cleanup once the structured seam is fully adopted