### PR TITLE
feat(u2.1-final): consume structured Pass 1 warning seam

### DIFF
--- a/lib/governance/__tests__/confidenceDerivation.test.ts
+++ b/lib/governance/__tests__/confidenceDerivation.test.ts
@@ -11,6 +11,7 @@ function makeBaseInput(overrides: Partial<ConfidenceInputs> = {}): ConfidenceInp
     governancePassed: true,
     passConvergencePassed: true,
     hasMaterialPassDisagreement: false,
+    pass1UnresolvedWarningCount: 0,
     usedFallbackPath: false,
     executionDegraded: false,
     invalidOutput: false,
@@ -49,6 +50,12 @@ describe("U1 confidence derivation", () => {
     const result = deriveConfidence(makeBaseInput({ usedFallbackPath: true }));
     expect(result.confidence).toBe("medium");
     expect(result.reasons).toContain("used_fallback_path");
+  });
+
+  test("4b) unresolved pass1 warnings + clean otherwise => medium", () => {
+    const result = deriveConfidence(makeBaseInput({ pass1UnresolvedWarningCount: 1 }));
+    expect(result.confidence).toBe("medium");
+    expect(result.reasons).toContain("pass1_unresolved_warnings_present");
   });
 
   test("5) passConvergencePassed=false + clean otherwise => medium", () => {

--- a/lib/governance/confidenceDerivation.ts
+++ b/lib/governance/confidenceDerivation.ts
@@ -23,6 +23,7 @@ export type ConfidenceReason =
   | "governance_block"
   | "pass_convergence_failed"
   | "pass_disagreement_material"
+  | "pass1_unresolved_warnings_present"
   | "used_fallback_path"
   | "execution_degraded"
   | "invalid_output"
@@ -36,6 +37,7 @@ export type ConfidenceInputs = {
   governancePassed: boolean;
   passConvergencePassed: boolean;
   hasMaterialPassDisagreement: boolean;
+  pass1UnresolvedWarningCount: number;
   usedFallbackPath: boolean;
   executionDegraded: boolean;
   invalidOutput: boolean;
@@ -69,6 +71,10 @@ export function deriveConfidence(input: ConfidenceInputs): ConfidenceResult {
 
   if (input.hasMaterialPassDisagreement) {
     reasons.push("pass_disagreement_material");
+  }
+
+  if (input.pass1UnresolvedWarningCount > 0) {
+    reasons.push("pass1_unresolved_warnings_present");
   }
 
   if (input.usedFallbackPath) {
@@ -116,6 +122,7 @@ export function deriveConfidence(input: ConfidenceInputs): ConfidenceResult {
 
   // Rule 3: medium confidence on degradations/partials.
   if (
+    input.pass1UnresolvedWarningCount > 0 ||
     input.usedFallbackPath ||
     input.executionDegraded ||
     input.evidenceCoverage === "partial" ||

--- a/lib/jobs/__tests__/finalize.confidence.test.ts
+++ b/lib/jobs/__tests__/finalize.confidence.test.ts
@@ -10,17 +10,18 @@ import type {
   PassArtifact,
   ConvergenceArtifact,
   EvaluationJob,
+  CriterionAssessment,
 } from "../finalize.types";
 
 // === Fixture Helpers ===
 
-function makeCriterion(overrides: Partial<{ criterion_id: string; score_0_10: number; confidence_0_1: number }> = {}) {
+function makeCriterion(overrides: Partial<CriterionAssessment> = {}): CriterionAssessment {
   return {
     criterion_id: overrides.criterion_id ?? CRITERIA_KEYS[0],
     score_0_10: overrides.score_0_10 ?? 7,
-    rationale: "test rationale",
+    rationale: overrides.rationale ?? "test rationale",
     confidence_0_1: overrides.confidence_0_1 ?? 0.85,
-    evidence: [{
+    evidence: overrides.evidence ?? [{
       anchor_id: "a1",
       source_type: "manuscript_chunk" as const,
       source_ref: "ref1",
@@ -28,7 +29,9 @@ function makeCriterion(overrides: Partial<{ criterion_id: string; score_0_10: nu
       end_offset: 100,
       excerpt: "test excerpt",
     }],
-    warnings: [],
+    warnings: overrides.warnings ?? [],
+    quality_warnings: overrides.quality_warnings ?? [],
+    propagated_warnings: overrides.propagated_warnings ?? [],
   };
 }
 
@@ -124,11 +127,24 @@ describe("buildConfidenceInputs", () => {
     expect(inputs.governancePassed).toBe(true);
     expect(inputs.passConvergencePassed).toBe(true);
     expect(inputs.hasMaterialPassDisagreement).toBe(false);
+    expect(inputs.pass1UnresolvedWarningCount).toBe(0);
     expect(inputs.evidenceCoverage).toBe("strong");
     expect(inputs.usedFallbackPath).toBe(false);
     expect(inputs.executionDegraded).toBe(false);
     expect(inputs.invalidOutput).toBe(false);
     expect(inputs.quarantinedOutput).toBe(false);
+  });
+
+  it("legacy warnings trigger fallback only when structured warning state is absent", () => {
+    const pass1 = makePassArtifact("pass1", [{ ...makeCriterion(), warnings: ["legacy-warning-1", "legacy-warning-2"] }]);
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const inputs = buildConfidenceInputs({ pass1, pass2, pass3, convergence });
+
+    expect(inputs.pass1UnresolvedWarningCount).toBe(2);
+    expect(inputs.usedFallbackPath).toBe(true);
   });
 
   it("material disagreement: >3pt spread triggers flag", () => {
@@ -201,6 +217,61 @@ describe("buildCanonicalArtifact confidence wiring", () => {
     // With material disagreement + partial evidence, should not be "high"
     expect(canonical.governance.confidence_label).not.toBe("high");
     expect(canonical.governance.confidence_reasons!.length).toBeGreaterThan(0);
+  });
+
+  it("unresolved structured pass1 warnings downgrade confidence without using fallback", () => {
+    const job = makeJob();
+    const pass1 = makePassArtifact("pass1", [
+      {
+        ...makeCriterion(),
+        quality_warnings: [
+          {
+            warning_code: "pass1_incomplete_evidence",
+            message: "Needs more evidence",
+            source_pass: "pass1",
+            resolution_status: "unresolved",
+          },
+        ],
+      },
+    ]);
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const inputs = buildConfidenceInputs({ pass1, pass2, pass3, convergence });
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+
+    expect(inputs.pass1UnresolvedWarningCount).toBe(1);
+    expect(inputs.usedFallbackPath).toBe(false);
+    expect(canonical.governance.confidence_label).toBe("medium");
+    expect(canonical.governance.confidence_reasons).toContain("pass1_unresolved_warnings_present");
+  });
+
+  it("resolved structured pass1 warnings do not trigger a confidence penalty", () => {
+    const job = makeJob();
+    const pass1 = makePassArtifact("pass1", [
+      {
+        ...makeCriterion(),
+        quality_warnings: [
+          {
+            warning_code: "pass1_incomplete_evidence",
+            message: "Handled",
+            source_pass: "pass1",
+            resolution_status: "resolved",
+          },
+        ],
+      },
+    ]);
+    const pass2 = makePassArtifact("pass2");
+    const pass3 = makePassArtifact("pass3");
+    const convergence = makeConvergenceArtifact();
+
+    const inputs = buildConfidenceInputs({ pass1, pass2, pass3, convergence });
+    const canonical = buildCanonicalArtifact({ job, pass1, pass2, pass3, convergence });
+
+    expect(inputs.pass1UnresolvedWarningCount).toBe(0);
+    expect(canonical.governance.confidence_label).toBe("high");
+    expect(canonical.governance.confidence_reasons).toEqual([]);
   });
 });
 

--- a/lib/jobs/__tests__/finalize.warning-propagation.test.ts
+++ b/lib/jobs/__tests__/finalize.warning-propagation.test.ts
@@ -148,4 +148,27 @@ describe("countPass1UnresolvedWarnings", () => {
     expect(result.pass1_unresolved_warning_count).toBe(2);
     expect(result.used_fallback).toBe(true);
   });
+
+  it("falls back for pass1 when only non-pass1 structured warnings are present during rollout", () => {
+    const pass1 = makePassArtifact([
+      makeCriterion({ warnings: ["legacy-pass1-warning"] }),
+    ]);
+    const convergence = makeConvergenceArtifact([
+      makeCriterion({
+        propagated_warnings: [
+          {
+            warning_code: "pass2_style_note",
+            message: "Pass 2 warning only",
+            source_pass: "pass2",
+            resolution_status: "unresolved",
+          },
+        ],
+      }),
+    ]);
+
+    const result = countPass1UnresolvedWarnings({ pass1, convergence });
+
+    expect(result.pass1_unresolved_warning_count).toBe(1);
+    expect(result.used_fallback).toBe(true);
+  });
 });

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -163,12 +163,14 @@ export function countPass1UnresolvedWarnings(args: {
     ]),
   ];
 
-  if (structuredWarnings.length > 0) {
+  const structuredPass1Warnings = structuredWarnings.filter(
+    (warning) => warning.source_pass === "pass1",
+  );
+
+  if (structuredPass1Warnings.length > 0) {
     const unresolvedPass1Warnings = new Set(
-      structuredWarnings
-        .filter(
-          (warning) => warning.source_pass === "pass1" && warning.resolution_status === "unresolved",
-        )
+      structuredPass1Warnings
+        .filter((warning) => warning.resolution_status === "unresolved")
         .map((warning) => `${warning.criterion_id}::${warning.warning_code}`),
     );
 

--- a/lib/jobs/finalize.ts
+++ b/lib/jobs/finalize.ts
@@ -117,13 +117,16 @@ export function buildConfidenceInputs(args: {
         ? "partial"
         : "thin";
 
+  const warningSummary = countPass1UnresolvedWarnings({ pass1, convergence });
+
   return {
     criterionCompletenessPassed,
     anchorIntegrityPassed,
     governancePassed,
     passConvergencePassed,
     hasMaterialPassDisagreement,
-    usedFallbackPath: false,
+    pass1UnresolvedWarningCount: warningSummary.pass1_unresolved_warning_count,
+    usedFallbackPath: warningSummary.used_fallback,
     executionDegraded: false,
     invalidOutput: false,
     quarantinedOutput: false,
@@ -175,12 +178,14 @@ export function countPass1UnresolvedWarnings(args: {
     };
   }
 
+  const legacyWarningCount = pass1.criteria.reduce(
+    (total, criterion) => total + criterion.warnings.length,
+    0,
+  );
+
   return {
-    pass1_unresolved_warning_count: pass1.criteria.reduce(
-      (total, criterion) => total + criterion.warnings.length,
-      0,
-    ),
-    used_fallback: true,
+    pass1_unresolved_warning_count: legacyWarningCount,
+    used_fallback: legacyWarningCount > 0,
   };
 }
 


### PR DESCRIPTION
Consumes the structured Pass 1 warning propagation seam introduced in U2.1-pre and updates finalizer confidence behavior to prefer structured unresolved-warning state over legacy string parsing.

**Why:**
- The producer/convergence seam now exists on main from U2.1-pre
- Finalizer confidence should consume that seam directly instead of relying on legacy-only inference
- This keeps fallback as a bridge only when structured warning state is absent

**Scope:**
- [lib/jobs/finalize.ts](lib/jobs/finalize.ts) — build confidence inputs from the structured warning seam and keep fallback secondary
- [lib/governance/confidenceDerivation.ts](lib/governance/confidenceDerivation.ts) — add the structured unresolved-warning reason and medium-confidence handling
- [lib/jobs/__tests__/finalize.confidence.test.ts](lib/jobs/__tests__/finalize.confidence.test.ts) and [lib/governance/__tests__/confidenceDerivation.test.ts](lib/governance/__tests__/confidenceDerivation.test.ts) — prove resolved warning → no penalty, unresolved warning → penalty eligible, fallback only when structured state is absent

**Out of scope:**
- No producer-side seam changes
- No workflow or lockfile edits
- No broader confidence-policy rewrite

**Verification:**
- `npm test -- --runInBand lib/governance/__tests__/confidenceDerivation.test.ts lib/jobs/__tests__/finalize.confidence.test.ts lib/jobs/__tests__/finalize.warning-propagation.test.ts tests/jobs/finalize.persistence.test.ts`
- Result: 4 suites passed, 40 tests passed, 0 failures