### PR TITLE
fix(pass4): harden Perplexity JSON parsing and fail-soft retry

### DIFF
--- a/lib/evaluation/pipeline/perplexityCrossCheck.ts
+++ b/lib/evaluation/pipeline/perplexityCrossCheck.ts
@@ -103,6 +103,7 @@ type PerplexityResponseShape = {
 
 const PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_MODEL = "sonar-reasoning-pro";
+const PERPLEXITY_MAX_TOKENS = 3000;
 const DISPUTE_THRESHOLD = 1.0;
 
 const CRITERION_KEYS: CriterionKey[] = [
@@ -255,6 +256,69 @@ function validateCanonCompleteness(
     reasons,
   };
 }
+
+function extractPerplexityResponseText(rawContent: unknown): string {
+  if (typeof rawContent === "string") {
+    return rawContent;
+  }
+
+  if (Array.isArray(rawContent)) {
+    return rawContent
+      .map((item) => {
+        if (typeof item === "string") {
+          return item;
+        }
+
+        if (!item || typeof item !== "object") {
+          return "";
+        }
+
+        const record = item as { text?: unknown; content?: unknown };
+        if (typeof record.text === "string") {
+          return record.text;
+        }
+        if (typeof record.content === "string") {
+          return record.content;
+        }
+        return "";
+      })
+      .join("")
+      .trim();
+  }
+
+  if (rawContent && typeof rawContent === "object") {
+    const record = rawContent as { text?: unknown; content?: unknown };
+    if (typeof record.text === "string") {
+      return record.text;
+    }
+    if (typeof record.content === "string") {
+      return record.content;
+    }
+  }
+
+  return "";
+}
+
+function getRetryPass4MaxTokens(currentMaxTokens: number): number {
+  return Math.min(5000, Math.max(PERPLEXITY_MAX_TOKENS, currentMaxTokens + 1000));
+}
+
+function isRetryableBoundaryFailure(error: unknown): boolean {
+  return (
+    error instanceof JsonBoundaryError &&
+    (error.code === "JSON_PARSE_FAILED_EMPTY" ||
+      error.code === "JSON_PARSE_FAILED_NO_OBJECT" ||
+      error.code === "JSON_PARSE_FAILED_TRUNCATED")
+  );
+}
+
+function parsePerplexityResponse(rawContent: string): PerplexityResponseShape {
+  const boundary = parseJsonObjectBoundary<Record<string, unknown>>(rawContent, {
+    label: "Pass4",
+  });
+  return validateParsedResponse(boundary.value);
+}
+
 export async function runPerplexityCrossCheck(opts: {
   openaiCriteria: Record<CriterionKey, OpenAICriterionInput>;
   openaiSynthesis: string;
@@ -343,64 +407,87 @@ PRIMARY EVALUATOR SYNTHESIS:
 ${openaiSynthesis?.slice(0, 900) ?? "(none)"}
 
 Now return the independent adjudication as JSON.`;
-  const response = await fetch(`${PERPLEXITY_BASE_URL}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${perplexityApiKey}`,
-    },
-    body: JSON.stringify({
-      model: PERPLEXITY_MODEL,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      temperature: 0.1,
-      max_tokens: 3000,
-      return_citations: false,
-    }),
-  });
 
-  if (!response.ok) {
-    const errText = await response.text();
-    throw new Error(
-      `[Pass4] Perplexity API error ${response.status}: ${errText.slice(0, 400)}`
-    );
-  }
+  const requestCompletion = async (maxTokens: number) => {
+    const response = await fetch(`${PERPLEXITY_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${perplexityApiKey}`,
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.1,
+        max_tokens: maxTokens,
+        return_citations: false,
+      }),
+    });
 
-  const raw = await response.json();
-  const rawContent: string = raw?.choices?.[0]?.message?.content ?? "";
-  const finishReason = typeof raw?.choices?.[0]?.finish_reason === "string"
-    ? raw.choices[0].finish_reason
-    : "unknown";
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(
+        `[Pass4] Perplexity API error ${response.status}: ${errText.slice(0, 400)}`
+      );
+    }
 
-  // P0: Check finish_reason — log a warning if the model stopped due to token limit
-  const finishReasonWarning = raw?.choices?.[0]?.finish_reason;
-  if (finishReasonWarning === "length") {
+    const raw = await response.json();
+    const rawMessageContent = raw?.choices?.[0]?.message?.content;
+    const rawContent = extractPerplexityResponseText(rawMessageContent);
+    const finishReason = typeof raw?.choices?.[0]?.finish_reason === "string"
+      ? raw.choices[0].finish_reason
+      : "unknown";
+
+    return { rawContent, finishReason };
+  };
+
+  const warnings: string[] = [];
+  let activeMaxTokens = PERPLEXITY_MAX_TOKENS;
+  let { rawContent, finishReason } = await requestCompletion(activeMaxTokens);
+
+  if (finishReason === "length") {
     console.warn("[Pass4] finish_reason=length — Perplexity output may be truncated", {
       model: PERPLEXITY_MODEL,
       rawContentLen: rawContent.length,
+      maxTokens: activeMaxTokens,
     });
   }
 
-  // P0: Log raw response preview before parse
   console.log(`[Pass4] raw Perplexity response preview len=${rawContent.length}: ${rawContent.slice(0, 200)}`);
 
   let parsed: PerplexityResponseShape;
   try {
-    const boundary = parseJsonObjectBoundary<Record<string, unknown>>(rawContent, {
-      label: "Pass4",
-    });
-    parsed = validateParsedResponse(boundary.value);
+    parsed = parsePerplexityResponse(rawContent);
   } catch (error) {
-    if (error instanceof JsonBoundaryError) {
+    const shouldRetry = finishReason === "length" || isRetryableBoundaryFailure(error);
+    if (shouldRetry) {
+      const retryMaxTokens = getRetryPass4MaxTokens(activeMaxTokens);
+      warnings.push("Perplexity cross-check required a retry after a truncated or incomplete JSON response.");
+      console.warn("[Pass4] Retrying Perplexity cross-check with higher token budget", {
+        model: PERPLEXITY_MODEL,
+        initialMaxTokens: activeMaxTokens,
+        retryMaxTokens,
+        finishReason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      activeMaxTokens = retryMaxTokens;
+      ({ rawContent, finishReason } = await requestCompletion(activeMaxTokens));
+      console.log(`[Pass4] retry raw Perplexity response preview len=${rawContent.length}: ${rawContent.slice(0, 200)}`);
+
+      parsed = parsePerplexityResponse(rawContent);
+    } else if (error instanceof JsonBoundaryError) {
       throw new Error(
         `[Pass4] ${error.code}: ${error.message}`
       );
+    } else {
+      throw new Error(
+        `[Pass4] JSON parse/validation failed: ${(error as Error).message}`
+      );
     }
-    throw new Error(
-      `[Pass4] JSON parse/validation failed: ${(error as Error).message}`
-    );
   }
 
   const criteria = {} as Record<CriterionKey, CrossCheckCriterionResult>;
@@ -502,6 +589,7 @@ Now return the independent adjudication as JSON.`;
     criteria,
     perplexitySynthesisNote: parsed.synthesisNote ?? "",
     canonValid: invalidCriteria.length === 0,
+    warnings: warnings.length > 0 ? warnings : undefined,
     rawPerplexityResponse: rawContent,
   };
 }

--- a/tests/evaluation/pipeline/perplexityCrossCheck.test.ts
+++ b/tests/evaluation/pipeline/perplexityCrossCheck.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  runPerplexityCrossCheck,
+  type CriterionKey,
+  type OpenAICriterionInput,
+} from "@/lib/evaluation/pipeline/perplexityCrossCheck";
+
+const PASS4_KEYS: CriterionKey[] = [
+  "concept",
+  "narrativeDrive",
+  "character",
+  "voice",
+  "sceneConstruction",
+  "dialogue",
+  "theme",
+  "worldbuilding",
+  "pacing",
+  "proseControl",
+  "tone",
+  "emotionalResonance",
+  "marketability",
+];
+
+function makeOpenAICriteria(): Record<CriterionKey, OpenAICriterionInput> {
+  return Object.fromEntries(
+    PASS4_KEYS.map((key) => [
+      key,
+      {
+        score: 7,
+        rationale: `OpenAI rationale for ${key}.`,
+        evidence: ["The river moved slowly through the valley."],
+        detectedSignals: ["scene pressure", "voice consistency"],
+        scoringBand: "7-8",
+      },
+    ]),
+  ) as Record<CriterionKey, OpenAICriterionInput>;
+}
+
+function makePerplexityPayload() {
+  return {
+    criteria: Object.fromEntries(
+      PASS4_KEYS.map((key) => [
+        key,
+        {
+          score: 7,
+          rationale: `Perplexity rationale for ${key}.`,
+          evidence: [
+            {
+              quote: "The river moved slowly through the valley.",
+              explanation: `Evidence for ${key}.`,
+            },
+          ],
+          detectedSignals: ["scene pressure", "voice consistency"],
+          scoringBand: "7-8",
+          doctrineTrace: ["signal-grounded scoring"],
+        },
+      ]),
+    ),
+    synthesisNote: "Cross-check agrees with the primary evaluation.",
+  };
+}
+
+type MockResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+function makeFetchResponse(content: unknown, finishReason = "stop"): MockResponse {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [
+        {
+          finish_reason: finishReason,
+          message: { content },
+        },
+      ],
+    }),
+    text: async () => JSON.stringify({ choices: [{ message: { content } }] }),
+  };
+}
+
+describe("runPerplexityCrossCheck", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("parses JSON returned in Perplexity content blocks", async () => {
+    const payload = makePerplexityPayload();
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
+      makeFetchResponse([
+        {
+          type: "output_text",
+          text: `\`\`\`json\n${JSON.stringify(payload)}\n\`\`\``,
+        },
+      ]) as unknown as Response,
+    );
+    global.fetch = fetchMock;
+
+    const result = await runPerplexityCrossCheck({
+      openaiCriteria: makeOpenAICriteria(),
+      openaiSynthesis: "Primary evaluator synthesis.",
+      manuscriptExcerpt: "The river moved slowly through the valley.",
+      workType: "literary_fiction",
+      title: "The Valley",
+      perplexityApiKey: "pplx-test",
+    });
+
+    expect(result.canonValid).toBe(true);
+    expect(result.overallAgreement).toBe("STRONG");
+    expect(result.disputedCriteria).toHaveLength(0);
+  });
+
+  it("retries once with a higher token budget when the first response is truncated", async () => {
+    const payload = makePerplexityPayload();
+    const fullJson = JSON.stringify(payload);
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeFetchResponse(fullJson.slice(0, Math.floor(fullJson.length / 2)), "length") as unknown as Response,
+      )
+      .mockResolvedValueOnce(makeFetchResponse(fullJson) as unknown as Response);
+    global.fetch = fetchMock;
+
+    const result = await runPerplexityCrossCheck({
+      openaiCriteria: makeOpenAICriteria(),
+      openaiSynthesis: "Primary evaluator synthesis.",
+      manuscriptExcerpt: "The river moved slowly through the valley.",
+      workType: "literary_fiction",
+      title: "The Valley",
+      perplexityApiKey: "pplx-test",
+    });
+
+    expect(result.canonValid).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body ?? "{}"));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body ?? "{}"));
+    expect(secondBody.max_tokens).toBeGreaterThan(firstBody.max_tokens);
+  });
+});

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -387,6 +387,45 @@ describe("runPipeline (e2e with injected runners)", () => {
     }
   });
 
+  it("keeps Pass 4 fail-soft when Perplexity returns malformed JSON", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { content: "{ this: is invalid }" },
+          },
+        ],
+      }),
+      text: async () => "{ this: is invalid }",
+    } as Response);
+
+    try {
+      const result = await runPipeline({
+        manuscriptText: "The river moved slowly through the valley. She watched from the bank.",
+        workType: "literary_fiction",
+        title: "The Valley",
+        openaiApiKey: "sk-test",
+        perplexityApiKey: "pplx-test",
+        _runners: {
+          runPass1: mockRunPass1,
+          runPass2: mockRunPass2,
+          runPass3Synthesis: mockRunPass3,
+        },
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.quality_gate.pass).toBe(true);
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it("dedupes duplicate recommendation actions pre-gate so quality gate can pass", async () => {
     const synthesisWithDupes = makeSynthesisOutput();
     const duplicateAction =


### PR DESCRIPTION
## Summary

This follow-up keeps scope tightly limited to Pass 4 cross-check resilience.

## What changed

- handle malformed and truncated Perplexity JSON responses more defensively
- retry once with a higher token budget when the first response is clearly incomplete or length-limited
- support content-block style response payloads during extraction
- preserve the existing fail-soft contract so Pass 4 issues do not block evaluation completion
- add focused regression coverage for malformed JSON and truncation retry behavior

## Verification

- focused Pass 4 suite passed: 2 suites, 25 tests
- full TypeScript compile passed
- fail-soft behavior remains intact in pipeline e2e coverage

## Scope discipline

This PR does not change Pass 1 through Pass 3 behavior and does not re-open the already merged stabilization work. It is only the narrow Pass 4 resilience follow-up.
