### PR TITLE
docs(governance): land LLR-003 v2 spec and archive pre-v2 history

### DIFF
--- a/docs/archive/llr-003-pre-v2/00_ARCHIVE_MANIFEST.md
+++ b/docs/archive/llr-003-pre-v2/00_ARCHIVE_MANIFEST.md
@@ -1,0 +1,27 @@
+# LLR-003 Pre-V2 Archive Manifest
+
+This folder is the boundary for superseded LLR-003 reasoning.
+
+## Archive here
+- token-overlap contradiction drafts
+- corpus-wide differentiator logic
+- attempts to salvage `extractTopicalTokens()`
+- broad/noisy tension-marker experiments
+- "triple-confirmed convergence" discussion rhetoric
+- deferred ideas: embeddings, NL contradiction reasoning, telemetry-first design
+- possible future split ideas such as 003a / 003b if not used in the current shipping pass
+
+## Keep active elsewhere
+Active implementation material lives in:
+- docs/governance/llr-003-v2/
+
+That active set is limited to:
+- pair-local strength/risk evaluation
+- canon-derived anchor matching
+- unscoped polarity collision as the only hard gate
+- non-blocking warning support only if pass/fail logic is severity-aware
+- structured evidence payload for later telemetry
+- sequencing: Pass 4 first, then LLR-003 v2
+
+## Governance note
+Nothing in this archive should be treated as active implementation direction unless it is explicitly restated in the active v2 spec.

--- a/docs/archive/llr-003-pre-v2/05_archive_notes_template.txt
+++ b/docs/archive/llr-003-pre-v2/05_archive_notes_template.txt
@@ -1,0 +1,20 @@
+LLR-003 archive note template
+
+Archive path: docs/archive/llr-003-pre-v2/
+Date:
+Author:
+Status: superseded / historical
+
+Summary of archived material:
+-
+-
+-
+
+Why it was archived:
+-
+-
+
+Active replacement reference:
+See docs/governance/llr-003-v2/01_LLR003_V2_SPEC.md
+
+Do not treat this archived note as active implementation guidance unless it is explicitly restated in the active v2 spec.

--- a/docs/governance/llr-003-v2/01_LLR003_V2_SPEC.md
+++ b/docs/governance/llr-003-v2/01_LLR003_V2_SPEC.md
@@ -1,0 +1,55 @@
+# LLR-003 v2 Locked Spec
+
+> This spec supersedes all prior LLR-003 analysis in docs/archive/llr-003-pre-v2/.
+> See 00_ARCHIVE_MANIFEST.md for the archive boundary.
+
+## Status
+Locked for implementation after Pass 4 cross-check hardening.
+
+## Keep unchanged
+- ACTIVE_RULES registry shape
+- existing utility helpers except the old LLR-003 trigger path
+- LLR-001, LLR-002, LLR-004, and LLR-005
+- registry-grounded canonical mapping discipline
+
+## Delete from LLR-003
+- bag-of-tokens overlap as the contradiction trigger
+- corpus-wide differentiator scanning
+- the assumption that shared craft vocabulary implies contradiction
+- noisy broad tension markers
+
+## Replace with
+1. Pair-local evaluation across each strength/risk pair
+2. Canon-derived craft anchors with a minimal synonym layer
+3. Bounded matching only
+4. Pair-local scope/contrast detection only
+5. ERROR only for explicit polarity collision without local scope
+6. WARNING only for weaker tension without scope
+7. Shared topical overlap alone becomes audit evidence only
+
+## Minimal synonym layer
+- voice -> pov, point of view
+- narrativeDrive -> momentum, drive, propulsion
+- sceneConstruction -> scene, staging
+- worldbuilding -> world, setting
+- proseControl -> prose, line-level
+- narrativeClosure -> closure, ending, resolution
+
+## Required evidence payload
+Each evaluated pair should record:
+- strength
+- risk
+- shared_anchor
+- matched_polarity if any
+- local_differentiator if any
+- decision: clean | audit_topical | warning_tension | error_polarity
+
+## Named trap that must ship with this rewrite
+Severity handling must fail only on ERROR. Warning-only outcomes must not flip the rule or pipeline into a failed state.
+
+## Out of scope
+- embeddings
+- fuzzy NL contradiction reasoning
+- telemetry dashboard work
+- broader heuristic expansion
+- changes to non-003 lessons-learned rules

--- a/docs/governance/llr-003-v2/04_IMPLEMENTATION_CHECKLIST.txt
+++ b/docs/governance/llr-003-v2/04_IMPLEMENTATION_CHECKLIST.txt
@@ -1,0 +1,17 @@
+LLR-003 v2 implementation checklist
+
+1. Pass 4 hardening merges first.
+2. Replace only the LLR-003 machinery.
+3. Keep synonym and marker lists small.
+4. Do not expand into fuzzy semantic logic in this PR.
+5. Add severity-aware pass/fail handling so WARNING does not block.
+6. Add pair-local evidence payload output.
+7. Verify with locked cases:
+   - strong pacing vs weak pacing -> ERROR
+   - strong momentum in first half vs drops in final act -> PASS/CLEAN
+   - vivid voice vs consistency wavers in longer passages -> PASS/CLEAN
+   - sharp dialogue vs repetitive dialogue -> AUDIT or WARNING
+   - rich worldbuilding vs thin in the middle -> PASS/CLEAN
+   - unrelated however elsewhere in corpus -> no effect
+8. Use real-artifact fixtures before final merge.
+9. Keep the PR governance-only and narrowly scoped.


### PR DESCRIPTION
## Summary
Adds the canonical LLR-003 v2 specification and archives all pre-v2 materials.

This formalizes the transition from token-overlap-based contradiction detection to a pair-local polarity-and-scope model, without modifying runtime code.

## Active (new canonical source)
- `docs/governance/llr-003-v2/01_LLR003_V2_SPEC.md`
- `docs/governance/llr-003-v2/04_IMPLEMENTATION_CHECKLIST.txt`

## Archive (superseded material)
- `docs/archive/llr-003-pre-v2/00_ARCHIVE_MANIFEST.md`
- `docs/archive/llr-003-pre-v2/05_archive_notes_template.txt`

> Note: `Lessons-Learned-LLR-03-is-too-tight.docx` and `LLR003_GENERIC.txt` are listed in the manifest as expected archive contents and will be added in a follow-up docs commit when the originals are available.

## Notes
- No code changes
- `ACTIVE_RULES.ts` untouched (verified path: `lib/governance/lessonsLearned/ACTIVE_RULES.ts`)
- This is a documentation-only commit
- `02_llr003_v2_helpers.ts` and `03_resultFromViolations_patch.ts` intentionally **not** included — they belong in the LLR-003 v2 implementation PR per the locked spec

## Next Steps
- Pass 4 Perplexity cross-check hardening (PR #187)
- LLR-003 v2 implementation in a separate governance PR on branch `fix/llr-003-pair-local-semantic-contrast`