### PR TITLE
ci: harden workflow checkout with fetch-depth: 0

### DIFF
--- a/.github/workflows/canon.yml
+++ b/.github/workflows/canon.yml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Run Canon Guard
         run: bash ./scripts/canon-guard.sh

--- a/.github/workflows/ci-staging-tests.yml
+++ b/.github/workflows/ci-staging-tests.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -46,6 +48,8 @@ jobs:
       CANON_VERSION: v1
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
@@ -71,6 +75,8 @@ jobs:
       TEST_MODE: "true"
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"

--- a/.github/workflows/fixture-guard.yml
+++ b/.github/workflows/fixture-guard.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/flow1-proof-pack.yml
+++ b/.github/workflows/flow1-proof-pack.yml
@@ -14,6 +14,8 @@ jobs:
       # "expected 'packfile'" during checkout. actions/checkout@v5 has built-in retry logic
       # that recovers. The annotation is informational (shows retry worked), not a failure.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
@@ -40,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
@@ -56,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
@@ -74,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
           node-version: "24"

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -143,6 +143,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Debug Supabase URL
         run: |
@@ -360,6 +362,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/phase1-evidence.yml
+++ b/.github/workflows/phase1-evidence.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/phase2c-evidence.yml
+++ b/.github/workflows/phase2c-evidence.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/phase2d-evidence.yml
+++ b/.github/workflows/phase2d-evidence.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/phase2e-anchor-guard.yml
+++ b/.github/workflows/phase2e-anchor-guard.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Verify anchors in PHASE2E_STATUS.md
         shell: bash

--- a/.github/workflows/phase2e-evidence.yml
+++ b/.github/workflows/phase2e-evidence.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Verify required secrets are present (no values printed)
         env:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          fetch-depth: 1  # Shallow clone (faster, sufficient for full-repo scan)
+          fetch-depth: 0
       
       - name: Run secret scanner on full repository
         run: |


### PR DESCRIPTION
## Summary
- add `fetch-depth: 0` to workflow checkout steps across all 13 workflow files
- standardize full-history checkout behavior to reduce shallow-clone git issues in CI
- keep this change workflow-only with no reusable-workflow or gate-file changes

## Notes
- no `workflow_call` conversion in this PR
- no `ref:` forcing added
- no trigger, permission, concurrency, or step-order changes
- `secret-scan.yml` moves from `fetch-depth: 1` to `fetch-depth: 0` for consistency with the hardening pass

## Why
This is Phase 2 of evaluation hardening: a minimal checkout-history hardening sweep intended to eliminate the shallow-clone cause of this class of warnings without changing workflow contracts or orchestration. Other root causes of `git` exit code 128 would require separate fixes if they surface.
