### PR TITLE
fix(ci): unmask migration setup failure in Job System CI Supabase-Backed Job Tests

### DIFF
--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -382,8 +382,48 @@ jobs:
         with:
           version: latest
 
+      - name: Validate migration prerequisites
+        id: migration_prereqs
+        shell: bash
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+
+          [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]] && missing+=("SUPABASE_ACCESS_TOKEN")
+          [[ -z "${SUPABASE_PROJECT_REF:-}" ]] && missing+=("SUPABASE_PROJECT_REF")
+          [[ -z "${SUPABASE_DB_URL:-}" ]] && missing+=("SUPABASE_DB_URL")
+
+          EFFECTIVE_DB_PASSWORD="${SUPABASE_DB_PASSWORD:-}"
+
+          if [[ -z "${EFFECTIVE_DB_PASSWORD}" && -n "${SUPABASE_DB_URL:-}" ]]; then
+            DERIVED_DB_PASSWORD="$(python3 -c 'import os, urllib.parse; u=os.environ.get("SUPABASE_DB_URL", ""); print(urllib.parse.unquote(urllib.parse.urlparse(u).password or "") if u else "")')"
+            if [[ -n "${DERIVED_DB_PASSWORD}" ]]; then
+              echo "✅ Derived SUPABASE_DB_PASSWORD from SUPABASE_DB_URL"
+              EFFECTIVE_DB_PASSWORD="${DERIVED_DB_PASSWORD}"
+            fi
+          fi
+
+          if [[ -z "${EFFECTIVE_DB_PASSWORD}" ]]; then
+            missing+=("SUPABASE_DB_PASSWORD")
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Migration prerequisites missing: ${missing[*]}"
+            echo "prereqs_ok=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          echo "prereqs_ok=true" >> "$GITHUB_OUTPUT"
+
       - name: Apply migrations to CI Supabase
-        continue-on-error: true
+        if: steps.migration_prereqs.outputs.prereqs_ok == 'true'
+        shell: bash
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

Make `Job System CI / Supabase-Backed Job Tests` truthful by removing the current “red inside green” behavior in the migration-apply path.

## Problem

`Apply migrations to CI Supabase` can fail with exit code 1 while the job continues and still concludes success.

This allows a prerequisite setup failure to coexist with passing downstream checks, weakening confidence in Evaluation Process 2.0.

## What changed

- added an explicit migration prerequisite validation step
- removed masking behavior from the real migration-apply path
- required a usable `SUPABASE_DB_PASSWORD` or validated derivation path before running migrations
- preserved downstream verification only after migration setup truthfully succeeds

## Why

Evaluation Process 2.0 should not allow CI to report green when required migration setup failed.

## Acceptance criteria

- [x] No prerequisite migration/setup failure is silently masked
- [x] Migration path is fail-closed by default
- [x] One verification PR run demonstrates truthful green/red behavior
- [x] No step with `continue-on-error: true` masks a failing prerequisite without an explicit downstream gate

## Out of scope

- stale `.worktrees/pr116` checkout-cleanup warning (#192)
- Node 20 action runtime deprecations (#193)

## Related

- #191
- #192
- #193
- #190
