### PR TITLE
chore(ci): remove deprecated Node 20 Supabase setup action runtime

### DIFF
--- a/.github/workflows/flow1-proof-pack.yml
+++ b/.github/workflows/flow1-proof-pack.yml
@@ -23,9 +23,13 @@ jobs:
           cache: "npm"
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz -o /tmp/supabase.tar.gz
+          tar -xzf /tmp/supabase.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/supabase /usr/local/bin/supabase
+          supabase --version
 
       - name: Install deps
         run: npm ci

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -378,9 +378,13 @@ jobs:
         run: mkdir -p scripts-artifacts
 
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz -o /tmp/supabase.tar.gz
+          tar -xzf /tmp/supabase.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/supabase /usr/local/bin/supabase
+          supabase --version
 
       - name: Validate migration prerequisites
         id: migration_prereqs


### PR DESCRIPTION
## Summary
- replace `supabase/setup-cli@v1` in CI workflows with direct Supabase CLI binary installation
- keep runtime and behavior unchanged beyond installation method

## Why
`supabase/setup-cli@v1` runs on `node20`, which is deprecated in GitHub Actions runtime notices. This PR removes the Node 20 action-runtime dependency from our workflows while preserving existing CI gates.

## Scope
- in scope: Node 20 action-runtime cleanup for Supabase CLI setup (#193)
- out of scope: `.worktrees` cleanup, workflow redesign, branch protection changes

Closes #193
