### PR TITLE
chore(ci): pin Supabase CLI with SHA-256 verification

### DIFF
--- a/.github/workflows/flow1-proof-pack.yml
+++ b/.github/workflows/flow1-proof-pack.yml
@@ -26,8 +26,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz -o /tmp/supabase.tar.gz
-          tar -xzf /tmp/supabase.tar.gz -C /tmp
+          SUPABASE_VERSION="v2.90.0"
+          SUPABASE_TARBALL="supabase_linux_amd64.tar.gz"
+          SUPABASE_URL="https://github.com/supabase/cli/releases/download/${SUPABASE_VERSION}/${SUPABASE_TARBALL}"
+          SUPABASE_SHA256="34e264108d0502f922f2a11c4481d512335e8a6b621c8d8c25524eb9f25e9576"
+
+          curl -fsSL "$SUPABASE_URL" -o /tmp/$SUPABASE_TARBALL
+          echo "${SUPABASE_SHA256}  /tmp/${SUPABASE_TARBALL}" | sha256sum -c -
+
+          tar -xzf /tmp/$SUPABASE_TARBALL -C /tmp
           sudo install -m 0755 /tmp/supabase /usr/local/bin/supabase
           supabase --version
 

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -381,8 +381,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsSL https://github.com/supabase/cli/releases/latest/download/supabase_linux_amd64.tar.gz -o /tmp/supabase.tar.gz
-          tar -xzf /tmp/supabase.tar.gz -C /tmp
+          SUPABASE_VERSION="v2.90.0"
+          SUPABASE_TARBALL="supabase_linux_amd64.tar.gz"
+          SUPABASE_URL="https://github.com/supabase/cli/releases/download/${SUPABASE_VERSION}/${SUPABASE_TARBALL}"
+          SUPABASE_SHA256="34e264108d0502f922f2a11c4481d512335e8a6b621c8d8c25524eb9f25e9576"
+
+          curl -fsSL "$SUPABASE_URL" -o /tmp/$SUPABASE_TARBALL
+          echo "${SUPABASE_SHA256}  /tmp/${SUPABASE_TARBALL}" | sha256sum -c -
+
+          tar -xzf /tmp/$SUPABASE_TARBALL -C /tmp
           sudo install -m 0755 /tmp/supabase /usr/local/bin/supabase
           supabase --version
 


### PR DESCRIPTION
## Summary
- pin Supabase CLI to `v2.90.0` in CI workflows
- verify the downloaded Linux AMD64 tarball with a literal SHA-256 before install
- fail closed on checksum mismatch

## Why
The current direct-binary install path downloads a mutable `latest` artifact at runtime. This PR freezes the version and checksum in-repo so CI remains deterministic and supply-chain verification is explicit.

## Scope
- in scope: Supabase CLI pin + SHA-256 verification for `job-system-ci.yml` and `flow1-proof-pack.yml` (#197)
- out of scope: installer redesign, broader workflow cleanup, Node20 audit follow-up (#198), branch protection changes

## Pinned Artifact
- Version: `v2.90.0`
- File: `supabase_linux_amd64.tar.gz`
- SHA-256: `34e264108d0502f922f2a11c4481d512335e8a6b621c8d8c25524eb9f25e9576`

Closes #197
