### PR TITLE
fix(processor): wire claim RPC contract guard into claimQueuedJobs

### DIFF
--- a/__tests__/lib/evaluation/processor.atomic-claim.test.ts
+++ b/__tests__/lib/evaluation/processor.atomic-claim.test.ts
@@ -40,6 +40,21 @@ function makeJob(overrides: Record<string, unknown> = {}): Record<string, unknow
   };
 }
 
+function makeClaimedRpcRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    manuscript_id: 42,
+    phase: 'phase_1',
+    status: 'running',
+    phase_status: 'running',
+    claimed_by: 'worker-abc',
+    claimed_at: new Date().toISOString(),
+    lease_token: '22222222-2222-4222-8222-222222222222',
+    lease_expires_at: new Date(Date.now() + 180_000).toISOString(),
+    ...overrides,
+  };
+}
+
 function buildSupabaseStub(opts: {
   rpcResult?: { data: unknown; error: null | { message: string } };
   jobData?: Record<string, unknown> | null;
@@ -97,14 +112,7 @@ describe('claimQueuedJobs', () => {
   });
 
   test('calls claim_evaluation_jobs RPC with correct parameters', async () => {
-    const claimedJob = {
-      id: 'job-claimed-1',
-      phase: 'phase_1',
-      phase_status: 'running',
-      claimed_by: 'worker-abc',
-      claimed_at: new Date().toISOString(),
-      lease_expires_at: new Date(Date.now() + 180_000).toISOString(),
-    };
+    const claimedJob = makeClaimedRpcRow();
     const stub = buildSupabaseStub({ rpcResult: { data: [claimedJob], error: null } }) as any;
     createClientMock.mockReturnValue(stub);
 
@@ -118,7 +126,7 @@ describe('claimQueuedJobs', () => {
       p_lease_expires_at: expect.any(String),
     });
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('job-claimed-1');
+    expect(result[0].id).toBe('11111111-1111-4111-8111-111111111111');
     expect(result[0].phase).toBe('phase_1');
   });
 
@@ -168,12 +176,38 @@ describe('claimQueuedJobs', () => {
       .mockImplementation((_fn: string, params: { p_worker_id: string }) => {
         if (params.p_worker_id === 'worker-a') {
           return Promise.resolve({
-            data: [{ id: 'a1', phase: 'phase_1' }, { id: 'a2', phase: 'phase_2' }],
+            data: [
+              makeClaimedRpcRow({
+                id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+                phase: 'phase_1',
+                lease_token: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
+                claimed_by: 'worker-a',
+              }),
+              makeClaimedRpcRow({
+                id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2',
+                phase: 'phase_2',
+                lease_token: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2',
+                claimed_by: 'worker-a',
+              }),
+            ],
             error: null,
           });
         }
         return Promise.resolve({
-          data: [{ id: 'b1', phase: 'phase_1' }, { id: 'b2', phase: 'phase_2' }],
+          data: [
+            makeClaimedRpcRow({
+              id: 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1',
+              phase: 'phase_1',
+              lease_token: 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1',
+              claimed_by: 'worker-b',
+            }),
+            makeClaimedRpcRow({
+              id: 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2',
+              phase: 'phase_2',
+              lease_token: 'dddddddd-dddd-4ddd-8ddd-ddddddddddd2',
+              claimed_by: 'worker-b',
+            }),
+          ],
           error: null,
         });
       });
@@ -209,8 +243,16 @@ describe('processQueuedJobs — atomic claim path', () => {
 
   test('returns claimed count equal to jobs claimed by RPC', async () => {
     const claimedRows = [
-      { id: 'j1', phase: 'phase_1', phase_status: 'running', claimed_by: 'w', claimed_at: '', lease_expires_at: '' },
-      { id: 'j2', phase: 'phase_1', phase_status: 'running', claimed_by: 'w', claimed_at: '', lease_expires_at: '' },
+      makeClaimedRpcRow({
+        id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee1',
+        claimed_by: 'w',
+        lease_token: 'ffffffff-ffff-4fff-8fff-fffffffffff1',
+      }),
+      makeClaimedRpcRow({
+        id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeee2',
+        claimed_by: 'w',
+        lease_token: 'ffffffff-ffff-4fff-8fff-fffffffffff2',
+      }),
     ];
 
     // The claimed job fetched inside processEvaluationJob (pre-claimed running job)

--- a/__tests__/lib/jobs/contracts/claimEvaluationJobs.contract.test.ts
+++ b/__tests__/lib/jobs/contracts/claimEvaluationJobs.contract.test.ts
@@ -1,0 +1,57 @@
+import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
+
+function makeCanonicalClaimedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    phase: 'phase_1',
+    status: 'running',
+    phase_status: 'running',
+    claimed_by: 'worker-abc',
+    claimed_at: new Date().toISOString(),
+    lease_token: '22222222-2222-4222-8222-222222222222',
+    lease_expires_at: new Date(Date.now() + 180_000).toISOString(),
+    manuscript_id: 42,
+    ...overrides,
+  };
+}
+
+describe('assertClaimedJobsContract', () => {
+  test('canonical row passes', () => {
+    const rows = [makeCanonicalClaimedRow()];
+
+    const parsed = assertClaimedJobsContract(rows);
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe(rows[0].id);
+    expect(parsed[0].phase).toBe('phase_1');
+    expect(parsed[0].status).toBe('running');
+  });
+
+  test('missing claimed_by fails', () => {
+    const rows = [makeCanonicalClaimedRow({ claimed_by: null })];
+
+    expect(() => assertClaimedJobsContract(rows)).toThrow('missing claimed_by');
+  });
+
+  test('non-UUID lease_token fails', () => {
+    const rows = [makeCanonicalClaimedRow({ lease_token: 'not-a-uuid' })];
+
+    expect(() => assertClaimedJobsContract(rows)).toThrow('lease_token must be a UUID');
+  });
+
+  test('legacy custom-table shape fails', () => {
+    const rows = [{
+      id: '11111111-1111-4111-8111-111111111111',
+      manuscript_id: 42,
+      claim_count: 1,
+    }];
+
+    expect(() => assertClaimedJobsContract(rows)).toThrow('contract violation');
+  });
+
+  test('non-numeric manuscript_id fails', () => {
+    const rows = [makeCanonicalClaimedRow({ manuscript_id: 'abc' })];
+
+    expect(() => assertClaimedJobsContract(rows)).toThrow('manuscript_id');
+  });
+});

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -86,6 +86,7 @@ import {
 import { JOB_STATUS, type JobStatus } from '@/lib/jobs/types';
 import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
+import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -1597,7 +1598,9 @@ export async function claimQueuedJobs(
     return [];
   }
 
-  return (data as Array<{ id: string; phase: string }>).map((row) => ({
+  const claimedRows = assertClaimedJobsContract(data);
+
+  return claimedRows.map((row) => ({
     id: row.id,
     phase: row.phase,
   }));

--- a/lib/jobs/contracts/claimEvaluationJobs.contract.ts
+++ b/lib/jobs/contracts/claimEvaluationJobs.contract.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+const ClaimedJobPhaseSchema = z.enum(['phase_1', 'phase_2'], {
+  required_error: 'claimed job must include phase',
+  invalid_type_error: 'claimed job phase must be one of: phase_1, phase_2',
+});
+
+const ClaimedJobStatusSchema = z.literal('running', {
+  invalid_type_error: 'claimed job status must be running',
+  required_error: 'claimed job must include status',
+});
+
+const ClaimedJobManuscriptIdSchema = z.preprocess((value) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string' && /^[0-9]+$/.test(value)) {
+    return Number(value);
+  }
+
+  return value;
+}, z.number().int().finite({ message: 'manuscript_id must be a finite integer' }));
+
+/**
+ * Canonical shape expected from claim_evaluation_jobs RPC.
+ * Maps to SETOF public.evaluation_jobs (the fields we actually consume).
+ *
+ * Fail-closed by design on required invariants while permitting additional
+ * canonical columns returned by SETOF public.evaluation_jobs.
+ */
+export const ClaimedJobRowSchema = z
+  .object({
+    id: z.string().uuid({ message: 'claimed job id must be a UUID' }),
+    phase: ClaimedJobPhaseSchema,
+    status: ClaimedJobStatusSchema,
+    phase_status: z.string().nullable().optional(),
+    claimed_by: z.string().nullable().optional(),
+    claimed_at: z.string().datetime().nullable().optional(),
+    lease_token: z
+      .string()
+      .uuid({ message: 'lease_token must be a UUID — check RPC arg type (text vs uuid)' })
+      .nullable()
+      .optional(),
+    lease_expires_at: z.string().datetime().nullable().optional(),
+    manuscript_id: ClaimedJobManuscriptIdSchema.optional(),
+  })
+  .passthrough();
+
+export const ClaimedJobsArraySchema = z.array(ClaimedJobRowSchema);
+
+export type ClaimedJobRow = z.infer<typeof ClaimedJobRowSchema>;
+
+export function assertClaimedJobsContract(raw: unknown): ClaimedJobRow[] {
+  const result = ClaimedJobsArraySchema.safeParse(raw);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `[${issue.path.join('.')}] ${issue.message}`)
+      .join('; ');
+
+    throw new Error(
+      `[claim_evaluation_jobs] RPC return shape contract violation: ${issues}`,
+    );
+  }
+
+  for (const job of result.data) {
+    if (!job.claimed_by) {
+      throw new Error(
+        `[claim_evaluation_jobs] contract violation: job ${job.id} missing claimed_by`,
+      );
+    }
+
+    if (job.lease_token === null || job.lease_token === undefined) {
+      throw new Error(
+        `[claim_evaluation_jobs] contract violation: job ${job.id} missing lease_token`,
+      );
+    }
+  }
+
+  return result.data;
+}


### PR DESCRIPTION
### Summary

Activate runtime contract enforcement for `claim_evaluation_jobs` at the processor claim seam by wiring `assertClaimedJobsContract()` into `claimQueuedJobs()` and adding focused contract tests.

### Why

PR #202 introduced the contract module, but the guard was not yet active in the live claim path.
This PR turns that foundation into runtime protection so contract drift fails loudly at the seam instead of silently causing stuck queue behavior.

### What changes

- Wire `assertClaimedJobsContract()` into `claimQueuedJobs()` in `lib/evaluation/processor.ts`
- Add `lib/jobs/contracts/claimEvaluationJobs.contract.ts` runtime schema/invariant guard:
  - `phase` constrained to `phase_1 | phase_2`
  - `status` constrained to literal `running`
  - `lease_token` UUID validation
  - `manuscript_id` safe preprocess + finite integer validation
  - invariant throws for missing `claimed_by` and missing `lease_token`
- Add focused contract test suite:
  - `__tests__/lib/jobs/contracts/claimEvaluationJobs.contract.test.ts`
  - covers canonical pass + key drift/failure cases
- Update atomic claim-path test mocks to satisfy the activated runtime contract:
  - `__tests__/lib/evaluation/processor.atomic-claim.test.ts`

### Strictness decision

At this seam, RPC returns `SETOF public.evaluation_jobs` (`RETURNING j.*`), which includes additional canonical DB columns beyond the subset consumed by processor logic.
For that reason, row schema uses passthrough for canonical extra columns while remaining fail-closed on required contract fields and invariants.

### What does NOT change

- No queue redesign
- No worker scheduling/cron redesign
- No prompt/pipeline behavior changes
- No UI changes
- No DB migration in this PR

### Test evidence

Focused verification run:

- `__tests__/lib/jobs/contracts/claimEvaluationJobs.contract.test.ts` ✅ (5/5)
- `__tests__/lib/evaluation/processor.atomic-claim.test.ts` ✅ (14/14)

### Scope note

This PR is intentionally narrow: **activate guard + harden seam + prove with focused tests**.
