### PR TITLE
feat(latency): add phase timing instrumentation across job and pipeline seams

### DIFF
--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/jobs/rateLimiter";
 import { JOB_TYPES, type JobType } from "@/lib/jobs/types";
 import { generateTraceId, logger, jobLogger } from "@/lib/observability/logger";
+import { emitLatencyTrace } from "@/lib/observability/latencyTrace";
 import { getAuthenticatedUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { backpressureGuard } from "@/lib/jobs/backpressure";
@@ -313,6 +314,18 @@ export async function POST(req: Request) {
       job_type: validatedJobType,
     });
 
+    const jobAcceptedAt = new Date().toISOString();
+    emitLatencyTrace({
+      job_id: job.id,
+      stage: "job_create",
+      state: "accepted",
+      started_at: jobAcceptedAt,
+      metadata: {
+        source: "api.jobs.create",
+        job_type: validatedJobType,
+      },
+    });
+
     // Emit observability events
     jobLogger.created(job.id, validatedJobType, {
       trace_id,
@@ -326,12 +339,23 @@ export async function POST(req: Request) {
 
     // Belt-and-suspenders dispatch: cron remains the recovery path, while this
     // immediate kickoff prevents preview/local orphaned queued jobs.
+    const kickoffDispatchStartedAt = new Date().toISOString();
+    emitLatencyTrace({
+      job_id: job.id,
+      stage: "worker_kickoff",
+      state: "dispatch_started",
+      started_at: kickoffDispatchStartedAt,
+      metadata: {
+        source: "api.jobs.create",
+      },
+    });
     void triggerEvaluationWorker({
       req,
       jobId: job.id,
       trace_id,
       request_id,
       source: "api.jobs.create",
+      kickoffDispatchStartedAt,
     });
 
     logger.info("Job created successfully", {

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -609,15 +609,15 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   }
 
   // ── Pass 3: Synthesis & Reconciliation ─────────────────────────────────
+  const pass3StartMs = nowMs();
+  const pass3StartedAt = startLatencyStage({
+    jobId: latencyJobId,
+    stage: 'pass3',
+    metadata: {
+      model: opts.model ?? null,
+    },
+  });
   try {
-    const pass3StartMs = nowMs();
-    const pass3StartedAt = startLatencyStage({
-      jobId: latencyJobId,
-      stage: 'pass3',
-      metadata: {
-        model: opts.model ?? null,
-      },
-    });
     pass3Output = await withTimeout(
       _runPass3({
         pass1: pass1Output,
@@ -640,10 +640,11 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       state: 'completed',
     });
   } catch (err) {
+    timings.pass3_ms = nowMs() - pass3StartMs;
     finishLatencyStage({
       jobId: latencyJobId,
       stage: 'pass3',
-      startedAt: new Date(Date.now() - (timings.pass3_ms ?? 0)).toISOString(),
+      startedAt: pass3StartedAt,
       state: 'failed',
       metadata: {
         finish_reason: err instanceof Error ? err.message : String(err),

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -49,6 +49,11 @@ import {
   evaluateLessonsLearnedRules as defaultEvaluateLessonsLearnedRules,
   deriveLessonsLearnedEnforcementDecision as defaultDeriveLessonsLearnedEnforcementDecision,
 } from "@/lib/governance/lessonsLearned";
+import {
+  emitLatencyTrace,
+  finishLatencyStage,
+  startLatencyStage,
+} from "@/lib/observability/latencyTrace";
 import { JsonBoundaryError } from "@/lib/llm/jsonParseBoundary";
 import type {
   RuleEvaluationInput,
@@ -238,6 +243,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   const passTimeoutMs = opts._passTimeoutMs ?? DEFAULT_PASS_TIMEOUT_MS;
   const pipelineStartMs = nowMs();
   const timings: PipelineTimings = {};
+  const latencyJobId = String(opts.jobId ?? opts.manuscriptId ?? 'pipeline-only');
 
   const _runPass1 = opts._runners?.runPass1 ?? defaultRunPass1;
   const _runPass2 = opts._runners?.runPass2 ?? defaultRunPass2;
@@ -360,6 +366,32 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   // updating both this comment and the audit log structure below.
   const pass1StartMs = nowMs();
   const pass2StartMs = nowMs();
+  const pass1StartedAt = startLatencyStage({
+    jobId: latencyJobId,
+    stage: 'pass1',
+    metadata: {
+      model: opts.model ?? null,
+      manuscript_length_bucket:
+        opts.manuscriptText.length >= 200_000
+          ? '200k+'
+          : opts.manuscriptText.length >= 50_000
+            ? '50k-199k'
+            : 'lt50k',
+    },
+  });
+  const pass2StartedAt = startLatencyStage({
+    jobId: latencyJobId,
+    stage: 'pass2',
+    metadata: {
+      model: opts.model ?? null,
+      manuscript_length_bucket:
+        opts.manuscriptText.length >= 200_000
+          ? '200k+'
+          : opts.manuscriptText.length >= 50_000
+            ? '50k-199k'
+            : 'lt50k',
+    },
+  });
 
   const pass1Promise = withTimeout(
     _runPass1({
@@ -373,9 +405,30 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     }),
     passTimeoutMs,
     "Pass 1",
-  ).finally(() => {
-    timings.pass1_ms = nowMs() - pass1StartMs;
-  });
+  )
+    .then((value) => {
+      timings.pass1_ms = nowMs() - pass1StartMs;
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass1',
+        startedAt: pass1StartedAt,
+        state: 'completed',
+      });
+      return value;
+    })
+    .catch((error) => {
+      timings.pass1_ms = nowMs() - pass1StartMs;
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass1',
+        startedAt: pass1StartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw error;
+    });
 
   const pass2Promise = withTimeout(
     _runPass2({
@@ -391,9 +444,30 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     }),
     passTimeoutMs,
     "Pass 2",
-  ).finally(() => {
-    timings.pass2_ms = nowMs() - pass2StartMs;
-  });
+  )
+    .then((value) => {
+      timings.pass2_ms = nowMs() - pass2StartMs;
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass2',
+        startedAt: pass2StartedAt,
+        state: 'completed',
+      });
+      return value;
+    })
+    .catch((error) => {
+      timings.pass2_ms = nowMs() - pass2StartMs;
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass2',
+        startedAt: pass2StartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw error;
+    });
 
   const [pass1Settled, pass2Settled] = await Promise.allSettled([pass1Promise, pass2Promise]);
 
@@ -537,6 +611,13 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   // ── Pass 3: Synthesis & Reconciliation ─────────────────────────────────
   try {
     const pass3StartMs = nowMs();
+    const pass3StartedAt = startLatencyStage({
+      jobId: latencyJobId,
+      stage: 'pass3',
+      metadata: {
+        model: opts.model ?? null,
+      },
+    });
     pass3Output = await withTimeout(
       _runPass3({
         pass1: pass1Output,
@@ -552,7 +633,23 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       "Pass 3",
     );
     timings.pass3_ms = nowMs() - pass3StartMs;
+    finishLatencyStage({
+      jobId: latencyJobId,
+      stage: 'pass3',
+      startedAt: pass3StartedAt,
+      state: 'completed',
+    });
   } catch (err) {
+    finishLatencyStage({
+      jobId: latencyJobId,
+      stage: 'pass3',
+      startedAt: new Date(Date.now() - (timings.pass3_ms ?? 0)).toISOString(),
+      state: 'failed',
+      metadata: {
+        finish_reason: err instanceof Error ? err.message : String(err),
+      },
+    });
+
     const failure = normalizePassFailure("pass3", err);
     timings.total_ms = nowMs() - pipelineStartMs;
     logPipelineTimings("failure", {
@@ -602,9 +699,23 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   }
 
   const pass4StartMs = nowMs();
+  const qualityGateStartedAt = startLatencyStage({
+    jobId: latencyJobId,
+    stage: 'quality_gate',
+  });
   const qualityGate = _runQualityGate(pass3Output, pass1Output, pass2Output, opts.manuscriptText);
   timings.pass4_ms = nowMs() - pass4StartMs;
   if (!qualityGate.pass) {
+    finishLatencyStage({
+      jobId: latencyJobId,
+      stage: 'quality_gate',
+      startedAt: qualityGateStartedAt,
+      state: 'failed',
+      metadata: {
+        finish_reason: 'quality_gate_failed',
+      },
+    });
+
     const qualityGateCheckpoint = getGovernanceCheckpointById("QUALITY_GATE", governanceInjectionMap);
     const failedChecks = qualityGate.checks.filter((c) => !c.passed);
     const errorCode = failedChecks[0]?.error_code ?? "QG_UNKNOWN";
@@ -643,10 +754,25 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     };
   }
 
+  finishLatencyStage({
+    jobId: latencyJobId,
+    stage: 'quality_gate',
+    startedAt: qualityGateStartedAt,
+    state: 'completed',
+  });
+
   // ── Pass 4b: Optional external cross-check + governance ─────────────────
   // Cross-check runs only on the success path (quality gate already passed).
   // Fail-soft on execution; fail-hard if governance decision is not ok.
   if (opts.perplexityApiKey) {
+    const pass4CrossCheckStartedAt = startLatencyStage({
+      jobId: latencyJobId,
+      stage: 'pass4_cross_check',
+      metadata: {
+        provider: 'perplexity',
+      },
+    });
+
     try {
       // Map SynthesizedCriterion[] → Record<CriterionKey, OpenAICriterionInput>
       const criteriaRecord = Object.fromEntries(
@@ -668,12 +794,39 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
         title: opts.title,
         perplexityApiKey: opts.perplexityApiKey,
       });
+
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass4_cross_check',
+        startedAt: pass4CrossCheckStartedAt,
+        state: 'completed',
+      });
     } catch (err) {
+      finishLatencyStage({
+        jobId: latencyJobId,
+        stage: 'pass4_cross_check',
+        startedAt: pass4CrossCheckStartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: err instanceof Error ? err.message : String(err),
+        },
+      });
+
       console.warn(
         "[Pass4] Perplexity cross-check failed (non-fatal):",
         err instanceof Error ? err.message : String(err),
       );
     }
+  } else {
+    emitLatencyTrace({
+      job_id: latencyJobId,
+      stage: 'pass4_cross_check',
+      state: 'skipped',
+      started_at: new Date().toISOString(),
+      metadata: {
+        finish_reason: 'missing_perplexity_api_key',
+      },
+    });
   }
 
   pass4Governance = evaluatePass4Governance(crossCheckResult);

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1252,9 +1252,8 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     console.log(`[Processor] ${jobId}: ENTER runPipeline model=${getCanonicalPipelineModel(openAiModel)} passTimeoutMs=${evalPassTimeoutMs}`);
     const runPipelineStartedAt = startLatencyStage({
       jobId,
-      stage: 'pass3',
+      stage: 'pipeline_run',
       metadata: {
-        state: 'canonical_pipeline_started',
         model: getCanonicalPipelineModel(openAiModel),
       },
     });
@@ -1274,9 +1273,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     finishLatencyStage({
       jobId,
-      stage: 'pass3',
+      stage: 'pipeline_run',
       startedAt: runPipelineStartedAt,
-      state: pipelineResult.ok ? 'canonical_pipeline_finished' : 'failed',
+      state: pipelineResult.ok ? 'completed' : 'failed',
       metadata: {
         finish_reason: pipelineResult.ok
           ? 'ok'
@@ -1491,12 +1490,12 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: readBackMsg };
     }
 
-      finishLatencyStage({
-        jobId,
-        stage: 'persist_artifacts',
-        startedAt: persistArtifactsStartedAt,
-        state: 'completed',
-      });
+    finishLatencyStage({
+      jobId,
+      stage: 'persist_artifacts',
+      startedAt: persistArtifactsStartedAt,
+      state: 'completed',
+    });
     } catch (artifactError) {
       finishLatencyStage({
         jobId,

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -80,6 +80,11 @@ import {
   getEvalPassTimeoutMs,
 } from '@/lib/evaluation/config';
 import {
+  emitLatencyTrace,
+  finishLatencyStage,
+  startLatencyStage,
+} from '@/lib/observability/latencyTrace';
+import {
   assertValidJobStatusTransition,
   normalizeEvaluationJobStatus,
 } from '@/lib/evaluation/status';
@@ -906,6 +911,13 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
   let lifecycleStatus: JobStatus | null = null;
 
+  emitLatencyTrace({
+    job_id: jobId,
+    stage: 'claim',
+    state: 'processor_entered',
+    started_at: new Date().toISOString(),
+  });
+
   const nextLifecycleStatus = (target: JobStatus): JobStatus => {
     const normalizedTarget = normalizeEvaluationJobStatus(target) as JobStatus;
 
@@ -1131,6 +1143,14 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     console.log(`[Processor] Job ${jobId} status updated to running`);
 
     // 3. Fetch the manuscript
+    const fetchManuscriptStartedAt = startLatencyStage({
+      jobId,
+      stage: 'fetch_manuscript',
+      metadata: {
+        manuscript_id: job.manuscript_id,
+      },
+    });
+
     const { data: manuscript, error: manuscriptError } = await supabase
       .from('manuscripts')
       .select('*')
@@ -1138,10 +1158,30 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       .single();
 
     if (manuscriptError || !manuscript) {
+      finishLatencyStage({
+        jobId,
+        stage: 'fetch_manuscript',
+        startedAt: fetchManuscriptStartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: 'manuscript_not_found',
+        },
+      });
+
       const message = `Manuscript not found: ${manuscriptError?.message}`;
       await markFailed(message);
       return { success: false, error: message };
     }
+
+    finishLatencyStage({
+      jobId,
+      stage: 'fetch_manuscript',
+      startedAt: fetchManuscriptStartedAt,
+      state: 'completed',
+      metadata: {
+        manuscript_id: manuscript.id,
+      },
+    });
 
     console.log(`[Processor] Manuscript ${manuscript.id} fetched: "${manuscript.title}"`);
 
@@ -1210,6 +1250,15 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     }
 
     console.log(`[Processor] ${jobId}: ENTER runPipeline model=${getCanonicalPipelineModel(openAiModel)} passTimeoutMs=${evalPassTimeoutMs}`);
+    const runPipelineStartedAt = startLatencyStage({
+      jobId,
+      stage: 'pass3',
+      metadata: {
+        state: 'canonical_pipeline_started',
+        model: getCanonicalPipelineModel(openAiModel),
+      },
+    });
+
     const pipelineResult = await runPipeline({
       manuscriptText: manuscriptWithContent.content || '',
       workType: manuscriptWithContent.work_type || 'novel',
@@ -1222,6 +1271,19 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       executionMode: 'TRUSTED_PATH',
       _passTimeoutMs: evalPassTimeoutMs,
     });
+
+    finishLatencyStage({
+      jobId,
+      stage: 'pass3',
+      startedAt: runPipelineStartedAt,
+      state: pipelineResult.ok ? 'canonical_pipeline_finished' : 'failed',
+      metadata: {
+        finish_reason: pipelineResult.ok
+          ? 'ok'
+          : ('error_code' in pipelineResult ? pipelineResult.error_code : 'pipeline_failed'),
+      },
+    });
+
     console.log(
       `[Processor] ${jobId}: EXIT runPipeline ok=${pipelineResult.ok}` +
         (pipelineResult.ok === false
@@ -1380,6 +1442,14 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: invalidManuscriptIdError };
     }
 
+    const persistArtifactsStartedAt = startLatencyStage({
+      jobId,
+      stage: 'persist_artifacts',
+      metadata: {
+        manuscript_id: job.manuscript_id,
+      },
+    });
+
     try {
       console.log(
         `[Processor] ${jobId}: ENTER upsertEvaluationArtifact manuscriptId=${job.manuscript_id}`,
@@ -1406,11 +1476,38 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       .eq('artifact_type', 'evaluation_result_v2')
       .maybeSingle();
     if (readBackError || !readBackArtifact) {
+      finishLatencyStage({
+        jobId,
+        stage: 'persist_artifacts',
+        startedAt: persistArtifactsStartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: 'artifact_read_back_failed',
+        },
+      });
+
       const readBackMsg = `Fail-closed: artifact read-back failed after upsert (${readBackError?.message ?? 'row not found'})`;
       await markFailed(readBackMsg);
       return { success: false, error: readBackMsg };
     }
+
+      finishLatencyStage({
+        jobId,
+        stage: 'persist_artifacts',
+        startedAt: persistArtifactsStartedAt,
+        state: 'completed',
+      });
     } catch (artifactError) {
+      finishLatencyStage({
+        jobId,
+        stage: 'persist_artifacts',
+        startedAt: persistArtifactsStartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: artifactError instanceof Error ? artifactError.message : String(artifactError),
+        },
+      });
+
       const errorMsg = artifactError instanceof Error ? artifactError.message : String(artifactError);
       await markFailed(`Artifact persistence failed: ${errorMsg}`);
 
@@ -1448,6 +1545,14 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       completed_at: completionTime,
     };
 
+    const finalizeStartedAt = startLatencyStage({
+      jobId,
+      stage: 'finalize',
+      metadata: {
+        state: 'completion_update_started',
+      },
+    });
+
     let { error: updateError } = await supabase
       .from('evaluation_jobs')
       .update({
@@ -1471,11 +1576,28 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     );
 
     if (updateError) {
+      finishLatencyStage({
+        jobId,
+        stage: 'finalize',
+        startedAt: finalizeStartedAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: updateError.message,
+        },
+      });
+
       await markFailed(`Completion update failed: ${updateError.message}`);
 
       console.error(`[Processor] Failed to update job ${jobId}:`, updateError);
       return { success: false, error: `Failed to store result: ${updateError.message}` };
     }
+
+    finishLatencyStage({
+      jobId,
+      stage: 'finalize',
+      startedAt: finalizeStartedAt,
+      state: 'completed',
+    });
 
     logProcessorStageBoundary({
       jobId,
@@ -1538,7 +1660,7 @@ export async function claimQueuedJobs(
     batchSize?: number;
     leaseMs?: number;
   },
-): Promise<Array<{ id: string; phase: string }>> {
+): Promise<Array<{ id: string; phase: string; claimedAt?: string }>> {
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   const workerId = options.workerId;
@@ -1588,6 +1710,7 @@ export async function claimQueuedJobs(
         .map((row) => ({
           id: row.id as string,
           phase: typeof row.phase === 'string' ? row.phase : 'phase_1',
+          claimedAt: undefined,
         }));
     }
     console.error('[Processor] claim_evaluation_jobs RPC error:', error);
@@ -1603,6 +1726,7 @@ export async function claimQueuedJobs(
   return claimedRows.map((row) => ({
     id: row.id,
     phase: row.phase,
+    claimedAt: row.claimed_at ?? undefined,
   }));
 }
 
@@ -1628,7 +1752,7 @@ export async function processQueuedJobs(options?: {
   await failStaleRunningJobs();
 
   // Atomically claim a batch of queued jobs via SKIP LOCKED RPC.
-  let jobs: Array<{ id: string; phase: string }> = [];
+  let jobs: Array<{ id: string; phase: string; claimedAt?: string }> = [];
   try {
     jobs = await claimQueuedJobs({
       workerId: effectiveWorkerId,
@@ -1654,6 +1778,19 @@ export async function processQueuedJobs(options?: {
 
   console.log(`[Processor] Claimed ${jobs.length} job(s) for worker ${effectiveWorkerId}`);
   console.log(`[Processor] Claimed job phase breakdown: ${JSON.stringify(phaseBreakdown)}`);
+
+  for (const job of jobs) {
+    emitLatencyTrace({
+      job_id: job.id,
+      stage: 'claim',
+      state: 'acquired',
+      started_at: job.claimedAt ?? new Date().toISOString(),
+      metadata: {
+        worker_id: effectiveWorkerId,
+        phase: job.phase,
+      },
+    });
+  }
 
   const results = {
     processed: jobs.length,

--- a/lib/jobs/triggerWorker.ts
+++ b/lib/jobs/triggerWorker.ts
@@ -81,9 +81,11 @@ export async function triggerEvaluationWorker(
       source,
       trace_id,
       request_id,
-      dispatch_gap_ms: kickoffDispatchStartedAt
-        ? Math.max(0, Date.now() - Date.parse(kickoffDispatchStartedAt))
-        : undefined,
+      dispatch_gap_ms: (() => {
+        if (!kickoffDispatchStartedAt) return undefined;
+        const parsed = Date.parse(kickoffDispatchStartedAt);
+        return Number.isFinite(parsed) ? Math.max(0, Date.now() - parsed) : undefined;
+      })(),
     },
   });
 

--- a/lib/jobs/triggerWorker.ts
+++ b/lib/jobs/triggerWorker.ts
@@ -11,6 +11,10 @@
  * - cron remains the durable fallback
  */
 import { logger } from '@/lib/observability/logger';
+import {
+  finishLatencyStage,
+  startLatencyStage,
+} from '@/lib/observability/latencyTrace';
 
 export interface TriggerWorkerArgs {
   /** Originating request — used to derive the worker base URL. */
@@ -23,6 +27,8 @@ export interface TriggerWorkerArgs {
   request_id: string;
   /** Short label identifying which endpoint fired the kickoff (e.g. 'api.jobs.create'). */
   source: string;
+  /** Optional kickoff dispatch start time from caller for end-to-end route->kickoff timing. */
+  kickoffDispatchStartedAt?: string;
 }
 
 function getConfiguredAppBaseUrl(): string | null {
@@ -65,10 +71,35 @@ function buildWorkerUrlFromTrustedOrigin(req: Request): string | null {
 export async function triggerEvaluationWorker(
   args: TriggerWorkerArgs,
 ): Promise<void> {
-  const { req, jobId, trace_id, request_id, source } = args;
+  const { req, jobId, trace_id, request_id, source, kickoffDispatchStartedAt } = args;
+
+  const kickoffStartAt = startLatencyStage({
+    jobId,
+    stage: 'worker_kickoff',
+    startedAt: kickoffDispatchStartedAt,
+    metadata: {
+      source,
+      trace_id,
+      request_id,
+      dispatch_gap_ms: kickoffDispatchStartedAt
+        ? Math.max(0, Date.now() - Date.parse(kickoffDispatchStartedAt))
+        : undefined,
+    },
+  });
 
   const cronSecret = process.env.CRON_SECRET?.trim();
   if (!cronSecret) {
+    finishLatencyStage({
+      jobId,
+      stage: 'worker_kickoff',
+      startedAt: kickoffStartAt,
+      state: 'skipped',
+      metadata: {
+        finish_reason: 'missing_cron_secret',
+        source,
+      },
+    });
+
     logger.warn('Worker kickoff skipped: CRON_SECRET not set', {
       trace_id,
       request_id,
@@ -81,6 +112,17 @@ export async function triggerEvaluationWorker(
 
   const workerUrl = buildWorkerUrlFromTrustedOrigin(req);
   if (!workerUrl) {
+    finishLatencyStage({
+      jobId,
+      stage: 'worker_kickoff',
+      startedAt: kickoffStartAt,
+      state: 'skipped',
+      metadata: {
+        finish_reason: 'no_trusted_base_url',
+        source,
+      },
+    });
+
     logger.warn('Worker kickoff skipped: no trusted app base URL in production', {
       trace_id,
       request_id,
@@ -104,6 +146,18 @@ export async function triggerEvaluationWorker(
     });
 
     if (!response.ok) {
+      finishLatencyStage({
+        jobId,
+        stage: 'worker_kickoff',
+        startedAt: kickoffStartAt,
+        state: 'failed',
+        metadata: {
+          finish_reason: 'non_ok_response',
+          worker_status: response.status,
+          source,
+        },
+      });
+
       logger.warn('Worker kickoff returned non-ok response', {
         trace_id,
         request_id,
@@ -116,6 +170,17 @@ export async function triggerEvaluationWorker(
       return;
     }
 
+    finishLatencyStage({
+      jobId,
+      stage: 'worker_kickoff',
+      startedAt: kickoffStartAt,
+      state: 'dispatched',
+      metadata: {
+        finish_reason: 'ok_response',
+        source,
+      },
+    });
+
     logger.info('Worker kickoff dispatched', {
       trace_id,
       request_id,
@@ -125,6 +190,17 @@ export async function triggerEvaluationWorker(
       worker_url: workerUrl,
     });
   } catch (error) {
+    finishLatencyStage({
+      jobId,
+      stage: 'worker_kickoff',
+      startedAt: kickoffStartAt,
+      state: 'failed',
+      metadata: {
+        finish_reason: 'network_or_timeout',
+        source,
+      },
+    });
+
     logger.warn('Worker kickoff failed (network/timeout)', {
       trace_id,
       request_id,

--- a/lib/observability/latencyTrace.ts
+++ b/lib/observability/latencyTrace.ts
@@ -1,0 +1,80 @@
+export type LatencyStage =
+  | 'job_create'
+  | 'worker_kickoff'
+  | 'claim'
+  | 'fetch_manuscript'
+  | 'pass1'
+  | 'pass2'
+  | 'pass3'
+  | 'pass4_cross_check'
+  | 'quality_gate'
+  | 'persist_artifacts'
+  | 'finalize';
+
+export interface LatencyTraceEvent {
+  job_id: string;
+  stage: LatencyStage;
+  state: string;
+  started_at?: string;
+  ended_at?: string;
+  duration_ms?: number;
+  metadata?: Record<string, unknown>;
+}
+
+function toIsoDate(value: string | Date): string {
+  return typeof value === 'string' ? value : value.toISOString();
+}
+
+function toMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function shouldLogLatencyTrace(): boolean {
+  return process.env.ENABLE_LATENCY_TRACE_LOGS === '1';
+}
+
+export function emitLatencyTrace(event: LatencyTraceEvent): void {
+  if (shouldLogLatencyTrace()) {
+    console.log('[LatencyTrace]', event);
+  }
+}
+
+export function startLatencyStage(args: {
+  jobId: string;
+  stage: LatencyStage;
+  state?: string;
+  startedAt?: string | Date;
+  metadata?: Record<string, unknown>;
+}): string {
+  const startedAtIso = toIsoDate(args.startedAt ?? new Date());
+  emitLatencyTrace({
+    job_id: args.jobId,
+    stage: args.stage,
+    state: args.state ?? 'started',
+    started_at: startedAtIso,
+    metadata: args.metadata,
+  });
+  return startedAtIso;
+}
+
+export function finishLatencyStage(args: {
+  jobId: string;
+  stage: LatencyStage;
+  startedAt: string;
+  state?: string;
+  endedAt?: string | Date;
+  metadata?: Record<string, unknown>;
+}): void {
+  const endedAtIso = toIsoDate(args.endedAt ?? new Date());
+  const durationMs = Math.max(0, toMs(endedAtIso) - toMs(args.startedAt));
+  emitLatencyTrace({
+    job_id: args.jobId,
+    stage: args.stage,
+    state: args.state ?? 'completed',
+    started_at: args.startedAt,
+    ended_at: endedAtIso,
+    duration_ms: durationMs,
+    metadata: args.metadata,
+  });
+}

--- a/lib/observability/latencyTrace.ts
+++ b/lib/observability/latencyTrace.ts
@@ -3,6 +3,7 @@ export type LatencyStage =
   | 'worker_kickoff'
   | 'claim'
   | 'fetch_manuscript'
+  | 'pipeline_run'
   | 'pass1'
   | 'pass2'
   | 'pass3'


### PR DESCRIPTION
## Summary
Adds seam-level latency tracing across job creation, worker kickoff, processor stages, pipeline passes, quality gate, Pass 4 cross-check, artifact persistence, and finalization.

## What changed
- Added `lib/observability/latencyTrace.ts` for stage trace helpers.
- Instrumented job creation and kickoff in `app/api/jobs/route.ts` and `lib/jobs/triggerWorker.ts`.
- Instrumented processor lifecycle in `lib/evaluation/processor.ts`.
- Instrumented pipeline pass lifecycle and gate/cross-check stages in `lib/evaluation/pipeline/runPipeline.ts`.

## Behavior and safety
- Preserves existing control flow and fail-closed behavior.
- Trace console output is gated behind `ENABLE_LATENCY_TRACE_LOGS=1` to avoid noisy normal test runs.
- Pipeline-only fallback trace id is explicit (`pipeline-only`) instead of ambiguous (`unknown`).

## Verification
Focused suites run green:
- `tests/lib/jobs/triggerWorker.test.ts`
- `__tests__/lib/evaluation/processor.canonical-pipeline.test.ts`
- `__tests__/lib/evaluation/processor.phase-routing.test.ts`
- `tests/evaluation/pipeline/pipeline-independence.test.ts`
- `tests/evaluation/pipeline/pipeline-e2e.test.ts` (27/27)

## Notes
- `PHASE_2_7_REAL_RUN_01.md` is intentionally left out of this PR scope.