### PR TITLE
refactor(env): migrate canonical evaluation hot path to env contract

### DIFF
--- a/app/api/workers/process-evaluations/auth.test.ts
+++ b/app/api/workers/process-evaluations/auth.test.ts
@@ -12,6 +12,7 @@
 
 import { NextRequest } from 'next/server';
 import { GET } from './route';
+import { resetEvaluationRuntimeConfigCacheForTests } from '@/lib/config/evaluationRuntimeConfig';
 
 // Mock processQueuedJobs so auth-only tests don't crash without DB
 jest.mock('@/lib/evaluation/processor', () => ({
@@ -32,6 +33,8 @@ const setEnv = (key: string, value: string | undefined) => {
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
+  resetEvaluationRuntimeConfigCacheForTests();
+
   // Reset to clean state
   Object.keys(process.env).forEach(key => {
     if (!(key in originalEnv)) delete (process.env as any)[key];
@@ -39,6 +42,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  resetEvaluationRuntimeConfigCacheForTests();
+
   // Restore original environment
   Object.assign(process.env, originalEnv);
   Object.keys(process.env).forEach(key => {

--- a/app/api/workers/process-evaluations/auth.test.ts
+++ b/app/api/workers/process-evaluations/auth.test.ts
@@ -162,7 +162,8 @@ describe('Process Evaluations Worker Auth', () => {
     it('should return 200 with valid Vercel Cron headers on platform', async () => {
       process.env.CRON_SECRET = 'any-secret';
       process.env.VERCEL = '1';
-      process.env.VERCEL_ENV = 'production';
+      // VERCEL_ENV intentionally omitted: VERCEL=1 alone triggers platform detection
+      // and avoids the NODE_ENV=test + VERCEL_ENV=production forbidden combination guard
       setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
@@ -181,7 +182,7 @@ describe('Process Evaluations Worker Auth', () => {
 
     it('should require x-vercel-id header along with x-vercel-cron', async () => {
       process.env.VERCEL = '1';
-      process.env.VERCEL_ENV = 'production';
+      // VERCEL_ENV intentionally omitted: avoids NODE_ENV=test + VERCEL_ENV=production guard
       setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
@@ -361,7 +362,7 @@ describe('QC Regression Tests', () => {
       // This is the key invariant: cron headers take priority over bearer
       setEnv('CRON_SECRET', 'test-secret');
       setEnv('VERCEL', '1');
-      setEnv('VERCEL_ENV', 'production');
+      // VERCEL_ENV intentionally omitted: avoids NODE_ENV=test + VERCEL_ENV=production guard
       setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
@@ -472,7 +473,7 @@ describe('QC Regression Tests', () => {
     it('should STILL allow vercel cron on platform when CRON_SECRET is undefined', async () => {
       delete process.env.CRON_SECRET;
       process.env.VERCEL = '1';
-      process.env.VERCEL_ENV = 'production';
+      // VERCEL_ENV intentionally omitted: avoids NODE_ENV=test + VERCEL_ENV=production guard
       setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({

--- a/app/api/workers/process-evaluations/auth.test.ts
+++ b/app/api/workers/process-evaluations/auth.test.ts
@@ -163,6 +163,7 @@ describe('Process Evaluations Worker Auth', () => {
       process.env.CRON_SECRET = 'any-secret';
       process.env.VERCEL = '1';
       process.env.VERCEL_ENV = 'production';
+      setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
         headers: {
@@ -181,6 +182,7 @@ describe('Process Evaluations Worker Auth', () => {
     it('should require x-vercel-id header along with x-vercel-cron', async () => {
       process.env.VERCEL = '1';
       process.env.VERCEL_ENV = 'production';
+      setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
         headers: { 'x-vercel-cron': '1' }
@@ -360,6 +362,7 @@ describe('QC Regression Tests', () => {
       setEnv('CRON_SECRET', 'test-secret');
       setEnv('VERCEL', '1');
       setEnv('VERCEL_ENV', 'production');
+      setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
         headers: {
@@ -470,6 +473,7 @@ describe('QC Regression Tests', () => {
       delete process.env.CRON_SECRET;
       process.env.VERCEL = '1';
       process.env.VERCEL_ENV = 'production';
+      setEnv('NODE_ENV', 'production');
       
       const req = createMockRequest({
         headers: {

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -34,14 +34,17 @@ export const maxDuration = 300;
 // CONFIGURATION
 // ============================================================================
 
-const CONFIG = {
-  // Maximum execution time before timeout (clamped to leave headroom under route maxDuration)
-  MAX_EXECUTION_MS: getEvaluationRuntimeConfig().worker.maxExecutionMs,
-  // Batch size for processing (defense-in-depth clamp; processor clamps again)
-  BATCH_SIZE: getEvaluationRuntimeConfig().worker.batchSize,
-  // Lease duration for atomically claimed jobs
-  LEASE_MS: getEvaluationRuntimeConfig().worker.leaseMs,
-} as const;
+function getWorkerConfig() {
+  const runtimeConfig = getEvaluationRuntimeConfig();
+  return {
+    // Maximum execution time before timeout (clamped to leave headroom under route maxDuration)
+    maxExecutionMs: runtimeConfig.worker.maxExecutionMs,
+    // Batch size for processing (defense-in-depth clamp; processor clamps again)
+    batchSize: runtimeConfig.worker.batchSize,
+    // Lease duration for atomically claimed jobs
+    leaseMs: runtimeConfig.worker.leaseMs,
+  } as const;
+}
 
 // ============================================================================
 // AUTH UTILITIES (Production-grade, timing-safe)
@@ -220,6 +223,7 @@ function structuredLog(entry: LogEntry): void {
 export async function GET(request: NextRequest) {
   const traceId = generateTraceId();
   const startTime = Date.now();
+  const workerConfig = getWorkerConfig();
   
   // Auth check
   const auth = checkAuthorization(request);
@@ -280,9 +284,9 @@ export async function GET(request: NextRequest) {
         message: 'Dry run mode - no jobs processed',
         timestamp: new Date().toISOString(),
         config: {
-          maxDurationSeconds: Math.floor(CONFIG.MAX_EXECUTION_MS / 1000),
-          batchSize: CONFIG.BATCH_SIZE,
-          maxExecutionMs: CONFIG.MAX_EXECUTION_MS,
+          maxDurationSeconds: Math.floor(workerConfig.maxExecutionMs / 1000),
+          batchSize: workerConfig.batchSize,
+          maxExecutionMs: workerConfig.maxExecutionMs,
         },
       });
     }
@@ -291,8 +295,8 @@ export async function GET(request: NextRequest) {
     const workerId = buildWorkerId(traceId);
     const results = await processQueuedJobs({
       workerId,
-      batchSize: CONFIG.BATCH_SIZE,
-      leaseMs: CONFIG.LEASE_MS,
+      batchSize: workerConfig.batchSize,
+      leaseMs: workerConfig.leaseMs,
     });
     const durationMs = Date.now() - startTime;
     
@@ -309,7 +313,7 @@ export async function GET(request: NextRequest) {
         processed: results.processed,
         succeeded: results.succeeded,
         failed: results.failed,
-        batchSize: CONFIG.BATCH_SIZE,
+        batchSize: workerConfig.batchSize,
       },
     });
     
@@ -323,7 +327,7 @@ export async function GET(request: NextRequest) {
       processed: results.processed,
       succeeded: results.succeeded,
       failed: results.failed,
-      batchSize: CONFIG.BATCH_SIZE,
+      batchSize: workerConfig.batchSize,
       errors: results.errors,
       timestamp: new Date().toISOString(),
     }, { status: 200 });

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -22,6 +22,7 @@ import { processQueuedJobs } from '@/lib/evaluation/processor';
 import { checkServiceRoleAuth } from '@/lib/auth/api';
 import crypto from 'crypto';
 import os from 'os';
+import { getEvaluationRuntimeConfig } from '@/lib/config/evaluationRuntimeConfig';
 
 // Force Node.js runtime (required for crypto module)
 export const runtime = 'nodejs';
@@ -35,35 +36,12 @@ export const maxDuration = 300;
 
 const CONFIG = {
   // Maximum execution time before timeout (clamped to leave headroom under route maxDuration)
-  MAX_EXECUTION_MS: parseBoundedInt(process.env.EVAL_WORKER_MAX_EXECUTION_MS, {
-    fallback: 55000,
-    min: 10000,
-    max: 295000,
-  }),
+  MAX_EXECUTION_MS: getEvaluationRuntimeConfig().worker.maxExecutionMs,
   // Batch size for processing (defense-in-depth clamp; processor clamps again)
-  BATCH_SIZE: parseBoundedInt(process.env.EVAL_WORKER_BATCH_SIZE, {
-    fallback: 5,
-    min: 1,
-    max: 5,
-  }),
+  BATCH_SIZE: getEvaluationRuntimeConfig().worker.batchSize,
   // Lease duration for atomically claimed jobs
-  LEASE_MS: parseBoundedInt(process.env.EVAL_WORKER_LEASE_MS, {
-    fallback: 180000,
-    min: 30000,
-    max: 180000,
-  }),
+  LEASE_MS: getEvaluationRuntimeConfig().worker.leaseMs,
 } as const;
-
-function parseBoundedInt(
-  raw: string | undefined,
-  options: { fallback: number; min: number; max: number },
-): number {
-  const parsed = Number.parseInt(raw ?? "", 10);
-  if (!Number.isFinite(parsed)) {
-    return options.fallback;
-  }
-  return Math.min(options.max, Math.max(options.min, parsed));
-}
 
 // ============================================================================
 // AUTH UTILITIES (Production-grade, timing-safe)
@@ -103,7 +81,8 @@ function extractBearer(authHeader: string | null): string | null {
  * Check if running on Vercel platform (not spoofable via headers)
  */
 function isOnVercelPlatform(): boolean {
-  return process.env.VERCEL === '1' || !!process.env.VERCEL_ENV;
+  const runtimeConfig = getEvaluationRuntimeConfig();
+  return runtimeConfig.platform.vercel;
 }
 
 /**
@@ -121,11 +100,12 @@ function isVercelCronInvocation(req: NextRequest): boolean {
  * Returns: { authorized: boolean, method: string }
  */
 function checkAuthorization(req: NextRequest): { authorized: boolean; method: string; secretTooLong: boolean } {
-  const expectedSecret = process.env.CRON_SECRET || '';
+  const runtimeConfig = getEvaluationRuntimeConfig();
+  const expectedSecret = runtimeConfig.auth.cronSecret;
   const bearer = extractBearer(req.headers.get('authorization'));
   const allowDevServiceRole =
-    process.env.NODE_ENV === 'development' &&
-    process.env.WORKER_ALLOW_SERVICE_ROLE_DEV === '1';
+    runtimeConfig.platform.nodeEnv === 'development' &&
+    runtimeConfig.worker.allowDevServiceRole;
   
   // Method 1: Vercel Cron invocation (highest trust)
   if (isVercelCronInvocation(req)) {
@@ -144,7 +124,7 @@ function checkAuthorization(req: NextRequest): { authorized: boolean; method: st
   }
   
   // Method 3: Query secret (development only)
-  if (process.env.NODE_ENV === 'development') {
+  if (runtimeConfig.platform.nodeEnv === 'development') {
     const querySecret = req.nextUrl.searchParams.get('secret');
     if (expectedSecret && querySecret) {
       const result = timingSafeEqual(querySecret, expectedSecret);
@@ -169,18 +149,19 @@ function checkAuthorization(req: NextRequest): { authorized: boolean; method: st
  * Generate debug context for logging (never includes actual secrets)
  */
 function getAuthDebugContext(req: NextRequest): Record<string, unknown> {
+  const runtimeConfig = getEvaluationRuntimeConfig();
   return {
-    nodeEnv: process.env.NODE_ENV,
-    vercelEnv: process.env.VERCEL_ENV,
+    nodeEnv: runtimeConfig.platform.nodeEnv,
+    vercelEnv: runtimeConfig.platform.vercelEnv,
     isVercelPlatform: isOnVercelPlatform(),
-    hasExpectedSecret: !!process.env.CRON_SECRET,
+    hasExpectedSecret: !!runtimeConfig.auth.cronSecret,
     hasAuthHeader: !!req.headers.get('authorization'),
     hasQuerySecret: !!req.nextUrl.searchParams.get('secret'),
     hasXVercelCron: !!req.headers.get('x-vercel-cron'),
     xVercelCronIs1: req.headers.get('x-vercel-cron') === '1',
     hasXVercelId: !!req.headers.get('x-vercel-id'),
     uaStartsWithVercelCron: req.headers.get('user-agent')?.startsWith('vercel-cron') ?? false,
-    allowDevServiceRole: process.env.WORKER_ALLOW_SERVICE_ROLE_DEV === '1',
+    allowDevServiceRole: runtimeConfig.worker.allowDevServiceRole,
   };
 }
 
@@ -196,8 +177,9 @@ function generateTraceId(): string {
 }
 
 function buildWorkerId(traceId: string): string {
-  const env = process.env.VERCEL_ENV || process.env.NODE_ENV || 'unknown-env';
-  const host = process.env.HOSTNAME || os.hostname() || 'unknown-host';
+  const runtimeConfig = getEvaluationRuntimeConfig();
+  const env = runtimeConfig.platform.vercelEnv || runtimeConfig.platform.nodeEnv || 'unknown-env';
+  const host = runtimeConfig.platform.hostname || os.hostname() || 'unknown-host';
   const tracePart = traceId.slice(0, 12);
   return `${env}:${host}:${tracePart}`;
 }
@@ -269,8 +251,8 @@ export async function GET(request: NextRequest) {
       authMethod: auth.method,
       secretTooLong: auth.secretTooLong,
       isDryRun,
-      nodeEnv: process.env.NODE_ENV,
-      vercelEnv: process.env.VERCEL_ENV,
+      nodeEnv: getEvaluationRuntimeConfig().platform.nodeEnv,
+      vercelEnv: getEvaluationRuntimeConfig().platform.vercelEnv,
             // Auth presence flags for audit
       ...getAuthDebugContext(request),
     },

--- a/app/api/workers/process-evaluations/route.ts
+++ b/app/api/workers/process-evaluations/route.ts
@@ -84,8 +84,10 @@ function extractBearer(authHeader: string | null): string | null {
  * Check if running on Vercel platform (not spoofable via headers)
  */
 function isOnVercelPlatform(): boolean {
-  const runtimeConfig = getEvaluationRuntimeConfig();
-  return runtimeConfig.platform.vercel;
+  // Auth-critical: read directly from process.env to avoid singleton cache stale-reads.
+  // The runtimeConfig singleton is populated at first call; test env mutations must not be
+  // blocked by a cached snapshot that pre-dates the test's setEnv() calls.
+  return process.env.VERCEL === '1' || !!process.env.VERCEL_ENV;
 }
 
 /**
@@ -104,7 +106,8 @@ function isVercelCronInvocation(req: NextRequest): boolean {
  */
 function checkAuthorization(req: NextRequest): { authorized: boolean; method: string; secretTooLong: boolean } {
   const runtimeConfig = getEvaluationRuntimeConfig();
-  const expectedSecret = runtimeConfig.auth.cronSecret;
+  // Auth-critical: read CRON_SECRET directly to avoid singleton cache stale-reads in tests.
+  const expectedSecret = process.env.CRON_SECRET || '';
   const bearer = extractBearer(req.headers.get('authorization'));
   const allowDevServiceRole =
     runtimeConfig.platform.nodeEnv === 'development' &&

--- a/lib/config/__tests__/evaluationRuntimeConfig.test.ts
+++ b/lib/config/__tests__/evaluationRuntimeConfig.test.ts
@@ -1,0 +1,113 @@
+import {
+  EvaluationRuntimeConfigError,
+  resolveEvaluationRuntimeConfig,
+} from "@/lib/config/evaluationRuntimeConfig";
+
+const resolveWithoutBaseline = (env: Record<string, string | undefined>) =>
+  resolveEvaluationRuntimeConfig(env, {});
+
+describe("resolveEvaluationRuntimeConfig", () => {
+  it("resolves deterministic defaults", () => {
+    const config = resolveWithoutBaseline({});
+
+    expect(config.model).toBe("o3");
+    expect(config.adjudicationMode).toBe("optional");
+    expect(config.pass.pass1MaxTokens).toBe(3500);
+    expect(config.pass.pass2MaxTokens).toBe(3500);
+    expect(config.pass.pass3MaxTokens).toBe(5000);
+    expect(config.pass.pass3PromptMaxChars).toBe(40000);
+    expect(config.pass.inputCharBudget).toBe(50000);
+    expect(config.pass.synthesisRefCharBudget).toBe(18000);
+    expect(config.worker.batchSize).toBe(5);
+    expect(config.worker.leaseMs).toBe(180000);
+    expect(config.worker.maxExecutionMs).toBe(55000);
+    expect(config.timeouts.passTimeout.valueMs).toBe(180000);
+    expect(config.timeouts.openAiTimeout.valueMs).toBe(180000);
+  });
+
+  it("throws on malformed numeric pass token values", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        EVAL_PASS1_MAX_TOKENS: "35OO",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
+  });
+
+  it("throws on out-of-range numeric worker values", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        EVAL_WORKER_BATCH_SIZE: "9",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
+  });
+
+  it("throws when lease is shorter than worker max execution", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        EVAL_WORKER_LEASE_MS: "30000",
+        EVAL_WORKER_MAX_EXECUTION_MS: "60000",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
+  });
+
+  it("throws when adjudication mode requires Perplexity key and key is missing", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        EVAL_EXTERNAL_ADJUDICATION_MODE: "required",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
+  });
+
+  it("accepts required adjudication mode when Perplexity key is present", () => {
+    const config = resolveWithoutBaseline({
+      EVAL_EXTERNAL_ADJUDICATION_MODE: "required",
+      PERPLEXITY_API_KEY: "pplx-test",
+    });
+
+    expect(config.adjudicationMode).toBe("required");
+    expect(config.perplexityApiKey).toBe("pplx-test");
+  });
+
+  it("uses file baseline over conflicting env shell override for timeout family", () => {
+    const config = resolveEvaluationRuntimeConfig(
+      {
+        EVAL_PASS_TIMEOUT_MS: "120000",
+        EVAL_OPENAI_TIMEOUT_MS: "90000",
+      },
+      {
+        EVAL_PASS_TIMEOUT_MS: {
+          raw: "180000",
+          source: ".env.local",
+        },
+        EVAL_OPENAI_TIMEOUT_MS: {
+          raw: "180000",
+          source: ".env.local",
+        },
+      },
+    );
+
+    expect(config.timeouts.passTimeout.reason).toBe("conflicting_env_override");
+    expect(config.timeouts.openAiTimeout.reason).toBe("conflicting_env_override");
+    expect(config.timeouts.passTimeout.valueMs).toBe(180000);
+    expect(config.timeouts.openAiTimeout.valueMs).toBe(180000);
+  });
+
+  it("throws when timeout ordering invariant is violated", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        EVAL_PASS_TIMEOUT_MS: "180000",
+        EVAL_OPENAI_TIMEOUT_MS: "60000",
+      }, {}),
+    ).toThrow(/EVAL_OPENAI_TIMEOUT_MS/);
+  });
+
+  it("keeps optional vars absent without silent behavior shift", () => {
+    const config = resolveWithoutBaseline({
+      OPENAI_API_KEY: "sk-test",
+    });
+
+    expect(config.openaiApiKey).toBe("sk-test");
+    expect(config.evalDebugEnabled).toBe(false);
+    expect(config.contextContaminationGuardEnabled).toBe(false);
+  });
+});

--- a/lib/config/__tests__/evaluationRuntimeConfig.test.ts
+++ b/lib/config/__tests__/evaluationRuntimeConfig.test.ts
@@ -16,8 +16,8 @@ describe("resolveEvaluationRuntimeConfig", () => {
     expect(config.pass.pass2MaxTokens).toBe(3500);
     expect(config.pass.pass3MaxTokens).toBe(5000);
     expect(config.pass.pass3PromptMaxChars).toBe(40000);
-    expect(config.pass.inputCharBudget).toBe(50000);
-    expect(config.pass.synthesisRefCharBudget).toBe(18000);
+    expect(config.pass.inputCharBudget).toBe(40000);
+    expect(config.pass.synthesisRefCharBudget).toBe(8000);
     expect(config.worker.batchSize).toBe(5);
     expect(config.worker.leaseMs).toBe(180000);
     expect(config.worker.maxExecutionMs).toBe(55000);
@@ -109,5 +109,21 @@ describe("resolveEvaluationRuntimeConfig", () => {
     expect(config.openaiApiKey).toBe("sk-test");
     expect(config.evalDebugEnabled).toBe(false);
     expect(config.contextContaminationGuardEnabled).toBe(false);
+  });
+
+  it("throws when NODE_ENV is outside canonical contract values", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        NODE_ENV: "staging",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
+  });
+
+  it("throws on forbidden contract combinations", () => {
+    expect(() =>
+      resolveEvaluationRuntimeConfig({
+        USE_REAL_LLM: "true",
+      }, {}),
+    ).toThrow(EvaluationRuntimeConfigError);
   });
 });

--- a/lib/config/evaluationRuntimeConfig.ts
+++ b/lib/config/evaluationRuntimeConfig.ts
@@ -1,11 +1,18 @@
+import "server-only";
+
 import {
   assertEvalTimeoutConfig,
   resolveEvaluationTimeoutConfig,
   type EvaluationTimeoutConfig,
   type TimeoutBaseline,
 } from "@/lib/config/evaluationTimeouts";
+import {
+  resolveEvalEnvContract,
+  type AdjudicationMode,
+  type NodeEnv,
+} from "@/lib/config/envContract";
 
-export type ExternalAdjudicationMode = "optional" | "required" | "veto";
+export type ExternalAdjudicationMode = AdjudicationMode;
 
 export type EnvLike = Readonly<Record<string, string | undefined>>;
 
@@ -43,7 +50,7 @@ export interface EvaluationRuntimeConfig {
     cronSecret: string;
   };
   platform: {
-    nodeEnv: string;
+    nodeEnv: NodeEnv;
     vercel: boolean;
     vercelEnv?: string;
     hostname?: string;
@@ -89,26 +96,6 @@ function parseBoundedInteger(
   return parsed;
 }
 
-function parseAdjudicationMode(env: EnvLike): ExternalAdjudicationMode {
-  const raw = (env.EVAL_EXTERNAL_ADJUDICATION_MODE ?? "optional").trim().toLowerCase();
-  if (raw === "optional" || raw === "required" || raw === "veto") {
-    return raw;
-  }
-
-  throw new EvaluationRuntimeConfigError(
-    `EVAL_EXTERNAL_ADJUDICATION_MODE must be one of "optional", "required", "veto"; got ${JSON.stringify(raw)}`,
-  );
-}
-
-function parseModel(env: EnvLike): string {
-  const model = (env.EVAL_OPENAI_MODEL ?? "o3").trim();
-  if (!model) {
-    throw new EvaluationRuntimeConfigError(
-      "EVAL_OPENAI_MODEL is set but empty. Remove it or provide a valid model name.",
-    );
-  }
-  return model;
-}
 
 export function resolveEvaluationRuntimeConfig(
   env: EnvLike = process.env,
@@ -117,8 +104,16 @@ export function resolveEvaluationRuntimeConfig(
   const timeouts = resolveEvaluationTimeoutConfig(env, timeoutBaseline);
   assertEvalTimeoutConfig(env, timeoutBaseline);
 
-  const model = parseModel(env);
-  const adjudicationMode = parseAdjudicationMode(env);
+  let envContract: ReturnType<typeof resolveEvalEnvContract>;
+  try {
+    envContract = resolveEvalEnvContract(env as NodeJS.ProcessEnv);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new EvaluationRuntimeConfigError(`env contract validation failed: ${message}`);
+  }
+
+  const model = envContract.openAiModel;
+  const adjudicationMode = envContract.adjudicationMode;
 
   const pass1MaxTokens = parseBoundedInteger(env, "EVAL_PASS1_MAX_TOKENS", {
     defaultValue: 3500,
@@ -140,20 +135,8 @@ export function resolveEvaluationRuntimeConfig(
     min: 8000,
     max: 120000,
   });
-  const inputCharBudget = parseBoundedInteger(env, "EVAL_PIPELINE_INPUT_CHAR_BUDGET", {
-    defaultValue: 50000,
-    min: 12000,
-    max: 100000,
-  });
-  const synthesisRefCharBudget = parseBoundedInteger(
-    env,
-    "EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET",
-    {
-      defaultValue: 18000,
-      min: 4000,
-      max: 50000,
-    },
-  );
+  const inputCharBudget = envContract.inputCharBudget;
+  const synthesisRefCharBudget = envContract.synthesisRefCharBudget;
 
   const batchSize = parseBoundedInteger(env, "EVAL_WORKER_BATCH_SIZE", {
     defaultValue: 5,
@@ -185,7 +168,7 @@ export function resolveEvaluationRuntimeConfig(
     );
   }
 
-  const nodeEnv = (env.NODE_ENV ?? "development").trim() || "development";
+  const nodeEnv = envContract.nodeEnv;
 
   return {
     model,

--- a/lib/config/evaluationRuntimeConfig.ts
+++ b/lib/config/evaluationRuntimeConfig.ts
@@ -1,0 +1,271 @@
+import {
+  assertEvalTimeoutConfig,
+  resolveEvaluationTimeoutConfig,
+  type EvaluationTimeoutConfig,
+  type TimeoutBaseline,
+} from "@/lib/config/evaluationTimeouts";
+
+export type ExternalAdjudicationMode = "optional" | "required" | "veto";
+
+export type EnvLike = Readonly<Record<string, string | undefined>>;
+
+export class EvaluationRuntimeConfigError extends Error {
+  constructor(message: string) {
+    super(`[EVAL_RUNTIME_CONFIG] ${message}`);
+    this.name = "EvaluationRuntimeConfigError";
+  }
+}
+
+export interface EvaluationRuntimeConfig {
+  model: string;
+  adjudicationMode: ExternalAdjudicationMode;
+  openaiApiKey?: string;
+  perplexityApiKey?: string;
+  evalDebugEnabled: boolean;
+  minManuscriptWords: number;
+  staleRunningMinutes: number;
+  contextContaminationGuardEnabled: boolean;
+  pass: {
+    pass1MaxTokens: number;
+    pass2MaxTokens: number;
+    pass3MaxTokens: number;
+    pass3PromptMaxChars: number;
+    inputCharBudget: number;
+    synthesisRefCharBudget: number;
+  };
+  worker: {
+    batchSize: number;
+    leaseMs: number;
+    maxExecutionMs: number;
+    allowDevServiceRole: boolean;
+  };
+  auth: {
+    cronSecret: string;
+  };
+  platform: {
+    nodeEnv: string;
+    vercel: boolean;
+    vercelEnv?: string;
+    hostname?: string;
+  };
+  timeouts: EvaluationTimeoutConfig;
+}
+
+function parseStrictInteger(raw: string, name: string): number {
+  const trimmed = raw.trim();
+  if (!/^-?\d+$/u.test(trimmed)) {
+    throw new EvaluationRuntimeConfigError(
+      `${name} must be an integer string, got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new EvaluationRuntimeConfigError(
+      `${name} must be a finite integer, got ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseBoundedInteger(
+  env: EnvLike,
+  name: string,
+  options: { defaultValue: number; min: number; max: number },
+): number {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return options.defaultValue;
+  }
+
+  const parsed = parseStrictInteger(raw, name);
+  if (parsed < options.min || parsed > options.max) {
+    throw new EvaluationRuntimeConfigError(
+      `${name} must be between ${options.min} and ${options.max}, got ${parsed}`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseAdjudicationMode(env: EnvLike): ExternalAdjudicationMode {
+  const raw = (env.EVAL_EXTERNAL_ADJUDICATION_MODE ?? "optional").trim().toLowerCase();
+  if (raw === "optional" || raw === "required" || raw === "veto") {
+    return raw;
+  }
+
+  throw new EvaluationRuntimeConfigError(
+    `EVAL_EXTERNAL_ADJUDICATION_MODE must be one of "optional", "required", "veto"; got ${JSON.stringify(raw)}`,
+  );
+}
+
+function parseModel(env: EnvLike): string {
+  const model = (env.EVAL_OPENAI_MODEL ?? "o3").trim();
+  if (!model) {
+    throw new EvaluationRuntimeConfigError(
+      "EVAL_OPENAI_MODEL is set but empty. Remove it or provide a valid model name.",
+    );
+  }
+  return model;
+}
+
+export function resolveEvaluationRuntimeConfig(
+  env: EnvLike = process.env,
+  timeoutBaseline?: TimeoutBaseline,
+): EvaluationRuntimeConfig {
+  const timeouts = resolveEvaluationTimeoutConfig(env, timeoutBaseline);
+  assertEvalTimeoutConfig(env, timeoutBaseline);
+
+  const model = parseModel(env);
+  const adjudicationMode = parseAdjudicationMode(env);
+
+  const pass1MaxTokens = parseBoundedInteger(env, "EVAL_PASS1_MAX_TOKENS", {
+    defaultValue: 3500,
+    min: 1000,
+    max: 8000,
+  });
+  const pass2MaxTokens = parseBoundedInteger(env, "EVAL_PASS2_MAX_TOKENS", {
+    defaultValue: 3500,
+    min: 1000,
+    max: 8000,
+  });
+  const pass3MaxTokens = parseBoundedInteger(env, "EVAL_PASS3_MAX_TOKENS", {
+    defaultValue: 5000,
+    min: 2000,
+    max: 20000,
+  });
+  const pass3PromptMaxChars = parseBoundedInteger(env, "EVAL_PASS3_PROMPT_MAX_CHARS", {
+    defaultValue: 40000,
+    min: 8000,
+    max: 120000,
+  });
+  const inputCharBudget = parseBoundedInteger(env, "EVAL_PIPELINE_INPUT_CHAR_BUDGET", {
+    defaultValue: 50000,
+    min: 12000,
+    max: 100000,
+  });
+  const synthesisRefCharBudget = parseBoundedInteger(
+    env,
+    "EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET",
+    {
+      defaultValue: 18000,
+      min: 4000,
+      max: 50000,
+    },
+  );
+
+  const batchSize = parseBoundedInteger(env, "EVAL_WORKER_BATCH_SIZE", {
+    defaultValue: 5,
+    min: 1,
+    max: 5,
+  });
+  const leaseMs = parseBoundedInteger(env, "EVAL_WORKER_LEASE_MS", {
+    defaultValue: 180000,
+    min: 30000,
+    max: 180000,
+  });
+  const maxExecutionMs = parseBoundedInteger(env, "EVAL_WORKER_MAX_EXECUTION_MS", {
+    defaultValue: 55000,
+    min: 10000,
+    max: 295000,
+  });
+
+  if (leaseMs < maxExecutionMs) {
+    throw new EvaluationRuntimeConfigError(
+      `Invalid worker timing: EVAL_WORKER_LEASE_MS (${leaseMs}) must be >= EVAL_WORKER_MAX_EXECUTION_MS (${maxExecutionMs})`,
+    );
+  }
+
+  const openaiApiKey = env.OPENAI_API_KEY?.trim() || undefined;
+  const perplexityApiKey = env.PERPLEXITY_API_KEY?.trim() || undefined;
+  if ((adjudicationMode === "required" || adjudicationMode === "veto") && !perplexityApiKey) {
+    throw new EvaluationRuntimeConfigError(
+      `PERPLEXITY_API_KEY is required when EVAL_EXTERNAL_ADJUDICATION_MODE=${adjudicationMode}`,
+    );
+  }
+
+  const nodeEnv = (env.NODE_ENV ?? "development").trim() || "development";
+
+  return {
+    model,
+    adjudicationMode,
+    openaiApiKey,
+    perplexityApiKey,
+    evalDebugEnabled: env.EVAL_DEBUG === "1",
+    minManuscriptWords: (() => {
+      const minWordsRaw = env.EVAL_MIN_MANUSCRIPT_WORDS;
+      if (minWordsRaw && minWordsRaw.trim() !== "") {
+        return parseBoundedInteger(env, "EVAL_MIN_MANUSCRIPT_WORDS", {
+          defaultValue: 200,
+          min: 0,
+          max: 20000,
+        });
+      }
+
+      const minCharsRaw = env.EVAL_MIN_MANUSCRIPT_CHARS;
+      if (minCharsRaw && minCharsRaw.trim() !== "") {
+        const chars = parseBoundedInteger(env, "EVAL_MIN_MANUSCRIPT_CHARS", {
+          defaultValue: 1000,
+          min: 0,
+          max: 1_000_000,
+        });
+        return Math.ceil(chars / 5);
+      }
+
+      return 200;
+    })(),
+    staleRunningMinutes: parseBoundedInteger(env, "EVAL_STALE_RUNNING_MINUTES", {
+      defaultValue: 10,
+      min: 1,
+      max: 240,
+    }),
+    contextContaminationGuardEnabled: (() => {
+      const raw = (env.EVAL_CONTEXT_CONTAMINATION_GUARD ?? "auto").trim().toLowerCase();
+      if (raw === "true" || raw === "1" || raw === "yes" || raw === "on") {
+        return true;
+      }
+      if (raw === "false" || raw === "0" || raw === "no" || raw === "off") {
+        return false;
+      }
+      return nodeEnv === "production";
+    })(),
+    pass: {
+      pass1MaxTokens,
+      pass2MaxTokens,
+      pass3MaxTokens,
+      pass3PromptMaxChars,
+      inputCharBudget,
+      synthesisRefCharBudget,
+    },
+    worker: {
+      batchSize,
+      leaseMs,
+      maxExecutionMs,
+      allowDevServiceRole: env.WORKER_ALLOW_SERVICE_ROLE_DEV === "1",
+    },
+    auth: {
+      cronSecret: env.CRON_SECRET || "",
+    },
+    platform: {
+      nodeEnv,
+      vercel: env.VERCEL === "1" || !!env.VERCEL_ENV,
+      vercelEnv: env.VERCEL_ENV,
+      hostname: env.HOSTNAME,
+    },
+    timeouts,
+  };
+}
+
+let cachedRuntimeConfig: EvaluationRuntimeConfig | undefined;
+
+export function getEvaluationRuntimeConfig(): EvaluationRuntimeConfig {
+  if (!cachedRuntimeConfig) {
+    cachedRuntimeConfig = resolveEvaluationRuntimeConfig(process.env);
+  }
+  return cachedRuntimeConfig;
+}
+
+export function resetEvaluationRuntimeConfigCacheForTests(): void {
+  cachedRuntimeConfig = undefined;
+}

--- a/lib/evaluation/pipeline/promptInput.ts
+++ b/lib/evaluation/pipeline/promptInput.ts
@@ -1,12 +1,9 @@
-const DEFAULT_PASS_INPUT_CHAR_BUDGET = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PIPELINE_INPUT_CHAR_BUDGET || "50000", 10);
-  return Number.isFinite(parsed) && parsed >= 12000 && parsed <= 100000 ? parsed : 50000;
-})();
+import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
-const DEFAULT_SYNTHESIS_REFERENCE_CHAR_BUDGET = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET || "18000", 10);
-  return Number.isFinite(parsed) && parsed >= 4000 && parsed <= 50000 ? parsed : 18000;
-})();
+const DEFAULT_PASS_INPUT_CHAR_BUDGET = getEvaluationRuntimeConfig().pass.inputCharBudget;
+
+const DEFAULT_SYNTHESIS_REFERENCE_CHAR_BUDGET =
+  getEvaluationRuntimeConfig().pass.synthesisRefCharBudget;
 
 const OMITTED_SEPARATOR = "\n\n[... middle of manuscript omitted for prompt window ...]\n\n";
 

--- a/lib/evaluation/pipeline/promptInput.ts
+++ b/lib/evaluation/pipeline/promptInput.ts
@@ -1,5 +1,7 @@
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
+// DEFAULT_PASS_INPUT_CHAR_BUDGET and DEFAULT_SYNTHESIS_REFERENCE_CHAR_BUDGET are
+// resolved lazily (on first call) to avoid module-scope config reads.
 function getDefaultPassInputCharBudgetLazy(): number {
   return getEvaluationRuntimeConfig().pass.inputCharBudget;
 }

--- a/lib/evaluation/pipeline/promptInput.ts
+++ b/lib/evaluation/pipeline/promptInput.ts
@@ -1,9 +1,12 @@
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
-const DEFAULT_PASS_INPUT_CHAR_BUDGET = getEvaluationRuntimeConfig().pass.inputCharBudget;
+function getDefaultPassInputCharBudgetLazy(): number {
+  return getEvaluationRuntimeConfig().pass.inputCharBudget;
+}
 
-const DEFAULT_SYNTHESIS_REFERENCE_CHAR_BUDGET =
-  getEvaluationRuntimeConfig().pass.synthesisRefCharBudget;
+function getDefaultSynthesisReferenceCharBudgetLazy(): number {
+  return getEvaluationRuntimeConfig().pass.synthesisRefCharBudget;
+}
 
 const OMITTED_SEPARATOR = "\n\n[... middle of manuscript omitted for prompt window ...]\n\n";
 
@@ -23,21 +26,22 @@ export function estimateWordCount(text: string): number {
 }
 
 export function getDefaultPassInputCharBudget(): number {
-  return DEFAULT_PASS_INPUT_CHAR_BUDGET;
+  return getDefaultPassInputCharBudgetLazy();
 }
 
 export function getDefaultSynthesisReferenceCharBudget(): number {
-  return DEFAULT_SYNTHESIS_REFERENCE_CHAR_BUDGET;
+  return getDefaultSynthesisReferenceCharBudgetLazy();
 }
 
-export function buildPromptInputWindow(text: string, maxChars = DEFAULT_PASS_INPUT_CHAR_BUDGET): string {
+export function buildPromptInputWindow(text: string, maxChars?: number): string {
+  const effectiveMaxChars = maxChars ?? getDefaultPassInputCharBudgetLazy();
   const trimmed = text.trim();
-  if (trimmed.length <= maxChars) {
+  if (trimmed.length <= effectiveMaxChars) {
     return trimmed;
   }
 
   const separatorBudget = OMITTED_SEPARATOR.length * 2;
-  const segmentLen = Math.max(1500, Math.floor((maxChars - separatorBudget) / 3));
+  const segmentLen = Math.max(1500, Math.floor((effectiveMaxChars - separatorBudget) / 3));
 
   const start = trimmed.slice(0, segmentLen).trim();
   const middleStart = Math.max(0, Math.floor(trimmed.length / 2) - Math.floor(segmentLen / 2));
@@ -47,8 +51,9 @@ export function buildPromptInputWindow(text: string, maxChars = DEFAULT_PASS_INP
   return `${start}${OMITTED_SEPARATOR}${middle}${OMITTED_SEPARATOR}${end}`;
 }
 
-export function summarizePromptCoverage(text: string, maxChars = DEFAULT_PASS_INPUT_CHAR_BUDGET): PromptCoverage {
-  const window = buildPromptInputWindow(text, maxChars);
+export function summarizePromptCoverage(text: string, maxChars?: number): PromptCoverage {
+  const effectiveMaxChars = maxChars ?? getDefaultPassInputCharBudgetLazy();
+  const window = buildPromptInputWindow(text, effectiveMaxChars);
   const source = text.trim();
   const normalizedWindow = window.replaceAll(OMITTED_SEPARATOR, " ");
 

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -23,7 +23,7 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS1_TEMPERATURE = 0.3;
-const PASS1_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass1MaxTokens;
+function getPass1MaxTokens(): number { return getEvaluationRuntimeConfig().pass.pass1MaxTokens; }
 const PASS1_MODEL = "o3";
 
 function nowMs(): number {
@@ -88,7 +88,7 @@ function buildEmptyResponseDiagnostic(params: {
   return (
     `[Pass1] Empty response from OpenAI ` +
     `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
-    `max_output_tokens=${PASS1_MAX_TOKENS}` +
+    `max_output_tokens=${getPass1MaxTokens()}` +
     `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
     `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
     `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
@@ -145,7 +145,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
   const promptAssemblyMs = nowMs() - promptAssemblyStartMs;
   const inputChars = opts.manuscriptText.length;
 
-  const outputTokenParam = buildOpenAIOutputTokenParam(selectedModel, PASS1_MAX_TOKENS);
+  const outputTokenParam = buildOpenAIOutputTokenParam(selectedModel, getPass1MaxTokens());
   const configuredMaxTokens =
     typeof (outputTokenParam as { max_completion_tokens?: unknown }).max_completion_tokens === "number"
       ? Number((outputTokenParam as { max_completion_tokens: number }).max_completion_tokens)
@@ -193,7 +193,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
       contentType: rawContent === null ? "null" : Array.isArray(rawContent) ? "array" : typeof rawContent,
       contentPreview: typeof rawContent === "string" ? rawContent.slice(0, 160) : undefined,
       usage: completion.usage,
-      maxOutputTokens: PASS1_MAX_TOKENS,
+      maxOutputTokens: getPass1MaxTokens(),
       refusal:
         typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined,
     });
@@ -223,7 +223,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
   if (finishReasonWarning === "length") {
     console.warn("[Pass1] finish_reason=length — output may be truncated", {
       model: selectedModel,
-      maxOutputTokens: PASS1_MAX_TOKENS,
+      maxOutputTokens: getPass1MaxTokens(),
       responseLen: responseText.length,
       usage: completion.usage,
     });

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -20,12 +20,10 @@ import {
 } from "@/lib/evaluation/policy";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
+import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS1_TEMPERATURE = 0.3;
-const PASS1_MAX_TOKENS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS1_MAX_TOKENS || "3500", 10);
-  return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 8000 ? parsed : 3500;
-})();
+const PASS1_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass1MaxTokens;
 const PASS1_MODEL = "o3";
 
 function nowMs(): number {
@@ -298,7 +296,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
  * Separated so the constructor is only called when no DI override is provided.
  */
 function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
-  const apiKey = openaiApiKey ?? process.env.OPENAI_API_KEY;
+  const apiKey = openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey;
   if (!apiKey) {
     throw new Error("[Pass1] OPENAI_API_KEY is not configured");
   }

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -22,12 +22,10 @@ import {
 } from "@/lib/evaluation/policy";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
+import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS2_TEMPERATURE = 0.3;
-const PASS2_MAX_TOKENS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS2_MAX_TOKENS || "3500", 10);
-  return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 8000 ? parsed : 3500;
-})();
+const PASS2_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass2MaxTokens;
 const PASS2_MODEL = "o3";
 
 function getRetryPass2MaxTokens(currentMaxTokens: number): number {
@@ -349,7 +347,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
  * Separated so the constructor is only called when no DI override is provided.
  */
 function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
-  const apiKey = openaiApiKey ?? process.env.OPENAI_API_KEY;
+  const apiKey = openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey;
   if (!apiKey) {
     throw new Error("[Pass2] OPENAI_API_KEY is not configured");
   }

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -25,7 +25,7 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS2_TEMPERATURE = 0.3;
-const PASS2_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass2MaxTokens;
+function getPass2MaxTokens(): number { return getEvaluationRuntimeConfig().pass.pass2MaxTokens; }
 const PASS2_MODEL = "o3";
 
 function getRetryPass2MaxTokens(currentMaxTokens: number): number {
@@ -187,7 +187,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
 
   console.log(`[Pass2] completion request model=${selectedModel}`);
 
-  let activeMaxTokens = PASS2_MAX_TOKENS;
+  let activeMaxTokens = getPass2MaxTokens();
   const modelCallStartMs = nowMs();
   let { completion, configuredMaxTokens } = await requestCompletion(activeMaxTokens);
   let modelCallMs = nowMs() - modelCallStartMs;

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -28,9 +28,9 @@ import { enforcePass3QualityGuards } from "@/lib/evaluation/governance/runtimeQu
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS3_TEMPERATURE = 0.2;
-const PASS3_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass3MaxTokens;
+function getPass3MaxTokens(): number { return getEvaluationRuntimeConfig().pass.pass3MaxTokens; }
 const PASS3_MODEL = "o3";
-const PASS3_PROMPT_MAX_CHARS = getEvaluationRuntimeConfig().pass.pass3PromptMaxChars;
+function getPass3PromptMaxChars(): number { return getEvaluationRuntimeConfig().pass.pass3PromptMaxChars; }
 const PASS3_MIN_RATIONALE_LENGTH = 40;
 const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
 
@@ -98,7 +98,7 @@ function buildEmptyResponseDiagnostic(params: {
   return (
     `[Pass3] Empty response from OpenAI ` +
     `(model=${model} finish_reason=${finishReason} content_type=${contentType} choices=${choiceCount} ` +
-    `max_output_tokens=${PASS3_MAX_TOKENS} prompt_chars=${promptChars} comparison_packet_chars=${comparisonPacketChars} ` +
+    `max_output_tokens=${getPass3MaxTokens()} prompt_chars=${promptChars} comparison_packet_chars=${comparisonPacketChars} ` +
     `reference_chars=${coverage.analyzedChars} source_chars=${coverage.sourceChars}` +
     `${typeof usage?.prompt_tokens === "number" ? ` prompt_tokens=${usage.prompt_tokens}` : ""}` +
     `${typeof usage?.completion_tokens === "number" ? ` completion_tokens=${usage.completion_tokens}` : ""}` +
@@ -109,9 +109,9 @@ function buildEmptyResponseDiagnostic(params: {
 }
 
 function assertPass3PromptTripwires(userPrompt: string): void {
-  if (userPrompt.length > PASS3_PROMPT_MAX_CHARS) {
+  if (userPrompt.length > getPass3PromptMaxChars()) {
     throw new Error(
-      `[Pass3] PROMPT_TOO_LARGE: prompt_chars=${userPrompt.length} limit=${PASS3_PROMPT_MAX_CHARS}`,
+      `[Pass3] PROMPT_TOO_LARGE: prompt_chars=${userPrompt.length} limit=${getPass3PromptMaxChars()}`,
     );
   }
 
@@ -222,7 +222,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     comparison_packet_chars: comparisonPacketJson.length,
     system_prompt_chars: PASS3_SYSTEM_PROMPT.length,
     user_prompt_chars: userPrompt.length,
-    max_output_tokens: PASS3_MAX_TOKENS,
+    max_output_tokens: getPass3MaxTokens(),
   });
   
   // Compute coverage metadata (for truth enforcement)
@@ -238,7 +238,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
       { role: "user", content: userPrompt },
     ],
     ...buildOpenAITemperatureParam(selectedModel, PASS3_TEMPERATURE),
-    ...buildOpenAIOutputTokenParam(selectedModel, PASS3_MAX_TOKENS),
+    ...buildOpenAIOutputTokenParam(selectedModel, getPass3MaxTokens()),
     response_format: { type: "json_object" },
   });
 
@@ -271,7 +271,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
       comparisonPacketChars: comparisonPacketJson.length,
       promptChars: userPrompt.length,
       promptCoverage: coverage,
-      maxOutputTokens: PASS3_MAX_TOKENS,
+      maxOutputTokens: getPass3MaxTokens(),
       refusal:
         typeof firstChoice?.message?.refusal === "string" ? firstChoice.message.refusal : undefined,
     });
@@ -283,7 +283,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   if (finishReasonWarning === "length") {
     console.warn("[Pass3] finish_reason=length — output may be truncated", {
       model: selectedModel,
-      maxOutputTokens: PASS3_MAX_TOKENS,
+      maxOutputTokens: getPass3MaxTokens(),
       responseLen: responseText.length,
       usage: completion.usage,
     });

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -25,17 +25,12 @@ import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from 
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { enforcePass3QualityGuards } from "@/lib/evaluation/governance/runtimeQualityGuards";
+import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS3_TEMPERATURE = 0.2;
-const PASS3_MAX_TOKENS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS3_MAX_TOKENS || "5000", 10);
-  return Number.isFinite(parsed) && parsed >= 2000 && parsed <= 20000 ? parsed : 3500;
-})();
+const PASS3_MAX_TOKENS = getEvaluationRuntimeConfig().pass.pass3MaxTokens;
 const PASS3_MODEL = "o3";
-const PASS3_PROMPT_MAX_CHARS = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_PASS3_PROMPT_MAX_CHARS || "40000", 10);
-  return Number.isFinite(parsed) && parsed >= 8000 && parsed <= 120000 ? parsed : 40000;
-})();
+const PASS3_PROMPT_MAX_CHARS = getEvaluationRuntimeConfig().pass.pass3PromptMaxChars;
 const PASS3_MIN_RATIONALE_LENGTH = 40;
 const PASS3_PLACEHOLDER_RATIONALE_PATTERNS = PLACEHOLDER_RATIONALE_PATTERNS;
 
@@ -357,7 +352,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
  * Separated so the constructor is only called when no DI override is provided.
  */
 function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
-  const apiKey = openaiApiKey ?? process.env.OPENAI_API_KEY;
+  const apiKey = openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey;
   if (!apiKey) {
     throw new Error("[Pass3] OPENAI_API_KEY is not configured");
   }

--- a/lib/evaluation/policy.ts
+++ b/lib/evaluation/policy.ts
@@ -9,7 +9,9 @@ export type OpenAITemperatureParam = {
 
 export type ExternalAdjudicationMode = "optional" | "required" | "veto";
 
-const DEFAULT_PIPELINE_MODEL = (process.env.EVAL_OPENAI_MODEL || "o3").trim() || "o3";
+import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
+
+const DEFAULT_PIPELINE_MODEL = getEvaluationRuntimeConfig().model;
 
 export function isReasoningStyleModel(model: string): boolean {
   const normalizedModel = model.trim().toLowerCase();
@@ -43,11 +45,5 @@ export function getCanonicalPipelineModel(overrideModel?: string): string {
 }
 
 export function getExternalAdjudicationMode(): ExternalAdjudicationMode {
-  const raw = (process.env.EVAL_EXTERNAL_ADJUDICATION_MODE || "optional").trim().toLowerCase();
-
-  if (raw === "required" || raw === "veto") {
-    return raw;
-  }
-
-  return "optional";
+  return getEvaluationRuntimeConfig().adjudicationMode;
 }

--- a/lib/evaluation/policy.ts
+++ b/lib/evaluation/policy.ts
@@ -11,7 +11,7 @@ export type ExternalAdjudicationMode = "optional" | "required" | "veto";
 
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
-const DEFAULT_PIPELINE_MODEL = getEvaluationRuntimeConfig().model;
+function getDefaultPipelineModel(): string { return getEvaluationRuntimeConfig().model; }
 
 export function isReasoningStyleModel(model: string): boolean {
   const normalizedModel = model.trim().toLowerCase();
@@ -41,7 +41,7 @@ export function buildOpenAITemperatureParam(
 
 export function getCanonicalPipelineModel(overrideModel?: string): string {
   const candidate = (overrideModel || "").trim();
-  return candidate.length > 0 ? candidate : DEFAULT_PIPELINE_MODEL;
+  return candidate.length > 0 ? candidate : getDefaultPipelineModel();
 }
 
 export function getExternalAdjudicationMode(): ExternalAdjudicationMode {

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -96,17 +96,26 @@ import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJ
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-const runtimeConfig = getEvaluationRuntimeConfig();
-const openaiApiKey = runtimeConfig.openaiApiKey;
-const perplexityApiKey = runtimeConfig.perplexityApiKey ?? "";
-const evalDebugEnabled = runtimeConfig.evalDebugEnabled;
-const evalMinManuscriptWords = runtimeConfig.minManuscriptWords;
-const openAiModel = runtimeConfig.model;
-const evalPassTimeoutMs = getEvalPassTimeoutMs();
-const evalOpenAiTimeoutMs = getEvalOpenAiTimeoutMs();
-assertEvalTimeoutConfig();
+
+function getProcessorRuntimeDeps() {
+  assertEvalTimeoutConfig();
+  const runtimeConfig = getEvaluationRuntimeConfig();
+  return {
+    runtimeConfig,
+    openaiApiKey: runtimeConfig.openaiApiKey,
+    perplexityApiKey: runtimeConfig.perplexityApiKey ?? "",
+    evalDebugEnabled: runtimeConfig.evalDebugEnabled,
+    evalMinManuscriptWords: runtimeConfig.minManuscriptWords,
+    openAiModel: runtimeConfig.model,
+    staleRunningMinutes: runtimeConfig.staleRunningMinutes,
+    evalWorkerBatchSize: getValidatedWorkerBatchSize(runtimeConfig.worker.batchSize, 5),
+    evalContextContaminationGuardEnabled: runtimeConfig.contextContaminationGuardEnabled,
+    evalPassTimeoutMs: getEvalPassTimeoutMs(),
+    evalOpenAiTimeoutMs: getEvalOpenAiTimeoutMs(),
+  };
+}
+
 const EVALUATION_PROGRESS_TOTAL_UNITS = 3;
-const staleRunningMinutes = runtimeConfig.staleRunningMinutes;
 
 export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
   const parsed =
@@ -132,8 +141,7 @@ function isMissingSchemaCacheColumnError(error: unknown, columnName: string): bo
   return code === 'PGRST204' && message.includes(columnName) && message.includes('schema cache');
 }
 
-const evalWorkerBatchSize = getValidatedWorkerBatchSize(runtimeConfig.worker.batchSize, 5);
-const evalContextContaminationGuardEnabled = runtimeConfig.contextContaminationGuardEnabled;
+
 
 interface EvaluationJob {
   id: string;
@@ -182,14 +190,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function evalDebugLog(message: string, ...args: unknown[]): void {
-  if (!evalDebugEnabled) {
+  if (!getEvaluationRuntimeConfig().evalDebugEnabled) {
     return;
   }
   console.log(message, ...args);
 }
 
 function evalDebugWarn(message: string, ...args: unknown[]): void {
-  if (!evalDebugEnabled) {
+  if (!getEvaluationRuntimeConfig().evalDebugEnabled) {
     return;
   }
   console.warn(message, ...args);
@@ -562,17 +570,18 @@ async function resolveManuscriptText(
 
 export function isManuscriptTextLongEnough(
   text: string,
-  minWords = evalMinManuscriptWords,
+  minWords?: number,
 ): boolean {
+  const effectiveMinWords = minWords ?? getProcessorRuntimeDeps().evalMinManuscriptWords;
   const trimmed = text.trim();
   if (!trimmed) {
-    return minWords <= 0;
+    return effectiveMinWords <= 0;
   }
 
   // Use word-boundary matching rather than split(/\s+/) to avoid overcounting
   // malformed whitespace-heavy text or undercounting punctuation-dense content.
   const wordCount = (trimmed.match(/\b\w+\b/g) || []).length;
-  return wordCount >= minWords;
+  return wordCount >= effectiveMinWords;
 }
 
 function normalizeCriterionEntry(
@@ -793,6 +802,7 @@ export async function failStaleRunningJobs(): Promise<{
   failed: number;
   ids: string[];
 }> {
+  const { staleRunningMinutes } = getProcessorRuntimeDeps();
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
   const now = new Date().toISOString();
   const cutoff = new Date(Date.now() - staleRunningMinutes * 60_000).toISOString();
@@ -873,6 +883,16 @@ export async function failStaleRunningJobs(): Promise<{
  * Process a single evaluation job
  */
 export async function processEvaluationJob(jobId: string): Promise<{ success: boolean; error?: string }> {
+  const {
+    openaiApiKey,
+    perplexityApiKey,
+    evalDebugEnabled,
+    evalMinManuscriptWords,
+    openAiModel,
+    evalPassTimeoutMs,
+    evalOpenAiTimeoutMs,
+    evalContextContaminationGuardEnabled,
+  } = getProcessorRuntimeDeps();
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
   let lifecycleStatus: JobStatus | null = null;
 
@@ -1625,6 +1645,7 @@ export async function claimQueuedJobs(
     leaseMs?: number;
   },
 ): Promise<Array<{ id: string; phase: string; claimedAt?: string }>> {
+  const { evalWorkerBatchSize } = getProcessorRuntimeDeps();
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   const workerId = options.workerId;
@@ -1708,6 +1729,7 @@ export async function processQueuedJobs(options?: {
   claimed: number;
   errors: Array<{ jobId: string; error: string }>;
 }> {
+  const { evalWorkerBatchSize } = getProcessorRuntimeDeps();
   const effectiveWorkerId = options?.workerId ?? randomUUID();
   const requestedBatchSize = options?.batchSize ?? evalWorkerBatchSize;
   const requestedLeaseMs = options?.leaseMs ?? 180_000;

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -79,6 +79,7 @@ import {
   getEvalOpenAiTimeoutMs,
   getEvalPassTimeoutMs,
 } from '@/lib/evaluation/config';
+import { getEvaluationRuntimeConfig } from '@/lib/config/evaluationRuntimeConfig';
 import {
   emitLatencyTrace,
   finishLatencyStage,
@@ -95,42 +96,17 @@ import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJ
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-const openaiApiKey = process.env.OPENAI_API_KEY;
-const perplexityApiKey = process.env.PERPLEXITY_API_KEY ?? "";
-const evalDebugEnabled = process.env.EVAL_DEBUG === '1';
-const evalMinManuscriptWords = (() => {
-  if (process.env.EVAL_MIN_MANUSCRIPT_WORDS) {
-    const parsed = Number.parseInt(process.env.EVAL_MIN_MANUSCRIPT_WORDS, 10);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      return parsed;
-    }
-  }
-
-  if (process.env.EVAL_MIN_MANUSCRIPT_CHARS) {
-    const parsed = Number.parseInt(process.env.EVAL_MIN_MANUSCRIPT_CHARS, 10);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      console.warn(
-        '[Processor] EVAL_MIN_MANUSCRIPT_CHARS is deprecated. Converting chars to words (~5 chars/word). Prefer EVAL_MIN_MANUSCRIPT_WORDS.',
-      );
-      return Math.ceil(parsed / 5);
-    }
-
-    console.warn(
-      '[Processor] EVAL_MIN_MANUSCRIPT_CHARS is deprecated and invalid. Defaulting to 200 words. Prefer EVAL_MIN_MANUSCRIPT_WORDS.',
-    );
-  }
-
-  return 200;
-})();
-const openAiModel = (process.env.EVAL_OPENAI_MODEL || 'o3').trim() || 'o3';
+const runtimeConfig = getEvaluationRuntimeConfig();
+const openaiApiKey = runtimeConfig.openaiApiKey;
+const perplexityApiKey = runtimeConfig.perplexityApiKey ?? "";
+const evalDebugEnabled = runtimeConfig.evalDebugEnabled;
+const evalMinManuscriptWords = runtimeConfig.minManuscriptWords;
+const openAiModel = runtimeConfig.model;
 const evalPassTimeoutMs = getEvalPassTimeoutMs();
 const evalOpenAiTimeoutMs = getEvalOpenAiTimeoutMs();
 assertEvalTimeoutConfig();
 const EVALUATION_PROGRESS_TOTAL_UNITS = 3;
-const staleRunningMinutes = (() => {
-  const parsed = Number.parseInt(process.env.EVAL_STALE_RUNNING_MINUTES || '10', 10);
-  return Number.isFinite(parsed) && parsed >= 1 && parsed <= 240 ? parsed : 10;
-})();
+const staleRunningMinutes = runtimeConfig.staleRunningMinutes;
 
 export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
   const parsed =
@@ -156,19 +132,8 @@ function isMissingSchemaCacheColumnError(error: unknown, columnName: string): bo
   return code === 'PGRST204' && message.includes(columnName) && message.includes('schema cache');
 }
 
-const evalWorkerBatchSize = (() => {
-  return getValidatedWorkerBatchSize(process.env.EVAL_WORKER_BATCH_SIZE, 5);
-})();
-const evalContextContaminationGuardEnabled = (() => {
-  const raw = (process.env.EVAL_CONTEXT_CONTAMINATION_GUARD || 'auto').trim().toLowerCase();
-  if (raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on') {
-    return true;
-  }
-  if (raw === 'false' || raw === '0' || raw === 'no' || raw === 'off') {
-    return false;
-  }
-  return process.env.NODE_ENV === 'production';
-})();
+const evalWorkerBatchSize = getValidatedWorkerBatchSize(runtimeConfig.worker.batchSize, 5);
+const evalContextContaminationGuardEnabled = runtimeConfig.contextContaminationGuardEnabled;
 
 interface EvaluationJob {
   id: string;


### PR DESCRIPTION
## Summary

Migrate canonical evaluation hot-path modules off direct `process.env` reads onto `getEvaluationRuntimeConfig()`, which was introduced as a foundation in #211.

This PR does **one thing**: make canonical runtime readers consume the contract authority already established. No latency tuning. No prompt changes. No scoring semantics changes. No opportunistic refactors.

## Scope

- [x] This PR affects one optimization lane and keeps scope tight
- [x] No unrelated refactors included
- [x] No hidden scoring or schema logic changes

**Pass targeted:**
- [x] Pass 1
- [x] Pass 2
- [x] Pass 3

## Contract Integrity

- [x] Canonical hot-path modules stop interpreting their own env values
- [x] All migrated surfaces read through `getEvaluationRuntimeConfig()`
- [x] Existing behavior is unchanged except where the resolver intentionally hard-fails bad input
- [x] Worker lease invariant enforced: `leaseMs >= maxExecutionMs`
- [x] Conditional Perplexity key requirement enforced in resolver, not at call site

## Surfaces migrated

| File | What moved |
|---|---|
| `lib/evaluation/processor.ts` | model selection, adjudication mode, API key access |
| `lib/evaluation/policy.ts` | model and adjudication mode defaults |
| `lib/evaluation/pipeline/promptInput.ts` | `inputCharBudget`, `synthesisRefCharBudget` |
| `lib/evaluation/pipeline/runPass1.ts` | `pass1MaxTokens`, `openaiApiKey` |
| `lib/evaluation/pipeline/runPass2.ts` | `pass2MaxTokens`, `openaiApiKey` |
| `lib/evaluation/pipeline/runPass3Synthesis.ts` | `pass3MaxTokens`, `pass3PromptMaxChars`, `openaiApiKey` |
| `app/api/workers/process-evaluations/route.ts` | `batchSize`, `leaseMs`, `maxExecutionMs`, auth, platform flags |

## Also adds

- `lib/config/evaluationRuntimeConfig.ts` — canonical hot-path resolver with strict integer parsing, adjudication mode enum guard, worker lease invariant, conditional Perplexity key, timeout chain via `evaluationTimeouts.ts`, cached singleton
- `lib/config/__tests__/evaluationRuntimeConfig.test.ts` — focused contract tests

## Behavioral Quality

- [x] No prompt-quality logic removed in this PR
- [x] Quality behavior remains governed by existing runtime quality gates
- [x] Quality Gate / anomaly disclosure included below

Quality gate note: no new `QG_` regression introduced. Config-only migration.
Pass 3 divergence distribution (from fixture-driven verification): `criteria_count_by_state` remains unchanged from baseline semantics in this config-only migration.

## Latency Evidence

Baseline (Pre-change)

| Metric | Value |
|---|---|
| passX_ms | N/A (env hot-path migration PR, not latency tuning) |
| total_ms | N/A |
| quality gate | stable baseline expected |

Post-change Runs

| Run | passX_ms | total_ms | quality gate / anomaly |
|---|---:|---:|---|
| Run 1 | N/A | N/A | 53/53 focused tests pass; no new QG_ signal |
| Run 2 | N/A | N/A | auth regression suite green after cache-safety fix; no new QG_ signal |

Targeted verification evidence:
- `lib/config/__tests__/evaluationRuntimeConfig.test.ts` → PASS
- `lib/config/__tests__/envContract.test.ts` → PASS
- `__tests__/lib/evaluation/processor.config-invariant.test.ts` → PASS
- `__tests__/lib/evaluation/processor.openai-params.test.ts` → PASS
- `app/api/workers/process-evaluations/auth.test.ts` → PASS (34/34)

## Risks & Anomalies

- Evidence artifacts and audit docs remain local-only and are excluded from this merge scope.
- Remaining hot-path surfaces (any direct `process.env` reads in non-canonical modules) are out of scope until a deliberate cleanup pass.
- No risk to scoring semantics; config sourcing only.

## Final Rule

This change is completing the contract adoption the foundation PR established. We are not changing what the pipeline does — only who answers when it asks what the env says, and we are explicitly not reducing intelligence.
