### PR TITLE
refactor(eval): lazy env reads in contextContaminationGuard; exempt comments on DB credentials

### DIFF
--- a/lib/evaluation/governance/contextContaminationGuard.ts
+++ b/lib/evaluation/governance/contextContaminationGuard.ts
@@ -45,10 +45,6 @@ function parseIntEnv(name: string, fallback: number, min: number, max: number): 
   return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : fallback;
 }
 
-const MIN_TOKEN_LENGTH = parseIntEnv("EVAL_CONTEXT_CONTAMINATION_MIN_TOKEN_LENGTH", 4, 3, 12);
-
-const MAX_REPORTED_ENTITIES = parseIntEnv("EVAL_CONTEXT_CONTAMINATION_MAX_REPORTED", 25, 1, 100);
-
 export type ContextContaminationResult = {
   contaminated: boolean;
   offendingEntities: string[];
@@ -63,7 +59,7 @@ function normalize(text: string): string {
     .trim();
 }
 
-function tokenizeClean(text: string, stop: Set<string>): Set<string> {
+function tokenizeClean(text: string, stop: Set<string>, minTokenLength: number): Set<string> {
   const normalized = normalize(text);
   if (!normalized) {
     return new Set<string>();
@@ -73,7 +69,7 @@ function tokenizeClean(text: string, stop: Set<string>): Set<string> {
   const result = new Set<string>();
 
   for (const token of tokens) {
-    if (token.length < MIN_TOKEN_LENGTH) continue;
+    if (token.length < minTokenLength) continue;
     if (stop.has(token)) continue;
     result.add(token);
   }
@@ -115,11 +111,14 @@ export function detectContextContamination(params: {
 }): ContextContaminationResult {
   const sourceText = params.sourceText || "";
   const outputText = buildEvaluationOutputText(params.evaluationResult);
+  // Lazy env reads — resolved at call time, not module load time.
+  const minTokenLength = parseIntEnv("EVAL_CONTEXT_CONTAMINATION_MIN_TOKEN_LENGTH", 4, 3, 12);
+  const maxReportedEntities = parseIntEnv("EVAL_CONTEXT_CONTAMINATION_MAX_REPORTED", 25, 1, 100);
 
   // Hard-fail check: use token-set membership to avoid substring false-positives
   // (e.g. "mariage" would wrongly match "maria" with .includes()).
-  const outputTokenSet = tokenizeClean(outputText, STOPWORDS);
-  const sourceTokenSet = tokenizeClean(sourceText, STOPWORDS);
+  const outputTokenSet = tokenizeClean(outputText, STOPWORDS, minTokenLength);
+  const sourceTokenSet = tokenizeClean(sourceText, STOPWORDS, minTokenLength);
 
   const hardFailHits: string[] = [];
   for (const token of HARD_FAIL_TOKENS) {
@@ -132,7 +131,7 @@ export function detectContextContamination(params: {
     hardFailHits.sort();
     return {
       contaminated: true,
-      offendingEntities: hardFailHits.slice(0, MAX_REPORTED_ENTITIES),
+      offendingEntities: hardFailHits.slice(0, maxReportedEntities),
       reasons: hardFailHits.map((token) => `Hard contamination token detected: ${token}`),
     };
   }

--- a/lib/evaluation/pipeline/gatePhase2OnPhase1.ts
+++ b/lib/evaluation/pipeline/gatePhase2OnPhase1.ts
@@ -89,6 +89,7 @@ export async function checkPhase1GateForJob(jobId: string): Promise<boolean> {
   try {
     const { createClient } = await import("@supabase/supabase-js");
     const supabase = createClient(
+      // DB bootstrap — intentionally reads process.env directly (not evaluation config).
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY!
     );

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -94,6 +94,7 @@ import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 
+// DB bootstrap — intentionally reads process.env directly (not evaluation config).
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 


### PR DESCRIPTION
## Summary

Completes the `refactor/eval-env-read-audit` pass.

### Changes

**`contextContaminationGuard.ts`** — only remaining non-exempt `process.env` read in `lib/evaluation/`:
- `MIN_TOKEN_LENGTH` and `MAX_REPORTED_ENTITIES` were resolved at module load time via `parseIntEnv()`. Moved both inside `detectContextContamination()` as local `const`s — resolved lazily at call time, consistent with the pattern established in #212.
- Added `minTokenLength: number` parameter to `tokenizeClean()` so it no longer consumes module-scope state.

**`processor.ts` / `gatePhase2OnPhase1.ts`** — DB credential reads:
- Added `// DB bootstrap — intentionally reads process.env directly (not evaluation config).` comments to document the intentional exemption for future audits.

### Test results
63/63 passing (evaluation bundle, config invariant, auth)