### PR TITLE
feat(latency): promote Pass 1 sub-timings to structured LatencyTrace; thread jobId

### DIFF
--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -19,6 +19,7 @@ import {
   getCanonicalPipelineModel,
 } from "@/lib/evaluation/policy";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
+import { emitLatencyTrace } from "@/lib/observability/latencyTrace";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
@@ -113,6 +114,8 @@ export interface RunPass1Options {
   registry: CanonRegistry;
   model?: string;
   openaiApiKey?: string;
+  /** Job ID forwarded from the processor for latency trace correlation. */
+  jobId?: string;
   /** Override the completion function (for testing). Production callers omit this. */
   _createCompletion?: CreateCompletionFn;
   _onCompletion?: (capture: PassCompletionCapture) => void;
@@ -198,21 +201,25 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     });
     const parseValidationMs = nowMs() - parseValidationStartMs;
     const totalMs = nowMs() - passStartMs;
-    console.log("[Pass1][Timing]", {
-      stage: "failure",
-      model: selectedModel,
-      input_chars: inputChars,
-      output_chars: responseText.length,
-      prompt_assembly_ms: promptAssemblyMs,
-      model_call_ms: modelCallMs,
-      parse_validation_ms: parseValidationMs,
-      total_ms: totalMs,
-      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
-      configured_max_tokens: configuredMaxTokens,
-      usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
-      usage_completion_tokens: completion.usage?.completion_tokens ?? null,
-      usage_total_tokens: completion.usage?.total_tokens ?? null,
-      error: "empty_response",
+    emitLatencyTrace({
+      job_id: opts.jobId ?? 'unknown',
+      stage: 'pass1',
+      state: 'pass1_timings_failure',
+      metadata: {
+        finish_reason: 'empty_response',
+        model: selectedModel,
+        input_chars: inputChars,
+        output_chars: responseText.length,
+        prompt_assembly_ms: promptAssemblyMs,
+        model_call_ms: modelCallMs,
+        parse_validation_ms: parseValidationMs,
+        total_ms: totalMs,
+        configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+        configured_max_tokens: configuredMaxTokens,
+        usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
+        usage_completion_tokens: completion.usage?.completion_tokens ?? null,
+        usage_total_tokens: completion.usage?.total_tokens ?? null,
+      },
     });
     throw new Error(diagnosticMessage);
   }
@@ -271,20 +278,24 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
   const parseValidationMs = nowMs() - parseValidationStartMs;
   const totalMs = nowMs() - passStartMs;
 
-  console.log("[Pass1][Timing]", {
-    stage: "success",
-    model: selectedModel,
-    input_chars: inputChars,
-    output_chars: responseText.length,
-    prompt_assembly_ms: promptAssemblyMs,
-    model_call_ms: modelCallMs,
-    parse_validation_ms: parseValidationMs,
-    total_ms: totalMs,
-    configured_timeout_ms: getEvalOpenAiTimeoutMs(),
-    configured_max_tokens: configuredMaxTokens,
-    usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
-    usage_completion_tokens: completion.usage?.completion_tokens ?? null,
-    usage_total_tokens: completion.usage?.total_tokens ?? null,
+  emitLatencyTrace({
+    job_id: opts.jobId ?? 'unknown',
+    stage: 'pass1',
+    state: 'pass1_timings',
+    metadata: {
+      model: selectedModel,
+      input_chars: inputChars,
+      output_chars: responseText.length,
+      prompt_assembly_ms: promptAssemblyMs,
+      model_call_ms: modelCallMs,
+      parse_validation_ms: parseValidationMs,
+      total_ms: totalMs,
+      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+      configured_max_tokens: configuredMaxTokens,
+      usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
+      usage_completion_tokens: completion.usage?.completion_tokens ?? null,
+      usage_total_tokens: completion.usage?.total_tokens ?? null,
+    },
   });
 
   return parsedOutput;

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -401,6 +401,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       executionMode: opts.executionMode,
       model: opts.model,
       openaiApiKey: opts.openaiApiKey,
+      jobId: opts.jobId,
       registry,
     }),
     passTimeoutMs,


### PR DESCRIPTION
## Measurement baseline — no behavior changes

### What this does

Pass 1 already captured four sub-timing breakdowns internally via `console.log`:
- `prompt_assembly_ms` — time to build the user prompt
- `model_call_ms` — OpenAI network + inference time (the number that matters)
- `parse_validation_ms` — JSON boundary parse + criteria validation
- `total_ms` — full pass wall-clock

Plus `input_chars`, `output_chars`, and token usage (`prompt_tokens`, `completion_tokens`).

These were unstructured and job-untagged — impossible to correlate across runs.

### Changes

- Add `jobId?: string` to `RunPass1Options` (optional, non-breaking)
- Thread `jobId` from `runPipeline` into the `_runPass1` call
- Replace both `console.log('[Pass1][Timing]')` calls (success + failure) with `emitLatencyTrace` — structured, tagged with `job_id`, surfaced under `ENABLE_LATENCY_TRACE_LOGS=1`

### Trace shape after this PR

With `ENABLE_LATENCY_TRACE_LOGS=1`, a single Pass 1 call now emits three events:
```
{ job_id, stage:'pass1', state:'started' }                                    // runPipeline
{ job_id, stage:'pass1', state:'pass1_timings', metadata:{ model_call_ms, prompt_assembly_ms, ... } }
{ job_id, stage:'pass1', state:'completed', duration_ms }                     // runPipeline
```
The middle event is an informational emit inside the existing start/finish window — no double-finish, no structural change.

### What this enables

The next branch (`feat/latency-pass1-compression-1`) can now target `model_call_ms` and `input_chars` specifically, with a measured pre-optimization baseline to compare against.

### Tests
63/63 passing