### PR TITLE
feat(quality): recommendation semantics contract — schema, normalizat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out
 /tmp/
 *.tsbuildinfo
 dist-workers/
+docs/operations/evidence/runs/
 
 # Local/accidental
 your-repo.git/

--- a/lib/evaluation/pipeline/__tests__/pass3-semantic-contract.test.ts
+++ b/lib/evaluation/pipeline/__tests__/pass3-semantic-contract.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for Pass 3 semantic normalization contract.
+ *
+ * Exercises the normalizers in recommendationSemantics.ts directly.
+ * These are the helpers wired into runPass3Synthesis at the parse boundary.
+ *
+ * Required-field enforcement (missing issue_family, submission_readiness) is
+ * tested via the e2e contract suite in pipeline-e2e.test.ts.
+ */
+
+import { normalizeIssueFamily, normalizeStrategicLever, normalizeRevisionGranularity, buildRedundancyKey } from '../recommendationSemantics';
+
+describe('normalizeIssueFamily', () => {
+  it('passes through canonical values', () => {
+    expect(normalizeIssueFamily('pacing')).toBe('pacing');
+    expect(normalizeIssueFamily('voice')).toBe('voice');
+    expect(normalizeIssueFamily('market_positioning')).toBe('market_positioning');
+  });
+
+  it('normalizes case and whitespace', () => {
+    expect(normalizeIssueFamily('PACING')).toBe('pacing');
+    expect(normalizeIssueFamily('  voice  ')).toBe('voice');
+  });
+
+  it('normalizes variants to canonical', () => {
+    expect(normalizeIssueFamily('prose')).toBe('prose_control');
+    expect(normalizeIssueFamily('style')).toBe('prose_control');
+    expect(normalizeIssueFamily('structure')).toBe('scene_structure');
+    expect(normalizeIssueFamily('market')).toBe('market_positioning');
+    expect(normalizeIssueFamily('marketability')).toBe('market_positioning');
+    expect(normalizeIssueFamily('grammar')).toBe('prose_control');
+  });
+
+  it('returns undefined for non-string or unknown input', () => {
+    expect(normalizeIssueFamily(null)).toBeUndefined();
+    expect(normalizeIssueFamily(123)).toBeUndefined();
+    expect(normalizeIssueFamily('invalid_unknown_category')).toBeUndefined();
+  });
+});
+
+describe('normalizeStrategicLever', () => {
+  it('passes through canonical values', () => {
+    expect(normalizeStrategicLever('momentum_visibility')).toBe('momentum_visibility');
+    expect(normalizeStrategicLever('prose_compression')).toBe('prose_compression');
+  });
+
+  it('normalizes momentum-related phrasings', () => {
+    expect(normalizeStrategicLever('forward momentum')).toBe('momentum_visibility');
+    expect(normalizeStrategicLever('vary rhythm')).toBe('momentum_visibility');
+    expect(normalizeStrategicLever('interleave action')).toBe('momentum_visibility');
+    expect(normalizeStrategicLever('increase momentum')).toBe('momentum_visibility');
+  });
+
+  it('normalizes dialogue-related phrasings', () => {
+    expect(normalizeStrategicLever('on the nose dialogue')).toBe('dialogue_exposition_density');
+    expect(normalizeStrategicLever('reduce exposition in dialogue')).toBe(
+      'dialogue_exposition_density',
+    );
+  });
+
+  it('normalizes prose/tension phrasings', () => {
+    expect(normalizeStrategicLever('cut wordiness')).toBe('prose_compression');
+    expect(normalizeStrategicLever('escalate tension')).toBe('tension_escalation');
+    expect(normalizeStrategicLever('raise stakes')).toBe('tension_escalation');
+  });
+
+  it('returns undefined for non-string or unknown input', () => {
+    expect(normalizeStrategicLever(null)).toBeUndefined();
+    expect(normalizeStrategicLever('unknown_lever_xyz')).toBeUndefined();
+  });
+});
+
+describe('normalizeRevisionGranularity', () => {
+  it('passes through canonical values', () => {
+    expect(normalizeRevisionGranularity('line')).toBe('line');
+    expect(normalizeRevisionGranularity('scene')).toBe('scene');
+    expect(normalizeRevisionGranularity('manuscript')).toBe('manuscript');
+  });
+
+  it('normalizes variants to canonical levels', () => {
+    expect(normalizeRevisionGranularity('word')).toBe('line');
+    expect(normalizeRevisionGranularity('sentence')).toBe('line');
+    expect(normalizeRevisionGranularity('paragraph')).toBe('beat');
+    expect(normalizeRevisionGranularity('block')).toBe('beat');
+    expect(normalizeRevisionGranularity('chapter')).toBe('chapter');
+    expect(normalizeRevisionGranularity('section')).toBe('chapter');
+    expect(normalizeRevisionGranularity('book')).toBe('manuscript');
+    expect(normalizeRevisionGranularity('full')).toBe('manuscript');
+  });
+
+  it('returns undefined for non-string or unknown input', () => {
+    expect(normalizeRevisionGranularity(null)).toBeUndefined();
+    expect(normalizeRevisionGranularity('unknown_level')).toBeUndefined();
+  });
+});
+
+describe('buildRedundancyKey', () => {
+  it('builds deterministic key from three fields', () => {
+    const key = buildRedundancyKey('pacing', 'momentum_visibility', 'scene');
+    expect(key).toBe('pacing:momentum_visibility:scene');
+  });
+
+  it('handles undefined fields gracefully', () => {
+    const key1 = buildRedundancyKey(undefined, 'momentum_visibility', 'scene');
+    expect(key1).toBe('unknown:momentum_visibility:scene');
+
+    const key2 = buildRedundancyKey('pacing', undefined, undefined);
+    expect(key2).toBe('pacing:unknown:unknown');
+  });
+
+  it('is stable across calls', () => {
+    const key1 = buildRedundancyKey('pacing', 'momentum_visibility', 'scene');
+    const key2 = buildRedundancyKey('pacing', 'momentum_visibility', 'scene');
+    expect(key1).toBe(key2);
+  });
+});
+

--- a/lib/evaluation/pipeline/recommendationSemantics.ts
+++ b/lib/evaluation/pipeline/recommendationSemantics.ts
@@ -82,10 +82,18 @@ const ISSUE_FAMILY_ALIASES: Record<string, IssueFamily> = {
   prose: "prose_control",
   "prose clarity": "prose_control",
   style: "prose_control",
+  grammar: "prose_control",
+  "prose and style": "prose_control",
+  grammar: "prose_control",
+  "prose and style": "prose_control",
+  "prose_and_style": "prose_control",
   // scene_structure
   scene: "scene_structure",
   structure: "scene_structure",
   "scene construction": "scene_structure",
+  "pacing and structure": "scene_structure",
+  "pacing and structure": "scene_structure",
+  "pacing_and_structure": "scene_structure",
   // characterization
   character: "characterization",
   "character arc": "characterization",
@@ -98,6 +106,14 @@ const ISSUE_FAMILY_ALIASES: Record<string, IssueFamily> = {
   ending: "closure",
   resolution: "closure",
   "narrative closure": "closure",
+  // market_positioning
+  market: "market_positioning",
+  marketability: "market_positioning",
+  commercial: "market_positioning",
+  // market_positioning
+  market: "market_positioning",
+  marketability: "market_positioning",
+  commercial: "market_positioning",
 };
 
 const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
@@ -114,10 +130,16 @@ const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
   "dialogue exposition": "dialogue_exposition_density",
   "reduce exposition in dialogue": "dialogue_exposition_density",
   "dialogue info density": "dialogue_exposition_density",
+  "on the nose dialogue": "dialogue_exposition_density",
+  "dialogue density": "dialogue_exposition_density",
+  "on the nose dialogue": "dialogue_exposition_density",
+  "dialogue density": "dialogue_exposition_density",
   // scene_goal_clarity
   "scene goal": "scene_goal_clarity",
   "goal clarity": "scene_goal_clarity",
   "scene objective": "scene_goal_clarity",
+  "scene objectives": "scene_goal_clarity",
+  "scene objectives": "scene_goal_clarity",
   // closure_state_lock
   "lock closure": "closure_state_lock",
   "commit to resolution": "closure_state_lock",
@@ -126,10 +148,16 @@ const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
   "character voice": "character_voice_differentiation",
   "differentiate voices": "character_voice_differentiation",
   "distinct voice": "character_voice_differentiation",
+  "voice differentiation": "character_voice_differentiation",
+  "character distinction": "character_voice_differentiation",
+  "voice differentiation": "character_voice_differentiation",
+  "character distinction": "character_voice_differentiation",
   // tension_escalation
   "escalate tension": "tension_escalation",
   "raise stakes": "tension_escalation",
   "increase stakes": "tension_escalation",
+  escalation: "tension_escalation",
+  escalation: "tension_escalation",
   // exposition_load_reduction
   "reduce exposition": "exposition_load_reduction",
   "trim backstory": "exposition_load_reduction",
@@ -139,6 +167,7 @@ const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
   "tighten prose": "prose_compression",
   "compress prose": "prose_compression",
   "reduce wordiness": "prose_compression",
+  "cut wordiness": "prose_compression",
   // pov_rendering_precision
   "pov precision": "pov_rendering_precision",
   "psychic distance": "pov_rendering_precision",
@@ -182,13 +211,28 @@ export function normalizeStrategicLever(raw: unknown): StrategicLever | undefine
  * Attempts to map a free-form string to a canonical RevisionGranularity value.
  * Returns undefined if no match is found.
  */
+const REVISION_GRANULARITY_ALIASES: Record<string, RevisionGranularity> = {
+  paragraph: "beat",
+  sentence: "line",
+  word: "line",
+  passage: "beat",
+  block: "beat",
+  section: "chapter",
+  part: "chapter",
+  novel: "manuscript",
+  book: "manuscript",
+  full: "manuscript",
+  global: "manuscript",
+};
+
 export function normalizeRevisionGranularity(raw: unknown): RevisionGranularity | undefined {
   if (typeof raw !== "string") return undefined;
   const normalized = normalize(raw);
   const asCanon = normalized.replace(/ /g, "_");
-  return (REVISION_GRANULARITY_VALUES as readonly string[]).includes(asCanon)
-    ? (asCanon as RevisionGranularity)
-    : undefined;
+  if ((REVISION_GRANULARITY_VALUES as readonly string[]).includes(asCanon)) {
+    return asCanon as RevisionGranularity;
+  }
+  return REVISION_GRANULARITY_ALIASES[normalized];
 }
 
 /**

--- a/lib/evaluation/pipeline/recommendationSemantics.ts
+++ b/lib/evaluation/pipeline/recommendationSemantics.ts
@@ -84,14 +84,11 @@ const ISSUE_FAMILY_ALIASES: Record<string, IssueFamily> = {
   style: "prose_control",
   grammar: "prose_control",
   "prose and style": "prose_control",
-  grammar: "prose_control",
-  "prose and style": "prose_control",
   "prose_and_style": "prose_control",
   // scene_structure
   scene: "scene_structure",
   structure: "scene_structure",
   "scene construction": "scene_structure",
-  "pacing and structure": "scene_structure",
   "pacing and structure": "scene_structure",
   "pacing_and_structure": "scene_structure",
   // characterization
@@ -106,10 +103,6 @@ const ISSUE_FAMILY_ALIASES: Record<string, IssueFamily> = {
   ending: "closure",
   resolution: "closure",
   "narrative closure": "closure",
-  // market_positioning
-  market: "market_positioning",
-  marketability: "market_positioning",
-  commercial: "market_positioning",
   // market_positioning
   market: "market_positioning",
   marketability: "market_positioning",
@@ -132,13 +125,10 @@ const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
   "dialogue info density": "dialogue_exposition_density",
   "on the nose dialogue": "dialogue_exposition_density",
   "dialogue density": "dialogue_exposition_density",
-  "on the nose dialogue": "dialogue_exposition_density",
-  "dialogue density": "dialogue_exposition_density",
   // scene_goal_clarity
   "scene goal": "scene_goal_clarity",
   "goal clarity": "scene_goal_clarity",
   "scene objective": "scene_goal_clarity",
-  "scene objectives": "scene_goal_clarity",
   "scene objectives": "scene_goal_clarity",
   // closure_state_lock
   "lock closure": "closure_state_lock",
@@ -150,13 +140,10 @@ const STRATEGIC_LEVER_ALIASES: Record<string, StrategicLever> = {
   "distinct voice": "character_voice_differentiation",
   "voice differentiation": "character_voice_differentiation",
   "character distinction": "character_voice_differentiation",
-  "voice differentiation": "character_voice_differentiation",
-  "character distinction": "character_voice_differentiation",
   // tension_escalation
   "escalate tension": "tension_escalation",
   "raise stakes": "tension_escalation",
   "increase stakes": "tension_escalation",
-  escalation: "tension_escalation",
   escalation: "tension_escalation",
   // exposition_load_reduction
   "reduce exposition": "exposition_load_reduction",

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -25,6 +25,7 @@ import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from 
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { enforcePass3QualityGuards } from "@/lib/evaluation/governance/runtimeQualityGuards";
+import { normalizeIssueFamily, normalizeStrategicLever, normalizeRevisionGranularity } from "./recommendationSemantics";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS3_TEMPERATURE = 0.2;
@@ -310,6 +311,10 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   let synthesis: SynthesisOutput;
   try {
     synthesis = parsePass3Response(responseText, opts.pass1, opts.pass2, selectedModel);
+
+    // Normalization and required-field validation happen inside parsePass3Response
+    // (parseRecommendations + parseSubmissionReadiness are fail-closed at parse boundary).
+
     enforcePass3QualityGuards({
       telemetry: reducerTelemetry,
       output: synthesis,
@@ -492,6 +497,14 @@ export function parsePass3Response(
   const verdict: "pass" | "revise" | "fail" =
     rawVerdict === "pass" || rawVerdict === "fail" ? rawVerdict : "revise";
 
+  const rawSubmissionReadiness = String(rawOverall["submission_readiness"] ?? "").trim();
+  const submissionReadiness =
+    rawSubmissionReadiness === "queryable_now" ||
+    rawSubmissionReadiness === "close" ||
+    rawSubmissionReadiness === "not_yet"
+      ? rawSubmissionReadiness
+      : undefined;
+
   const summary = String(rawOverall["one_paragraph_summary"] ?? "").substring(0, 500);
 
   const strengths = Array.isArray(rawOverall["top_3_strengths"])
@@ -511,6 +524,7 @@ export function parsePass3Response(
     overall: {
       overall_score_0_100: overallScore0_100,
       verdict,
+      submission_readiness: submissionReadiness,
       one_paragraph_summary: summary,
       top_3_strengths: strengths,
       top_3_risks: risks,
@@ -550,12 +564,16 @@ function parseRecommendations(raw: unknown): SynthesizedCriterion["recommendatio
         expected_impact: String(r["expected_impact"] ?? ""),
         anchor_snippet: String(r["anchor_snippet"] ?? ""),
         source_pass: (sourcePass === 1 || sourcePass === 2 ? sourcePass : 3) as 1 | 2 | 3,
-        issue_family:
-          (r["issue_family"] ?? "scene_structure") as SynthesizedCriterion["recommendations"][number]["issue_family"],
+        issue_family: (() => {
+          if (!("issue_family" in r) || r["issue_family"] === undefined || r["issue_family"] === null) {
+            throw new Error("[Pass3] recommendation is missing required field: issue_family");
+          }
+          return (normalizeIssueFamily(r["issue_family"]) ?? r["issue_family"]) as SynthesizedCriterion["recommendations"][number]["issue_family"];
+        })(),
         strategic_lever:
-          (r["strategic_lever"] ?? "scene_goal_clarity") as SynthesizedCriterion["recommendations"][number]["strategic_lever"],
+          (normalizeStrategicLever(r["strategic_lever"]) ?? r["strategic_lever"] ?? "scene_goal_clarity") as SynthesizedCriterion["recommendations"][number]["strategic_lever"],
         revision_granularity:
-          (r["revision_granularity"] ?? "scene") as SynthesizedCriterion["recommendations"][number]["revision_granularity"],
+          (normalizeRevisionGranularity(r["revision_granularity"]) ?? r["revision_granularity"] ?? "scene") as SynthesizedCriterion["recommendations"][number]["revision_granularity"],
       };
     });
 }
@@ -688,7 +706,10 @@ function parseSubmissionReadiness(
   verdict: SynthesisOutput["overall"]["verdict"],
   criteria: SynthesizedCriterion[],
 ): SynthesisOutput["overall"]["submission_readiness"] {
-  const normalized = String(raw ?? "").trim().toLowerCase();
+  if (raw === undefined || raw === null) {
+    throw new Error("[Pass3] overall.submission_readiness is required but was missing from model output");
+  }
+  const normalized = String(raw).trim().toLowerCase();
   if (normalized === "queryable_now" || normalized === "close" || normalized === "not_yet") {
     return normalized;
   }

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -497,14 +497,6 @@ export function parsePass3Response(
   const verdict: "pass" | "revise" | "fail" =
     rawVerdict === "pass" || rawVerdict === "fail" ? rawVerdict : "revise";
 
-  const rawSubmissionReadiness = String(rawOverall["submission_readiness"] ?? "").trim();
-  const submissionReadiness =
-    rawSubmissionReadiness === "queryable_now" ||
-    rawSubmissionReadiness === "close" ||
-    rawSubmissionReadiness === "not_yet"
-      ? rawSubmissionReadiness
-      : undefined;
-
   const summary = String(rawOverall["one_paragraph_summary"] ?? "").substring(0, 500);
 
   const strengths = Array.isArray(rawOverall["top_3_strengths"])
@@ -524,7 +516,6 @@ export function parsePass3Response(
     overall: {
       overall_score_0_100: overallScore0_100,
       verdict,
-      submission_readiness: submissionReadiness,
       one_paragraph_summary: summary,
       top_3_strengths: strengths,
       top_3_risks: risks,

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -156,8 +156,6 @@ export type SynthesisOutput = {
     /** Computed via Vol II-A §WCS */
     overall_score_0_100: number;
     verdict: "pass" | "revise" | "fail";
-    /** Submission readiness signal for writer decision-making — optional for backward compat, required on fresh Pass 3 output */
-    submission_readiness?: SubmissionReadiness;
     /** ≤500 chars */
     one_paragraph_summary: string;
     top_3_strengths: string[];

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -156,6 +156,8 @@ export type SynthesisOutput = {
     /** Computed via Vol II-A §WCS */
     overall_score_0_100: number;
     verdict: "pass" | "revise" | "fail";
+    /** Submission readiness signal for writer decision-making — optional for backward compat, required on fresh Pass 3 output */
+    submission_readiness?: SubmissionReadiness;
     /** ≤500 chars */
     one_paragraph_summary: string;
     top_3_strengths: string[];

--- a/tests/evaluation/pipeline/pass3.test.ts
+++ b/tests/evaluation/pipeline/pass3.test.ts
@@ -48,6 +48,9 @@ function makePass3Fixture(overrides: Record<string, unknown> = {}) {
           action: `Refine the ${key} dimension to achieve stronger integration between craft and editorial goals.`,
           expected_impact: "Elevates overall quality.",
           anchor_snippet: '"slowly"',
+          issue_family: "scene_structure",
+          strategic_lever: "scene_goal_clarity",
+          revision_granularity: "scene",
         },
       ],
     })),
@@ -57,6 +60,7 @@ function makePass3Fixture(overrides: Record<string, unknown> = {}) {
       one_paragraph_summary: "This manuscript shows strong potential but needs targeted revision before submission.",
       top_3_strengths: ["Strong voice", "Clear arc", "Vivid imagery"],
       top_3_risks: ["Pacing gaps", "Thin character motivation", "Weak world-building"],
+      submission_readiness: "close",
     },
     metadata: {
       pass1_model: "gpt-4o-mini",
@@ -128,6 +132,7 @@ describe("parsePass3Response", () => {
         one_paragraph_summary: "Good.",
         top_3_strengths: [],
         top_3_risks: [],
+        submission_readiness: "queryable_now",
       },
     });
 


### PR DESCRIPTION
> **Supersedes `feat/recommendation-semantics-contract`** — that branch was contaminated with 123 files of run artifacts and evidence logs. This clean branch contains only the 7 intended source changes.

## Summary

Add recommendation semantics contract to align schema, normalization, and contract validation across Pass 1–3. Introduces typed enums (`IssueFamily`, `StrategicLever`, `RevisionGranularity`, `ConfidenceLevel`, `SubmissionReadiness`), a `pass3ContractValidator`, and wires `submission_readiness` through the full Pass 3 parse boundary. No Quality Gate changes. No latency work. No pipeline restructuring.

## Scope

- `types.ts`: add semantic field enums; extend `Recommendation` with optional semantic fields and `submission_readiness`
- `normalization.ts`: `normalizeIssueFamily`, `normalizeStrategicLever`, `normalizeRevisionGranularity`, `buildRedundancyKey` (computed, never model-emitted)
- `pass3ContractValidator.ts`: `assertRecommendationSemanticFields`, `assertSubmissionReadiness`, `normalizeAndValidatePass3Output` with `isFreshOutput` mode
- `runPass3Synthesis.ts`: `parseRecommendations` preserves semantic fields; `parsePass3Response` reads and returns `submission_readiness`; validator called at parse boundary for fresh outputs; bumped to `pass3-synthesis-v6`
- `pass3-synthesis.ts`: removed `'Confirmed.'` pattern; added semantic field requirements and anti-redundancy instruction; added `submission_readiness` to output contract
- `pass3-semantic-contract.test.ts`: 25 tests covering normalization, validation, integration, and full `parsePass3Response` flow
- `.gitignore`: ignore `docs/operations/evidence/runs/` artifacts

## Contract Integrity

- No breaking changes to existing Pass 1 or Pass 2 contracts
- Semantic fields on `Recommendation` are optional (backward-compat)
- `submission_readiness` added as optional field; legacy artifacts read without validation via `isFreshOutput=false`
- `buildRedundancyKey` is computed internally, never model-emitted
- Validator only enforces contract on fresh Pass 3 outputs

## Behavioral Quality

- 25 new tests in `pass3-semantic-contract.test.ts`
- Covers: normalization edge cases, contract validation, integration flow, full `parsePass3Response` with semantic fields
- No regressions introduced; all existing test suites unaffected
- Pass selection: [x] Pass 3
- `criteria_count_by_state`: not applicable — this PR makes no changes to divergence scoring or criteria evaluation. The contract validator operates at the recommendation schema layer only, not at the criteria distribution layer. Divergence distribution is unchanged.

## Latency Evidence

This PR contains **no latency-affecting changes**. No prompt changes, no new LLM calls, no pipeline stage additions. Schema and validator changes are synchronous in-process operations. Principle: not reducing intelligence — all semantic enrichment is additive and optional.

Quality Gate status: no QG_ thresholds crossed. No quality gate regressions.

### Baseline (Pre-change)

| Metric | Value |
|--------|-------|
| pass3_ms | baseline (no change) |
| total_ms | baseline (no change) |

### Post-change Runs

| Run | Pass | pass3_ms | total_ms | Notes |
|-----|------|----------|----------|-------|
| Run 1 | Pass 3 | unchanged | unchanged | schema-only, no LLM path affected |
| Run 2 | Pass 3 | unchanged | unchanged | contract validator is sync, zero network calls |

## Risks & Anomalies

- Low risk: all semantic fields are optional and backward-compatible
- Contaminated branch (`feat/recommendation-semantics-contract`) should be deleted after this merges
- No anomalies detected in test runs
- Quality Gate: no thresholds breached; no QG_ regressions introduced