### PR TITLE
feat(artifact-gate-enforcement): canonical FAIL-close via gates.ts/qualityGate.ts

### DIFF
--- a/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
+++ b/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
@@ -69,6 +69,16 @@ function makeSupabaseStub() {
 
   return {
     evaluationJobUpdates,
+    rpc: async (fn: string) => {
+      if (fn === "finalize_job_failure_atomic") {
+        return {
+          data: [{ attempt_count: 1, max_attempts: 3, notified_at: null }],
+          error: null,
+        };
+      }
+
+      return { data: null, error: null };
+    },
     from(table: string) {
       if (table === "evaluation_jobs") {
         return {
@@ -79,8 +89,13 @@ function makeSupabaseStub() {
           }),
           update: (payload: Record<string, unknown>) => {
             evaluationJobUpdates.push(payload);
+            const query = {
+              eq: () => query,
+              then: (resolve: (value: { error: null }) => void) =>
+                resolve({ error: null }),
+            };
             return {
-              eq: async () => ({ error: null }),
+              eq: () => query,
             };
           },
         };
@@ -312,6 +327,16 @@ describe("processEvaluationJob canonical pipeline integration", () => {
     };
 
     const supabaseStub = {
+      rpc: async (fn: string) => {
+        if (fn === "finalize_job_failure_atomic") {
+          return {
+            data: [{ attempt_count: 1, max_attempts: 3, notified_at: null }],
+            error: null,
+          };
+        }
+
+        return { data: null, error: null };
+      },
       from(table: string) {
         if (table === "evaluation_jobs") {
           return {
@@ -322,22 +347,28 @@ describe("processEvaluationJob canonical pipeline integration", () => {
             }),
             update: (payload: Record<string, unknown>) => {
               evaluationJobUpdates.push(payload);
-              return {
-                eq: async () => {
+              const query = {
+                eq: () => query,
+                then: (resolve: (value: { error: { code: string; message: string } | null }) => void) => {
                   if (
                     payload.status === "complete" &&
                     Object.prototype.hasOwnProperty.call(payload, "phase2_completed_at")
                   ) {
-                    return {
+                    resolve({
                       error: {
                         code: "PGRST204",
                         message:
                           "Could not find the 'phase2_completed_at' column of 'evaluation_jobs' in the schema cache",
                       },
-                    };
+                    });
+                    return;
                   }
-                  return { error: null };
+
+                  resolve({ error: null });
                 },
+              };
+              return {
+                eq: () => query,
               };
             },
           };

--- a/__tests__/lib/evaluation/processor.real-gate.test.ts
+++ b/__tests__/lib/evaluation/processor.real-gate.test.ts
@@ -138,6 +138,16 @@ function makeSupabaseStub() {
 
   return {
     evaluationJobUpdates,
+    rpc: async (fn: string) => {
+      if (fn === "finalize_job_failure_atomic") {
+        return {
+          data: [{ attempt_count: 1, max_attempts: 3, notified_at: null }],
+          error: null,
+        };
+      }
+
+      return { data: null, error: null };
+    },
     from(table: string) {
       if (table === "evaluation_jobs") {
         return {
@@ -148,7 +158,12 @@ function makeSupabaseStub() {
           }),
           update: (payload: Record<string, unknown>) => {
             evaluationJobUpdates.push(payload);
-            return { eq: async () => ({ error: null }) };
+            const query = {
+              eq: () => query,
+              then: (resolve: (value: { error: null }) => void) =>
+                resolve({ error: null }),
+            };
+            return { eq: () => query };
           },
         };
       }

--- a/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
+++ b/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
@@ -3,6 +3,9 @@ import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
 import { validateEvaluationResultV2 } from "@/schemas/evaluation-result-v2";
 import { runQualityGateV2 } from "@/lib/evaluation/pipeline/qualityGate";
+import type { EvaluationArtifact } from "@/lib/evaluation/pipeline/types";
+import { buildScoreLedger } from "@/lib/evaluation/pipeline/buildScoreLedger";
+import { buildExcellenceFilter } from "@/lib/evaluation/pipeline/buildExcellenceFilter";
 
 function makeBaseV2Fixture(): EvaluationResultV2 {
   return {
@@ -68,19 +71,51 @@ function makeBaseV2Fixture(): EvaluationResultV2 {
   };
 }
 
+function makeArtifactFixtureFromV2(result: EvaluationResultV2): EvaluationArtifact {
+  const criteria = result.criteria.map((criterion) => ({
+    key: criterion.key,
+    final_score_0_10: criterion.score_0_10 ?? 0,
+    reasoning: criterion.rationale,
+    evidence: criterion.evidence.map((e) => `"${e.snippet}"`).join(" | "),
+    interpretation: criterion.rationale,
+  }));
+
+  const scoreLedger = buildScoreLedger({
+    criteria: criteria.map((criterion) => ({
+      final_score_0_10: criterion.final_score_0_10,
+    })),
+  });
+
+  const efg = buildExcellenceFilter({
+    criteria: criteria.map((criterion) => ({
+      key: criterion.key,
+      final_score_0_10: criterion.final_score_0_10,
+    })),
+  });
+
+  return {
+    criteria,
+    ledger: scoreLedger,
+    efg,
+  };
+}
+
 describe("runQualityGateV2 integration", () => {
   it("passes a canonical EvaluationResultV2 fixture", () => {
     const fixture = makeBaseV2Fixture();
+    const artifact = makeArtifactFixtureFromV2(fixture);
     const validation = validateEvaluationResultV2(fixture);
     expect(validation.valid).toBe(true);
 
-    const result = runQualityGateV2(fixture);
+    const result = runQualityGateV2(fixture, artifact);
     expect(result.pass).toBe(true);
     expect(result.checks.every((check) => check.passed)).toBe(true);
+    expect(result.artifactGate.verdict).toBe("PASS");
   });
 
   it("fails when non-scorable criteria carry numeric scores", () => {
     const fixture = makeBaseV2Fixture();
+    const artifact = makeArtifactFixtureFromV2(fixture);
     fixture.criteria[0] = {
       ...fixture.criteria[0],
       scorable: false,
@@ -100,9 +135,47 @@ describe("runQualityGateV2 integration", () => {
       },
     } as EvaluationResultV2["criteria"][number];
 
-    const result = runQualityGateV2(fixture);
+    const result = runQualityGateV2(fixture, artifact);
     expect(result.pass).toBe(false);
     expect(result.checks.some((check) => check.check_id === "v2_score_without_signal" && !check.passed)).toBe(true);
+  });
+
+  it("fails closed when artifact gate verdict is FAIL", () => {
+    const fixture = makeBaseV2Fixture();
+    const artifact = makeArtifactFixtureFromV2(fixture);
+
+    artifact.criteria = [];
+    artifact.ledger = {
+      rawTotal: 0,
+      maxTotal: 130,
+      normalized: 0,
+      weighting: "equal",
+    };
+    artifact.efg = {
+      verdict: "not-yet-ready",
+      blockingCriteria: ["concept"],
+    };
+
+    const result = runQualityGateV2(fixture, artifact);
+    expect(result.pass).toBe(false);
+    expect(result.artifactGate.verdict).toBe("FAIL");
+    expect(
+      result.checks.some(
+        (check) => check.check_id === "v2_artifact_gate" && !check.passed,
+      ),
+    ).toBe(true);
+  });
+
+  it("allows HOLD artifact verdict with warning-only behavior", () => {
+    const fixture = makeBaseV2Fixture();
+    const artifact = makeArtifactFixtureFromV2(fixture);
+
+    artifact.criteria[0].evidence = "";
+
+    const result = runQualityGateV2(fixture, artifact);
+    expect(result.pass).toBe(true);
+    expect(result.artifactGate.verdict).toBe("HOLD");
+    expect(result.warnings.some((w) => w.includes("[ArtifactGate:HOLD]"))).toBe(true);
   });
 
   it("rejects non-canonical signal values via schema contract", () => {

--- a/lib/evaluation/pipeline/gates.ts
+++ b/lib/evaluation/pipeline/gates.ts
@@ -1,4 +1,13 @@
 import type { ValidityState } from "@/lib/governance/types";
+import {
+  validateEvaluationArtifact,
+  type ArtifactValidationMode,
+} from "./validateEvaluationArtifact";
+import type {
+  ArtifactGateResult,
+  ArtifactReasonCode,
+  EvaluationArtifact,
+} from "./types";
 // RevisionGrade EG Validator Layer — Fail-Closed
 // Enforces EG-6 (Evidence integrity + anchor parity),
 // EG-7 (Generic language prohibition),
@@ -63,6 +72,13 @@ export interface GateResult {
   passed: boolean;
   validity: ValidityState;
   violations: GateViolation[];
+}
+
+export interface ArtifactGateDecision {
+  verdict: ArtifactGateResult;
+  reasonCodes: ArtifactReasonCode[];
+  validatedAt: string;
+  enforcementMode: ArtifactValidationMode;
 }
 
 /** Optional context for anchor-aware EG-6 validation */
@@ -397,4 +413,26 @@ export function adaptResultToCriteria(
   }
 
   return criteria.length > 0 ? criteria : null;
+}
+
+/**
+ * Canonical artifact gate decision.
+ *
+ * Ownership boundary:
+ * - gates.ts decides PASS/HOLD/FAIL from deterministic validation output
+ * - qualityGate.ts enforces fail-close policy based on this verdict
+ * - processor.ts reads persisted decision, but never decides enforcement
+ */
+export function evaluateArtifactGate(
+  artifact: EvaluationArtifact,
+  mode: ArtifactValidationMode = "enforce",
+): ArtifactGateDecision {
+  const validation = validateEvaluationArtifact(artifact, { mode });
+
+  return {
+    verdict: validation.result,
+    reasonCodes: validation.reasonCodes,
+    validatedAt: validation.validatedAt,
+    enforcementMode: validation.enforcementMode,
+  };
 }

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -31,6 +31,9 @@ import { analyzePovRendering } from "@/lib/evaluation/pov/analyzePovRendering";
 import { analyzeDialogueAttribution } from "@/lib/evaluation/pov/analyzeDialogueAttribution";
 import { validatePovCriterionEvidence } from "@/lib/evaluation/pov/validatePovCriterionEvidence";
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
+import type { EvaluationArtifact } from "./types";
+import type { ArtifactGateDecision } from "./gates";
+import { evaluateArtifactGate } from "./gates";
 import {
   isCriterionComplete,
   minAnchorsFor,
@@ -98,6 +101,10 @@ export type QualityGateFailureTelemetry = {
   failures_by_error_code: Record<string, number>;
   failed_check_ids: string[];
 };
+
+export interface QualityGateV2Result extends QualityGateResult {
+  artifactGate: ArtifactGateDecision;
+}
 
 function normalizeForPhraseMatch(text: string): string {
   return (text || "").toLowerCase().replace(/\s+/g, " ").trim();
@@ -642,9 +649,21 @@ export function summarizeQualityGateFailures(checks: QualityGateCheck[]): Qualit
  * completed EvaluationResultV2 obeys status/score invariants and canonical
  * 13-key coverage.
  */
-export function runQualityGateV2(result: EvaluationResultV2): QualityGateResult {
+export function runQualityGateV2(
+  result: EvaluationResultV2,
+  artifact?: EvaluationArtifact,
+): QualityGateV2Result {
   const checks: QualityGateCheck[] = [];
   const warnings: string[] = [];
+
+  const artifactGate = artifact
+    ? evaluateArtifactGate(artifact, "enforce")
+    : {
+        verdict: "PASS" as const,
+        reasonCodes: [],
+        validatedAt: new Date().toISOString(),
+        enforcementMode: "enforce" as const,
+      };
 
   const criteria = result.criteria;
   const expectedCount = CRITERIA_KEYS.length;
@@ -795,10 +814,33 @@ export function runQualityGateV2(result: EvaluationResultV2): QualityGateResult 
     warnings.push(`LOW_EVALUABILITY_COVERAGE: scored_criteria_count=${scoredCount}/${expectedCount}`);
   }
 
+  const artifactReasonSummary = artifactGate.reasonCodes.join(",") || "none";
+  if (artifactGate.verdict === "FAIL") {
+    checks.push({
+      check_id: "v2_artifact_gate",
+      passed: false,
+      error_code: "QG_ARTIFACT_GATE_FAIL",
+      details: `Artifact gate verdict=FAIL reason_codes=${artifactReasonSummary}`,
+    });
+  } else {
+    checks.push({
+      check_id: "v2_artifact_gate",
+      passed: true,
+      details: `Artifact gate verdict=${artifactGate.verdict} reason_codes=${artifactReasonSummary}`,
+    });
+
+    if (artifactGate.verdict === "HOLD") {
+      warnings.push(
+        `[ArtifactGate:HOLD] reason_codes=${artifactReasonSummary}`,
+      );
+    }
+  }
+
   const failedHardChecks = checks.filter((c) => !c.passed);
   return {
     pass: failedHardChecks.length === 0,
     checks,
     warnings,
+    artifactGate,
   };
 }

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -69,9 +69,6 @@ import {
   synthesisToEvaluationResultV2,
 } from '@/lib/evaluation/pipeline/runPipeline';
 import { runQualityGateV2 } from '@/lib/evaluation/pipeline/qualityGate';
-import {
-  validateEvaluationArtifact,
-} from '@/lib/evaluation/pipeline/validateEvaluationArtifact';
 import { buildScoreLedger } from '@/lib/evaluation/pipeline/buildScoreLedger';
 import { buildExcellenceFilter } from '@/lib/evaluation/pipeline/buildExcellenceFilter';
 import { mapEvaluationResultV2ToGovernanceEnvelope } from '@/lib/governance/evaluationBridge';
@@ -1598,17 +1595,6 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       `[Processor] ${jobId}: evaluationResult synthesized overall=${evaluationResult.overview.overall_score_0_100}`,
     );
 
-    const qualityGateV2 = runQualityGateV2(evaluationResult);
-    if (!qualityGateV2.pass) {
-      const failedChecks = qualityGateV2.checks
-        .filter((check) => !check.passed)
-        .map((check) => `${check.check_id}: ${check.details ?? check.error_code ?? 'failed'}`);
-      const gateError = `[QualityGateV2] ${failedChecks.join('; ')}`;
-      await markFailed(gateError, 'QG_FAILED');
-
-      return { success: false, error: gateError };
-    }
-
     const artifactCriteria = pipelineResult.synthesis.criteria.map((criterion) => ({
       key: criterion.key,
       final_score_0_10: criterion.final_score_0_10,
@@ -1640,28 +1626,42 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       })),
     });
 
-    const artifactValidation = validateEvaluationArtifact(
-      {
-        criteria: artifactCriteria,
-        ledger: scoreLedger,
-        efg: excellenceFilter,
-      },
-      { mode: 'log' },
-    );
+    const qualityGateV2 = runQualityGateV2(evaluationResult, {
+      criteria: artifactCriteria,
+      ledger: scoreLedger,
+      efg: excellenceFilter,
+    });
+
+    if (!qualityGateV2.pass) {
+      const failedChecks = qualityGateV2.checks
+        .filter((check) => !check.passed)
+        .map((check) => `${check.check_id}: ${check.details ?? check.error_code ?? 'failed'}`);
+      const gateError = `[QualityGateV2] ${failedChecks.join('; ')}`;
+      await markFailed(gateError, 'QG_FAILED');
+
+      return { success: false, error: gateError };
+    }
+
+    const artifactGateDecision = qualityGateV2.artifactGate ?? {
+      verdict: 'PASS',
+      reasonCodes: [] as string[],
+      validatedAt: new Date().toISOString(),
+      enforcementMode: 'enforce' as const,
+    };
 
     evaluationResult.governance.warnings = [
       ...(evaluationResult.governance.warnings ?? []),
-      ...(artifactValidation.reasonCodes.length > 0
+      ...(artifactGateDecision.reasonCodes.length > 0
         ? [
-            `[ArtifactValidation:${artifactValidation.result}] reason_codes=${artifactValidation.reasonCodes.join(',')}`,
+            `[ArtifactValidation:${artifactGateDecision.verdict}] reason_codes=${artifactGateDecision.reasonCodes.join(',')}`,
           ]
         : []),
     ];
     evaluationResult.governance.transparency = {
       ...(evaluationResult.governance.transparency ?? {}),
-      artifact_validation_result: artifactValidation.result,
-      artifact_reason_codes: artifactValidation.reasonCodes,
-      artifact_validated_at: artifactValidation.validatedAt,
+      artifact_validation_result: artifactGateDecision.verdict,
+      artifact_reason_codes: artifactGateDecision.reasonCodes,
+      artifact_validated_at: artifactGateDecision.validatedAt,
       score_ledger: {
         raw_total: scoreLedger.rawTotal,
         max_total: scoreLedger.maxTotal,


### PR DESCRIPTION
## Summary
Move artifact enforcement authority into the canonical gate chain:
- `gates.ts` now owns deterministic artifact PASS/HOLD/FAIL decision (`evaluateArtifactGate`).
- `qualityGate.ts` now enforces fail-close when artifact verdict is `FAIL`.
- `processor.ts` no longer owns artifact enforcement decisions; it consumes gate output and persists transparency metadata only.

## Scope
- In scope: artifact gate enforcement path (`gates.ts` -> `qualityGate.ts` -> `processor.ts`) and targeted tests.
- Out of scope: SLA/latency redesign, retry architecture redesign, and non-canonical pipeline behavior changes.

## Contract Integrity
- JobStatus contract unchanged (`queued|running|complete|failed`).
- Illegal transitions remain centralized and fail-closed.
- No new job statuses, no renamed canon identifiers, no DB schema change.

## Behavioral Quality
- `runQualityGateV2` now records artifact gate check `v2_artifact_gate`.
- Artifact verdict semantics:
  - `FAIL` => hard gate failure (`QG_ARTIFACT_GATE_FAIL`) and no persistence.
  - `HOLD` => warning-only (`[ArtifactGate:HOLD] ...`) and persistence allowed.
  - `PASS` => clean pass.
- Processor transparency fields remain persisted (`artifact_validation_result`, `artifact_reason_codes`, `artifact_validated_at`, ledger, excellence filter).

## Latency Evidence
This change adds deterministic in-process checks only (no new LLM or network calls).

Baseline (Pre-change)
- targeted suites previously green in PR #227 closeout

Post-change Runs
- `lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts` -> PASS
- `__tests__/lib/evaluation/processor.canonical-pipeline.test.ts` -> PASS
- `__tests__/lib/evaluation/processor.real-gate.test.ts` -> PASS
- `tests/evaluation/pipeline/pipeline-e2e.test.ts` -> PASS (23/23)

Run 1
- targeted enforcement suites: 3/3 PASS

Pass Selection
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Run 2
- pipeline e2e: 1 suite PASS, 23 tests PASS

pass3_ms
- N/A for isolated unit tests; no regression signal observed

total_ms
- pipeline-e2e local run completed in ~0.833s in this session

criteria_count_by_state
- unchanged by this PR (enforcement placement + gating behavior only)

quality gate / QG_
- introduces `QG_ARTIFACT_GATE_FAIL` for artifact verdict FAIL handling

not reducing intelligence
- No prompt/model downgrade, no rubric simplification, no heuristic quality rollback.

## Risks & Anomalies
- Pre-existing infra-only noise already addressed separately (`prod-alignment-guard` schedule removal).
- Added Supabase test harness hardening (`rpc` + chainable `eq().eq()` support) to prevent false negatives in failure-path tests.
