### PR TITLE
fix(jobs): repair finalize_job_failure_atomic schema contract

### DIFF
--- a/supabase/migrations/20260425000000_fix_finalize_job_failure_atomic_schema.sql
+++ b/supabase/migrations/20260425000000_fix_finalize_job_failure_atomic_schema.sql
@@ -1,0 +1,66 @@
+-- Repairs finalize_job_failure_atomic to match its original design intent
+-- by adding the two columns that were referenced but never landed
+-- (failure_code, notified_at), then recreating the function with the
+-- canonical 3-column return shape.
+--
+-- NOTE: Intentionally authored as a single top-level SQL statement to avoid
+-- environments that reject multi-command prepared SQL during migration apply.
+
+DO $migration$
+BEGIN
+  -- 1) Add the two columns the function expects.
+  EXECUTE 'ALTER TABLE public.evaluation_jobs ADD COLUMN IF NOT EXISTS failure_code text';
+  EXECUTE 'ALTER TABLE public.evaluation_jobs ADD COLUMN IF NOT EXISTS notified_at timestamptz';
+
+  -- 2) Drop previous signature before recreate (return-shape-safe across drifted envs).
+  EXECUTE 'DROP FUNCTION IF EXISTS public.finalize_job_failure_atomic(uuid, text, text, boolean)';
+
+  -- 3) Recreate with canonical 3-column return shape.
+  EXECUTE $fn$
+    CREATE FUNCTION public.finalize_job_failure_atomic(
+      p_job_id        uuid,
+      p_failure_code  text,
+      p_error_message text,
+      p_retryable     boolean
+    )
+    RETURNS TABLE (
+      attempt_count int,
+      max_attempts  int,
+      notified_at   timestamptz
+    )
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = public
+    AS $finalize_job_failure_atomic$
+    DECLARE
+      v_now timestamptz := now();
+    BEGIN
+      RETURN QUERY
+      UPDATE public.evaluation_jobs AS j
+      SET
+        attempt_count   = j.attempt_count + 1,
+        last_error      = p_error_message,
+        failure_code    = p_failure_code,
+        failed_at       = v_now,
+        updated_at      = v_now,
+        status          = 'failed',
+        phase_status    = 'failed',
+        next_attempt_at = CASE
+          WHEN p_retryable = true
+           AND (j.attempt_count + 1) < j.max_attempts
+          THEN v_now + interval '30 seconds'
+          ELSE NULL
+        END
+      WHERE j.id = p_job_id
+        AND j.status IN ('queued', 'running')
+      RETURNING j.attempt_count, j.max_attempts, j.notified_at;
+    END;
+    $finalize_job_failure_atomic$;
+  $fn$;
+
+  -- 4) Lock down execution to service_role only.
+  EXECUTE 'REVOKE EXECUTE ON FUNCTION public.finalize_job_failure_atomic(uuid, text, text, boolean) FROM PUBLIC';
+  EXECUTE 'REVOKE EXECUTE ON FUNCTION public.finalize_job_failure_atomic(uuid, text, text, boolean) FROM authenticated';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.finalize_job_failure_atomic(uuid, text, text, boolean) TO service_role';
+END
+$migration$;

--- a/tests/jobs/finalize-job-failure.unit.test.ts
+++ b/tests/jobs/finalize-job-failure.unit.test.ts
@@ -196,4 +196,31 @@ describe('finalizeJobFailure', () => {
 
     expect(result.status).toBe('failed');
   });
+
+  test('persists failure_code and uses notified_at return shape', async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [{ attempt_count: 1, max_attempts: 3, notified_at: null }],
+      error: null,
+    });
+
+    const result = await jobStore.finalizeJobFailure({
+      jobId: 'job-x',
+      errorEnvelope: {
+        code: 'QG_DIALOGUE_ATTRIBUTION_UNDERAUDITED',
+        message: '[Pipeline:pass4] QG_DIALOGUE_ATTRIBUTION_UNDERAUDITED ...',
+        retryable: false,
+      },
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith('finalize_job_failure_atomic', {
+      p_job_id: 'job-x',
+      p_failure_code: 'QG_DIALOGUE_ATTRIBUTION_UNDERAUDITED',
+      p_error_message: expect.stringContaining('QG_DIALOGUE_ATTRIBUTION_UNDERAUDITED'),
+      p_retryable: false,
+    });
+    expect(result.attemptCount).toBe(1);
+    expect(result.maxAttempts).toBe(3);
+    expect(result.shouldNotify).toBe(true);
+    expect(result.status).toBe('failed');
+  });
 });


### PR DESCRIPTION
## Summary
Repair `finalize_job_failure_atomic` and reconcile schema contract drift by adding the two columns the function has always referenced: `failure_code` and `notified_at`.

## Why
Production entered a transient state with a 2-column return shape for `finalize_job_failure_atomic`, while canonical logic expects:
- persisted `evaluation_jobs.failure_code`
- returned `evaluation_jobs.notified_at`

This PR restores the intended contract through the migration system of record.

## Scope
Schema-only / migration-only change.
No evaluation pipeline code paths, no LLM passes, no scoring logic, and no latency-affecting surfaces are modified.

## Changes
- `supabase/migrations/20260425000000_fix_finalize_job_failure_atomic_schema.sql`
  - `ALTER TABLE evaluation_jobs ADD COLUMN IF NOT EXISTS failure_code text`
  - `ALTER TABLE evaluation_jobs ADD COLUMN IF NOT EXISTS notified_at timestamptz`
  - Drop/recreate `finalize_job_failure_atomic(uuid,text,text,boolean)`
  - Restore canonical return shape: `(attempt_count, max_attempts, notified_at)`
  - Persist `failure_code = p_failure_code`
  - Re-apply service_role-only EXECUTE grants
- `tests/jobs/finalize-job-failure.unit.test.ts`
  - Add explicit RPC contract test for `failure_code` persistence + `notified_at` return semantics

## Contract Integrity
| Surface | Before | After |
|---|---|---|
| `evaluation_jobs.failure_code` | absent in transient prod state | present (text, nullable) |
| `evaluation_jobs.notified_at` | absent in transient prod state | present (timestamptz, nullable) |
| `finalize_job_failure_atomic` return shape | drifted 2-column variant | canonical 3-column variant (`attempt_count`, `max_attempts`, `notified_at`) |
| Migration ledger | drift uncaptured | captured via `20260425000000_fix_finalize_job_failure_atomic_schema.sql` |

- Canon/Governance contracts unchanged.
- JobStatus contract unchanged (`queued`, `running`, `complete`, `failed`).

## Behavioral Quality
N/A — schema-only change. No prompt/pass/rubric/verdict logic touched.

Quality Gate (QG_*) behavior unchanged; this PR only restores `failure_code` persistence for downstream `QG_*` diagnostics.

`criteria_count_by_state`: N/A (Pass 3 not invoked by this change).

## Latency Evidence
N/A — schema-only change. Included explicitly for template compliance.

### Baseline (Pre-change)
| metric | value |
|---|---|
| `total_ms` | N/A (no evaluation invoked by this PR) |
| `pass1_ms` | N/A |
| `pass2_ms` | N/A |
| `pass3_ms` | N/A |

### Post-change Runs
| metric | value |
|---|---|
| `total_ms` | N/A (no evaluation invoked by this PR) |
| `pass1_ms` | N/A |
| `pass2_ms` | N/A |
| `pass3_ms` | N/A |

### Run 1
- `npm test -- tests/jobs/finalize-job-failure.unit.test.ts --runInBand` ✅ (8/8)

### Run 2
- `npm test -- __tests__/lib/evaluation/processor.canonical-pipeline.test.ts --runInBand` ✅ (5/5)

`criteria_count_by_state`: N/A.
`quality gate / QG_`: unchanged behavior; persistence path repaired.
`not reducing intelligence`: no model/prompt/rubric downgrades.

## Risks & Anomalies
- Additive columns only (`IF NOT EXISTS`) and controlled function replacement (`DROP IF EXISTS` + recreate).
- Main operational risk is migration application order; mitigated by canonical migration runner and ledger verification.
- No runtime behavior anomalies observed in CI-required suites.

## Apply Path (required)
Canonical migration runner only:
- `npx -y supabase@2.95.2 db push --db-url "$DATABASE_URL"`

## Post-merge production verification (required before calibration)
1. `evaluation_jobs` has `failure_code` and `notified_at` columns.
2. `finalize_job_failure_atomic` returns `(attempt_count, max_attempts, notified_at)`.
3. Migration `20260425000000` is present in `supabase_migrations.schema_migrations`.
4. One deliberate failure-path evaluation persists `failure_code`, `last_error`, and `failed_at`.

## Pass Selection
- [x] Pass 3
- [ ] Pass 1
- [ ] Pass 2

