### PR TITLE
docs: enforce V2 architecture (README + roadmap + contributing)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to RevisionGrade
+
+---
+
+## 🔴 First Rule
+
+> **If it is not enforced, it is not real.**
+
+All contributions must uphold this.
+
+---
+
+## 🚪 The Persistence Boundary Rule
+
+All evaluation artifacts MUST pass through:
+
+`persistEvaluationResultV2(...)`
+
+You are NOT allowed to:
+- Write directly to `evaluation_artifacts`
+- Set `evaluation_jobs.status = "complete"` outside the boundary
+- Introduce alternate persistence paths
+
+---
+
+## 🔒 Enforcement-First Development
+
+Before adding any feature:
+
+1. Identify the enforcement boundary
+2. Prove it is singular (no bypass paths)
+3. Add guard tests
+4. Only then extend behavior
+
+---
+
+## 🧪 Required Tests
+
+Every enforcement-related change must include:
+
+### 1. Negative Test
+
+Invalid input MUST:
+- not persist
+- not mark job complete
+
+### 2. Guard Test
+
+System MUST fail if:
+- a new persistence path is introduced
+- enforcement is bypassed
+
+---
+
+## 🚫 Forbidden Patterns
+
+Do NOT introduce:
+
+- `skip_gate` flags
+- “temporary” bypass logic
+- silent fallbacks
+- partial persistence (artifact without validation/gate)
+- multiple write paths to evaluation artifacts
+
+---
+
+## 🧠 Persistence Chokepoint Enforcement
+
+A CI guard must enforce that repo-wide search for evaluation artifact writes and V2 completion writes resolves to the single canonical boundary only.
+
+If a new direct persistence path appears outside that boundary, CI must fail.
+
+---
+
+## 🔄 Change Process
+
+For any significant change:
+
+1. Update `ROADMAP.md` if scope or sequence changes
+2. Update enforcement logic (if applicable)
+3. Add or update tests
+4. Verify CI guard passes
+5. Verify no bypass exists
+
+---
+
+## 📊 Definition of Done
+
+A task is NOT complete unless:
+
+- enforcement exists
+- tests prove enforcement
+- no bypass paths exist
+- CI guard passes
+
+---
+
+## ⚠️ Common Failure Mode
+
+Adding logic without enforcing the boundary creates:
+
+- false confidence
+- silent system failure
+
+Avoid this at all costs.
+
+---
+
+## 🧭 Development Philosophy
+
+We do NOT:
+
+- optimize prematurely
+- build UI first
+- trust model outputs blindly
+
+We DO:
+
+- enforce invariants
+- verify behavior
+- block invalid states
+
+---
+
+## 🔑 Final Rule
+
+If a change allows invalid evaluation to exist, it is rejected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,13 @@ System MUST fail if:
 Do NOT introduce:
 
 - `skip_gate` flags
+- equivalent bypass parameters (renamed forms of `skip_gate`)
 - “temporary” bypass logic
 - silent fallbacks
 - partial persistence (artifact without validation/gate)
 - multiple write paths to evaluation artifacts
+- “deprecated but callable” persistence paths for V2
+- convention-only enforcement (every invariant must be backed by tests and/or CI guard)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ If those are not true, the system can still lie, and feature work is premature.
 
 ## Canonical persistence direction
 
-All evaluation-result persistence is converging on a single named boundary:
+All evaluation-result persistence must route through a single named boundary:
 
 `persistEvaluationResultV2(...)`
 
-That boundary is intended to become the only place where the system may:
+That boundary is the only place where the system is permitted to:
 
 - validate an evaluation artifact
 - apply the quality gate
@@ -107,6 +107,6 @@ A change is done only when:
 
 ## Final note
 
-This repository should prefer explicit failure over comforting fiction.
+This repository must prefer explicit failure over comforting fiction.
 
 If the system can persist an invalid evaluation, it is not finished.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The immediate goal is to establish a single persistence boundary for evaluation 
 
 Until that exists, downstream work is secondary.
 
-Start with:
+Read first:
 
 - `ROADMAP.md` — authoritative execution order
 - `CONTRIBUTING.md` — contribution rules and forbidden patterns

--- a/README.md
+++ b/README.md
@@ -1,165 +1,112 @@
-# RevisionGrade - Literary AI Partner
+# RevisionGrade
 
-## 🎯 Quick Start
+## What this repository is optimizing for
 
-### 🚀 NEXT 72 HOURS: Build Agent Proof
-**Start here:** [72HR-INDEX.md](./72HR-INDEX.md) — Complete sprint documentation hub
+RevisionGrade is not currently prioritizing feature velocity.
 
-Then choose your entry point:
-- **Quick action plan:** [START-HERE-72HR.md](./START-HERE-72HR.md)
-- **Copy-paste code:** [72-HOUR-SPRINT-QUICK-START.md](./72-HOUR-SPRINT-QUICK-START.md)
-- **Full context:** [72-HOUR-SPRINT.md](./72-HOUR-SPRINT.md)
-- **Executive summary:** [72HR-EXECUTIVE-SUMMARY.md](./72HR-EXECUTIVE-SUMMARY.md)
+It is prioritizing **truthful evaluation persistence**.
 
-### ⚠️ First Time Setup
-Start here:** [docs/QUICK_START.md](./docs/QUICK_START.md)
+The governing principle for work in this repository is:
 
-### Daily Workflow
-```bash
-# 1. Verify configuration (CRITICAL - do this daily!)
-bash scripts/verify-supabase-project.sh
+> **If it is not enforced, it is not real.**
 
-# 2. Start development
-npm run dev
-```
+That means roadmap claims, completion labels, and UX signals are only meaningful when the runtime prevents invalid states from being persisted.
 
-## 🔒 Supabase Configuration
+## Current priority
 
-### Production Project (Active)
-- **Name**: RevisionGrade Production
-- **Project ID**: `xtumxjnzdswuumndcbwc`
-- **Status**: ✅ ALL CODE POINTS HERE
-- **Used By**: Local dev, Vercel, CI/CD
+The active priority is the **Eval 2.0 trust layer**.
 
-**Full Details**: [docs/SUPABASE_PROJECTS.md](./docs/SUPABASE_PROJECTS.md)
+The immediate goal is to establish a single persistence boundary for evaluation results and then enforce validation, gating, and confidence derivation at that boundary.
 
-## 📋 Prerequisites
+Until that exists, downstream work is secondary.
 
-1. Clone the repository using the project's Git URL
-2. Navigate to the project directory
-3. Install dependencies: `npm install`
-4. Create an `.env.local` file with production credentials:
+Start with:
 
-```bash
-NEXT_PUBLIC_SUPABASE_URL=https://xtumxjnzdswuumndcbwc.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=[from Supabase Dashboard → RevisionGrade Production → Settings → API]
-NEXT_PUBLIC_SUPABASE_ANON_KEY=[from same location]
-USE_SUPABASE_JOBS=true
-ALLOW_HEADER_USER_ID=true
-```
+- `ROADMAP.md` — authoritative execution order
+- `CONTRIBUTING.md` — contribution rules and forbidden patterns
+- `AI_GOVERNANCE.md` — binding AI governance policy
+- `docs/JOB_CONTRACT_v1.md` — canonical job status contract
 
-## 🛡️ Safety Features
+## What must be true before new feature work
 
-### Automatic Guards
-- ✅ **Project Guard**: Prevents accidental use of testing database
-- ✅ **RLS Security**: Row Level Security enabled on all production tables
-- ✅ **Verification Scripts**: Check configuration before work
+Before adding behavior to the evaluation pipeline, the system must prove:
 
-### Manual Checks
-```bash
-# Verify Supabase project
-bash scripts/verify-supabase-project.sh
+1. There is exactly one persistence boundary for `evaluation_result_v2`
+2. Invalid artifacts cannot persist
+3. Invalid artifacts cannot mark jobs `complete`
+4. CI fails if a bypass path is introduced
 
-# Verify remote migrations
-bash scripts/verify-remote-migration.sh
+If those are not true, the system can still lie, and feature work is premature.
 
-# Run tests
-npm test
-```
+## Canonical persistence direction
 
-### Phase 2C Evidence (TypeScript Type Verification)
-⚠️ **CRITICAL**: Evidence must be produced via `tsc -p <tsconfig>`, never single-file tsc.
+All evaluation-result persistence is converging on a single named boundary:
 
-Single-file TypeScript compilation bypasses project configuration and surfaces spurious errors (e.g., ES2018 private field errors in ES2020+ code).
+`persistEvaluationResultV2(...)`
 
-```bash
-# ✅ CANONICAL (use this for evidence)
-npm run evidence:phase2c
+That boundary is intended to become the only place where the system may:
 
-# ❌ WRONG (surfaces TS18028 errors, not in actual build)
-npx tsc --noEmit workers/phase2Evaluation.ts
-```
+- validate an evaluation artifact
+- apply the quality gate
+- derive confidence
+- persist the artifact
+- mark the job complete
 
-See [docs/CANONICAL_RUNTIME_OPERATIONS.md](./docs/CANONICAL_RUNTIME_OPERATIONS.md) for current runtime authority,
-and [docs/PERSISTENCE_CONTRACT.md](./docs/PERSISTENCE_CONTRACT.md) for legacy Phase 2C persistence history.
+Any alternative write path is a defect.
 
-## 📚 Documentation
+## What is blocked right now
 
-- **[QUICK_START.md](./docs/QUICK_START.md)** - First-time setup and daily workflow
-- **[SUPABASE_PROJECTS.md](./docs/SUPABASE_PROJECTS.md)** - Complete Supabase configuration
-- **[JOB_CONTRACT_v1.md](./docs/JOB_CONTRACT_v1.md)** - Canonical job state machine contract
-- **[DEPLOYMENT_QUICK_REFERENCE.md](./DEPLOYMENT_QUICK_REFERENCE.md)** - Deployment guide
+The following remain intentionally blocked until the trust layer is real:
 
-## 🚀 Deployment
+- liveness and latency improvements
+- dashboards and observability polish
+- UX progress enhancements
+- prompt tuning and calibration expansion
+- recommendation semantics improvements
 
-### Vercel (Automatic)
-```bash
-git push origin main
-# Vercel auto-deploys from main branch
-# ✅ Already configured to use Production project
-```
+Nice ideas can wait. False confidence cannot.
 
-### Base44 (Manual Publish)
-Open [Base44.com](http://Base44.com) and click Publish.
+## Repository rules in one minute
 
-## 🔧 Development
+- Do not invent or rename canonical identifiers
+- Do not introduce new job statuses
+- Do not add bypass flags or silent fallbacks
+- Do not write evaluation artifacts outside the canonical boundary
+- Do not treat documentation claims as reality unless tests and enforcement prove them
 
-### Run Development Server
-```bash
-npm run dev
-```
+## Development entry points
 
-### Evaluation Timeout Env Contract
+Use these documents first:
 
-For `EVAL_OPENAI_TIMEOUT_MS` and `EVAL_PASS_TIMEOUT_MS`, the canonical resolver prefers local file-backed values in `.env.local`, then `.env`, then built-in defaults. Conflicting exported shell values are treated as stale local overrides for this subsystem and are ignored with diagnostics so builds and local test runs stay deterministic.
+- `ROADMAP.md` — what happens next
+- `CONTRIBUTING.md` — how changes are allowed to happen
+- `docs/NOMENCLATURE_CANON_v1.md` — canonical identifiers only
+- `docs/JOB_CONTRACT_v1.md` — allowed job states only
+- `docs/QUICK_START.md` — local setup when you actually need to run the app
 
-```bash
-npm run config:validate
-```
+## Local setup
 
-Expected startup message:
-```
-✅ Supabase Project Configuration ✅
-   Environment: PRODUCTION
-   Project ID: xtumxjnzdswuumndcbwc
-   ✅ Production database active
-```
+When local execution is needed:
 
-### Run Tests
-```bash
-npm test                     # All tests
-npm test -- jobStore.test.ts # Specific test
-```
+1. Install dependencies with `npm install`
+2. Configure local environment files as required by the app
+3. Run the project checks relevant to your change
 
-## 🚨 Troubleshooting
+If your change affects enforcement or persistence behavior, tests are not optional.
 
-### Wrong Supabase Project Error
-If you see: `❌ CRITICAL ERROR: TESTING DATABASE DETECTED!`
+## Definition of done
 
-**Fix**: Update `.env.local` to use production URL (see Prerequisites above)
+A change is not done because code exists.
 
-### Migration Not Found
-If `verify-remote-migration.sh` fails:
+A change is done only when:
 
-1. Go to Supabase Dashboard → **RevisionGrade Production** (not testing!)
-2. SQL Editor → Run your migration
-3. Rerun: `bash scripts/verify-remote-migration.sh`
+- the invariant is enforced
+- the tests prove it
+- bypass paths do not exist
+- CI guards would fail on regression
 
-### Full Troubleshooting
-See [docs/QUICK_START.md](./docs/QUICK_START.md#-emergency-procedures)
+## Final note
 
-## 📞 Support
+This repository should prefer explicit failure over comforting fiction.
 
-- **Documentation**: [https://docs.base44.com/Integrations/Using-GitHub](https://docs.base44.com/Integrations/Using-GitHub)
-- **Support**: [https://app.base44.com/support](https://app.base44.com/support)
-
----
-
-**⚠️ CRITICAL**: Always verify you're using the **Production** project before starting work!
-
-```bash
-bash scripts/verify-supabase-project.sh
-```
-
-**Last Updated**: January 27, 2026  
-**Status**: ✅ Error-proof and production-ready
+If the system can persist an invalid evaluation, it is not finished.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,8 @@
 
 > If it is not enforced, it is not real.
 
+> Before any enforcement diff, prove the boundary it will be installed at.
+
 This roadmap separates:
 - **System Build (what we build)**
 - **System Truth (what is provably enforced)**
@@ -67,9 +69,13 @@ Paths:
 grep shows exactly ONE persistence path
 ```
 
+### Gating rule:
+
+Step 1 and all later steps are blocked until Step 0c is green.
+
 ## STEP 1 — Install Enforcement Kernel
 
-Only AFTER Step 0 is complete.
+Only AFTER Step 0c is complete.
 
 Inside `persistEvaluationResultV2()`:
 
@@ -124,6 +130,15 @@ System is CERTIFIED only when:
 
 ---
 
+## 🧭 ROADMAP vs WORKBOOK (SOURCE SPLIT)
+
+- `ROADMAP.md` = contract (stable, external, what must be true)
+- Workbook/Ledger artifacts = state (live, internal, what is currently true)
+
+If they diverge, treat `ROADMAP.md` as contract authority and reconcile workbook state to match.
+
+---
+
 ## 🧱 SYSTEM BUILD ROADMAP (SECONDARY)
 
 These remain important, but are blocked until the trust layer is enforced.
@@ -165,6 +180,7 @@ These remain important, but are blocked until the trust layer is enforced.
 - No bypass
 - Fail closed
 - Prove before proceed
+- Enforce before claiming progress
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,175 @@
+# RevisionGrade System Roadmap (V2 – Enforcement First)
+
+---
+
+## 🎯 Core Principle
+
+> If it is not enforced, it is not real.
+
+This roadmap separates:
+- **System Build (what we build)**
+- **System Truth (what is provably enforced)**
+
+Certification is based ONLY on enforced invariants.
+
+---
+
+# 🔴 CURRENT PRIORITY: EVAL 2.0 TRUST LAYER
+
+We are not building features.
+
+We are building:
+
+> **A system where invalid evaluation artifacts cannot exist.**
+
+---
+
+# 🧠 EXECUTION MODEL
+
+All work follows this rule:
+
+> **Prove the prerequisite before installing the next layer**
+
+---
+
+# 🔴 EXECUTION BLOCK (ACTIVE)
+
+## STEP 0 — Establish Persistence Boundary (CRITICAL)
+
+Goal:
+Create the only door where evaluation results can be persisted.
+
+### 0a — Define boundary
+- Create:
+  `persistEvaluationResultV2()`
+- No logic yet
+
+### 0b — Route all paths
+All of the following must:
+- route through the function OR
+- be removed/quarantined
+
+Paths:
+- `processor.ts`
+- `store.finalizer.ts`
+- `phase2.ts`
+- `claimJob.ts`
+- `writeArtifact.ts`
+
+### 0c — Enforce via CI
+- Repo-wide guard:
+  - No writes to `evaluation_artifacts` outside boundary
+  - No `status = complete` outside boundary
+
+### Success condition:
+
+```text
+grep shows exactly ONE persistence path
+```
+
+## STEP 1 — Install Enforcement Kernel
+
+Only AFTER Step 0 is complete.
+
+Inside `persistEvaluationResultV2()`:
+
+- `validateEvaluationArtifact()`
+- `evaluateQualityGate()`
+- `deriveConfidence()`
+
+Rule:
+- `FAIL` → no persistence
+- `PASS` → atomic write
+
+## STEP 2 — Guard Invariants
+
+Add tests:
+
+- invalid artifact → no DB row
+- invalid artifact → no `status = complete`
+- no completed job has failed gate
+
+## STEP 3 — Golden Proof (Initial)
+
+Add:
+
+- 1 valid case
+- 1 invalid case
+
+Goal:
+
+- prove fail-closed behavior
+
+## STEP 4 — Secondary work (blocked until trust layer lands)
+
+Blocked until the persistence boundary and enforcement kernel are real:
+
+- Liveness & latency
+- Observability dashboards
+- UX improvements
+- Prompt tuning
+- Calibration expansion
+- Recommendation semantics improvements
+
+---
+
+## 📊 CERTIFICATION DEFINITION
+
+System is CERTIFIED only when:
+
+- U1 ENFORCED
+- U2 ENFORCED
+- U3 ENFORCED
+- Invalid escape rate = 0 on golden set
+
+---
+
+## 🧱 SYSTEM BUILD ROADMAP (SECONDARY)
+
+These remain important, but are blocked until the trust layer is enforced.
+
+### Liveness & Latency
+- worker kickoff improvements
+- sub-3-minute E2E execution
+
+### Observability
+- per-stage timing
+- structured logs
+- metrics dashboard
+
+### UX
+- job progress UI
+- evaluation visibility
+- governance transparency
+
+### Prompt & Quality
+- calibration
+- convergence testing
+- recommendation semantics
+
+---
+
+## 🚫 WHAT IS NOT ALLOWED
+
+- No “COMPLETE” without enforcement
+- No new persistence paths
+- No feature work before enforcement boundary
+- No “temporary bypass” flags
+- No “deprecated but callable” code paths
+
+---
+
+## 🧠 DEVELOPMENT RULES
+
+- One boundary
+- No bypass
+- Fail closed
+- Prove before proceed
+
+---
+
+## 🔑 FINAL PRINCIPLE
+
+We are not building features.
+
+We are building a system that cannot lie.

--- a/docs/archive/RevisionGrade_Roadmap_UPDATED.md
+++ b/docs/archive/RevisionGrade_Roadmap_UPDATED.md
@@ -1,3 +1,6 @@
+> Superseded by `ROADMAP.md` as of 2026-04-25.
+> Do not use as current guidance.
+
 # README
 
 | RevisionGrade Project Management Roadmap Tracker |


### PR DESCRIPTION
## Summary
This PR replaces root repo guidance with enforcement-first documentation and locks drift vectors identified in review.

## What changed
- Replaced `README.md` with a trust-layer-first orientation
  - repo priority = truthful evaluation persistence
  - explicit links near top to `ROADMAP.md` and `CONTRIBUTING.md`
- Added root `ROADMAP.md` as authoritative contract for execution order
  - includes both operating rules
  - Step 0 explicitly split as `0a / 0b / 0c`
  - Step 1+ explicitly gated on Step `0c`
  - certification rule includes `U1/U2/U3 ENFORCED` + invalid escape rate = 0
  - added roadmap-vs-workbook source split
- Added root `CONTRIBUTING.md` with explicit enforcement discipline
  - persistence boundary rule (`persistEvaluationResultV2(...)`)
  - required negative/guard tests
  - explicit forbidden escape hatches (`skip_gate` equivalents, deprecated-but-callable paths, convention-only enforcement)
- Archived legacy roadmap surface
  - moved `RevisionGrade_Roadmap_UPDATED.md` to `docs/archive/RevisionGrade_Roadmap_UPDATED.md`
  - added superseded banner:
    - "Superseded by `ROADMAP.md` as of 2026-04-25"
    - "Do not use as current guidance"

## Why
Align top-level repository contract with enforcement-first system truth so docs cannot drift into non-enforced claims.

## Scope
Docs-only. No runtime code path changes.

Refs #231