### PR TITLE
fix(env): align ProcessEnv typing in config tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Read first:
 - `ROADMAP.md` — authoritative execution order
 - `CONTRIBUTING.md` — contribution rules and forbidden patterns
 - `AI_GOVERNANCE.md` — binding AI governance policy
+- `docs/CANONICAL_RUNTIME_OPERATIONS.md` — canonical runtime authority
 - `docs/JOB_CONTRACT_v1.md` — canonical job status contract
 
 ## What must be true before new feature work

--- a/lib/config/__tests__/envContract.test.ts
+++ b/lib/config/__tests__/envContract.test.ts
@@ -7,6 +7,9 @@ const BASE_ENV: NodeJS.ProcessEnv = {
   NODE_ENV: 'test',
 };
 
+const asProcessEnv = (env: Record<string, string | undefined>): NodeJS.ProcessEnv =>
+  env as NodeJS.ProcessEnv;
+
 beforeEach(() => {
   __resetEvalEnvContract();
 });
@@ -84,7 +87,7 @@ describe('resolveEvalEnvContract', () => {
     });
 
     it('throws on invalid NODE_ENV value', () => {
-      const env = { ...BASE_ENV, NODE_ENV: 'staging' };
+      const env = asProcessEnv({ ...BASE_ENV, NODE_ENV: 'staging' });
       expect(() => resolveEvalEnvContract(env)).toThrow('NODE_ENV must be one of');
     });
   });
@@ -162,22 +165,22 @@ describe('resolveEvalEnvContract', () => {
 
   describe('forbidden combinations', () => {
     it('throws when CI=true in Vercel production', () => {
-      const env = { NODE_ENV: 'production', VERCEL_ENV: 'production', CI: 'true' };
+      const env = asProcessEnv({ NODE_ENV: 'production', VERCEL_ENV: 'production', CI: 'true' });
       expect(() => resolveEvalEnvContract(env)).toThrow('CI=true is not permitted in Vercel production');
     });
 
     it('throws when NODE_ENV=test in Vercel production', () => {
-      const env = { NODE_ENV: 'test', VERCEL_ENV: 'production' };
+      const env = asProcessEnv({ NODE_ENV: 'test', VERCEL_ENV: 'production' });
       expect(() => resolveEvalEnvContract(env)).toThrow('NODE_ENV=test is not permitted in Vercel production');
     });
 
     it('throws when FLOW1_EVIDENCE=1 in Vercel production', () => {
-      const env = { NODE_ENV: 'production', VERCEL_ENV: 'production', FLOW1_EVIDENCE: '1' };
+      const env = asProcessEnv({ NODE_ENV: 'production', VERCEL_ENV: 'production', FLOW1_EVIDENCE: '1' });
       expect(() => resolveEvalEnvContract(env)).toThrow('FLOW1_EVIDENCE=1 is not permitted in Vercel production');
     });
 
     it('throws when FLOW_A7_EVIDENCE=1 in Vercel production', () => {
-      const env = { NODE_ENV: 'production', VERCEL_ENV: 'production', FLOW_A7_EVIDENCE: '1' };
+      const env = asProcessEnv({ NODE_ENV: 'production', VERCEL_ENV: 'production', FLOW_A7_EVIDENCE: '1' });
       expect(() => resolveEvalEnvContract(env)).toThrow('FLOW_A7_EVIDENCE=1 is not permitted in Vercel production');
     });
   });

--- a/lib/config/__tests__/productionConfigValidation.test.ts
+++ b/lib/config/__tests__/productionConfigValidation.test.ts
@@ -4,6 +4,7 @@ describe("validateProductionConfig", () => {
   it("rejects worker timing when lease is shorter than max execution", () => {
     const result = validateProductionConfig(
       {
+        NODE_ENV: "test",
         EVAL_WORKER_LEASE_MS: "180000",
         EVAL_WORKER_MAX_EXECUTION_MS: "280000",
       },
@@ -22,6 +23,7 @@ describe("validateProductionConfig", () => {
   it("accepts aligned worker lease and execution values at the policy ceiling", () => {
     const result = validateProductionConfig(
       {
+        NODE_ENV: "test",
         EVAL_WORKER_LEASE_MS: "180000",
         EVAL_WORKER_MAX_EXECUTION_MS: "180000",
       },


### PR DESCRIPTION
## Summary
Unblocks the failing Phase 2C Evidence Gate by fixing strict `ProcessEnv` typing in config tests only.

## Scope
- Test files plus one documentation authority pointer fix required for repository guards.
- No runtime evaluation logic changed.
- No persistence path changes.

## Contract Integrity
- Preserves canonical job/persistence contract behavior.
- Keeps env contract typing strictness explicit in tests.
- Adds canonical runtime authority pointer in `README.md` to satisfy runtime authority guard.

## Behavioral Quality
- Quality gate behavior is unchanged.
- No modifications to `persistEvaluationResultV2(...)` or runtime policy code.
- QG_ semantics remain exactly as-is (no behavior change).

## Latency Evidence
### Baseline (Pre-change)
| Run | passX_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | No runtime path or latency logic touched |
| Run 2 | N/A | N/A | Test/doc-only change set |

### Post-change Runs
| Run | passX_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | No latency-affecting code changed |
| Run 2 | N/A | N/A | Expected no latency delta |

Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Risks & Anomalies
- Main risk is CI policy/template mismatch, not runtime regression.
- Vercel preview may fail independently of this test/doc-only scope.
- No anomaly introduced in evaluation runtime or persistence flow.

Final principle: this change is not reducing intelligence; it is only enforcing correctness and guard compliance.

## Verification
- `npm run evidence:phase2c` passes locally on branch `fix/env-contract-test-typing` after dependency install.
- CI blockers addressed: canonical runtime pointer + latency template sections.

## Why this unblocks #238
PR #238 is blocked by baseline check failures. This PR removes the env typing baseline failures and aligns guard requirements so #238 can be re-evaluated against a green base.
