### PR TITLE
feat(db): add persist_evaluation_v2_atomic RPC (migration only, no callers)

### DIFF
--- a/docs/prs/block-b-atomicity-boundary-switch-pr-body.md
+++ b/docs/prs/block-b-atomicity-boundary-switch-pr-body.md
@@ -1,0 +1,169 @@
+## Summary
+
+Switches Eval 2 success-path persistence from sequential writes to one atomic RPC call (`persist_evaluation_v2_atomic`).
+
+This removes the partial-write window where artifact upsert could succeed but job completion update could fail.
+
+## Dependency (CRITICAL)
+
+Requires `persist_evaluation_v2_atomic` RPC to exist in target Supabase before this code is deployed.
+
+Deploy order:
+1. Merge/apply migration PR first
+2. Verify RPC exists and permissions are correct
+3. Deploy this boundary-switch PR
+
+Failure mode if order is violated:
+- success-path evaluations fail closed due to missing RPC/function
+
+## Scope
+
+- `lib/evaluation/persistEvaluationResultV2.ts`
+  - success path now calls `persist_evaluation_v2_atomic`
+  - old `upsert -> readback -> completion update` sequence removed
+- `__tests__/lib/evaluation/persistEvaluationResultV2.boundary-gate.test.ts`
+  - success assertions updated for RPC path
+  - RPC fail/no-artifact-id fail-closed tests added
+- `__tests__/lib/evaluation/processor.contamination-guard.test.ts`
+  - updated to assert atomic RPC persistence path
+
+Failure paths remain unchanged:
+- structural validation fail path
+- boundary gate fail path
+
+## Contract Integrity
+
+Before:
+- artifact upsert
+- artifact readback
+- completion update
+
+After:
+- single boundary RPC call:
+  - artifact upsert + job completion in one transaction
+
+Preserved fields include:
+- `status=complete`
+- `phase=phase_2`
+- `phase_status=complete`
+- `validity_status=valid`
+- `evaluation_result`
+- `evaluation_result_version`
+- `progress.gate_enforcement`
+- completion/heartbeat timestamps
+
+## Behavioral Quality
+
+- Quality-gate behavior unchanged.
+- Validation/gate failure paths unchanged.
+- Boundary ownership preserved.
+- Layering doctrine preserved (pipeline produces, boundary persists).
+
+## Latency Evidence
+
+Pass selection:
+- [ ] Pass 1
+- [ ] Pass 2
+- [x] Pass 3
+
+| Run | pass3_ms | total_ms | Notes |
+|-----|---------:|---------:|-------|
+| Baseline Run 1 | N/A | ~3:12 | Job `5cca06a2` (pre-Block-B) |
+| Baseline Run 2 | N/A | varies | Job `01cbbf9e` (pre-Block-B) |
+| Post-change Run 1 | N/A | TBD | pending deploy + smoke |
+| Post-change Run 2 | N/A | TBD | pending deploy + smoke |
+
+Expected impact: one fewer Supabase roundtrip per successful evaluation.
+
+## Risks & Anomalies
+
+- Deploy-order risk mitigated by PR split.
+- Quality gate anomaly disclosure: none (no gate logic changed).
+- Final principle: invalid artifacts remain impossible to persist; partial-write success states are now structurally impossible.
+
+## Verification (local structural)
+
+- Focused tests: 15/15 passing
+- Boundary guard: PASS
+- Build: PASS (post-change)
+
+## Post-deploy verification
+
+Run:
+
+```bash
+npm run jobs:smoke:service-role
+```
+
+For a successful job (`<SUCCESS_JOB_ID>`):
+
+```sql
+SELECT
+  id,
+  status,
+  phase,
+  phase_status,
+  validity_status,
+  evaluation_result_version,
+  completed_at,
+  updated_at,
+  progress->'gate_enforcement' AS gate_enforcement
+FROM evaluation_jobs
+WHERE id = '<SUCCESS_JOB_ID>';
+```
+
+Expected:
+- `status = complete`
+- `phase = phase_2`
+- `phase_status = complete`
+- `gate_enforcement` populated
+
+Artifact existence:
+
+```sql
+SELECT
+  id,
+  job_id,
+  manuscript_id,
+  artifact_type,
+  artifact_version,
+  source_hash,
+  created_at,
+  updated_at
+FROM evaluation_artifacts
+WHERE job_id = '<SUCCESS_JOB_ID>';
+```
+
+Expected:
+- one row
+- `artifact_type = evaluation_result_v2`
+- `artifact_version = evaluation_result_v2`
+
+Also verify Block A failure-path when next phase_1 failure occurs (`<FAILED_PHASE_1_JOB_ID>`):
+
+```sql
+SELECT
+  id,
+  status,
+  phase,
+  phase_status,
+  failure_code,
+  progress->'pipeline_failure_envelope' AS pipeline_failure_envelope,
+  last_error
+FROM evaluation_jobs
+WHERE id = '<FAILED_PHASE_1_JOB_ID>';
+```
+
+Expected post-deploy:
+- `status = failed`
+- `phase = phase_1`
+- `pipeline_failure_envelope` populated
+
+## Status line for workbook
+
+`ATOMICITY_HARDENING: STRUCTURAL ENFORCED, EMPIRICAL PENDING DEPLOY + MIGRATION APPLY.`
+
+## Rollback
+
+- Revert boundary code to prior sequential success path.
+- RPC may remain deployed and unused safely.

--- a/docs/prs/block-b-atomicity-migration-pr-body.md
+++ b/docs/prs/block-b-atomicity-migration-pr-body.md
@@ -1,0 +1,105 @@
+## Summary
+
+Adds the `persist_evaluation_v2_atomic` Supabase RPC for atomic V2 evaluation persistence.
+This PR introduces the database function only. No application code calls it yet.
+
+## Scope
+
+- Adds migration:
+  - `supabase/migrations/20260426210500_persist_evaluation_v2_atomic.sql`
+- No TypeScript/runtime code changes.
+- No production behavior change until the boundary switch PR lands.
+
+## Contract Integrity
+
+The RPC is designed to replace the current two-write success path:
+1. `evaluation_artifacts` upsert
+2. `evaluation_jobs` completion update
+
+with one database transaction.
+
+The RPC uses the verified production contract:
+- `ON CONFLICT (job_id, artifact_type)`
+- service-role-only execution
+- `SECURITY DEFINER`
+- no public/authenticated/anon execution rights
+
+## Behavioral Quality
+
+- This migration is additive only.
+- No existing quality-gate logic or boundary behavior is changed in this PR.
+- No caller is wired yet.
+
+## Latency Evidence
+
+Pass selection:
+- [ ] Pass 1
+- [ ] Pass 2
+- [ ] Pass 3 (N/A — migration-only)
+
+| Run | passX_ms | total_ms | Notes |
+|-----|---------:|---------:|-------|
+| Run 1 | N/A | N/A | Migration-only PR; no pipeline path executes |
+| Run 2 | N/A | N/A | Migration-only PR; no pipeline path executes |
+
+## Risks & Anomalies
+
+- Migration-only: runtime risk is low because no deployed path depends on this RPC yet.
+- Quality gate anomaly disclosure: none (no evaluation logic changed).
+- Final principle: this preserves fail-closed doctrine by introducing the atomic primitive that PR 2 will call at the boundary.
+
+## Verification
+
+After applying migration:
+
+```sql
+SELECT proname, prosecdef
+FROM pg_proc
+WHERE proname = 'persist_evaluation_v2_atomic';
+```
+
+Expected:
+- one row
+- `prosecdef = true`
+
+Permission check:
+
+```sql
+SELECT grantee, privilege_type
+FROM information_schema.routine_privileges
+WHERE routine_name = 'persist_evaluation_v2_atomic'
+ORDER BY grantee;
+```
+
+Expected:
+- `service_role` has `EXECUTE`
+- `anon` does not
+- `authenticated` does not
+
+## Apply steps
+
+- Option A: Supabase Dashboard SQL Editor (paste migration SQL and run)
+- Option B: `npx supabase db push`
+
+## Rollback
+
+```sql
+DROP FUNCTION IF EXISTS public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+);
+```

--- a/supabase/migrations/20260426210500_persist_evaluation_v2_atomic.sql
+++ b/supabase/migrations/20260426210500_persist_evaluation_v2_atomic.sql
@@ -1,0 +1,191 @@
+-- Atomic persistence for evaluation_result_v2 success path.
+-- Replaces boundary two-write sequence (artifact upsert + completion update)
+-- with a single transactional RPC.
+
+CREATE OR REPLACE FUNCTION public.persist_evaluation_v2_atomic(
+  p_job_id uuid,
+  p_manuscript_id bigint,
+  p_artifact_type text,
+  p_artifact_content jsonb,
+  p_source_hash text,
+  p_artifact_version text,
+  p_evaluation_result jsonb,
+  p_progress jsonb,
+  p_completed_at timestamptz,
+  p_phase2_completed_at timestamptz,
+  p_validity_status text,
+  p_total_units integer,
+  p_completed_units integer,
+  p_last_heartbeat timestamptz,
+  p_last_heartbeat_at timestamptz,
+  p_heartbeat_at timestamptz
+)
+RETURNS TABLE (
+  artifact_id uuid,
+  job_id uuid,
+  status text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_artifact_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.evaluation_jobs WHERE id = p_job_id) THEN
+    RAISE EXCEPTION 'persist_evaluation_v2_atomic: job % not found', p_job_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  INSERT INTO public.evaluation_artifacts (
+    job_id,
+    manuscript_id,
+    artifact_type,
+    content,
+    source_hash,
+    artifact_version,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    p_job_id,
+    p_manuscript_id,
+    p_artifact_type,
+    p_artifact_content,
+    p_source_hash,
+    p_artifact_version,
+    p_completed_at,
+    p_completed_at
+  )
+  ON CONFLICT (job_id, artifact_type) DO UPDATE
+    SET manuscript_id = EXCLUDED.manuscript_id,
+        content = EXCLUDED.content,
+        source_hash = EXCLUDED.source_hash,
+        artifact_version = EXCLUDED.artifact_version,
+        updated_at = EXCLUDED.updated_at
+  RETURNING id INTO v_artifact_id;
+
+  UPDATE public.evaluation_jobs
+  SET
+    status = 'complete',
+    validity_status = p_validity_status,
+    phase = 'phase_2',
+    phase_status = 'complete',
+    total_units = p_total_units,
+    completed_units = p_completed_units,
+    progress = p_progress,
+    evaluation_result = p_evaluation_result,
+    evaluation_result_version = p_artifact_version,
+    last_heartbeat = p_last_heartbeat,
+    last_heartbeat_at = p_last_heartbeat_at,
+    heartbeat_at = p_heartbeat_at,
+    last_error = NULL,
+    updated_at = p_completed_at,
+    completed_at = p_completed_at,
+    phase2_completed_at = p_phase2_completed_at
+  WHERE id = p_job_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'persist_evaluation_v2_atomic: completion update affected 0 rows for job %', p_job_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  RETURN QUERY
+  SELECT v_artifact_id, p_job_id, 'complete'::text;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+) FROM authenticated;
+
+REVOKE ALL ON FUNCTION public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+) FROM anon;
+
+GRANT EXECUTE ON FUNCTION public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+) TO service_role;
+
+COMMENT ON FUNCTION public.persist_evaluation_v2_atomic(
+  uuid,
+  bigint,
+  text,
+  jsonb,
+  text,
+  text,
+  jsonb,
+  jsonb,
+  timestamptz,
+  timestamptz,
+  text,
+  integer,
+  integer,
+  timestamptz,
+  timestamptz,
+  timestamptz
+) IS 'Atomic boundary RPC: upsert evaluation_result_v2 artifact and complete evaluation job in one transaction.';


### PR DESCRIPTION
## Summary

Adds the `persist_evaluation_v2_atomic` Supabase RPC for atomic V2 evaluation persistence.
This PR introduces the database function only. No application code calls it yet.

## Scope

- Adds migration:
  - `supabase/migrations/20260426210500_persist_evaluation_v2_atomic.sql`
- Adds PR documentation templates under `docs/prs/` for migration and boundary-switch sequencing.
- No TypeScript/runtime code path changes.

## Contract Integrity

The RPC provides a single-transaction primitive for:
1. Artifact upsert (`evaluation_artifacts`)
2. Job completion update (`evaluation_jobs`)

No caller wiring is introduced in this PR, so runtime behavior remains unchanged until boundary switch lands.

## Behavioral Quality

- Additive migration only.
- No quality gate behavior changes in runtime execution.
- Quality/anomaly disclosure: quality gate logic is untouched in this PR; this is infra only.

## Latency Evidence

Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

### Baseline (Pre-change)
| Run | passX_ms | total_ms | Notes |
|-----|---------:|---------:|-------|
| Run 1 | N/A | N/A | Migration-only PR; no pipeline path executes |
| Run 2 | N/A | N/A | Migration-only PR; no pipeline path executes |

### Post-change Runs
| Run | passX_ms | total_ms | Notes |
|-----|---------:|---------:|-------|
| Run 1 | N/A | N/A | Migration-only PR; no pipeline path executes |
| Run 2 | N/A | N/A | Migration-only PR; no pipeline path executes |

## Risks & Anomalies

- Runtime risk is low because no caller is switched in this PR.
- Deploy order requirement remains strict for next PR: migration first, boundary switch second.
- Final rule: this change preserves correctness and is not reducing intelligence.

## Verification

After applying migration:

```sql
SELECT proname, prosecdef
FROM pg_proc
WHERE proname = 'persist_evaluation_v2_atomic';
```

Expected: one row with `prosecdef = true`.

```sql
SELECT grantee, privilege_type
FROM information_schema.routine_privileges
WHERE routine_name = 'persist_evaluation_v2_atomic'
ORDER BY grantee;
```

Expected: `service_role` has EXECUTE; `anon` and `authenticated` do not.
