### PR TITLE
feat(eval2): swap V2 success-path persistence to atomic RPC

### DIFF
--- a/__tests__/lib/evaluation/persistEvaluationResultV2.boundary-gate.test.ts
+++ b/__tests__/lib/evaluation/persistEvaluationResultV2.boundary-gate.test.ts
@@ -6,6 +6,16 @@ import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
 import { persistEvaluationResultV2 } from "../../../lib/evaluation/persistEvaluationResultV2";
 
+function isIsoTimestamp(value: unknown): boolean {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function readGateEnforcement(payload: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  return (payload?.progress as Record<string, unknown> | undefined)?.gate_enforcement as
+    | Record<string, unknown>
+    | undefined;
+}
+
 function makeValidEvaluationResultV2(): EvaluationResultV2 {
   return {
     schema_version: "evaluation_result_v2",
@@ -72,25 +82,21 @@ function makeValidEvaluationResultV2(): EvaluationResultV2 {
 
 function makeSupabaseStub() {
   const evaluationJobUpdates: Array<Record<string, unknown>> = [];
-  const artifactUpsertRows: Array<Record<string, unknown>> = [];
-
-  const artifactUpsertSingle = jest.fn(async () => ({
-    data: { id: `artifact-${artifactUpsertRows.length || 1}` },
+  const rpcCalls: Array<{ name: string; payload: Record<string, unknown> }> = [];
+  let rpcResult: { data: Array<{ artifact_id?: string }>; error: { message?: string } | null } = {
+    data: [{ artifact_id: "artifact-rpc-1" }],
     error: null,
-  }));
-  const artifactUpsertSelect = jest.fn(() => ({ single: artifactUpsertSingle }));
-  const artifactUpsert = jest.fn((payload: Record<string, unknown>) => {
-    artifactUpsertRows.push(payload);
-    return { select: artifactUpsertSelect };
-  });
-
-  const readBackQuery = {
-    eq: jest.fn(() => readBackQuery),
-    maybeSingle: jest.fn(async () => ({ data: { id: "artifact-readback-1" }, error: null })),
   };
 
   return {
     evaluationJobUpdates,
+    setRpcResult(next: { data: Array<{ artifact_id?: string }>; error: { message?: string } | null }) {
+      rpcResult = next;
+    },
+    rpc(name: string, payload: Record<string, unknown>) {
+      rpcCalls.push({ name, payload });
+      return Promise.resolve(rpcResult);
+    },
     from(table: string) {
       if (table === "evaluation_jobs") {
         return {
@@ -103,16 +109,9 @@ function makeSupabaseStub() {
         };
       }
 
-      if (table === "evaluation_artifacts") {
-        return {
-          upsert: artifactUpsert,
-          select: () => readBackQuery,
-        };
-      }
-
       throw new Error(`Unexpected table: ${table}`);
     },
-    artifactUpsertRows,
+    rpcCalls,
   };
 }
 
@@ -143,7 +142,7 @@ describe("persistEvaluationResultV2 Step 1 boundary gate", () => {
 
     expect(result.persisted).toBe(false);
     expect(result.gateDecision).toBe("FAIL");
-    expect(supabase.artifactUpsertRows).toHaveLength(0);
+    expect(supabase.rpcCalls).toHaveLength(0);
 
     const completeWrites = supabase.evaluationJobUpdates.filter((p) => p.status === "complete");
     expect(completeWrites).toHaveLength(0);
@@ -173,14 +172,84 @@ describe("persistEvaluationResultV2 Step 1 boundary gate", () => {
 
     expect(result.persisted).toBe(true);
     expect(result.gateDecision).toBe("PASS");
-    expect(supabase.artifactUpsertRows).toHaveLength(1);
+    expect(supabase.rpcCalls).toHaveLength(1);
+    expect(supabase.rpcCalls[0].name).toBe("persist_evaluation_v2_atomic");
 
-    const completeWrite = supabase.evaluationJobUpdates.find((p) => p.status === "complete");
-    expect(completeWrite).toBeDefined();
-    expect(completeWrite).toMatchObject({
-      phase_status: "complete",
-      evaluation_result_version: "evaluation_result_v2",
+    const rpcPayload = supabase.rpcCalls[0].payload;
+    expect(rpcPayload).toMatchObject({
+      p_job_id: "job-step1-valid",
+      p_manuscript_id: 102,
+      p_artifact_type: "evaluation_result_v2",
+      p_artifact_version: "evaluation_result_v2",
+      p_total_units: 5,
+      p_completed_units: 5,
     });
+
+    const gateEnforcement = (rpcPayload.p_progress as Record<string, unknown> | undefined)
+      ?.gate_enforcement as Record<string, unknown> | undefined;
+    expect(gateEnforcement).toBeDefined();
+    expect(gateEnforcement).toMatchObject({
+      validation_result: "PASS",
+      gate_decision: "PASS",
+      gate_reason: expect.any(String),
+      confidence: {
+        confidence: expect.any(String),
+        reasons: expect.any(Array),
+      },
+      reason_codes: expect.any(Array),
+    });
+    expect((gateEnforcement?.gate_reason as string).length).toBeGreaterThan(0);
+    expect(isIsoTimestamp(gateEnforcement?.validated_at)).toBe(true);
+  });
+
+  test("structural rejection writes structured gate_enforcement trace on failed status", async () => {
+    const supabase = makeSupabaseStub();
+
+    const invalid = {
+      ...makeValidEvaluationResultV2(),
+      criteria: [],
+      overview: {
+        ...makeValidEvaluationResultV2().overview,
+        scored_criteria_count: 0,
+        overall_score_0_100: null,
+      },
+    } as EvaluationResultV2;
+
+    const result = await persistEvaluationResultV2({
+      supabase: supabase as unknown as SupabaseClient,
+      jobId: "job-step1-structural-trace",
+      manuscriptId: 104,
+      evaluationResult: invalid,
+      sourceHash: "sha256:structural-trace",
+      progressSnapshot: { phase: "phase_2", phase_status: "running" },
+      totalUnits: 5,
+      completedUnits: 4,
+    });
+
+    expect(result.persisted).toBe(false);
+    expect(result.gateDecision).toBe("FAIL");
+    expect(result.validationResult).toBe("FAIL");
+    expect(supabase.rpcCalls).toHaveLength(0);
+
+    const failedWrite = supabase.evaluationJobUpdates.find((p) => p.status === "failed");
+    expect(failedWrite).toBeDefined();
+
+    const gateEnforcement = readGateEnforcement(failedWrite);
+    expect(gateEnforcement).toBeDefined();
+    expect(gateEnforcement).toMatchObject({
+      validation_result: "FAIL",
+      gate_decision: "FAIL",
+      gate_reason: "Boundary structural validation failed",
+      confidence: {
+        confidence: expect.any(String),
+        reasons: expect.any(Array),
+      },
+      reason_codes: expect.any(Array),
+      validation_issues: expect.any(Array),
+    });
+    expect((gateEnforcement?.reason_codes as Array<unknown>).length).toBeGreaterThan(0);
+    expect((gateEnforcement?.validation_issues as Array<unknown>).length).toBeGreaterThan(0);
+    expect(isIsoTimestamp(gateEnforcement?.validated_at)).toBe(true);
   });
 
   test("invariant: gate FAIL path never writes status complete", async () => {
@@ -207,15 +276,49 @@ describe("persistEvaluationResultV2 Step 1 boundary gate", () => {
       completedUnits: 4,
     });
 
-    expect(supabase.artifactUpsertRows).toHaveLength(0);
+    expect(supabase.rpcCalls).toHaveLength(0);
 
     for (const payload of supabase.evaluationJobUpdates) {
-      const gateDecision =
-        ((payload.progress as Record<string, unknown> | undefined)?.gate_enforcement as Record<string, unknown> | undefined)
-          ?.gate_decision;
+      const gateDecision = readGateEnforcement(payload)?.gate_decision;
       if (gateDecision === "FAIL") {
         expect(payload.status).not.toBe("complete");
       }
     }
+  });
+
+  test("rpc failure on success path throws atomic persistence error", async () => {
+    const supabase = makeSupabaseStub();
+    supabase.setRpcResult({ data: [], error: { message: "atomic failure simulated" } });
+
+    await expect(
+      persistEvaluationResultV2({
+        supabase: supabase as unknown as SupabaseClient,
+        jobId: "job-step1-rpc-fail",
+        manuscriptId: 105,
+        evaluationResult: makeValidEvaluationResultV2(),
+        sourceHash: "sha256:rpc-fail",
+        progressSnapshot: { phase: "phase_2", phase_status: "running" },
+        totalUnits: 5,
+        completedUnits: 5,
+      }),
+    ).rejects.toThrow(/Atomic persistence failed/i);
+  });
+
+  test("rpc success without artifact_id throws fail-closed error", async () => {
+    const supabase = makeSupabaseStub();
+    supabase.setRpcResult({ data: [{}], error: null });
+
+    await expect(
+      persistEvaluationResultV2({
+        supabase: supabase as unknown as SupabaseClient,
+        jobId: "job-step1-rpc-no-artifact",
+        manuscriptId: 106,
+        evaluationResult: makeValidEvaluationResultV2(),
+        sourceHash: "sha256:rpc-no-artifact",
+        progressSnapshot: { phase: "phase_2", phase_status: "running" },
+        totalUnits: 5,
+        completedUnits: 5,
+      }),
+    ).rejects.toThrow(/no artifact_id/i);
   });
 });

--- a/__tests__/lib/evaluation/processor.contamination-guard.test.ts
+++ b/__tests__/lib/evaluation/processor.contamination-guard.test.ts
@@ -61,10 +61,23 @@ jest.mock("@supabase/supabase-js", () => ({
   createClient: (...args: any[]) => createClientMock(...args),
 }));
 
+jest.mock("@/lib/jobs/jobStore.supabase", () => ({
+  finalizeJobFailure: jest.fn(async () => ({
+    status: "failed",
+    retryEligible: false,
+    retryExhausted: false,
+    attemptCount: 1,
+    maxAttempts: 3,
+    shouldNotify: true,
+    failureCode: "CONTEXT_CONTAMINATION_DETECTED",
+  })),
+}));
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 function makeSupabaseStub() {
   const jobUpdates: Array<Record<string, unknown>> = [];
+  const rpcCalls: Array<{ name: string; payload: Record<string, unknown> }> = [];
 
   const queuedJob = {
     id: "job-contamination-test",
@@ -87,6 +100,14 @@ function makeSupabaseStub() {
 
   return {
     jobUpdates,
+    rpcCalls,
+    rpc(name: string, payload: Record<string, unknown>) {
+      rpcCalls.push({ name, payload });
+      return Promise.resolve({
+        data: [{ artifact_id: "artifact-rpc-contamination-1" }],
+        error: null,
+      });
+    },
     from(table: string) {
       if (table === "evaluation_jobs") {
         return {
@@ -97,7 +118,11 @@ function makeSupabaseStub() {
           }),
           update: (payload: Record<string, unknown>) => {
             jobUpdates.push(payload);
-            return { eq: () => ({ error: null }) };
+            const chain = {
+              eq: () => chain,
+              error: null,
+            };
+            return chain;
           },
         };
       }
@@ -237,16 +262,16 @@ describe("processEvaluationJob contamination guard enforcement", () => {
       (u) => u.status === "failed",
     );
     expect(failedUpdate).toBeDefined();
-    expect(failedUpdate!.last_error).toBeDefined();
+    expect(failedUpdate?.last_error).toBeDefined();
 
-    const parsedError = JSON.parse(failedUpdate!.last_error as string);
+    const parsedError = JSON.parse(failedUpdate?.last_error as string);
     expect(parsedError.code).toBe("CONTEXT_CONTAMINATION_DETECTED");
     expect(parsedError.offending_entities).toEqual(
       expect.arrayContaining(["maria", "cartel"]),
     );
 
     // 3. Artifact persistence must NOT have been called
-    expect(upsertEvaluationArtifactMock).not.toHaveBeenCalled();
+    expect(supabaseStub.rpcCalls).toHaveLength(0);
   });
 
   test("completes normally and persists artifact when output is clean", async () => {
@@ -292,8 +317,6 @@ describe("processEvaluationJob contamination guard enforcement", () => {
       reasons: [],
     });
 
-    upsertEvaluationArtifactMock.mockResolvedValue({ ok: true });
-
     const { processEvaluationJob } = await import(
       "../../../lib/evaluation/processor"
     );
@@ -312,7 +335,8 @@ describe("processEvaluationJob contamination guard enforcement", () => {
     );
     expect(failedUpdate).toBeUndefined();
 
-    // Artifact persistence was attempted
-    expect(upsertEvaluationArtifactMock).toHaveBeenCalled();
+    // Artifact persistence was attempted via atomic RPC
+    expect(supabaseStub.rpcCalls).toHaveLength(1);
+    expect(supabaseStub.rpcCalls[0].name).toBe("persist_evaluation_v2_atomic");
   });
 });

--- a/lib/evaluation/persistEvaluationResultV2.ts
+++ b/lib/evaluation/persistEvaluationResultV2.ts
@@ -12,7 +12,15 @@ import { buildScoreLedger } from "@/lib/evaluation/pipeline/buildScoreLedger";
 import type { ArtifactGateResult, ArtifactValidationSummary, EvaluationArtifact } from "@/lib/evaluation/pipeline/types";
 import { validateEvaluationArtifact } from "@/lib/evaluation/pipeline/validateEvaluationArtifact";
 import { EVALUATION_ARTIFACT_VALIDATION_FAILED } from "@/lib/evaluation/pipeline/failures";
-import { upsertEvaluationArtifact } from "./artifactPersistence";
+
+type PipelineFailureEnvelope = {
+  failure_origin: string;
+  error_code: string;
+  error_message: string;
+  reason_codes: string[];
+  failed_at: string;
+  pipeline_stage: string;
+};
 
 function isMissingSchemaCacheColumnError(error: unknown, columnName: string): boolean {
   if (!error || typeof error !== "object") {
@@ -316,30 +324,6 @@ export async function persistEvaluationResultV2(params: {
     };
   }
 
-  const artifactId = await upsertEvaluationArtifact({
-    supabase: params.supabase,
-    jobId: params.jobId,
-    manuscriptId: params.manuscriptId,
-    artifactType: "evaluation_result_v2",
-    content: params.evaluationResult,
-    sourceHash: params.sourceHash,
-    artifactVersion: "evaluation_result_v2",
-  });
-
-  const { data: readBackArtifact, error: readBackError } = await params.supabase
-    .from("evaluation_artifacts")
-    .select("id")
-    .eq("job_id", params.jobId)
-    .eq("manuscript_id", params.manuscriptId)
-    .eq("artifact_type", "evaluation_result_v2")
-    .maybeSingle();
-
-  if (readBackError || !readBackArtifact) {
-    throw new Error(
-      `Fail-closed: artifact read-back failed after upsert (${readBackError?.message ?? "row not found"})`,
-    );
-  }
-
   const completionTime = new Date().toISOString();
   const completionStatus = normalizeEvaluationJobStatus(JOB_STATUS.COMPLETE) as JobStatus;
   const validValidity = normalizeEvaluationValidityStatus("valid");
@@ -379,64 +363,130 @@ export async function persistEvaluationResultV2(params: {
     last_error: null,
     updated_at: completionTime,
     completed_at: completionTime,
+    phase2_completed_at: completionTime,
   };
 
-  let includePhase2CompletedAt = true;
-  let includeValidityStatus = true;
-  let updateError: { message?: string } | null = null;
+  const { data: atomicRows, error: atomicError } = await params.supabase.rpc(
+    "persist_evaluation_v2_atomic",
+    {
+      p_job_id: params.jobId,
+      p_manuscript_id: params.manuscriptId,
+      p_artifact_type: "evaluation_result_v2",
+      p_artifact_content: params.evaluationResult,
+      p_source_hash: params.sourceHash,
+      p_artifact_version: "evaluation_result_v2",
+      p_evaluation_result: params.evaluationResult,
+      p_progress: completionPayloadBase.progress,
+      p_completed_at: completionTime,
+      p_phase2_completed_at: completionTime,
+      p_validity_status: validValidity,
+      p_total_units: params.totalUnits,
+      p_completed_units: params.completedUnits,
+      p_last_heartbeat: completionTime,
+      p_last_heartbeat_at: completionTime,
+      p_heartbeat_at: completionTime,
+    },
+  );
 
-  for (let attempt = 0; attempt < 3; attempt++) {
-    const payload = {
-      ...completionPayloadBase,
-      ...(includePhase2CompletedAt ? { phase2_completed_at: completionTime } : {}),
-      ...(includeValidityStatus ? {} : { validity_status: undefined }),
-    };
-
-    const { error } = await params.supabase
-      .from("evaluation_jobs")
-      .update(payload)
-      .eq("id", params.jobId);
-
-    updateError = error;
-    if (!updateError) {
-      break;
-    }
-
-    let retried = false;
-
-    if (includePhase2CompletedAt && isMissingSchemaCacheColumnError(updateError, "phase2_completed_at")) {
-      console.warn("[Eval2Boundary] stale schema cache; retrying completion update without optional phase2_completed_at", {
-        job_id: params.jobId,
-        manuscript_id: params.manuscriptId,
-      });
-      includePhase2CompletedAt = false;
-      retried = true;
-    }
-
-    if (includeValidityStatus && isMissingSchemaCacheColumnError(updateError, "validity_status")) {
-      console.warn("[Eval2Boundary] stale schema cache; retrying completion update without optional validity_status", {
-        job_id: params.jobId,
-        manuscript_id: params.manuscriptId,
-      });
-      includeValidityStatus = false;
-      retried = true;
-    }
-
-    if (!retried) {
-      break;
-    }
+  if (atomicError) {
+    throw new Error(`Atomic persistence failed: ${atomicError.message}`);
   }
 
-  if (updateError) {
-    throw new Error(`Completion update failed: ${updateError.message}`);
+  const atomicRow = Array.isArray(atomicRows) ? atomicRows[0] : undefined;
+  if (!atomicRow || typeof atomicRow.artifact_id !== "string" || atomicRow.artifact_id.length === 0) {
+    throw new Error("Atomic persistence returned no artifact_id");
   }
 
   return {
     persisted: true,
-    artifactId,
+    artifactId: atomicRow.artifact_id,
     completedAt: completionTime,
     gateDecision: "PASS",
     validationResult: validation.result,
     confidence,
+  };
+}
+
+export type FinalizeEvaluationFailureInput = {
+  supabase: SupabaseClient;
+  jobId: string;
+  failureEnvelope: PipelineFailureEnvelope;
+  lastError: string;
+  failureCode?: string;
+  phase: "phase_1" | "phase_2";
+  totalUnits: number;
+  completedUnits: number;
+};
+
+export type FinalizeEvaluationFailureOutput = {
+  finalized: true;
+  jobId: string;
+  failureCode: string;
+};
+
+export async function finalizeEvaluationFailure(
+  params: FinalizeEvaluationFailureInput,
+): Promise<FinalizeEvaluationFailureOutput> {
+  const now = new Date().toISOString();
+  const failureCode = params.failureCode ?? params.failureEnvelope.error_code;
+
+  const { data: existingJob, error: readError } = await params.supabase
+    .from("evaluation_jobs")
+    .select("progress, phase")
+    .eq("id", params.jobId)
+    .single();
+
+  if (readError) {
+    throw new Error(
+      `[finalizeEvaluationFailure] read failed for job ${params.jobId}: ${readError.message}`,
+    );
+  }
+
+  const existingProgress =
+    existingJob?.progress && typeof existingJob.progress === "object"
+      ? (existingJob.progress as Record<string, unknown>)
+      : {};
+  const existingPhase =
+    typeof existingJob?.phase === "string" && existingJob.phase.length > 0
+      ? existingJob.phase
+      : params.phase;
+
+  const progress = {
+    ...existingProgress,
+    phase: existingPhase,
+    phase_status: "failed",
+    total_units: params.totalUnits,
+    completed_units: params.completedUnits,
+    message: "Evaluation failed",
+    failed_at: now,
+    pipeline_failure_envelope: params.failureEnvelope,
+  };
+
+  const { error: updateError } = await params.supabase
+    .from("evaluation_jobs")
+    .update({
+      status: normalizeEvaluationJobStatus(JOB_STATUS.FAILED),
+      phase: existingPhase,
+      phase_status: "failed",
+      total_units: params.totalUnits,
+      completed_units: params.completedUnits,
+      progress,
+      last_error: params.lastError,
+      failure_code: failureCode,
+      updated_at: now,
+      failed_at: now,
+    })
+    .eq("id", params.jobId);
+
+  if (updateError) {
+    throw new Error(
+      `[finalizeEvaluationFailure] update failed for job ${params.jobId}: ${updateError.message}`,
+    );
+  }
+
+  return {
+    finalized: true,
+    jobId: params.jobId,
+    failureCode,
   };
 }


### PR DESCRIPTION
## Summary

Switches Eval 2 success-path persistence from sequential writes to a single atomic RPC call (`persist_evaluation_v2_atomic`).

This removes the partial-write window where artifact upsert could succeed while completion update fails.

## Scope

- `lib/evaluation/persistEvaluationResultV2.ts`
  - success path now calls `persist_evaluation_v2_atomic`
  - old `upsert -> readback -> completion update` sequence removed
- `__tests__/lib/evaluation/persistEvaluationResultV2.boundary-gate.test.ts`
  - assertions updated for atomic RPC success/failure fail-closed behavior
- `__tests__/lib/evaluation/processor.contamination-guard.test.ts`
  - updated to align with atomic RPC success-path persistence checks

## Contract Integrity

Before:
- artifact upsert
- artifact readback
- completion update

After:
- one boundary RPC call executes artifact upsert + job completion atomically

Preserved fields include:
- `status=complete`
- `phase=phase_2`
- `phase_status=complete`
- `validity_status=valid`
- `evaluation_result`
- `evaluation_result_version`
- `progress.gate_enforcement`
- completion/heartbeat timestamps

## Behavioral Quality

- Quality gate behavior unchanged.
- Structural gate fail path unchanged.
- Boundary ownership preserved.
- Quality/anomaly disclosure: no quality gate logic changed; this PR only changes persistence atomicity.

## Latency Evidence

Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

### Baseline (Pre-change)
| Run | passX_ms | total_ms | Notes |
|-----|---------:|---------:|-------|
| Run 1 | N/A | ~3:12 | Historical pre-atomic success path evidence |
| Run 2 | N/A | varies | Historical pre-atomic success path evidence |

### Post-change Runs
| Run | passX_ms | total_ms | Notes |
|-----|---------:|---------:|-------|
| Run 1 | N/A | TBD | Pending production deploy + smoke |
| Run 2 | N/A | TBD | Pending production deploy + smoke |

Expected impact: one fewer database roundtrip per successful evaluation.

## Risks & Anomalies

- Deploy-order dependency: migration must already exist in target DB.
- If order is violated, success-path evaluations fail closed (missing RPC), not silently.
- Final principle: this preserves correctness and is not reducing intelligence.

## Verification

Local structural verification:
- `npm run build` ✅
- `npm run guard:eval2-persistence-boundary` ✅
- targeted tests for updated boundary path ✅

Post-deploy verification:
- run `npm run jobs:smoke:service-role`
- verify successful job has `status=complete`, `phase=phase_2`, populated `progress->gate_enforcement`
- verify artifact row exists for same `job_id`
