### PR TITLE
fix(gitignore): apply double-unignore pattern for proof-log exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .env.*
 
 # Logs
-logs
+logs/**
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -12,9 +12,10 @@ pnpm-debug.log*
 lerna-debug.log*
 
 # Canonical proof-artifact exceptions under logs/
-!logs/
+# Double-unignore required: un-ignore directory first, re-ignore its contents,
+# then selectively un-ignore specific canonical files.
 !logs/u2-live-proof/
-logs/u2-live-proof/*
+logs/u2-live-proof/**
 !logs/u2-live-proof/RUN_NOTES.md
 !logs/u2-live-proof/u2-proof-*.json
 !logs/u2-live-proof/u2-proof-*.validation.txt


### PR DESCRIPTION
## Summary

Fix `.gitignore` so canonical U2 proof artifacts are not silently ignored by Git. No source code changed. Infra-only.

## Scope

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Contract Integrity

No job contract changes. No JobStatus values added or modified. No API routes changed. No DB schema changed. This is a `.gitignore` pattern fix only.

## Behavioral Quality

No behavioral changes. The fix makes existing tracked proof files correctly un-ignorable for future `git add` operations without `-f`. All previously tracked files remain tracked. Quality gate checks are unaffected.

## Latency Evidence

No pipeline code changed. This PR does not touch Pass 1 execution paths. Latency metrics are unchanged.

| Metric | Baseline (Pre-change) | Post-change Runs |
|---|---|---|
| pass1_ms | N/A — infra-only | N/A — infra-only |
| total_ms | N/A — infra-only | N/A — infra-only |

Run 1: N/A — no pipeline code changed, no latency measurement applicable.
Run 2: N/A — no pipeline code changed, no latency measurement applicable.

## Risks & Anomalies

Low risk. Only `.gitignore` pattern semantics change.

Quality Gate disclosure: No QG_ checks are affected. No quality gate thresholds changed. No anomaly to report.

Per the principle of not reducing intelligence: this PR does not remove or degrade any evaluation logic, quality gate, or scoring mechanism. It affects only the repository file-tracking configuration.