### PR TITLE
fix(evaluation): soft-fail dialogue under-anchor (PR-002.5)

### DIFF
--- a/lib/evaluation/signal/criterionObservability.ts
+++ b/lib/evaluation/signal/criterionObservability.ts
@@ -44,6 +44,7 @@ export type RawCriterionInput = {
 };
 
 const PATTERN_CRITERIA = new Set<CriterionKey>(["voice", "tone", "pacing", "theme"]);
+const SOFT_FAIL_DIALOGUE_ENABLED = process.env.RG_SOFT_FAIL_DIALOGUE !== "false";
 
 const MIN_ANCHORS: Record<CriterionKey, number> = {
   concept: 2,
@@ -67,6 +68,10 @@ export function isPatternCriterion(key: CriterionKey): boolean {
 
 export function minAnchorsFor(key: CriterionKey): number {
   return MIN_ANCHORS[key];
+}
+
+export function isDialogueUnderAnchorSoftFailEnabled(): boolean {
+  return SOFT_FAIL_DIALOGUE_ENABLED;
 }
 
 function lexicalTokens(s: string): string[] {
@@ -349,12 +354,19 @@ export function isCriterionComplete(c: EvaluationCriterionV2): boolean {
   }
 
   if (c.status === "SCORABLE") {
+    const requiredAnchors = minAnchorsFor(c.key);
+    const hasRequiredAnchors = c.evidence.length >= requiredAnchors;
+    const dialogueUnderAnchorSoftFail =
+      c.key === "dialogue" &&
+      SOFT_FAIL_DIALOGUE_ENABLED &&
+      c.evidence.length < requiredAnchors;
+
     return (
       c.scorable === true &&
       typeof c.score_0_10 === "number" &&
       c.score_0_10 >= 0 &&
       c.score_0_10 <= 10 &&
-      c.evidence.length >= minAnchorsFor(c.key)
+      (hasRequiredAnchors || dialogueUnderAnchorSoftFail)
     );
   }
 

--- a/tests/evaluation/dialogueSoftFail.test.ts
+++ b/tests/evaluation/dialogueSoftFail.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "@jest/globals";
+import { normalizeCriterion, isCriterionComplete } from "@/lib/evaluation/signal/criterionObservability";
+
+function makeScorable(key: any, evidenceCount: number) {
+  return normalizeCriterion({
+    key,
+    score_0_10: 5,
+    rationale: "test rationale",
+    evidence: Array.from({ length: evidenceCount }).map((_, i) => ({ snippet: `e${i}` })),
+  });
+}
+
+describe("dialogue soft-fail completeness", () => {
+  it("dialogue 1 anchor does not block completeness", () => {
+    const c = makeScorable("dialogue", 1);
+    expect(isCriterionComplete(c)).toBe(true);
+  });
+
+  it("voice 0 anchors still blocks", () => {
+    const c = makeScorable("voice", 0);
+    expect(isCriterionComplete(c)).toBe(false);
+  });
+
+  it("dialogue passes when >=2 anchors", () => {
+    const c = makeScorable("dialogue", 2);
+    expect(isCriterionComplete(c)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes false failures where dialogue anchor threshold (2) was applied globally.

## Scope
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3
- No scoring changes
- No schema changes (interim)

## Contract Integrity
- Canonical criterion processing preserved
- No schema or persistence contract changes
- Completeness semantics changed only for dialogue under-anchor via feature flag
- Existing non-dialogue anchor requirements remain enforced

## Behavioral Quality
- Root cause: global `MIN_ANCHORS.dialogue = 2` in `isCriterionComplete` over-blocked reflective/mythic chapters
- Fix: soft-fail under-anchor for dialogue when `RG_SOFT_FAIL_DIALOGUE` is enabled
- Quality Gate disclosure: no additional Quality Gate bypass added beyond scoped dialogue under-anchor soft-fail
- Guardrail retained: non-dialogue criteria still require minimum anchors

## Latency Evidence

### Baseline (Pre-change)
| Metric | Value |
|------|------|
| pass3_ms | N/A (logic-only gate behavior fix) |
| total_ms | N/A |
| criteria_count_by_state | baseline evidence available in prior runs |

### Post-change Runs
| Run | pass3_ms | total_ms | criteria_count_by_state | Notes |
|-----|---------:|---------:|-------------------------|------|
| Run 1 | N/A | N/A | present/validated in artifact | dialogue:1 no longer blocks completeness |
| Run 2 | N/A | N/A | present/validated in artifact | non-dialogue criteria unchanged |

## Risks & Anomalies
- Temporary risk: dialogue-heavy scenes with weak anchoring may pass under soft-fail mode
- Mitigation path: planned hardening in PR-011 (mode-aware gating)
- No system/database errors are masked as client validation errors in this PR

Final principle: not reducing intelligence.
