### PR TITLE
fix(worker): harden phase1 heartbeat renewal (closes #263)

### DIFF
--- a/lib/jobs/phase1.ts
+++ b/lib/jobs/phase1.ts
@@ -55,7 +55,7 @@ export function canRetryPhase1(options: {
   return scheduled.getTime() <= now.getTime();
 }
 
-import { getJob, updateJob } from "./store";
+import { getJob, setJobFailed, updateJob } from "./store";
 import {
   ensureChunks,
   getManuscriptChunks,
@@ -183,6 +183,7 @@ export async function runPhase1(jobId: string): Promise<void> {
   // Fail fast if heartbeat renewal mechanism breaks rather than waiting for stale sweeper
   let consecutiveHeartbeatFailures = 0;
   const MAX_CONSECUTIVE_HEARTBEAT_FAILURES = 3;
+  let heartbeatFatalError: string | null = null;
 
   console.log(
     `[Phase1] Resume state: ${doneChunks} done, ${eligibleChunks.length} eligible, ${allChunks.length} total`,
@@ -273,11 +274,10 @@ export async function runPhase1(jobId: string): Promise<void> {
             // If heartbeat fails repeatedly, fail the job immediately
             // This is faster and clearer than waiting for stale sweeper timeout
             if (consecutiveHeartbeatFailures >= MAX_CONSECUTIVE_HEARTBEAT_FAILURES) {
+              heartbeatFatalError = `Heartbeat renewal failed ${consecutiveHeartbeatFailures} times; worker subprocess/network appears degraded`;
               console.error(
                 `[Phase1Heartbeat] Max consecutive failures reached for job ${jobId}; triggering explicit job failure`
               );
-              // Trigger explicit failure outside this callback
-              // We'll check this flag after clearInterval and take action
             }
           });
       }, 10000); // 10 seconds between heartbeat attempts
@@ -338,14 +338,13 @@ export async function runPhase1(jobId: string): Promise<void> {
         clearInterval(heartbeatInterval);
 
         // Check for heartbeat failure threshold
-        if (consecutiveHeartbeatFailures >= MAX_CONSECUTIVE_HEARTBEAT_FAILURES) {
-          const errorMsg = `Heartbeat renewal failed ${consecutiveHeartbeatFailures} times; worker subprocess/network appears degraded`;
+        if (heartbeatFatalError) {
           console.error("[Phase1HeartbeatFatalFailure]", {
             job_id: jobId,
             consecutive_failures: consecutiveHeartbeatFailures,
-            error: errorMsg,
+            error: heartbeatFatalError,
           });
-          throw new Error(errorMsg);
+          throw new Error(heartbeatFatalError);
         }
       }
 
@@ -369,6 +368,12 @@ export async function runPhase1(jobId: string): Promise<void> {
       });
     }
   } catch (e) {
+    if (!heartbeatFatalError) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      if (errMsg.includes("Heartbeat renewal failed")) {
+        heartbeatFatalError = errMsg;
+      }
+    }
     console.error("Phase1Error", {
       job_id: jobId,
       phase: PHASES.PHASE_1,
@@ -378,6 +383,47 @@ export async function runPhase1(jobId: string): Promise<void> {
       total_units: allChunks.length,
     });
     // Don’t set processed = 0; let the deterministic outcome logic handle it
+  }
+
+  // Terminal heartbeat failure path: fail the job explicitly with clear last_error/progress.
+  // This prevents falling through to RUNNING outcome and waiting for stale sweeper.
+  if (heartbeatFatalError) {
+    const finished_at = new Date().toISOString();
+    await setJobFailed(jobId, {
+      code: "HEARTBEAT_RENEWAL_FAILED",
+      message: heartbeatFatalError,
+      retryable: false,
+      phase: PHASES.PHASE_1,
+      provider: null,
+      context: {
+        consecutive_heartbeat_failures: consecutiveHeartbeatFailures,
+        max_consecutive_heartbeat_failures: MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+      },
+      occurred_at: finished_at,
+    });
+
+    await updateJob(jobId, {
+      progress: {
+        ...job.progress,
+        message: heartbeatFatalError,
+        finished_at,
+        phase: PHASES.PHASE_1,
+        phase_status: PHASE_1_STATES.FAILED,
+        error_code: "HEARTBEAT_RENEWAL_FAILED",
+        lease_id: null,
+        lease_expires_at: null,
+      },
+    });
+
+    console.error("Phase1Outcome", {
+      job_id: jobId,
+      final_phase_status: PHASE_1_STATES.FAILED,
+      reason: "heartbeat_renewal_failure",
+      error: heartbeatFatalError,
+    });
+
+    metrics.onJobFailed(jobId, PHASES.PHASE_1, heartbeatFatalError);
+    return;
   }
 
   // Deterministic job outcome based on actual chunk states

--- a/lib/jobs/phase1.ts
+++ b/lib/jobs/phase1.ts
@@ -179,6 +179,11 @@ export async function runPhase1(jobId: string): Promise<void> {
   let failedCount = allChunks.filter((c) => c.status === "failed").length;
   let skippedCount = 0; // Track chunks skipped due to claim failure
 
+  // Issue #263: Track consecutive heartbeat failures to detect worker degradation
+  // Fail fast if heartbeat renewal mechanism breaks rather than waiting for stale sweeper
+  let consecutiveHeartbeatFailures = 0;
+  const MAX_CONSECUTIVE_HEARTBEAT_FAILURES = 3;
+
   console.log(
     `[Phase1] Resume state: ${doneChunks} done, ${eligibleChunks.length} eligible, ${allChunks.length} total`,
   );
@@ -233,11 +238,49 @@ export async function runPhase1(jobId: string): Promise<void> {
       }
 
       // Start heartbeat timer for this chunk
-      const heartbeatInterval = setInterval(async () => {
-        await updateJob(jobId, {
-          last_heartbeat: new Date().toISOString(),
-        });
-      }, 10000); // 10 seconds
+      // Issue #263: Hardened heartbeat renewal with failure detection
+      // If heartbeat mechanism breaks, fail fast instead of waiting for stale sweeper
+      const heartbeatInterval = setInterval(() => {
+        // Fire heartbeat update WITHOUT blocking chunk processing
+        // Use Promise.race to enforce 8-second timeout + error handling
+        Promise.race([
+          updateJob(jobId, {
+            last_heartbeat: new Date().toISOString(),
+          }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error('Heartbeat update timeout (>8s)')),
+              8000  // 8 seconds - more generous than 2s but still guards against hangs
+            )
+          ),
+        ])
+          .then(() => {
+            // Heartbeat succeeded; reset consecutive failure counter
+            if (consecutiveHeartbeatFailures > 0) {
+              console.log(
+                `[Phase1Heartbeat] Success after ${consecutiveHeartbeatFailures} failures; resetting counter for job ${jobId}`
+              );
+              consecutiveHeartbeatFailures = 0;
+            }
+          })
+          .catch((err) => {
+            consecutiveHeartbeatFailures += 1;
+            const errMsg = err instanceof Error ? err.message : String(err);
+            console.warn(
+              `[Phase1Heartbeat] Failure #${consecutiveHeartbeatFailures}/${MAX_CONSECUTIVE_HEARTBEAT_FAILURES} for job ${jobId}: ${errMsg}`
+            );
+
+            // If heartbeat fails repeatedly, fail the job immediately
+            // This is faster and clearer than waiting for stale sweeper timeout
+            if (consecutiveHeartbeatFailures >= MAX_CONSECUTIVE_HEARTBEAT_FAILURES) {
+              console.error(
+                `[Phase1Heartbeat] Max consecutive failures reached for job ${jobId}; triggering explicit job failure`
+              );
+              // Trigger explicit failure outside this callback
+              // We'll check this flag after clearInterval and take action
+            }
+          });
+      }, 10000); // 10 seconds between heartbeat attempts
 
       try {
         // Phase 1 LLM evaluation (stub with realistic latency, or real LLM if configured)
@@ -293,6 +336,17 @@ export async function runPhase1(jobId: string): Promise<void> {
       } finally {
         // Stop heartbeat timer
         clearInterval(heartbeatInterval);
+
+        // Check for heartbeat failure threshold
+        if (consecutiveHeartbeatFailures >= MAX_CONSECUTIVE_HEARTBEAT_FAILURES) {
+          const errorMsg = `Heartbeat renewal failed ${consecutiveHeartbeatFailures} times; worker subprocess/network appears degraded`;
+          console.error("[Phase1HeartbeatFatalFailure]", {
+            job_id: jobId,
+            consecutive_failures: consecutiveHeartbeatFailures,
+            error: errorMsg,
+          });
+          throw new Error(errorMsg);
+        }
       }
 
       // Update job progress after each chunk


### PR DESCRIPTION
## Summary
Harden Phase 1 heartbeat renewal in `lib/jobs/phase1.ts` so repeated heartbeat renewal failures are observable and terminal, instead of silently falling through and relying on stale-job sweeper as the primary detector.

## Scope
- In scope:
  - Add consecutive heartbeat failure tracking during Phase 1 chunk processing.
  - Add bounded heartbeat renewal timeout guard.
  - Enforce explicit terminal failure path after threshold breach.
  - Ensure job is not left in `running` when heartbeat renewal is fatally degraded.
- Out of scope:
  - No changes to scoring logic, policy math, or artifact schema.
  - No frontend/UI behavior changes.

## Contract Integrity
- Canonical lifecycle statuses remain unchanged: `queued`, `running`, `complete`, `failed`.
- Heartbeat fatal path now writes explicit failure via `setJobFailed` with:
  - `code=HEARTBEAT_RENEWAL_FAILED`
  - `retryable=false`
  - `phase=phase_1`
- Progress is updated with `phase_status=failed`, `error_code=HEARTBEAT_RENEWAL_FAILED`, and lease cleared.
- Early return prevents fall-through into deterministic RUNNING/COMPLETED matrix.

## Behavioral Quality
- Prior behavior risk: heartbeat fatal throw could be caught, then deterministic matrix could still leave job `running`.
- New behavior: repeated heartbeat renewal failure deterministically produces terminal failed state with clear `last_error` and progress message.
- Stale sweeper remains a backstop, not the primary failure detector.
- This change is about reliability and observability, not reducing intelligence or evaluation depth.

## Latency Evidence
Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

### Baseline (Pre-change)
| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | n/a (not instrumented in this PR path) | n/a | Pre-change behavior could defer failure to stale sweeper |
| Run 2 | n/a (not instrumented in this PR path) | n/a | Heartbeat failures were less explicit/observable |

### Post-change Runs
| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | n/a (no pass timing logic modified) | n/a | Added bounded heartbeat timeout + explicit terminal failure path |
| Run 2 | n/a (no pass timing logic modified) | n/a | Added clear failure envelope/progress update on threshold breach |

Quality/anomaly disclosure:
- Quality Gate / anomaly note: this PR does not alter QG scoring paths; it improves failure signaling around worker heartbeat degradation.

## Risks & Anomalies
- Risk: false-positive heartbeat fatal if DB/network is severely degraded for repeated intervals.
  - Mitigation: threshold requires 3 consecutive failures; transient successes reset counter.
- Risk: different environments may show varying heartbeat timeout sensitivity.
  - Mitigation: thresholded logic + explicit diagnostics in logs/error envelope.
- Known anomaly addressed: stale-running timeouts could mask proximal heartbeat failure cause.

Final principle:
- This reliability hardening is intentionally not reducing intelligence; it preserves evaluation quality while improving correctness, auditability, and operational clarity.

## Changed Files
- `lib/jobs/phase1.ts` (+106 / -6)

## Validation
- `npx tsc --noEmit` passes.
- PR includes:
  - `d628b3e0` — initial heartbeat hardening
  - `4a759742` — explicit terminal failure path on heartbeat fatal threshold

Closes #263
