### PR TITLE
fix(worker): renew lease during long pipeline execution

### DIFF
--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1683,34 +1683,56 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       stage: 'before_runPipeline',
     });
 
-    const pipelineResult = await runPipeline({
-      manuscriptText: manuscriptWithContent.content || '',
-      workType: manuscriptWithContent.work_type || 'novel',
-      title: manuscriptWithContent.title,
-      jobId: String(job.id),
-      model: getCanonicalPipelineModel(openAiModel),
-      openaiApiKey,
-      perplexityApiKey: perplexityApiKey || undefined,
-      manuscriptId: String(manuscriptWithContent.id),
-      executionMode: 'TRUSTED_PATH',
-      _passTimeoutMs: evalPassTimeoutMs,
-      onHeartbeat: async (stage) => {
-        await assertJobWithinSla({
-          supabase,
-          jobId,
-          hardDeadlineMs,
-          stage,
+    const leaseRenewalIntervalMs = 30_000;
+    const leaseRenewalLoop = setInterval(() => {
+      void renewEvaluationJobLease({
+        supabase,
+        jobId,
+        leaseMs: runtimeConfig.worker.leaseMs,
+        stage: 'runPipeline.interval',
+        hardDeadlineMs,
+      }).catch((error) => {
+        console.warn('[Processor] In-flight lease renewal failed', {
+          job_id: jobId,
+          stage: 'runPipeline.interval',
+          error: error instanceof Error ? error.message : String(error),
         });
+      });
+    }, leaseRenewalIntervalMs);
 
-        await renewEvaluationJobLease({
-          supabase,
-          jobId,
-          leaseMs: runtimeConfig.worker.leaseMs,
-          stage,
-          hardDeadlineMs,
-        });
-      },
-    });
+    let pipelineResult;
+    try {
+      pipelineResult = await runPipeline({
+        manuscriptText: manuscriptWithContent.content || '',
+        workType: manuscriptWithContent.work_type || 'novel',
+        title: manuscriptWithContent.title,
+        jobId: String(job.id),
+        model: getCanonicalPipelineModel(openAiModel),
+        openaiApiKey,
+        perplexityApiKey: perplexityApiKey || undefined,
+        manuscriptId: String(manuscriptWithContent.id),
+        executionMode: 'TRUSTED_PATH',
+        _passTimeoutMs: evalPassTimeoutMs,
+        onHeartbeat: async (stage) => {
+          await assertJobWithinSla({
+            supabase,
+            jobId,
+            hardDeadlineMs,
+            stage,
+          });
+
+          await renewEvaluationJobLease({
+            supabase,
+            jobId,
+            leaseMs: runtimeConfig.worker.leaseMs,
+            stage,
+            hardDeadlineMs,
+          });
+        },
+      });
+    } finally {
+      clearInterval(leaseRenewalLoop);
+    }
 
     finishLatencyStage({
       jobId,


### PR DESCRIPTION
## Summary

Adds 30-second in-flight lease renewal around the long `runPipeline` execution while preserving the existing stage-based `onHeartbeat` renewal. This fixes the production failure mode where a long evaluation can complete internally but hit the SLA/lease boundary before artifact persistence.

Production configuration has also been updated so `EVAL_WORKER_MAX_EXECUTION_MS=300000` in Production, allowing real evaluations to complete within the current Vercel 5-minute function envelope while the interval renewal keeps the job lease fresh during long silent spans.

## Scope

- [x] Pass 1
- [x] Pass 2
- [x] Pass 3

Changed file:

- `lib/evaluation/processor.ts`

This PR does not alter scoring, prompts, governance thresholds, criteria, or result rendering. It changes worker lifecycle behavior around the existing pipeline call.

## Contract Integrity

The existing pipeline already provided event/stage-based heartbeat renewal through `onHeartbeat`. Production logs showed that this was not sufficient during long blocking pass spans because there may be no stage heartbeat while an LLM call is in flight.

This PR preserves the existing `onHeartbeat` callback and adds a time-based 30-second renewal loop around `runPipeline`, clearing the interval in `finally` so the renewal loop cannot leak after pipeline completion or failure.

The lease renewal path continues to use the existing `renewEvaluationJobLease` function, including the prior contract that writes `lease_until` rather than generated/read-only `lease_expires_at`.

## Behavioral Quality

No model behavior, scoring behavior, criteria analysis, Pass 1/2/3/4 prompt semantics, quality gate logic, or recommendation generation is changed.

Pass 3 divergence distribution is unchanged by this PR. Baseline telemetry from the failing production proof run included `criteria_count_by_state` with normal reducer output; this PR only keeps the worker alive while those existing Pass 3 semantics execute.

Quality preservation rule: this PR is not reducing intelligence. It only prevents a successful long-running evaluation from being aborted before persistence because the worker lease expired during an in-flight pipeline span.

## Latency Evidence

| Baseline (Pre-change) | Evidence |
|---|---|
| Runtime failure shape | Production proof job completed pipeline internally but aborted at SLA boundary before artifact persistence. |
| passX_ms | Pipeline logs showed real pass timings including Pass 1, Pass 2, and Pass 3 execution during a long worker run. |
| criteria_count_by_state | Present in Pass 3 reducer telemetry; this PR does not change divergence distribution semantics. |
| total_ms | Observed production pipeline runtime was approximately 234,527ms while the prior worker/lease envelope was too short for that run. |

| Post-change Runs | Evidence |
|---|---|
| Run 1 | Focused processor validation passed locally after adding the in-flight renewal loop. |
| Run 2 | Full local test suite passed: 121/121 test suites, 1193 tests. |
| pass1_ms / pass2_ms / pass3_ms | Not changed by this PR; pass latency optimization remains follow-up work. |
| criteria_count_by_state | Not changed by this PR; Pass 3 reducer behavior is untouched. |
| total_ms | This PR does not claim to reduce total runtime. It prevents lifecycle abort while the existing pipeline executes. |

## Risks & Anomalies

- `QG_` / quality gate behavior is unchanged.
- This is a lifecycle hardening change, not a latency optimization pass.
- Production `EVAL_WORKER_MAX_EXECUTION_MS` was set to `300000` to avoid the prior worker cap forcing premature aborts; this is a ceiling/guardrail, not a user-facing wait target.
- Preview env still needs separate cleanup if branch-scoped preview variables are required; production proof depends on Production env only.
- Post-merge success still requires redeploy and proof script success with repeated heartbeat advancement during a long run.

## Validation

Local validation completed before push:

- `pnpm test -- __tests__/lib/evaluation/processor.test.ts --runInBand`
- `pnpm test -- __tests__/lib/evaluation/processor.contamination-guard.test.ts --runInBand`
- `pnpm test` — passed: 121/121 test suites, 1193 tests
- `pnpm run config:validate` — passed with non-critical warnings

## Evidence anchor

Observed failing proof job: `9c2a4efe-bec0-4e45-b834-536741353856`.

Strict close condition remains unchanged: do not close #263 until the post-deploy proof script emits `ALL_GATES_PASS` and shows heartbeat advancement during the long pipeline run.