### PR TITLE
fix(evaluation): use effective prompt budget in coverage reporting

### DIFF
--- a/__tests__/lib/evaluation/coverage-truth-enforcement.test.ts
+++ b/__tests__/lib/evaluation/coverage-truth-enforcement.test.ts
@@ -19,8 +19,69 @@
 import { describe, test, expect } from "@jest/globals";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { summarizePromptCoverage } from "@/lib/evaluation/pipeline/promptInput";
+import { resetEvaluationRuntimeConfigCacheForTests } from "@/lib/config/evaluationRuntimeConfig";
+
+beforeEach(() => {
+  resetEvaluationRuntimeConfigCacheForTests();
+  delete process.env.EVAL_PIPELINE_INPUT_CHAR_BUDGET;
+});
 
 describe("Coverage-Truth Enforcement — No Silent Truncation", () => {
+  test("summarizePromptCoverage uses runtime default budget when maxChars is omitted", () => {
+    const text = "a".repeat(40_001);
+
+    const coverage = summarizePromptCoverage(text);
+
+    expect(coverage.budgetChars).toBe(40_000);
+    expect(coverage.truncated).toBe(true);
+    expect(coverage.strategy).toBe("sampled_beginning_middle_end");
+  });
+
+  test("truncated is false for text under the default budget", () => {
+    const text = "a".repeat(39_999);
+
+    const coverage = summarizePromptCoverage(text);
+
+    expect(coverage.budgetChars).toBe(40_000);
+    expect(coverage.truncated).toBe(false);
+    expect(coverage.strategy).toBe("full_text");
+  });
+
+  test("truncated is true for text over the default budget", () => {
+    const text = "a".repeat(40_001);
+
+    const coverage = summarizePromptCoverage(text);
+
+    expect(coverage.truncated).toBe(true);
+    expect(coverage.strategy).toBe("sampled_beginning_middle_end");
+  });
+
+  test("explicit maxChars overrides runtime default", () => {
+    process.env.EVAL_PIPELINE_INPUT_CHAR_BUDGET = "40000";
+    resetEvaluationRuntimeConfigCacheForTests();
+    const text = "a".repeat(2_500);
+
+    const coverage = summarizePromptCoverage(text, 2_000);
+
+    expect(coverage.budgetChars).toBe(2_000);
+    expect(coverage.truncated).toBe(true);
+    expect(coverage.strategy).toBe("sampled_beginning_middle_end");
+  });
+
+  test("budgetChars always reports the actual budget used", () => {
+    process.env.EVAL_PIPELINE_INPUT_CHAR_BUDGET = "50000";
+    resetEvaluationRuntimeConfigCacheForTests();
+
+    const defaultBudgetCoverage = summarizePromptCoverage("a".repeat(49_000));
+    const explicitBudgetCoverage = summarizePromptCoverage("a".repeat(49_000), 12_345);
+
+    expect(defaultBudgetCoverage.budgetChars).toBe(50_000);
+    expect(defaultBudgetCoverage.truncated).toBe(false);
+    expect(explicitBudgetCoverage.budgetChars).toBe(12_345);
+    expect(explicitBudgetCoverage.truncated).toBe(true);
+  });
+
   test("SynthesisOutput type includes coverage-truth fields or equivalent", async () => {
     // Read the type definition
     const typesFile = path.join(

--- a/lib/evaluation/pipeline/promptInput.ts
+++ b/lib/evaluation/pipeline/promptInput.ts
@@ -58,9 +58,9 @@ export function summarizePromptCoverage(text: string, maxChars?: number): Prompt
     sourceWords: estimateWordCount(source),
     analyzedChars: window.length,
     analyzedWords: estimateWordCount(normalizedWindow),
-    truncated: source.length > maxChars,
-    strategy: source.length > maxChars ? "sampled_beginning_middle_end" : "full_text",
-    budgetChars: maxChars,
+    truncated: source.length > effectiveMaxChars,
+    strategy: source.length > effectiveMaxChars ? "sampled_beginning_middle_end" : "full_text",
+    budgetChars: effectiveMaxChars,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes coverage-truth reporting in `summarizePromptCoverage` so omitted `maxChars` uses the resolved runtime budget (`effectiveMaxChars`) consistently for:
- `truncated`
- `strategy`
- `budgetChars`

Also adds regression tests for default-vs-explicit budget behavior.

## Scope
- Included:
  - `lib/evaluation/pipeline/promptInput.ts`
  - `__tests__/lib/evaluation/coverage-truth-enforcement.test.ts`
- Excluded:
  - timing/retry policy files
  - token/timeouts/pass ordering/prompt wording

## Contract Integrity
- No canonical identifiers renamed.
- No job status/type/state transition logic changed.
- No DB contract changes.
- Coverage metadata now reflects actual runtime-resolved budget when `maxChars` is omitted.

## Behavioral Quality
- Fix type: truth/observability correctness (no algorithmic scoring change).
- Expected behavior:
  - Omitted `maxChars` -> runtime default budget used consistently.
  - Under-budget text -> `truncated=false`, `strategy=full_text`.
  - Over-budget text -> `truncated=true`, `strategy=sampled_beginning_middle_end`.
  - Explicit `maxChars` still overrides default.

## Latency Evidence
This PR is **not** a latency optimization; it is a coverage-truth bug fix.

### Baseline (Pre-change)
| Run | Context | passX_ms | total_ms |
|---|---|---:|---:|
| Run 1 | Non-latency PR (metrics not collected) | N/A | N/A |
| Run 2 | Non-latency PR (metrics not collected) | N/A | N/A |

### Post-change Runs
| Run | Evidence | passX_ms | total_ms |
|---|---|---:|---:|
| Run 1 | `pnpm test -- __tests__/lib/evaluation/coverage-truth-enforcement.test.ts lib/config/__tests__/envContract.test.ts lib/config/__tests__/evaluationRuntimeConfig.test.ts` (pass) | N/A | N/A |
| Run 2 | `pnpm build` (pass) | N/A | N/A |

### Pass Selection
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Risks & Anomalies
- Quality gate/anomaly disclosure: no new `QG_` anomalies introduced by this patch.
- Existing repo warning remains environment-only and unchanged (`EVAL_OPENAI_TIMEOUT_MS` shell override vs `.env.local`).
- Risk level: low (narrow diff, regression tests added).

Final principle: this change is **not reducing intelligence**; it improves reporting correctness and auditability.
