### PR TITLE
fix(provider): harden retry and Perplexity timeout policy

### DIFF
--- a/__tests__/lib/evaluation/provider-retry-policy.test.ts
+++ b/__tests__/lib/evaluation/provider-retry-policy.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "@jest/globals";
+import { OPENAI_SDK_MAX_RETRIES } from "@/lib/evaluation/policy";
+
+const LIVE_OPENAI_PASS_FILES = [
+  "lib/evaluation/pipeline/runPass1.ts",
+  "lib/evaluation/pipeline/runPass2.ts",
+  "lib/evaluation/pipeline/runPass3Synthesis.ts",
+] as const;
+
+describe("provider retry policy", () => {
+  it("keeps OpenAI SDK retry ceiling explicit and low", () => {
+    expect(OPENAI_SDK_MAX_RETRIES).toBe(1);
+  });
+
+  it("prevents hardcoded retry drift in live OpenAI pass files", () => {
+    for (const file of LIVE_OPENAI_PASS_FILES) {
+      const content = fs.readFileSync(path.join(process.cwd(), file), "utf8");
+      expect(content).toContain("OPENAI_SDK_MAX_RETRIES");
+      expect(content).not.toMatch(/maxRetries:\s*2/);
+      expect(content).not.toMatch(/maxRetries:\s*0/);
+    }
+  });
+});

--- a/lib/evaluation/pipeline/perplexityCrossCheck.ts
+++ b/lib/evaluation/pipeline/perplexityCrossCheck.ts
@@ -104,6 +104,7 @@ type PerplexityResponseShape = {
 const PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
 const PERPLEXITY_MODEL = "sonar-reasoning-pro";
 const PERPLEXITY_MAX_TOKENS = 3000;
+const PERPLEXITY_REQUEST_TIMEOUT_MS = 60000;
 const DISPUTE_THRESHOLD = 1.0;
 
 const CRITERION_KEYS: CriterionKey[] = [
@@ -409,23 +410,38 @@ ${openaiSynthesis?.slice(0, 900) ?? "(none)"}
 Now return the independent adjudication as JSON.`;
 
   const requestCompletion = async (maxTokens: number) => {
-    const response = await fetch(`${PERPLEXITY_BASE_URL}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${perplexityApiKey}`,
-      },
-      body: JSON.stringify({
-        model: PERPLEXITY_MODEL,
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-        temperature: 0.1,
-        max_tokens: maxTokens,
-        return_citations: false,
-      }),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PERPLEXITY_REQUEST_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(`${PERPLEXITY_BASE_URL}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${perplexityApiKey}`,
+        },
+        body: JSON.stringify({
+          model: PERPLEXITY_MODEL,
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          temperature: 0.1,
+          max_tokens: maxTokens,
+          return_citations: false,
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(
+          `[Pass4] Perplexity request timed out after ${PERPLEXITY_REQUEST_TIMEOUT_MS}ms`
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
 
     if (!response.ok) {
       const errText = await response.text();


### PR DESCRIPTION
Harden provider-call policy for evaluation pipeline.

- Adds AbortController timeout handling for Pass 4 Perplexity fetch calls.
- Sets PERPLEXITY_REQUEST_TIMEOUT_MS to 60000.
- Adds provider retry policy regression guard to prevent hardcoded OpenAI retry drift in live pass files.

Scope:
- lib/evaluation/pipeline/perplexityCrossCheck.ts
- __tests__/lib/evaluation/provider-retry-policy.test.ts

Verification run:
- pnpm test -- __tests__/lib/evaluation/provider-retry-policy.test.ts
- pnpm test -- __tests__/lib/evaluation/processor.openai-params.test.ts
- pnpm test -- tests/evaluation/pipeline/perplexityCrossCheck.test.ts
- pnpm build
- rg "maxRetries:\\s*2|new OpenAI\\(" lib/evaluation lib/config __tests__ tests