### PR TITLE
ci(guard): block scoring PRs from runtime/worker scope

### DIFF
--- a/.github/workflows/scoring-pr-scope-guard.yml
+++ b/.github/workflows/scoring-pr-scope-guard.yml
@@ -1,0 +1,77 @@
+name: Scoring PR Scope Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  enforce-scoring-scope:
+    name: enforce-scoring-scope
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Enforce scoring PR file boundaries
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr?.title ?? "";
+            const headRef = pr?.head?.ref ?? "";
+
+            const isScoringPr = /\bscoring\b|score\s*ledger|weighted\s*criteria/i.test(title) ||
+              /scoring|weighted-criteria-ledger/i.test(headRef);
+
+            core.info(`PR title: ${title}`);
+            core.info(`PR head: ${headRef}`);
+            core.info(`isScoringPr=${isScoringPr}`);
+
+            if (!isScoringPr) {
+              core.info("Not a scoring PR. Scope guard is informational only for this PR.");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const pull_number = pr.number;
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number, per_page: 100 }
+            );
+
+            const changed = files.map(f => f.filename);
+
+            const forbiddenExact = new Set([
+              "lib/evaluation/pipeline/runPass1.ts",
+              "lib/evaluation/pipeline/runPass2.ts",
+              "lib/evaluation/pipeline/runPass3Synthesis.ts",
+              "lib/evaluation/policy.ts",
+              "lib/config/evaluationRuntimeConfig.ts",
+              "lib/config/productionConfigValidation.ts",
+              "lib/evaluation/config.ts",
+              "scripts/validate-production-config.ts",
+            ]);
+
+            const forbiddenPrefixes = [
+              "app/api/workers/",
+              "lib/jobs/",
+            ];
+
+            const blocked = changed.filter((file) => {
+              if (forbiddenExact.has(file)) return true;
+              return forbiddenPrefixes.some((prefix) => file.startsWith(prefix));
+            });
+
+            if (blocked.length > 0) {
+              core.setFailed(
+                [
+                  "Scoring PR scope violation: scoring PRs must not modify worker/pass/runtime files.",
+                  "Blocked files:",
+                  ...blocked.map((f) => `- ${f}`),
+                ].join("\n")
+              );
+              return;
+            }
+
+            core.info("Scoring PR scope guard passed.");


### PR DESCRIPTION
## Summary
Add a CI guard that blocks scoring PRs from touching worker/pass/runtime files.

## Scope
- New workflow: `Scoring PR Scope Guard`
- Enforces scoring-vs-runtime branch hygiene by changed-file policy

## Contract Integrity
- No runtime behavior changes
- No scoring math changes
- No prompt/pass execution logic changes
- No schema changes

## Behavioral Quality
Repo hardening only; no model behavior change and this is not reducing intelligence.

## Latency Evidence
Policy/workflow-only PR with no runtime execution-path modifications.

### Baseline (Pre-change)
| run | pass1_ms | pass2_ms | pass3_ms | total_ms |
|-----|----------|----------|----------|----------|
| Run 1 | n/a | n/a | n/a | n/a |
| Run 2 | n/a | n/a | n/a | n/a |

### Post-change Runs
| run | pass1_ms | pass2_ms | pass3_ms | total_ms |
|-----|----------|----------|----------|----------|
| Run 1 | n/a | n/a | n/a | n/a |
| Run 2 | n/a | n/a | n/a | n/a |

## Pass Selection
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Quality Gate / Anomalies
No QG_ behavior changes; this adds preventive governance enforcement.

## Risks & Anomalies
- Potential false positives if a PR is mislabeled as scoring
- Can be tuned by title/head-branch matching rules

## Principle
This change is not reducing intelligence.
