### PR TITLE
fix(pass2): route model through canonical runtime config

### DIFF
--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -26,7 +26,7 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS2_TEMPERATURE = 0.3;
-const PASS2_MODEL = "o3";
+// Pass 2 model is resolved exclusively via getCanonicalPipelineModel(opts.model). The central resolver in policy.ts enforces the production reasoning-model invariant (forbids o-series unless EVAL_ALLOW_REASONING_MODELS=true).
 
 function getRetryPass2MaxTokens(currentMaxTokens: number): number {
   return Math.min(8000, Math.max(4000, currentMaxTokens + 1500));
@@ -158,7 +158,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
   }
 
   const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
-  const selectedModel = getCanonicalPipelineModel(opts.model ?? PASS2_MODEL);
+  const selectedModel = getCanonicalPipelineModel(opts.model);
 
   const promptAssemblyStartMs = nowMs();
 
@@ -395,7 +395,11 @@ function hasTextualAnchor(reasoning: string, evidence: EvidenceAnchor[]): boolea
  * @returns Validated SinglePassOutput with axis="editorial_literary"
  * @throws on invalid structure, empty criteria, or parse errors
  */
-export function parsePass2Response(raw: string, fallbackModel = PASS2_MODEL): SinglePassOutput {
+export function parsePass2Response(raw: string, fallbackModel?: string): SinglePassOutput {
+    const resolvedFallback =
+    typeof fallbackModel === "string" && fallbackModel.length > 0
+      ? fallbackModel
+      : getCanonicalPipelineModel(undefined);
   // P0: Log raw response preview before parse
   console.log(`[Pass2] raw response preview len=${raw.length}: ${raw.slice(0, 200)}`);
 
@@ -481,7 +485,7 @@ export function parsePass2Response(raw: string, fallbackModel = PASS2_MODEL): Si
     pass: 2,
     axis: "editorial_literary",
     criteria,
-    model: String(obj["model"] ?? fallbackModel),
+    model: String(obj["model"] ?? resolvedFallback),
     prompt_version: PASS2_PROMPT_VERSION,
     temperature: PASS2_TEMPERATURE,
     generated_at: new Date().toISOString(),

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -396,7 +396,7 @@ function hasTextualAnchor(reasoning: string, evidence: EvidenceAnchor[]): boolea
  * @throws on invalid structure, empty criteria, or parse errors
  */
 export function parsePass2Response(raw: string, fallbackModel?: string): SinglePassOutput {
-    const resolvedFallback =
+  const resolvedFallback =
     typeof fallbackModel === "string" && fallbackModel.length > 0
       ? fallbackModel
       : getCanonicalPipelineModel(undefined);

--- a/lib/evaluation/policy.ts
+++ b/lib/evaluation/policy.ts
@@ -62,9 +62,11 @@ export function getCanonicalPipelineModel(overrideModel?: string): string {
       ? overrideModel.trim()
       : getEvaluationRuntimeConfig().model;
 
+  const normalizedCandidate = candidate.trim().toLowerCase();
+
   if (
     process.env.NODE_ENV === "production" &&
-    /^o[0-9]/.test(candidate) &&
+    /^o[0-9]/.test(normalizedCandidate) &&
     process.env.EVAL_ALLOW_REASONING_MODELS !== "true"
   ) {
     throw new Error(

--- a/lib/evaluation/policy.ts
+++ b/lib/evaluation/policy.ts
@@ -43,9 +43,36 @@ export function buildOpenAITemperatureParam(
   return isReasoningStyleModel(model) ? {} : { temperature };
 }
 
+/**
+ * Resolves the model used by every evaluation pipeline pass.
+ *
+ * Resolution order:
+ *   1. Caller-supplied non-empty `overrideModel` (after trim).
+ *   2. `getEvaluationRuntimeConfig().model` (driven by EVAL_OPENAI_MODEL).
+ *
+ * Production invariant:
+ *   Reasoning-style models (o1/o3/o4/...) are forbidden in production
+ *   unless explicitly allowed via EVAL_ALLOW_REASONING_MODELS=true.
+ *   Single point of enforcement for the policy:
+ *     "No reasoning models in deterministic production pipelines."
+ */
 export function getCanonicalPipelineModel(overrideModel?: string): string {
-  const candidate = (overrideModel || "").trim();
-  return candidate.length > 0 ? candidate : getEvaluationRuntimeConfig().model;
+  const candidate =
+    typeof overrideModel === "string" && overrideModel.trim().length > 0
+      ? overrideModel.trim()
+      : getEvaluationRuntimeConfig().model;
+
+  if (
+    process.env.NODE_ENV === "production" &&
+    /^o[0-9]/.test(candidate) &&
+    process.env.EVAL_ALLOW_REASONING_MODELS !== "true"
+  ) {
+    throw new Error(
+      `[Config] reasoning model '${candidate}' not permitted in production`,
+    );
+  }
+
+  return candidate;
 }
 
 export function getExternalAdjudicationMode(): ExternalAdjudicationMode {


### PR DESCRIPTION
## Summary

Route Pass 2 model selection through the canonical runtime model resolver and add a central production guard preventing accidental o-series reasoning-model use in deterministic production evaluation pipelines.

This fixes the Pass 2 fallback path where `PASS2_MODEL = "o3"` could bypass `EVAL_OPENAI_MODEL` when `opts.model` was omitted.

## Scope

- [ ] Pass 1
- [x] Pass 2
- [ ] Pass 3

Changed files:

- `lib/evaluation/policy.ts`
- `lib/evaluation/pipeline/runPass2.ts`

Out of scope:

- No timeout changes
- No token-budget changes
- No retry-ceiling changes
- No latency-policy changes
- No test fixture changes

## Contract Integrity

- Model selection now routes through `getCanonicalPipelineModel(opts.model)`.
- Production reasoning-model use now fails closed unless `EVAL_ALLOW_REASONING_MODELS=true`.
- `parsePass2Response` no longer hardcodes `"o3"` as fallback metadata.
- Existing Pass 2 independence contract is unchanged.
- No schema, status, persistence, scoring, or governance threshold changes.

## Behavioral Quality

This PR does not reduce evaluation depth, literary judgment, criteria coverage, or recommendation quality.

It removes an unsafe model-routing fallback only. The evaluation prompt, rubric, evidence requirements, retry policy, and token budgets are unchanged.

This PR is not reducing intelligence.

## Latency Evidence

This is not a latency optimization PR. Metrics are N/A because no runtime timing behavior is intentionally changed.

### Baseline (Pre-change)

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Routing bug identified: Pass 2 could fall back to hardcoded `o3` |
| Run 2 | N/A | N/A | No latency baseline claimed; failure mode was model routing correctness |

### Post-change Runs

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | PR body/template compliance update; no runtime run |
| Run 2 | N/A | N/A | CI/build verification pending; no latency claim |

## Quality Gate / Anomalies

No `QG_` behavior changes.

Quality Gate logic, anomaly detection, score normalization, governance gates, and artifact release rules are unchanged.

Known anomaly addressed: production Pass 2 could accidentally route to an o-series reasoning model through a hardcoded fallback.

## Risks & Anomalies

- If Production intentionally uses an o-series model, it will now fail closed unless `EVAL_ALLOW_REASONING_MODELS=true`.
- Vercel Production must have `EVAL_OPENAI_MODEL` set to the intended non-reasoning production model.
- `runPass3Synthesis.ts` still contains a hardcoded `PASS3_MODEL = "o3"` literal; the new central guard defangs it in production, and cleanup is deferred to a follow-up PR.

## Verification Plan

- CI must pass.
- Confirm Vercel Production `EVAL_OPENAI_MODEL` is not `o3`.
- Re-run the failed Chapter 18 evaluation.
- Confirm logs show `[Pass2] completion request model=<prod model>`, not `o3`.
- Confirm `PASS2_TIMEOUT` does not recur under unchanged timeout/token/retry policy.