### PR TITLE
fix(canon-loader): ingest only docs/canon/_md/**/*.md

### DIFF
--- a/__tests__/scripts/load-canon.test.ts
+++ b/__tests__/scripts/load-canon.test.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { isIngestable, CANON_ROOT } from '../../scripts/load-canon';
+
+describe('canon loader: _md-only ingest gate (PR-0)', () => {
+  it('CANON_ROOT resolves to docs/canon/_md', () => {
+    expect(CANON_ROOT.endsWith(path.join('docs', 'canon', '_md'))).toBe(true);
+  });
+
+  it('accepts .md files under docs/canon/_md', () => {
+    const f = path.join(CANON_ROOT, 'sample.md');
+    expect(isIngestable(f)).toEqual({ ok: true });
+  });
+
+  it('accepts .md files in nested subdirs of docs/canon/_md', () => {
+    const f = path.join(CANON_ROOT, 'subdir', 'nested.md');
+    expect(isIngestable(f)).toEqual({ ok: true });
+  });
+
+  it('rejects .txt files even under docs/canon/_md', () => {
+    const f = path.join(CANON_ROOT, 'legacy.txt');
+    const v = isIngestable(f);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toMatch(/^disallowed_extension:/);
+  });
+
+  it('rejects .docx files even under docs/canon/_md', () => {
+    const f = path.join(CANON_ROOT, 'legacy.docx');
+    expect(isIngestable(f).ok).toBe(false);
+  });
+
+  it('rejects extension-less files', () => {
+    const f = path.join(CANON_ROOT, 'README');
+    const v = isIngestable(f);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe('disallowed_extension:none');
+  });
+
+  it('rejects .md files outside docs/canon/_md (sibling dir)', () => {
+    const f = path.resolve(process.cwd(), 'docs/canon/raw/legacy.md');
+    const v = isIngestable(f);
+    expect(v.ok).toBe(false);
+    expect(v.reason).toBe('outside_canon_md_root');
+  });
+
+  it('rejects .md files outside docs/canon entirely', () => {
+    const f = path.resolve(process.cwd(), 'README.md');
+    expect(isIngestable(f)).toEqual({
+      ok: false,
+      reason: 'outside_canon_md_root',
+    });
+  });
+
+  it('rejects absolute paths outside the repo', () => {
+    const f = '/tmp/elsewhere/anything.md';
+    expect(isIngestable(f)).toEqual({
+      ok: false,
+      reason: 'outside_canon_md_root',
+    });
+  });
+});

--- a/scripts/load-canon.README.md
+++ b/scripts/load-canon.README.md
@@ -1,13 +1,30 @@
 # Canon Loader
 
-Run:
+Ingests the canonical RevisionGrade canon into Supabase as embedded chunks.
 
-pnpm tsx scripts/load-canon.ts ./docs/canon
+## Source of truth
 
-Requires:
-- SUPABASE_URL
-- SUPABASE_SERVICE_ROLE_KEY
-- OPENAI_API_KEY
+`docs/canon/_md/**/*.md` is the **only** ingest source. Files outside this root,
+or files with extensions other than `.md`, are skipped by design.
 
-Repo = source of truth
-Supabase = search index
+## Run
+
+```
+pnpm tsx scripts/load-canon.ts
+```
+
+The loader hard-pins its root to `docs/canon/_md` and ignores any path argument
+passed on the command line (a warning is logged if one is supplied).
+
+## Requires
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `OPENAI_API_KEY`
+
+## Contract
+
+- Repo (`docs/canon/_md/**/*.md`) = source of truth
+- Supabase (`canon_documents`, `canon_chunks`) = search index
+- Anything under `docs/canon/` outside `_md/` (e.g. `raw/`, `legacy/`, `*.txt`,
+  `*.docx`) is ignored by the loader. Do not place canonical material there.

--- a/scripts/load-canon.ts
+++ b/scripts/load-canon.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import fs from 'fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'path';
 import crypto from 'crypto';
 import OpenAI from 'openai';
@@ -10,9 +11,26 @@ const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY!;
 
-if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !OPENAI_API_KEY) {
-  console.error('Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENAI_API_KEY');
-  process.exit(1);
+// PR-0: env-var hard exit moved into main() for test importability.
+
+// --- PR-0: canon ingest gate (md-only under docs/canon/_md) ---
+export const CANON_ROOT = path.resolve(process.cwd(), 'docs/canon/_md');
+const ALLOWED_EXT = new Set(['.md']);
+
+/**
+ * Canon ingest gate. Returns ok=true only if absPath sits under CANON_ROOT
+ * and has an allowed extension. Used at walk-time and exported for tests.
+ */
+export function isIngestable(absPath: string): { ok: boolean; reason?: string } {
+  const rel = path.relative(CANON_ROOT, absPath);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return { ok: false, reason: 'outside_canon_md_root' };
+  }
+  const ext = path.extname(absPath).toLowerCase();
+  if (!ALLOWED_EXT.has(ext)) {
+    return { ok: false, reason: 'disallowed_extension:' + (ext || 'none') };
+  }
+  return { ok: true };
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
@@ -119,7 +137,7 @@ async function walk(dir: string): Promise<string[]> {
     if (entry.isDirectory()) {
       files.push(...(await walk(fullPath)));
     } else if (entry.isFile()) {
-      if (/\.(md|txt|docx)$/i.test(entry.name)) {
+      if (isIngestable(fullPath).ok) {
         files.push(fullPath);
       }
     }
@@ -129,11 +147,19 @@ async function walk(dir: string): Promise<string[]> {
 }
 
 async function main() {
-  const targetDir = process.argv[2];
-  if (!targetDir) {
-    console.error('Usage: tsx scripts/load-canon.ts <dir>');
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY || !OPENAI_API_KEY) {
+    console.error('Missing required env vars: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, OPENAI_API_KEY');
     process.exit(1);
   }
+  // PR-0: ignore argv; canon root is hard-pinned to docs/canon/_md.
+  if (process.argv[2]) {
+    console.warn('[canon-loader] ignoring argv path "' + process.argv[2] + '"; canon root is pinned to ' + CANON_ROOT);
+  }
+  if (!existsSync(CANON_ROOT)) {
+    console.error('Canon root missing: ' + CANON_ROOT);
+    process.exit(1);
+  }
+  const targetDir = CANON_ROOT;
 
   const files = await walk(targetDir);
   console.log(`Found ${files.length} canon files`);
@@ -153,7 +179,12 @@ async function main() {
   console.log('\nCanon load complete');
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// PR-0: only auto-run when invoked directly (allows isIngestable to be imported by tests).
+const _isEntrypoint =
+  typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module;
+if (_isEntrypoint) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Canon loader previously walked all of `docs/canon/**` and ingested `.md/.txt/.docx`, violating the documented "md is source of truth" policy and polluting RAG context with non-canonical material.

## Changes

- Hard-gate ingest root to `docs/canon/_md` via `CANON_ROOT` constant
- Allow only `.md` extension via exported `isIngestable()` gate function
- Reject paths outside root with structured skip reasons (`outside_canon_md_root`, `disallowed_extension:*`)
- Move env-var check into `main()` so `isIngestable`/`CANON_ROOT` are importable by tests without side effects
- Guard `main()` invocation with `require.main === module`
- Update README: pin command to `docs/canon/_md`, no path-arg override
- Add 9-case regression test covering accept/reject matrix

## Why this is a prerequisite

Prerequisite for `feat/submission-scope-governance` (PR-1): polluted canon would mask whether scope-aware criterion behavior is actually working.

## Test results

```
PASS __tests__/scripts/load-canon.test.ts
  canon loader: _md-only ingest gate (PR-0)
    9 passed, 9 total
    Time: 0.787s
```

## Acceptance checklist

- [x] `isIngestable()` accepts `.md` under `docs/canon/_md`
- [x] Rejects `.txt`, `.docx`, extension-less files
- [x] Rejects files outside `docs/canon/_md` (sibling dirs, repo root, absolute paths)
- [x] `tsc --noEmit` passes
- [x] Jest tests pass (9/9)
- [x] No path-arg override on script