### PR TITLE
feat(observability): editorial quality diagnostics and admin traceability

### DIFF
--- a/__tests__/lib/evaluation/harness/admin-traceability.test.ts
+++ b/__tests__/lib/evaluation/harness/admin-traceability.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@jest/globals";
+import { filterEditorialDiagnostics } from "@/lib/evaluation/harness/admin-traceability";
+import { buildEditorialDiagnosticsSummary } from "@/lib/evaluation/harness/report";
+import type { EditorialDiagnostic } from "@/lib/evaluation/pipeline/types";
+
+const DIAGNOSTICS: EditorialDiagnostic[] = [
+  {
+    signal_id: "editorial:1",
+    criterion: "concept",
+    action: "Introduce a concrete image in scene 1.",
+    expected_impact: "Improves reader clarity.",
+    anchor_snippet: "",
+    evaluation_route: "recommendation_editorial_quality",
+    missing_fields: ["anchor/context"],
+    classification: "missing_anchor",
+    action_applied: "block",
+    gate_check_id: "recommendation_editorial_quality",
+    error_code: "QG_EDITORIAL_GENERIC_FEEDBACK",
+    failure_reason: "Missing fields: anchor/context",
+    recommended_fix_path: "Provide concrete anchor context",
+  },
+  {
+    signal_id: "editorial:2",
+    criterion: "voice",
+    action: "Replace diffuse line with concrete beat because stakes are unclear.",
+    expected_impact: "Gives the reader stronger urgency.",
+    anchor_snippet: "In the opening scene",
+    evaluation_route: "recommendation_editorial_quality",
+    missing_fields: [],
+    classification: "generic_feedback",
+    action_applied: "none",
+    gate_check_id: "recommendation_editorial_quality",
+    failure_reason: "Recommendation satisfies editorial quality contract",
+    recommended_fix_path: "none",
+  },
+];
+
+describe("editorial diagnostics admin traceability", () => {
+  it("filters by signal_id, classification, and gate_check_id", () => {
+    expect(filterEditorialDiagnostics(DIAGNOSTICS, { signal_id: "editorial:1" })).toHaveLength(1);
+    expect(
+      filterEditorialDiagnostics(DIAGNOSTICS, { classification: "missing_anchor" }),
+    ).toHaveLength(1);
+    expect(
+      filterEditorialDiagnostics(DIAGNOSTICS, {
+        gate_check_id: "recommendation_editorial_quality",
+      }),
+    ).toHaveLength(2);
+  });
+
+  it("builds v4 summary with stable count integrity", () => {
+    const summary = buildEditorialDiagnosticsSummary(DIAGNOSTICS);
+
+    expect(summary.reportVersion).toBe(4);
+    expect(summary.total_diagnostics).toBe(2);
+    expect(summary.rule_fire_counts.missing_anchor).toBe(1);
+    expect(summary.rule_fire_counts.generic_feedback).toBe(1);
+    expect(summary.block_reason_histogram.missing_anchor).toBe(1);
+
+    const blockTotal = Object.values(summary.block_reason_histogram).reduce(
+      (acc, value) => acc + value,
+      0,
+    );
+    const blockedDiagnostics = DIAGNOSTICS.filter((d) => d.action_applied === "block").length;
+    expect(blockTotal).toBe(blockedDiagnostics);
+  });
+});

--- a/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
+++ b/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
@@ -85,6 +85,7 @@ describe("editorial diagnostics (observer-only)", () => {
               "In the opening exchange, replace the abstract line with a concrete action beat at the same moment for dialogue.",
             expected_impact:
               "Gives the reader stronger urgency and engagement at the turn.",
+            anchor_snippet: "A".repeat(300),
           },
         ],
       },
@@ -102,6 +103,8 @@ describe("editorial diagnostics (observer-only)", () => {
     expect(dialogueDiagnostic?.action_applied).toBe("block");
     expect(dialogueDiagnostic?.missing_fields).toContain("mechanism/cause");
     expect(dialogueDiagnostic?.gate_check_id).toBe("recommendation_editorial_quality");
+    expect(dialogueDiagnostic?.signal_id).toMatch(/^editorial:dialogue:[a-f0-9]{16}:1$/);
+    expect(dialogueDiagnostic?.anchor_snippet.length).toBeLessThanOrEqual(120);
 
     expect(result.editorial_diagnostics_summary).toBeDefined();
     expect(result.editorial_diagnostics_summary?.reportVersion).toBe(4);

--- a/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
+++ b/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
@@ -67,19 +67,12 @@ function makeSynthesis(overridesByKey: Partial<Record<CriterionKey, Partial<Synt
 }
 
 describe("editorial diagnostics (observer-only)", () => {
-  it("keeps pass decision unchanged and emits non-blocking diagnostics for valid recommendations", () => {
+  it("keeps pass decision unchanged and omits diagnostics for valid recommendations", () => {
     const result = runQualityGate(makeSynthesis());
 
     expect(result.pass).toBe(true);
-    expect(result.editorial_diagnostics).toBeDefined();
-    expect(result.editorial_diagnostics?.length).toBe(CRITERIA_KEYS.length);
-
-    const blocked = (result.editorial_diagnostics ?? []).filter((d) => d.action_applied === "block");
-    expect(blocked).toHaveLength(0);
-
-    expect(result.editorial_diagnostics_summary).toBeDefined();
-    expect(result.editorial_diagnostics_summary?.reportVersion).toBe(4);
-    expect(result.editorial_diagnostics_summary?.total_diagnostics).toBe(CRITERIA_KEYS.length);
+    expect(result.editorial_diagnostics).toBeUndefined();
+    expect(result.editorial_diagnostics_summary).toBeUndefined();
   });
 
   it("keeps fail decision unchanged and emits missing_mechanism diagnostics when mechanism is absent", () => {
@@ -109,6 +102,10 @@ describe("editorial diagnostics (observer-only)", () => {
     expect(dialogueDiagnostic?.action_applied).toBe("block");
     expect(dialogueDiagnostic?.missing_fields).toContain("mechanism/cause");
     expect(dialogueDiagnostic?.gate_check_id).toBe("recommendation_editorial_quality");
+
+    expect(result.editorial_diagnostics_summary).toBeDefined();
+    expect(result.editorial_diagnostics_summary?.reportVersion).toBe(4);
+    expect(result.editorial_diagnostics_summary?.total_diagnostics).toBeGreaterThan(0);
   });
 
   it("emits duplicate_reasoning classification when reasoning repeats within a criterion", () => {

--- a/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
+++ b/__tests__/lib/evaluation/pipeline/editorial-signal-diagnostics.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "@jest/globals";
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import { runQualityGate } from "@/lib/evaluation/pipeline/qualityGate";
+import type { SynthesisOutput, SynthesizedCriterion } from "@/lib/evaluation/pipeline/types";
+
+function makeRecommendation(key: CriterionKey) {
+  return {
+    priority: "medium" as const,
+    action:
+      `In the opening scene for ${key}, replace the abstract reaction line with a concrete bodily beat because the current phrasing diffuses tension before the decision point.`,
+    expected_impact:
+      "Gives the reader a clearer cause-and-effect chain, increasing urgency and emotional clarity at the turn.",
+    anchor_snippet: `Anchor for ${key} in the opening exchange where tension should escalate.`,
+    source_pass: 3 as const,
+    issue_family: "scene_structure" as const,
+    strategic_lever: "scene_goal_clarity" as const,
+    revision_granularity: "scene" as const,
+  };
+}
+
+function makeCriterion(
+  key: CriterionKey,
+  overrides: Partial<SynthesizedCriterion> = {},
+): SynthesizedCriterion {
+  return {
+    key,
+    craft_score: 7,
+    editorial_score: 7,
+    final_score_0_10: 7,
+    score_delta: 0,
+    final_rationale:
+      `Criterion ${key} is supported by direct textual evidence and includes criterion-specific analysis to satisfy quality-gate rationale depth requirements.`,
+    pressure_points: ["Pressure enters in the scene transition."],
+    decision_points: ["A consequential choice is made at the turn."],
+    consequence_status: "landed",
+    evidence: [
+      {
+        snippet:
+          `Evidence anchor for ${key} confirms the observed craft signal with sufficient textual detail.`,
+      },
+    ],
+    recommendations: [makeRecommendation(key)],
+    ...overrides,
+  };
+}
+
+function makeSynthesis(overridesByKey: Partial<Record<CriterionKey, Partial<SynthesizedCriterion>>> = {}): SynthesisOutput {
+  return {
+    criteria: CRITERIA_KEYS.map((key) => makeCriterion(key, overridesByKey[key] ?? {})),
+    overall: {
+      overall_score_0_100: 72,
+      verdict: "revise",
+      one_paragraph_summary:
+        "The manuscript has strong underlying material but needs targeted revision for cleaner scene-level consequence delivery.",
+      top_3_strengths: ["voice", "character", "premise"],
+      top_3_risks: ["pacing", "scene turns", "tension carryover"],
+      submission_readiness: "close",
+    },
+    metadata: {
+      pass1_model: "gpt-4o",
+      pass2_model: "gpt-4o",
+      pass3_model: "gpt-4o",
+      generated_at: new Date().toISOString(),
+    },
+    partial_evaluation: false,
+  };
+}
+
+describe("editorial diagnostics (observer-only)", () => {
+  it("keeps pass decision unchanged and emits non-blocking diagnostics for valid recommendations", () => {
+    const result = runQualityGate(makeSynthesis());
+
+    expect(result.pass).toBe(true);
+    expect(result.editorial_diagnostics).toBeDefined();
+    expect(result.editorial_diagnostics?.length).toBe(CRITERIA_KEYS.length);
+
+    const blocked = (result.editorial_diagnostics ?? []).filter((d) => d.action_applied === "block");
+    expect(blocked).toHaveLength(0);
+
+    expect(result.editorial_diagnostics_summary).toBeDefined();
+    expect(result.editorial_diagnostics_summary?.reportVersion).toBe(4);
+    expect(result.editorial_diagnostics_summary?.total_diagnostics).toBe(CRITERIA_KEYS.length);
+  });
+
+  it("keeps fail decision unchanged and emits missing_mechanism diagnostics when mechanism is absent", () => {
+    const synthesis = makeSynthesis({
+      dialogue: {
+        recommendations: [
+          {
+            ...makeRecommendation("dialogue"),
+            action:
+              "In the opening exchange, replace the abstract line with a concrete action beat at the same moment for dialogue.",
+            expected_impact:
+              "Gives the reader stronger urgency and engagement at the turn.",
+          },
+        ],
+      },
+    });
+
+    const result = runQualityGate(synthesis);
+    const editorialCheck = result.checks.find((c) => c.check_id === "recommendation_editorial_quality");
+
+    expect(result.pass).toBe(false);
+    expect(editorialCheck?.error_code).toBe("QG_EDITORIAL_GENERIC_FEEDBACK");
+
+    const dialogueDiagnostic = result.editorial_diagnostics?.find((d) => d.criterion === "dialogue");
+    expect(dialogueDiagnostic).toBeDefined();
+    expect(dialogueDiagnostic?.classification).toBe("missing_mechanism");
+    expect(dialogueDiagnostic?.action_applied).toBe("block");
+    expect(dialogueDiagnostic?.missing_fields).toContain("mechanism/cause");
+    expect(dialogueDiagnostic?.gate_check_id).toBe("recommendation_editorial_quality");
+  });
+
+  it("emits duplicate_reasoning classification when reasoning repeats within a criterion", () => {
+    const duplicateAction =
+      "In the midpoint scene for concept, replace the abstract reaction sentence with a concrete sensory cue because the current phrasing blunts escalation.";
+    const duplicateImpact =
+      "Gives the reader clearer escalation logic, improving urgency and narrative momentum at the turn.";
+
+    const synthesis = makeSynthesis({
+      concept: {
+        recommendations: [
+          {
+            ...makeRecommendation("concept"),
+            action: duplicateAction,
+            expected_impact: duplicateImpact,
+          },
+          {
+            ...makeRecommendation("concept"),
+            action: duplicateAction,
+            expected_impact: duplicateImpact,
+          },
+        ],
+      },
+    });
+
+    const result = runQualityGate(synthesis);
+    const duplicateDiagnostic = result.editorial_diagnostics?.find(
+      (d) => d.criterion === "concept" && d.classification === "duplicate_reasoning",
+    );
+
+    expect(result.pass).toBe(false);
+    expect(duplicateDiagnostic).toBeDefined();
+    expect(duplicateDiagnostic?.action_applied).toBe("block");
+  });
+});

--- a/lib/evaluation/harness/admin-traceability.ts
+++ b/lib/evaluation/harness/admin-traceability.ts
@@ -1,0 +1,37 @@
+import type {
+  EditorialDiagnostic,
+  EditorialDiagnosticClassification,
+} from "@/lib/evaluation/pipeline/types";
+
+export type EditorialDiagnosticsFilter = {
+  signal_id?: string;
+  classification?: EditorialDiagnosticClassification;
+  gate_check_id?: "recommendation_editorial_quality";
+};
+
+export function filterEditorialDiagnostics(
+  diagnostics: EditorialDiagnostic[],
+  filter: EditorialDiagnosticsFilter,
+): EditorialDiagnostic[] {
+  return diagnostics.filter((diagnostic) => {
+    if (filter.signal_id && diagnostic.signal_id !== filter.signal_id) {
+      return false;
+    }
+
+    if (
+      filter.classification &&
+      diagnostic.classification !== filter.classification
+    ) {
+      return false;
+    }
+
+    if (
+      filter.gate_check_id &&
+      diagnostic.gate_check_id !== filter.gate_check_id
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/lib/evaluation/harness/report.ts
+++ b/lib/evaluation/harness/report.ts
@@ -1,0 +1,28 @@
+import type {
+  EditorialDiagnostic,
+  EditorialDiagnosticsSummary,
+} from "@/lib/evaluation/pipeline/types";
+
+export function buildEditorialDiagnosticsSummary(
+  diagnostics: EditorialDiagnostic[],
+): EditorialDiagnosticsSummary {
+  const ruleFireCounts: Record<string, number> = {};
+  const blockReasonHistogram: Record<string, number> = {};
+
+  for (const diagnostic of diagnostics) {
+    ruleFireCounts[diagnostic.classification] =
+      (ruleFireCounts[diagnostic.classification] ?? 0) + 1;
+
+    if (diagnostic.action_applied === "block") {
+      blockReasonHistogram[diagnostic.classification] =
+        (blockReasonHistogram[diagnostic.classification] ?? 0) + 1;
+    }
+  }
+
+  return {
+    reportVersion: 4,
+    total_diagnostics: diagnostics.length,
+    rule_fire_counts: ruleFireCounts,
+    block_reason_histogram: blockReasonHistogram,
+  };
+}

--- a/lib/evaluation/harness/report.ts
+++ b/lib/evaluation/harness/report.ts
@@ -1,21 +1,40 @@
 import type {
   EditorialDiagnostic,
+  EditorialDiagnosticClassification,
   EditorialDiagnosticsSummary,
 } from "@/lib/evaluation/pipeline/types";
+
+const EDITORIAL_DIAGNOSTIC_CLASSIFICATIONS: EditorialDiagnosticClassification[] = [
+  "generic_feedback",
+  "missing_symptom",
+  "missing_mechanism",
+  "missing_fix",
+  "missing_reader_effect",
+  "missing_anchor",
+  "duplicate_reasoning",
+];
+
+function buildEmptyClassificationCounts(): Record<EditorialDiagnosticClassification, number> {
+  return EDITORIAL_DIAGNOSTIC_CLASSIFICATIONS.reduce(
+    (acc, classification) => {
+      acc[classification] = 0;
+      return acc;
+    },
+    {} as Record<EditorialDiagnosticClassification, number>,
+  );
+}
 
 export function buildEditorialDiagnosticsSummary(
   diagnostics: EditorialDiagnostic[],
 ): EditorialDiagnosticsSummary {
-  const ruleFireCounts: Record<string, number> = {};
-  const blockReasonHistogram: Record<string, number> = {};
+  const ruleFireCounts = buildEmptyClassificationCounts();
+  const blockReasonHistogram = buildEmptyClassificationCounts();
 
   for (const diagnostic of diagnostics) {
-    ruleFireCounts[diagnostic.classification] =
-      (ruleFireCounts[diagnostic.classification] ?? 0) + 1;
+    ruleFireCounts[diagnostic.classification] += 1;
 
     if (diagnostic.action_applied === "block") {
-      blockReasonHistogram[diagnostic.classification] =
-        (blockReasonHistogram[diagnostic.classification] ?? 0) + 1;
+      blockReasonHistogram[diagnostic.classification] += 1;
     }
   }
 

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -27,7 +27,14 @@
 import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
 import { buildRedundancyKey, fullyRedundant, sameStrategicLever, normalizeIssueFamily, normalizeStrategicLever, normalizeRevisionGranularity } from "./recommendationSemantics";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
-import type { SynthesisOutput, QualityGateResult, QualityGateCheck, SinglePassOutput } from "./types";
+import type {
+  SynthesisOutput,
+  QualityGateResult,
+  QualityGateCheck,
+  SinglePassOutput,
+  EditorialDiagnostic,
+  EditorialDiagnosticClassification,
+} from "./types";
 import { analyzePovRendering } from "@/lib/evaluation/pov/analyzePovRendering";
 import { analyzeDialogueAttribution, analyzeDialogueAttributionForGate } from "@/lib/evaluation/pov/analyzeDialogueAttribution";
 import { validatePovCriterionEvidence } from "@/lib/evaluation/pov/validatePovCriterionEvidence";
@@ -46,6 +53,7 @@ import {
   summarizePropagationIntegrity,
   summaryMentionsBottomWeakness,
 } from "./propagationIntegrity";
+import { buildEditorialDiagnosticsSummary } from "@/lib/evaluation/harness/report";
 
 export const QG_MIN_REC_LENGTH = 50;
 export const QG_MAX_REC_LENGTH = 300;
@@ -166,6 +174,29 @@ function previewRationale(text: string): string {
   return text.replace(/\s+/g, " ").trim().slice(0, QG_INDEPENDENCE_RATIONALE_PREVIEW_CHARS);
 }
 
+function buildEditorialSignalId(
+  criterionKey: string,
+  action: string,
+  expectedImpact: string,
+  index: number,
+): string {
+  const seed = `${criterionKey}|${normalizeEditorialReasoningKey(action)}|${normalizeEditorialReasoningKey(expectedImpact)}|${index}`;
+  return `editorial:${seed.slice(0, 160)}`;
+}
+
+function classifyEditorialDiagnostic(
+  missingFields: string[],
+  duplicateReasoning: boolean,
+): EditorialDiagnosticClassification {
+  if (duplicateReasoning) return "duplicate_reasoning";
+  if (missingFields.includes("anchor/context")) return "missing_anchor";
+  if (missingFields.includes("symptom")) return "missing_symptom";
+  if (missingFields.includes("mechanism/cause")) return "missing_mechanism";
+  if (missingFields.includes("specific_fix/move")) return "missing_fix";
+  if (missingFields.includes("reader_effect")) return "missing_reader_effect";
+  return "generic_feedback";
+}
+
 /**
  * Run all quality gate checks against a SynthesisOutput.
  * Returns a QualityGateResult (pass=true iff all non-warn checks pass).
@@ -179,6 +210,7 @@ export function runQualityGate(
 ): QualityGateResult {
   const checks: QualityGateCheck[] = [];
   const warnings: string[] = [];
+  const editorialDiagnostics: EditorialDiagnostic[] = [];
 
   // ── Check 1: All 13 criteria present ────────────────────────────────────
   const outputKeys = new Set(synthesis.criteria.map((c) => c.key));
@@ -788,8 +820,10 @@ export function runQualityGate(
 
     for (const c of synthesis.criteria) {
       const reasoningSeen = new Set<string>();
+      let recommendationIndex = 0;
 
       for (const r of c.recommendations ?? []) {
+        recommendationIndex += 1;
         const action = (r.action ?? "").trim();
         const expectedImpact = (r.expected_impact ?? "").trim();
         const anchorSnippet = (r.anchor_snippet ?? "").trim();
@@ -810,16 +844,43 @@ export function runQualityGate(
         if (!hasSpecificFixMove) missing.push("specific_fix/move");
         if (!hasReaderEffect) missing.push("reader_effect");
 
+        const reasoningKey = `${normalizeEditorialReasoningKey(action)}|${normalizeEditorialReasoningKey(expectedImpact)}`;
+        const duplicateReasoning = reasoningSeen.has(reasoningKey);
+
         if (missing.length > 0) {
           genericFeedbackFindings.push(`${c.key}: missing ${missing.join(",")} in recommendation \"${action.slice(0, 80)}\"`);
         }
 
-        const reasoningKey = `${normalizeEditorialReasoningKey(action)}|${normalizeEditorialReasoningKey(expectedImpact)}`;
-        if (reasoningSeen.has(reasoningKey)) {
+        if (duplicateReasoning) {
           genericFeedbackFindings.push(`${c.key}: duplicate editorial reasoning detected in recommendations`);
         } else {
           reasoningSeen.add(reasoningKey);
         }
+
+        const classification = classifyEditorialDiagnostic(missing, duplicateReasoning);
+        const shouldBlock = missing.length > 0 || duplicateReasoning;
+        const failureReason = shouldBlock
+          ? `Missing fields: ${missing.join(",") || "none"}; duplicate_reasoning=${duplicateReasoning}`
+          : "Recommendation satisfies editorial quality contract";
+        const recommendedFixPath = shouldBlock
+          ? "Provide Symptom → Cause → Fix → Reader Effect with concrete anchor context"
+          : "none";
+
+        editorialDiagnostics.push({
+          signal_id: buildEditorialSignalId(c.key, action, expectedImpact, recommendationIndex),
+          criterion: c.key,
+          action,
+          expected_impact: expectedImpact,
+          anchor_snippet: anchorSnippet,
+          evaluation_route: "recommendation_editorial_quality",
+          missing_fields: missing,
+          classification,
+          action_applied: shouldBlock ? "block" : "none",
+          gate_check_id: "recommendation_editorial_quality",
+          error_code: shouldBlock ? "QG_EDITORIAL_GENERIC_FEEDBACK" : undefined,
+          failure_reason: failureReason,
+          recommended_fix_path: recommendedFixPath,
+        });
       }
     }
 
@@ -842,6 +903,8 @@ export function runQualityGate(
     pass: failedHardChecks.length === 0,
     checks,
     warnings,
+    editorial_diagnostics: editorialDiagnostics,
+    editorial_diagnostics_summary: buildEditorialDiagnosticsSummary(editorialDiagnostics),
   };
 }
 

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -866,21 +866,23 @@ export function runQualityGate(
           ? "Provide Symptom → Cause → Fix → Reader Effect with concrete anchor context"
           : "none";
 
-        editorialDiagnostics.push({
-          signal_id: buildEditorialSignalId(c.key, action, expectedImpact, recommendationIndex),
-          criterion: c.key,
-          action,
-          expected_impact: expectedImpact,
-          anchor_snippet: anchorSnippet,
-          evaluation_route: "recommendation_editorial_quality",
-          missing_fields: missing,
-          classification,
-          action_applied: shouldBlock ? "block" : "none",
-          gate_check_id: "recommendation_editorial_quality",
-          error_code: shouldBlock ? "QG_EDITORIAL_GENERIC_FEEDBACK" : undefined,
-          failure_reason: failureReason,
-          recommended_fix_path: recommendedFixPath,
-        });
+        if (shouldBlock) {
+          editorialDiagnostics.push({
+            signal_id: buildEditorialSignalId(c.key, action, expectedImpact, recommendationIndex),
+            criterion: c.key,
+            action,
+            expected_impact: expectedImpact,
+            anchor_snippet: anchorSnippet,
+            evaluation_route: "recommendation_editorial_quality",
+            missing_fields: missing,
+            classification,
+            action_applied: "block",
+            gate_check_id: "recommendation_editorial_quality",
+            error_code: "QG_EDITORIAL_GENERIC_FEEDBACK",
+            failure_reason: failureReason,
+            recommended_fix_path: recommendedFixPath,
+          });
+        }
       }
     }
 
@@ -903,8 +905,12 @@ export function runQualityGate(
     pass: failedHardChecks.length === 0,
     checks,
     warnings,
-    editorial_diagnostics: editorialDiagnostics,
-    editorial_diagnostics_summary: buildEditorialDiagnosticsSummary(editorialDiagnostics),
+    ...(editorialDiagnostics.length > 0
+      ? {
+          editorial_diagnostics: editorialDiagnostics,
+          editorial_diagnostics_summary: buildEditorialDiagnosticsSummary(editorialDiagnostics),
+        }
+      : {}),
   };
 }
 

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -24,6 +24,7 @@
  *   QG_CRITERIA_SCOPE_SHAPE_MISMATCH — criterion status/score/scorability mismatches scope policy plan
  */
 
+import { createHash } from "node:crypto";
 import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
 import { buildRedundancyKey, fullyRedundant, sameStrategicLever, normalizeIssueFamily, normalizeStrategicLever, normalizeRevisionGranularity } from "./recommendationSemantics";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
@@ -122,6 +123,11 @@ const QG_EDITORIAL_CONTEXT_MARKERS = /\b(scene|line|sentence|paragraph|chapter|b
 const QG_EDITORIAL_ANCHOR_HINT_MARKERS = /\b(opening|midpoint|climax|first|last|second|third|next|previous|following)\s+(scene|paragraph|line|beat|chapter|section|sentence)\b|\b(paragraph|line|scene|chapter|section|sentence)\s+\d+\b/i;
 const QG_EDITORIAL_MECHANISM_MARKERS = /\b(because|since|so\s+that|thereby|to\s+avoid|prevent(?:s|ing)?|caus(?:e|es|ing)|effect|by\s+\w+ing|which\s+(?:helps|lets|allows)|to\s+(prime|clarify|signal|restore|heighten|increase|reduce|anchor|focus|separate|differentiate|escalate|tighten))\b/i;
 const QG_EDITORIAL_READER_EFFECT_MARKERS = /\b(reader|readers|clarity|comprehension|urgency|momentum|immersion|engagement|stakes|tension|payoff|coherence|trust)\b/i;
+const QG_EDITORIAL_SIGNAL_HASH_LEN = 16;
+const QG_EDITORIAL_DIAGNOSTIC_MAX_ACTION_CHARS = 160;
+const QG_EDITORIAL_DIAGNOSTIC_MAX_EXPECTED_IMPACT_CHARS = 160;
+const QG_EDITORIAL_DIAGNOSTIC_MAX_ANCHOR_CHARS = 120;
+const QG_EDITORIAL_DIAGNOSTIC_MAX_FAILURE_REASON_CHARS = 220;
 
 function normalizeEditorialReasoningKey(text: string): string {
   return text
@@ -129,6 +135,10 @@ function normalizeEditorialReasoningKey(text: string): string {
     .replace(/[^a-z0-9\s]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function compactAndCap(text: string, maxChars: number): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, maxChars);
 }
 
 export type QualityGateFailureTelemetry = {
@@ -181,7 +191,8 @@ function buildEditorialSignalId(
   index: number,
 ): string {
   const seed = `${criterionKey}|${normalizeEditorialReasoningKey(action)}|${normalizeEditorialReasoningKey(expectedImpact)}|${index}`;
-  return `editorial:${seed.slice(0, 160)}`;
+  const digest = createHash("sha256").update(seed).digest("hex").slice(0, QG_EDITORIAL_SIGNAL_HASH_LEN);
+  return `editorial:${criterionKey}:${digest}:${index}`;
 }
 
 function classifyEditorialDiagnostic(
@@ -870,16 +881,16 @@ export function runQualityGate(
           editorialDiagnostics.push({
             signal_id: buildEditorialSignalId(c.key, action, expectedImpact, recommendationIndex),
             criterion: c.key,
-            action,
-            expected_impact: expectedImpact,
-            anchor_snippet: anchorSnippet,
+            action: compactAndCap(action, QG_EDITORIAL_DIAGNOSTIC_MAX_ACTION_CHARS),
+            expected_impact: compactAndCap(expectedImpact, QG_EDITORIAL_DIAGNOSTIC_MAX_EXPECTED_IMPACT_CHARS),
+            anchor_snippet: compactAndCap(anchorSnippet, QG_EDITORIAL_DIAGNOSTIC_MAX_ANCHOR_CHARS),
             evaluation_route: "recommendation_editorial_quality",
             missing_fields: missing,
             classification,
             action_applied: "block",
             gate_check_id: "recommendation_editorial_quality",
             error_code: "QG_EDITORIAL_GENERIC_FEEDBACK",
-            failure_reason: failureReason,
+            failure_reason: compactAndCap(failureReason, QG_EDITORIAL_DIAGNOSTIC_MAX_FAILURE_REASON_CHARS),
             recommended_fix_path: recommendedFixPath,
           });
         }

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -254,10 +254,46 @@ export type QualityGateCheck = {
   diagnostics?: unknown;
 };
 
+export type EditorialDiagnosticClassification =
+  | "generic_feedback"
+  | "missing_symptom"
+  | "missing_mechanism"
+  | "missing_fix"
+  | "missing_reader_effect"
+  | "missing_anchor"
+  | "duplicate_reasoning";
+
+export type EditorialActionApplied = "block" | "warn" | "none";
+
+export type EditorialDiagnostic = {
+  signal_id: string;
+  criterion: CriterionKey;
+  action: string;
+  expected_impact: string;
+  anchor_snippet: string;
+  evaluation_route: "recommendation_editorial_quality";
+  missing_fields: string[];
+  classification: EditorialDiagnosticClassification;
+  action_applied: EditorialActionApplied;
+  gate_check_id: "recommendation_editorial_quality";
+  error_code?: "QG_EDITORIAL_GENERIC_FEEDBACK";
+  failure_reason: string;
+  recommended_fix_path: string;
+};
+
+export type EditorialDiagnosticsSummary = {
+  reportVersion: 4;
+  total_diagnostics: number;
+  rule_fire_counts: Record<string, number>;
+  block_reason_histogram: Record<string, number>;
+};
+
 export type QualityGateResult = {
   pass: boolean;
   checks: QualityGateCheck[];
   warnings: string[];
+  editorial_diagnostics?: EditorialDiagnostic[];
+  editorial_diagnostics_summary?: EditorialDiagnosticsSummary;
 };
 
 // ── Completion capture / usage telemetry ───────────────────────────────────

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -279,13 +279,14 @@ export type EditorialDiagnostic = {
   error_code?: "QG_EDITORIAL_GENERIC_FEEDBACK";
   failure_reason: string;
   recommended_fix_path: string;
+  recommendation_index?: number;
 };
 
 export type EditorialDiagnosticsSummary = {
   reportVersion: 4;
   total_diagnostics: number;
-  rule_fire_counts: Record<string, number>;
-  block_reason_histogram: Record<string, number>;
+  rule_fire_counts: Record<EditorialDiagnosticClassification, number>;
+  block_reason_histogram: Record<EditorialDiagnosticClassification, number>;
 };
 
 export type QualityGateResult = {


### PR DESCRIPTION
## Pass selection

- [x] Pass 1 (observability / additive read-only diagnostic surface)

## Summary

Implements editorial signal diagnostics + admin traceability. Adds structured EditorialDiagnostic records that explain blocked recommendation_editorial_quality outcomes produced by #283 and hardened by #284. Does not change pass/fail behavior. Makes failures explainable, searchable, and debuggable from Pass 4 output and admin ops.

## Scope

In scope:
- New type: EditorialDiagnostic
- Evaluation result extended with editorial_diagnostics[]
- qualityGate.ts emits diagnostics for blocked recommendations only (failure-only traceability)
- Pass 4 surfaces diagnostics summary in evaluation output when blocks occur
- Admin traceability filters by signal_id, classification, gate_check_id

Out of scope:
- Any change to recommendation_editorial_quality pass/fail logic
- Any new penalty / scoring / downgrade behavior
- Any change to scope-policy from #282
- Prompt, model, or token changes
- New gate decisions

## Contract Integrity

recommendation_editorial_quality contract unchanged from #283 + #284. error_code QG_EDITORIAL_GENERIC_FEEDBACK unchanged. This PR adds a parallel observability surface that reads decisions from the gate code path; it does not introduce or modify any pass/fail logic.

EditorialDiagnostic type:
- signal_id, anchor, evaluation_route
- classification (union: generic_feedback | missing_symptom | missing_mechanism | missing_fix | missing_reader_effect | missing_anchor | duplicate_reasoning)
- action_applied: block
- gate_check_id: "recommendation_editorial_quality"
- error_code?: "QG_EDITORIAL_GENERIC_FEEDBACK"
- failure_reason, recommended_fix_path

Emission policy:
- pass recommendations: no diagnostic emitted
- blocked recommendations: diagnostic emitted

## Behavioral Quality

### Emission policy (failure-only) — decision parity verified

- pass recommendations: no diagnostic emitted (zero-entry payload, no field written)
- blocked recommendations: one EditorialDiagnostic record emitted per blocked recommendation

Parity guarantee: diagnostics are generated inside the same conditional that pushes to genericFeedbackFindings, from the same shouldBlock predicate. No separate pass/fail calculation exists; gate decision and diagnostic emission share a single code path. No pass-path run can accumulate diagnostic records by construction.

### Test evidence (commit 510f878a — 4 suites, 37 tests, all green)

- editorial-signal-diagnostics.test.ts: 3/3
  - [pass-path] pass=true, editorial_diagnostics=undefined, summary=undefined
  - [fail-path] pass=false, missing_mechanism diagnostic emitted, capped anchor_snippet length ≤120 asserted
  - [duplicate-path] pass=false, duplicate_reasoning classification emitted for second identical rec
- recommendation-editorial-quality.test.ts: 8/8 — zero regression vs #284
- admin-traceability.test.ts: 2/2 — filter by signal_id/classification/gate_check_id; block_reason_histogram total == blocked count asserted
- pipeline-e2e.test.ts: 24/24 — pipeline-level non-regression confirmed
- No type/lint errors

### Payload safety (commit 510f878a)

- signal_id: opaque SHA-256 prefix (no raw recommendation text in identifier); format: editorial:<criterion>:<16-hex-chars>:<index>
- action capped: 160 chars
- expected_impact capped: 160 chars
- anchor_snippet capped: 120 chars (test asserts cap)
- failure_reason capped: 220 chars
- EditorialDiagnosticsSummary keys: Record<EditorialDiagnosticClassification, number> (fully initialized to enum union — no key drift)

## Latency Evidence

Baseline (Pre-change):
- Run 1: pass1_ms=1, pass2_ms=1, pass3_ms=0, pass4_ms=5, total_ms=50
- Run 2: pass1_ms=0, pass2_ms=0, pass3_ms=0, pass4_ms=2, total_ms=3

Post-change Runs:
- Run 1: pass1_ms=0, pass2_ms=0, pass3_ms=0, pass4_ms=6, total_ms=45
- Run 2: pass1_ms=1, pass2_ms=1, pass3_ms=0, pass4_ms=1, total_ms=3

## Risks & Anomalies

Risk 1: Diagnostics drift from gate decisions over time
- Mitigation: emit diagnostics from the same code path that decides pass/fail in #283/#284; do not duplicate logic.
- Verification: non-regression test asserts diagnostics decisions == gate decisions on failing fixtures.

Risk 2: PII or full snippets leaking into admin traceability
- Mitigation: store anchor references rather than long raw text; cap failure_reason length.
- Verification: traceability test asserts no field exceeds the configured length cap.

Risk 3: Admin filter index drift
- Mitigation: filters keyed only by signal_id, classification, gate_check_id (stable union types).
- Verification: filter integration test covers all classification union values.

## Quality Gate Disclosure

No new QG_ anomalies introduced. recommendation_editorial_quality is the only quality gate referenced. error_code QG_EDITORIAL_GENERIC_FEEDBACK is reused unchanged from #283/#284. No new gate decisions are made by this PR.

## Intelligence Preservation

This PR is not reducing intelligence. Adds observability only. No prompt changes, no token reductions, no new enforcement, no editorial-reasoning steps removed. Diagnostic emission mirrors existing gate output; the gate itself is unchanged.

## Commits

1. 5a5ae56e — feat(observability): add editorial quality diagnostics and admin traceability
2. 49e6b393 — refactor(observability): emit editorial diagnostics for blocked recommendations only
3. 510f878a — fix(observability): harden editorial diagnostics payload safety