### PR TITLE
feat(observability): persist pass3 reducer telemetry artifacts

### DIFF
--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -247,14 +247,16 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   });
   assertPass3PromptTripwires(userPrompt);
 
-  console.log("[Pass3][ReducerTelemetry]", {
+  const pass3ReducerTelemetry = {
     prompt_version: PASS3_PROMPT_VERSION,
     criteria_count_by_state: reducerTelemetry.criteria_count_by_state,
     comparison_packet_chars: comparisonPacketJson.length,
     system_prompt_chars: PASS3_SYSTEM_PROMPT.length,
     user_prompt_chars: userPrompt.length,
     max_output_tokens: getEvaluationRuntimeConfig().pass.pass3MaxTokens,
-  });
+  };
+
+  console.log("[Pass3][ReducerTelemetry]", pass3ReducerTelemetry);
   
   // Compute coverage metadata (for truth enforcement)
   const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
@@ -336,6 +338,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     finish_reason: typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : undefined,
     request_id: requestId,
     generated_at: new Date().toISOString(),
+    pass3_reducer_telemetry: pass3ReducerTelemetry,
   });
 
   const finishReason = typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -248,6 +248,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   assertPass3PromptTripwires(userPrompt);
 
   const pass3ReducerTelemetry = {
+    schema_version: "1" as const,
     prompt_version: PASS3_PROMPT_VERSION,
     criteria_count_by_state: reducerTelemetry.criteria_count_by_state,
     comparison_packet_chars: comparisonPacketJson.length,

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -305,10 +305,17 @@ export type CompletionUsage = {
   total_tokens?: number;
 };
 
+export type Pass3CriteriaCountByState = {
+  agree: number;
+  soft_divergence: number;
+  hard_divergence: number;
+  missing_or_invalid: number;
+};
+
 export type Pass3ReducerTelemetry = {
   schema_version: "1";
   prompt_version: string;
-  criteria_count_by_state: Record<string, number>;
+  criteria_count_by_state: Pass3CriteriaCountByState;
   comparison_packet_chars: number;
   system_prompt_chars: number;
   user_prompt_chars: number;

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -306,6 +306,7 @@ export type CompletionUsage = {
 };
 
 export type Pass3ReducerTelemetry = {
+  schema_version: "1";
   prompt_version: string;
   criteria_count_by_state: Record<string, number>;
   comparison_packet_chars: number;

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -305,6 +305,15 @@ export type CompletionUsage = {
   total_tokens?: number;
 };
 
+export type Pass3ReducerTelemetry = {
+  prompt_version: string;
+  criteria_count_by_state: Record<string, number>;
+  comparison_packet_chars: number;
+  system_prompt_chars: number;
+  user_prompt_chars: number;
+  max_output_tokens: number;
+};
+
 export type PassCompletionCapture = {
   pass: 1 | 2 | 3;
   raw_text: string;
@@ -313,6 +322,7 @@ export type PassCompletionCapture = {
   finish_reason?: string;
   request_id?: string;
   generated_at: string;
+  pass3_reducer_telemetry?: Pass3ReducerTelemetry;
 };
 
 // ── Pipeline result ──────────────────────────────────────────────────────────

--- a/scripts/pipeline/run-dominatus-i4-eval.ts
+++ b/scripts/pipeline/run-dominatus-i4-eval.ts
@@ -336,9 +336,17 @@ async function main(): Promise<void> {
       model: pass3Parsed?.metadata.pass3_model ?? null,
       usage: capturedPasses.pass3?.usage ?? null,
       generated_at: capturedPasses.pass3?.generated_at ?? null,
+      pass3_reducer_telemetry: capturedPasses.pass3?.pass3_reducer_telemetry ?? null,
       quality_gate: qualityGate ?? null,
     },
   });
+
+  if (capturedPasses.pass3?.pass3_reducer_telemetry) {
+    writeJson(
+      join(outDir, "pass3_telemetry.json"),
+      capturedPasses.pass3.pass3_reducer_telemetry,
+    );
+  }
 
   const governanceCheckpoints = buildGovernanceCheckpointArtifacts(pipelineResult);
   writeJson(join(outDir, "governance-checkpoints.json"), governanceCheckpoints);

--- a/scripts/pipeline/run-phase2-7-real-run.ts
+++ b/scripts/pipeline/run-phase2-7-real-run.ts
@@ -255,6 +255,13 @@ async function main(): Promise<void> {
   if (qualityGate) {
     writeFileSync(join(outputDir, "quality_gate.json"), JSON.stringify(qualityGate, null, 2), "utf8");
   }
+  if (capturedPasses.pass3?.pass3_reducer_telemetry) {
+    writeFileSync(
+      join(outputDir, "pass3_telemetry.json"),
+      JSON.stringify(capturedPasses.pass3.pass3_reducer_telemetry, null, 2),
+      "utf8",
+    );
+  }
   writeFileSync(join(outputDir, "pipeline_result.json"), JSON.stringify(pipelineResult, null, 2), "utf8");
   if (evaluationResult) {
     writeFileSync(
@@ -300,6 +307,9 @@ async function main(): Promise<void> {
     generated_at: new Date().toISOString(),
     output_dir: outputDir,
     quality_gate_pass: qualityGate?.pass ?? false,
+    pass3_telemetry_artifact: capturedPasses.pass3?.pass3_reducer_telemetry
+      ? join(outputDir, "pass3_telemetry.json")
+      : null,
   };
   writeFileSync(join(outputDir, "metadata.json"), JSON.stringify(metadata, null, 2), "utf8");
 

--- a/tests/evaluation/pipeline/pass3.test.ts
+++ b/tests/evaluation/pipeline/pass3.test.ts
@@ -262,12 +262,14 @@ describe("runPass3Synthesis", () => {
     expect(telemetry.schema_version).toBe("1");
     expect(telemetry.prompt_version).toBe(PASS3_PROMPT_VERSION);
     expect(telemetry.criteria_count_by_state).toBeDefined();
-    // Criteria-state invariant: all canonical criteria must be accounted for
+    // Criteria-state invariant: canonical keys must all be present and sum to 13
+    const counts = telemetry.criteria_count_by_state;
+    expect(typeof counts.agree).toBe("number");
+    expect(typeof counts.soft_divergence).toBe("number");
+    expect(typeof counts.hard_divergence).toBe("number");
+    expect(typeof counts.missing_or_invalid).toBe("number");
     expect(
-      Object.values(telemetry.criteria_count_by_state).reduce(
-        (sum, count) => sum + Number(count),
-        0,
-      ),
+      counts.agree + counts.soft_divergence + counts.hard_divergence + counts.missing_or_invalid,
     ).toBe(CRITERIA_KEYS.length);
     // Numeric sanity: no payload field may silently zero out
     expect(telemetry.comparison_packet_chars).toBeGreaterThan(0);

--- a/tests/evaluation/pipeline/pass3.test.ts
+++ b/tests/evaluation/pipeline/pass3.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from "@jest/globals";
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import { parsePass3Response, runPass3Synthesis } from "@/lib/evaluation/pipeline/runPass3Synthesis";
+import { PASS3_PROMPT_VERSION } from "@/lib/evaluation/pipeline/prompts/pass3-synthesis";
 import type { CreateCompletionFn } from "@/lib/evaluation/pipeline/runPass3Synthesis";
 import type { SinglePassOutput } from "@/lib/evaluation/pipeline/types";
 import { loadCanonicalRegistry } from "@/lib/governance/canonRegistry";
@@ -234,6 +235,36 @@ describe("runPass3Synthesis", () => {
     expect(result.criteria).toHaveLength(13);
     expect(result.overall.overall_score_0_100).toBe(70);
     expect(result.overall.verdict).toBe("revise");
+  });
+
+  it("emits pass3 reducer telemetry in completion capture", async () => {
+    const pass1 = makePassOutput(1, "craft_execution");
+    const pass2 = makePassOutput(2, "editorial_literary");
+    let capture: Parameters<NonNullable<Parameters<typeof runPass3Synthesis>[0]["_onCompletion"]>>[0] | undefined;
+
+    await runPass3Synthesis({
+      pass1,
+      pass2,
+      manuscriptText: "The river moved slowly through the valley.",
+      title: "Test Manuscript",
+      registry,
+      openaiApiKey: "sk-test",
+      _createCompletion: mockCompletion(JSON.stringify(makePass3Fixture())),
+      _onCompletion: (payload) => {
+        capture = payload;
+      },
+    });
+
+    expect(capture?.pass).toBe(3);
+    expect(capture?.pass3_reducer_telemetry).toBeDefined();
+    expect(capture?.pass3_reducer_telemetry?.prompt_version).toBe(PASS3_PROMPT_VERSION);
+    expect(capture?.pass3_reducer_telemetry?.criteria_count_by_state).toBeDefined();
+    expect(
+      Object.values(capture?.pass3_reducer_telemetry?.criteria_count_by_state ?? {}).reduce(
+        (sum, count) => sum + Number(count),
+        0,
+      ),
+    ).toBe(CRITERIA_KEYS.length);
   });
 
   it("throws when OPENAI_API_KEY is not configured", async () => {

--- a/tests/evaluation/pipeline/pass3.test.ts
+++ b/tests/evaluation/pipeline/pass3.test.ts
@@ -257,14 +257,23 @@ describe("runPass3Synthesis", () => {
 
     expect(capture?.pass).toBe(3);
     expect(capture?.pass3_reducer_telemetry).toBeDefined();
-    expect(capture?.pass3_reducer_telemetry?.prompt_version).toBe(PASS3_PROMPT_VERSION);
-    expect(capture?.pass3_reducer_telemetry?.criteria_count_by_state).toBeDefined();
+    const telemetry = capture?.pass3_reducer_telemetry!;
+    // Contract shape
+    expect(telemetry.schema_version).toBe("1");
+    expect(telemetry.prompt_version).toBe(PASS3_PROMPT_VERSION);
+    expect(telemetry.criteria_count_by_state).toBeDefined();
+    // Criteria-state invariant: all canonical criteria must be accounted for
     expect(
-      Object.values(capture?.pass3_reducer_telemetry?.criteria_count_by_state ?? {}).reduce(
+      Object.values(telemetry.criteria_count_by_state).reduce(
         (sum, count) => sum + Number(count),
         0,
       ),
     ).toBe(CRITERIA_KEYS.length);
+    // Numeric sanity: no payload field may silently zero out
+    expect(telemetry.comparison_packet_chars).toBeGreaterThan(0);
+    expect(telemetry.system_prompt_chars).toBeGreaterThan(0);
+    expect(telemetry.user_prompt_chars).toBeGreaterThan(0);
+    expect(telemetry.max_output_tokens).toBeGreaterThan(0);
   });
 
   it("throws when OPENAI_API_KEY is not configured", async () => {


### PR DESCRIPTION
## Pass selection
- [x] Pass 3 (telemetry persistence — additive observability only)

## Summary
Adds optional persistence of Pass 3 reducer telemetry to disk via the existing
`PassCompletionCapture` surface. No prompt, gate, verdict, or scoring behavior
changes. Backward compatible: telemetry field is optional; consumers that
ignore it see no change.

This closes the observability loop by routing the existing reducer telemetry
payload from log-only output into completion capture and run artifacts.

## Scope
Files changed:
- `lib/evaluation/pipeline/types.ts`
- `lib/evaluation/pipeline/runPass3Synthesis.ts`
- `scripts/pipeline/run-phase2-7-real-run.ts`
- `scripts/pipeline/run-dominatus-i4-eval.ts`
- `tests/evaluation/pipeline/pass3.test.ts`

In scope:
- Route existing reducer telemetry payload into completion capture.
- Persist sibling artifact `pass3_telemetry.json` in run outputs.
- Add regression assertions covering schema_version, prompt_version literal, criteria state invariant, and numeric sanity.

Out of scope:
- Prompt edits
- `qualityGate.ts` logic
- QG code changes
- Verdict/scoring aggregation changes
- `.gitignore` policy changes

Future cleanup (noted, not in scope): abstract the artifact write helper once a third runner is added.

## Telemetry Artifact Contract (`pass3_telemetry.json`)
Persisted object fields (all required when file is emitted):
- `schema_version: "1"` (added to enable non-breaking future evolution)
- `prompt_version: string`
- `criteria_count_by_state` with canonical keys: `agree`, `soft_divergence`, `hard_divergence`, `missing_or_invalid`
- `comparison_packet_chars: number`
- `system_prompt_chars: number`
- `user_prompt_chars: number`
- `max_output_tokens: number`

Notes:
- `pass3_telemetry.json` is emitted only when Pass 3 capture includes telemetry.
- `pass3_telemetry.json` is intentionally run-local (not in `.gitignore` evidence allow-list). Preserves lightweight committed evidence footprint.
- `metadata.json` now includes optional `pass3_telemetry_artifact: string | null`.

## Contract Integrity
- `Pass3ReducerTelemetry` is a **new** type; no existing field renamed/removed.
- `PassCompletionCapture.pass3_reducer_telemetry` is **optional**.
- `metadata.json` gains additive optional `pass3_telemetry_artifact`.
- No QG additions/removals/renames.
- No quality-gate control-flow changes.

## Behavioral Quality
Targeted suite:
- `tests/evaluation/pipeline/pass3.test.ts` → **25/25 passed**
- Includes capture-contract test asserting: `schema_version == "1"`, `prompt_version` literal match, `criteria_count_by_state` sum == 13, and all numeric fields `> 0`.

Decision-parity impact: none.

## Latency Evidence
### Baseline (Pre-change)
| Run | pass1_ms | total_ms |
|---|---:|---:|
| post-#287 main | 7788 | 59519 |

### Post-change Runs
| Run | pass1_ms | total_ms |
|---|---:|---:|
| Run 1 (feat/pass3-telemetry-persistence, unit-only validation) | N/A | N/A |
| Run 2 (unit suite — no runtime path changes) | N/A | N/A |

This PR is not reducing intelligence. Telemetry is observability output only.
Expected latency delta: one small JSON write (<2 KB) after pipeline completion — negligible.

## Risks & Anomalies
1. `metadata.json` has a new optional key; strict schema validators must tolerate unknown/additive fields. Mitigation: field is optional; no existing key renamed or removed.
2. `pass3_telemetry.json` remains run-local by policy (not in evidence allow-list). Mitigation: intentional and documented in PR body.
3. Anomaly observed in test output: `DIVERGENCE_COLLAPSE_WARNING` (agree:13, soft_divergence:0) on every pass3 test path. Pre-existing fixture artifact — zero divergences in test fixtures is expected. Not introduced by this PR. Follow-up issue filed separately for production divergence-collapse investigation using now-persisted telemetry.

## Quality Gate Disclosure
Quality gate logic unchanged (`lib/evaluation/pipeline/qualityGate.ts` untouched). No new `QG_` constants, no classification value changes.

## Intelligence Preservation
Routing-only change. The same payload previously logged at
`[Pass3][ReducerTelemetry]` is now also attached to completion capture and
optionally persisted to disk. No model, prompt, scoring, aggregation, or gate
behavior altered.

Enables follow-up: Pass 3 divergence-collapse investigation using newly-persisted telemetry (agree:13 / 0 divergences in baseline canary runs).

Refs: #283 #284 #285 #286 #287
