### PR TITLE
feat(evaluation): route long-form jobs through canonical chunking substrate

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -5,7 +5,6 @@ const synthesisToEvaluationResultV2Mock = jest.fn();
 const runQualityGateV2Mock = jest.fn();
 const mapEvaluationResultV2ToGovernanceEnvelopeMock = jest.fn();
 const ensureChunksMock = jest.fn();
-const getManuscriptChunksMock = jest.fn();
 
 jest.mock("@/lib/evaluation/pipeline/runPipeline", () => ({
   runPipeline: (...args: any[]) => runPipelineMock(...args),
@@ -23,7 +22,6 @@ jest.mock("@/lib/governance/evaluationBridge", () => ({
 
 jest.mock("@/lib/manuscripts/chunks", () => ({
   ensureChunks: (...args: any[]) => ensureChunksMock(...args),
-  getManuscriptChunks: (...args: any[]) => getManuscriptChunksMock(...args),
 }));
 
 const createClientMock = jest.fn();
@@ -221,7 +219,6 @@ describe("processEvaluationJob long-form chunk routing", () => {
     createClientMock.mockReturnValue(supabaseStub);
 
     ensureChunksMock.mockResolvedValue(4);
-    getManuscriptChunksMock.mockResolvedValueOnce([]);
 
     runPipelineMock.mockResolvedValue({
       ok: true,
@@ -265,8 +262,11 @@ describe("processEvaluationJob long-form chunk routing", () => {
 
     expect(result.success).toBe(true);
     expect(ensureChunksMock).toHaveBeenCalledWith(456, "job-long-form-routing");
-    expect(getManuscriptChunksMock).toHaveBeenCalledTimes(1);
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
+
+    const ensureChunksCallOrder = ensureChunksMock.mock.invocationCallOrder[0];
+    const runPipelineCallOrder = runPipelineMock.mock.invocationCallOrder[0];
+    expect(ensureChunksCallOrder).toBeLessThan(runPipelineCallOrder);
 
     const persistCall = supabaseStub.rpcCalls.find(
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
@@ -279,7 +279,6 @@ describe("processEvaluationJob long-form chunk routing", () => {
           route: "long_form",
           threshold_words: 25000,
           manuscript_words: 26000,
-          existing_chunk_count: 0,
           chunk_count: 4,
         }),
       }),
@@ -333,7 +332,6 @@ describe("processEvaluationJob long-form chunk routing", () => {
 
     expect(result.success).toBe(true);
     expect(ensureChunksMock).not.toHaveBeenCalled();
-    expect(getManuscriptChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
 
     const persistCall = supabaseStub.rpcCalls.find(
@@ -347,10 +345,24 @@ describe("processEvaluationJob long-form chunk routing", () => {
           route: "short_form",
           threshold_words: 25000,
           manuscript_words: 3000,
-          existing_chunk_count: 0,
           chunk_count: 0,
         }),
       }),
     );
+  });
+
+  test("does not run pipeline when ensureChunks throws for long-form manuscripts", async () => {
+    const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
+    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksMock.mockRejectedValueOnce(new Error("chunking failed"));
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(false);
+    expect(ensureChunksMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -1,0 +1,356 @@
+export {};
+
+const runPipelineMock = jest.fn();
+const synthesisToEvaluationResultV2Mock = jest.fn();
+const runQualityGateV2Mock = jest.fn();
+const mapEvaluationResultV2ToGovernanceEnvelopeMock = jest.fn();
+const ensureChunksMock = jest.fn();
+const getManuscriptChunksMock = jest.fn();
+
+jest.mock("@/lib/evaluation/pipeline/runPipeline", () => ({
+  runPipeline: (...args: any[]) => runPipelineMock(...args),
+  synthesisToEvaluationResultV2: (...args: any[]) => synthesisToEvaluationResultV2Mock(...args),
+}));
+
+jest.mock("@/lib/evaluation/pipeline/qualityGate", () => ({
+  runQualityGateV2: (...args: any[]) => runQualityGateV2Mock(...args),
+}));
+
+jest.mock("@/lib/governance/evaluationBridge", () => ({
+  mapEvaluationResultV2ToGovernanceEnvelope: (...args: any[]) =>
+    mapEvaluationResultV2ToGovernanceEnvelopeMock(...args),
+}));
+
+jest.mock("@/lib/manuscripts/chunks", () => ({
+  ensureChunks: (...args: any[]) => ensureChunksMock(...args),
+  getManuscriptChunks: (...args: any[]) => getManuscriptChunksMock(...args),
+}));
+
+const createClientMock = jest.fn();
+
+jest.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: any[]) => createClientMock(...args),
+}));
+
+function buildEvaluationResult() {
+  return {
+    schema_version: "evaluation_result_v2",
+    ids: {
+      evaluation_run_id: "run-long-form-1",
+      manuscript_id: 456,
+      user_id: "00000000-0000-0000-0000-000000000001",
+    },
+    generated_at: new Date().toISOString(),
+    engine: {
+      model: "o3",
+      provider: "openai",
+      prompt_version: "test",
+    },
+    overview: {
+      verdict: "pass",
+      overall_score_0_100: 82,
+      scored_criteria_count: 13,
+      one_paragraph_summary: "Summary",
+      top_3_strengths: [],
+      top_3_risks: [],
+    },
+    criteria: new Array(13).fill(null).map((_, idx) => ({
+      key: [
+        "concept",
+        "narrativeDrive",
+        "character",
+        "voice",
+        "sceneConstruction",
+        "dialogue",
+        "theme",
+        "worldbuilding",
+        "pacing",
+        "proseControl",
+        "tone",
+        "narrativeClosure",
+        "marketability",
+      ][idx],
+      scorable: true,
+      status: "SCORABLE",
+      signal_present: true,
+      signal_strength: "SUFFICIENT",
+      confidence_band: "MEDIUM",
+      score_0_10: 7,
+      rationale: "Criterion rationale backed by manuscript evidence.",
+      evidence: [{ snippet: "Evidence snippet with sufficient detail for quality gate checks." }],
+      recommendations: [],
+    })),
+    recommendations: {
+      quick_wins: [],
+      strategic_revisions: [],
+    },
+    metrics: {
+      manuscript: {},
+      processing: {},
+    },
+    artifacts: [],
+    governance: {
+      confidence: 0.9,
+      warnings: [],
+      limitations: [],
+      policy_family: "multi-pass-dual-axis",
+    },
+  };
+}
+
+function makeSupabaseStub(manuscriptContent: string) {
+  const evaluationJobUpdates: Array<Record<string, unknown>> = [];
+  const rpcCalls: Array<{ fn: string; args?: Record<string, unknown> }> = [];
+
+  const now = new Date();
+  const leaseUntil = new Date(now.getTime() + 5 * 60_000).toISOString();
+
+  const queuedJob = {
+    id: "job-long-form-routing",
+    manuscript_id: 456,
+    job_type: "evaluate_full",
+    status: "running",
+    phase: "phase_1",
+    phase_status: "running",
+    claimed_by: "test-worker",
+    worker_id: "test-worker",
+    lease_token: "test-lease-token",
+    lease_until: leaseUntil,
+    lease_expires_at: leaseUntil,
+    heartbeat_at: now.toISOString(),
+    started_at: now.toISOString(),
+    created_at: now.toISOString(),
+    progress: { phase: "phase_1", phase_status: "running" },
+  };
+
+  const manuscript = {
+    id: 456,
+    title: "Long Form Manuscript",
+    content: manuscriptContent,
+    work_type: "novel",
+    user_id: "00000000-0000-0000-0000-000000000001",
+  };
+
+  return {
+    evaluationJobUpdates,
+    rpcCalls,
+    rpc: async (fn: string, args?: Record<string, unknown>) => {
+      rpcCalls.push({ fn, args });
+
+      if (fn === "persist_evaluation_v2_atomic") {
+        return {
+          data: [{ artifact_id: "artifact-long-form-routing" }],
+          error: null,
+        };
+      }
+
+      if (fn === "finalize_job_failure_atomic") {
+        return {
+          data: [{ attempt_count: 1, max_attempts: 3, notified_at: null }],
+          error: null,
+        };
+      }
+
+      return { data: null, error: null };
+    },
+    from(table: string) {
+      if (table === "evaluation_jobs") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: queuedJob, error: null }),
+              maybeSingle: async () => ({ data: { status: queuedJob.status }, error: null }),
+            }),
+          }),
+          update: (payload: Record<string, unknown>) => {
+            evaluationJobUpdates.push(payload);
+            const query = {
+              eq: () => query,
+              then: (resolve: (value: { error: null }) => void) => resolve({ error: null }),
+            };
+            return {
+              eq: () => query,
+            };
+          },
+        };
+      }
+
+      if (table === "manuscripts") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: manuscript, error: null }),
+            }),
+          }),
+        };
+      }
+
+      if (table === "evaluation_artifacts") {
+        return {
+          select: () => {
+            const query = {
+              eq: () => query,
+              maybeSingle: async () => ({ data: { id: "artifact-long-form-routing" }, error: null }),
+            };
+            return query;
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table in chunk routing test stub: ${table}`);
+    },
+  };
+}
+
+describe("processEvaluationJob long-form chunk routing", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    process.env.OPENAI_API_KEY = "sk-test-key";
+    process.env.EVAL_PASS_TIMEOUT_MS = "180000";
+    process.env.EVAL_OPENAI_TIMEOUT_MS = "180000";
+    process.env.EVAL_EXTERNAL_ADJUDICATION_MODE = "optional";
+  });
+
+  test("ensures chunks before pipeline for long-form manuscripts and persists chunk routing telemetry", async () => {
+    const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
+    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksMock.mockResolvedValue(4);
+    getManuscriptChunksMock.mockResolvedValueOnce([]);
+
+    runPipelineMock.mockResolvedValue({
+      ok: true,
+      synthesis: {
+        criteria: [],
+        overall: {
+          overall_score_0_100: 82,
+          verdict: "pass",
+          one_paragraph_summary: "Summary",
+          top_3_strengths: [],
+          top_3_risks: [],
+        },
+        metadata: {
+          pass1_model: "gpt-4o",
+          pass2_model: "o3",
+          pass3_model: "o3",
+          generated_at: new Date().toISOString(),
+        },
+      },
+      quality_gate: {
+        pass: true,
+        checks: [],
+        warnings: [],
+      },
+      pass4_governance: { ok: true },
+    });
+
+    synthesisToEvaluationResultV2Mock.mockReturnValue(buildEvaluationResult());
+    runQualityGateV2Mock.mockReturnValue({
+      pass: true,
+      checks: [],
+      warnings: [],
+    });
+    mapEvaluationResultV2ToGovernanceEnvelopeMock.mockReturnValue({
+      evaluation_run_id: "run-long-form-1",
+      criteria: [],
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(true);
+    expect(ensureChunksMock).toHaveBeenCalledWith(456, "job-long-form-routing");
+    expect(getManuscriptChunksMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).toHaveBeenCalledTimes(1);
+
+    const persistCall = supabaseStub.rpcCalls.find(
+      (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
+    );
+    expect(persistCall).toBeDefined();
+    expect(persistCall?.args?.p_progress).toEqual(
+      expect.objectContaining({
+        chunk_routing: expect.objectContaining({
+          enabled: true,
+          route: "long_form",
+          threshold_words: 25000,
+          manuscript_words: 26000,
+          existing_chunk_count: 0,
+          chunk_count: 4,
+        }),
+      }),
+    );
+  });
+
+  test("does not call ensureChunks for short-form manuscripts and persists short_form telemetry", async () => {
+    const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(300);
+    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    createClientMock.mockReturnValue(supabaseStub);
+
+    runPipelineMock.mockResolvedValue({
+      ok: true,
+      synthesis: {
+        criteria: [],
+        overall: {
+          overall_score_0_100: 82,
+          verdict: "pass",
+          one_paragraph_summary: "Summary",
+          top_3_strengths: [],
+          top_3_risks: [],
+        },
+        metadata: {
+          pass1_model: "gpt-4o",
+          pass2_model: "o3",
+          pass3_model: "o3",
+          generated_at: new Date().toISOString(),
+        },
+      },
+      quality_gate: {
+        pass: true,
+        checks: [],
+        warnings: [],
+      },
+      pass4_governance: { ok: true },
+    });
+
+    synthesisToEvaluationResultV2Mock.mockReturnValue(buildEvaluationResult());
+    runQualityGateV2Mock.mockReturnValue({
+      pass: true,
+      checks: [],
+      warnings: [],
+    });
+    mapEvaluationResultV2ToGovernanceEnvelopeMock.mockReturnValue({
+      evaluation_run_id: "run-long-form-1",
+      criteria: [],
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(true);
+    expect(ensureChunksMock).not.toHaveBeenCalled();
+    expect(getManuscriptChunksMock).not.toHaveBeenCalled();
+    expect(runPipelineMock).toHaveBeenCalledTimes(1);
+
+    const persistCall = supabaseStub.rpcCalls.find(
+      (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
+    );
+    expect(persistCall).toBeDefined();
+    expect(persistCall?.args?.p_progress).toEqual(
+      expect.objectContaining({
+        chunk_routing: expect.objectContaining({
+          enabled: true,
+          route: "short_form",
+          threshold_words: 25000,
+          manuscript_words: 3000,
+          existing_chunk_count: 0,
+          chunk_count: 0,
+        }),
+      }),
+    );
+  });
+});

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -69,7 +69,7 @@ import {
   runPipeline,
   synthesisToEvaluationResultV2,
 } from '@/lib/evaluation/pipeline/runPipeline';
-import { classifySubmissionScope } from '@/lib/evaluation/pipeline/submissionScope';
+import { classifySubmissionScope, countWords } from '@/lib/evaluation/pipeline/submissionScope';
 import { runQualityGateV2 } from '@/lib/evaluation/pipeline/qualityGate';
 import {
   buildScoreLedger,
@@ -101,6 +101,7 @@ import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
+import { ensureChunks, getManuscriptChunks } from '@/lib/manuscripts/chunks';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -125,6 +126,16 @@ function getProcessorRuntimeDeps() {
 }
 
 const EVALUATION_PROGRESS_TOTAL_UNITS = 3;
+const LONG_FORM_CHUNKING_THRESHOLD_WORDS = 25_000;
+
+type ChunkRoutingTelemetry = {
+  enabled: boolean;
+  route: 'long_form' | 'short_form';
+  threshold_words: number;
+  manuscript_words: number;
+  existing_chunk_count: number;
+  chunk_count: number;
+}
 
 export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
   const parsed =
@@ -839,6 +850,37 @@ async function resolveManuscriptText(
   }
 
   return '';
+}
+
+async function maybeEnsureLongFormChunks(args: {
+  manuscriptId: number;
+  jobId: string;
+  manuscriptText: string;
+}): Promise<ChunkRoutingTelemetry> {
+  const manuscriptWords = countWords(args.manuscriptText);
+
+  if (manuscriptWords < LONG_FORM_CHUNKING_THRESHOLD_WORDS) {
+    return {
+      enabled: true,
+      route: 'short_form',
+      threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
+      manuscript_words: manuscriptWords,
+      existing_chunk_count: 0,
+      chunk_count: 0,
+    };
+  }
+
+  const existingChunks = await getManuscriptChunks(args.manuscriptId);
+  const chunkCount = await ensureChunks(args.manuscriptId, args.jobId);
+
+  return {
+    enabled: true,
+    route: 'long_form',
+    threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
+    manuscript_words: manuscriptWords,
+    existing_chunk_count: existingChunks.length,
+    chunk_count: chunkCount,
+  };
 }
 
 export function isManuscriptTextLongEnough(
@@ -1646,6 +1688,19 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       ...(manuscript as Manuscript),
       content: resolvedManuscriptText,
     };
+
+    const chunkRouting = await maybeEnsureLongFormChunks({
+      manuscriptId: manuscriptWithContent.id,
+      jobId: String(job.id),
+      manuscriptText: manuscriptWithContent.content || '',
+    });
+    progressState.chunk_routing = chunkRouting;
+
+    console.log('[Processor] chunk routing decision', {
+      job_id: jobId,
+      manuscript_id: manuscriptWithContent.id,
+      ...chunkRouting,
+    });
 
     // 4. Canonical evaluation via governed multi-pass pipeline (fail-closed)
     await markRunning('Running canonical evaluation pipeline', 1, executionPhase);

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -101,7 +101,7 @@ import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
-import { ensureChunks, getManuscriptChunks } from '@/lib/manuscripts/chunks';
+import { ensureChunks } from '@/lib/manuscripts/chunks';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -133,7 +133,6 @@ type ChunkRoutingTelemetry = {
   route: 'long_form' | 'short_form';
   threshold_words: number;
   manuscript_words: number;
-  existing_chunk_count: number;
   chunk_count: number;
 }
 
@@ -865,12 +864,13 @@ async function maybeEnsureLongFormChunks(args: {
       route: 'short_form',
       threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
       manuscript_words: manuscriptWords,
-      existing_chunk_count: 0,
       chunk_count: 0,
     };
   }
 
-  const existingChunks = await getManuscriptChunks(args.manuscriptId);
+  // TODO(#292): ensureChunks currently resolves manuscript text via getManuscriptText(),
+  // while evaluation uses resolveManuscriptText() in this worker path. Unify sources
+  // before chunk content is consumed by buildComparisonPacket().
   const chunkCount = await ensureChunks(args.manuscriptId, args.jobId);
 
   return {
@@ -878,7 +878,6 @@ async function maybeEnsureLongFormChunks(args: {
     route: 'long_form',
     threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
     manuscript_words: manuscriptWords,
-    existing_chunk_count: existingChunks.length,
     chunk_count: chunkCount,
   };
 }


### PR DESCRIPTION
## Pass selection
- [x] Pass 1
- [x] Worker routing / long-form chunk substrate (additive, observable, no behavior drift)

## Summary
Routes long-form evaluation jobs through the existing canonical manuscript chunking substrate (`ensureChunks`) before `runPipeline()`.

This PR does **not** rewrite chunking. Chunking canon and code already exist in `lib/manuscripts/chunking.ts`, `lib/manuscripts/chunks.ts`, and `lib/jobs/phase1.ts`. This fixes the **worker seam** where long-form evaluations bypassed `ensureChunks()` and produced `manuscript_chunks = 0`.

Closes the routing seam identified in #290. Provides the substrate to evaluate residual #289 (divergence collapse) symptoms after chunks are guaranteed for long-form jobs.

## Problem
Manuscript 5991 (83,611 words), job `4cf9f478-910d-46e6-9d49-e3169d3fcd10`, failed evaluation while production SQL showed `manuscript_chunks = 0`.

Root cause: `processEvaluationJob()` had access to `job.manuscript_id`, but the active worker path called `runPipeline()` directly on a single reconstructed manuscript string without invoking `ensureChunks()`.

This is not a chunking bug. Chunking is built, hardened, and proven. It is a **routing bug**: the worker path did not call chunking before evaluation.

## Scope
Files changed:
- `lib/evaluation/processor.ts`
- `__tests__/lib/evaluation/processor.chunk-routing.test.ts` (NEW)

In scope:
- Detect long-form manuscripts using the existing 25,000-word threshold (sourced from `lib/manuscripts/submissionScope.ts` precedent).
- Call `ensureChunks(manuscriptId, jobId)` before `runPipeline()` for long-form jobs.
- Idempotent: `ensureChunks()` short-circuits when chunks already exist.
- Persist `progress.chunk_routing` telemetry.

Out of scope:
- No chunking algorithm changes.
- No Pass 1 / Pass 2 / Pass 3 logic changes.
- No prompt changes.
- No `qualityGate.ts` changes.
- No scoring, verdict, or V2 alignment-guard changes.
- No `buildComparisonPacket()` changes.
- No `runPipeline()` signature changes.
- No new Supabase client; reuses existing worker DB handle via `ensureChunks`.

## Contract Integrity
- `ensureChunks(manuscriptId, jobId)` is the existing canonical entrypoint. No new entrypoint added.
- `progress.chunk_routing` is an additive optional field. Strict validators must tolerate optional/additive fields (same pattern as #288's `pass3_reducer_telemetry`).
- No `QG_` additions/removals/renames.
- No quality-gate control-flow changes.

## Telemetry Shape
Persisted to `progress.chunk_routing`:

```json
{
  "enabled": true,
  "route": "long_form",
  "threshold_words": 25000,
  "manuscript_words": 83611,
  "chunk_count": 12
}
```

Or for short-form jobs:

```json
{
  "enabled": true,
  "route": "short_form",
  "threshold_words": 25000,
  "manuscript_words": 4200,
  "chunk_count": 0
}
```

Five fields. Sufficient to prove "did routing happen?" without expanding schema surface.

## Behavioral Quality
**Short-form jobs (<25,000 words):** zero behavior change. `chunk_routing.route === "short_form"`. `ensureChunks` not invoked.

**Long-form jobs (≥25,000 words):** `manuscript_chunks` is populated via `ensureChunks()`. Pass 1/2/3 still consume the same single-string input as today. Net user-visible behavior change: zero. Observable change: chunks exist + telemetry confirms.

⚠️ **This PR does NOT make Pass 3 evaluate the full novel.** Chunks are populated but not yet consumed by `buildComparisonPacket()`. Expect after merge:
- `manuscript_chunks` for long-form jobs: 0 → >0 ✅
- `comparison_packet_chars`: minimal change (chunks unread)
- `criteria_count_by_state`: minimal change (representation unchanged)
- Quality gate verdicts: minimal change

The representation fix is deferred to PR #292. PR #291's job is to make the data exist; PR #292's job is to use it.

Decision-parity impact: none.

## Latency Evidence
### Baseline (Pre-change)
| Run | pass1_ms | total_ms |
|---|---:|---:|
| post-#288 main, manuscript 5991 (83,611 words) | TBD | TBD |

### Post-change Runs
| Run | pass1_ms | total_ms |
|---|---:|---:|
| Run 1 (manuscript 5991, long-form route, first run) | TBD | TBD |
| Run 2 (manuscript 5991, long-form route, idempotent re-run) | TBD | TBD |

Expected: long-form first run gains a one-time `ensureChunks()` cost. Idempotent re-runs hit the existing-chunks short-circuit and add only the cost of the existence check.

## Risks & Anomalies
1. Risk: `ensureChunks()` side effects may have unanticipated cost on long-form inputs.
   - Mitigation: idempotent; threshold-gated at 25k words; pure side effect (no downstream reads in this PR).
2. Risk: production traffic now writes to `manuscript_chunks` for long-form jobs that previously skipped it.
   - Mitigation: this is the intended, audited behavior. Telemetry confirms each routing decision.
3. Risk: a future refactor of `processEvaluationJob()` silently removes the `ensureChunks()` call.
   - Mitigation: `processor.chunk-routing.test.ts` regression test asserts `ensureChunks(manuscriptId, jobId)` is called for long-form input. Removing the call breaks the test loudly.

4. Anomaly observed in test output: pre-existing `supabase.rpc is not a function` noise in `processor.phase-routing.test.ts` and `processor.short-text.test.ts`.
   - Mitigation: out of scope for PR291 (routing-only); focused suites still pass and assert expected behavior.


### Deferred to #292
- Text-source unification is tracked in **#292**: `resolveManuscriptText()` (evaluation path) vs `getManuscriptText()` inside `ensureChunks()` (chunking path).
- Before chunk content is consumed by `buildComparisonPacket()`, both paths must resolve to the same canonical manuscript text + normalization contract.

## Mistake-Proofing
The new regression test asserts:
1. `ensureChunks(manuscriptId, jobId)` is called for a manuscript ≥25,000 words.
2. `ensureChunks` is **not** called for a manuscript <25,000 words.
3. **`ensureChunks` is called BEFORE `runPipeline`** (verified via Jest `mock.invocationCallOrder`). This is the central invariant of this PR — chunks must exist before the pipeline reads the manuscript. A refactor that reverses, parallelizes, or defers the order will fail this test loudly.
4. **If `ensureChunks` throws, `runPipeline` is NOT called.** Prevents silent fallback to un-chunked evaluation on chunker failure.
5. `progress.chunk_routing` telemetry is persisted with the correct `route` value.
6. Idempotency: a second invocation does not duplicate work.

Future worker-path changes that bypass long-form routing — by skipping the call, reordering it, swallowing chunker errors, or running them concurrently — will fail this test.

Text-source consistency follow-up: `ensureChunks()` currently resolves manuscript text via `getManuscriptText()` while this worker evaluates `resolveManuscriptText()` output. This is now explicitly tracked as `TODO(#292)` and will be unified before chunk content is consumed by `buildComparisonPacket()`.

Credit: assertions #3 and #4 added in response to GitHub Copilot review feedback (ordering invariant gap).

## Quality Gate Disclosure
Quality gate logic unchanged. `lib/evaluation/pipeline/qualityGate.ts` untouched. No `v2_fidelity_score_confidence_alignment` changes. No score caps. No `proseControl` logic touched. No new `QG_` constants.

## Intelligence Preservation
Routing-only change. No model, prompt, scoring, aggregation, or gate-decision behavior altered. Chunks are populated as a side effect; downstream consumption is deferred to PR #292.

This routing fix is **not reducing intelligence**; it preserves existing evaluation behavior while preventing long-form chunking bypass.

Enables follow-up: PR #292 will wire `buildComparisonPacket()` to consume chunks for divergence-preserving long-form evaluation.

## Production-Proof Validation Plan (post-merge)
1. Squash-merge and deploy.
2. Re-run manuscript 5991 (83,611 words) through evaluation.
3. DB check: `SELECT count(*) FROM manuscript_chunks WHERE manuscript_id = 5991;` → > 0.
4. Job-progress check: `progress.chunk_routing.enabled === true`, `progress.chunk_routing.route === "long_form"`, `progress.chunk_routing.chunk_count > 0`.
5. Confirm `pass3_telemetry.json` (#288 substrate) still emits with same shape.
6. Compare pre/post `comparison_packet_chars` and `criteria_count_by_state` — expected ~unchanged. If they change without `buildComparisonPacket` reading chunks, that's a real finding worth investigating before opening #292.

Refs: #283 #284 #285 #286 #287 #288 #289 #290



