### PR TITLE
feat(evaluation): unify long-form text source and build chunk-aware comparison packets

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -304,6 +304,9 @@ describe("processEvaluationJob long-form chunk routing", () => {
         ],
       }),
     );
+    expect(runPipelineArgs.manuscriptText).toContain("Chunk 0 text");
+    expect(runPipelineArgs.manuscriptText).toContain("Chunk 1 text");
+    expect(runPipelineArgs.manuscriptText).not.toBe(manuscriptContent);
 
     const persistCall = supabaseStub.rpcCalls.find(
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",

--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -96,9 +96,15 @@ function buildEvaluationResult() {
   };
 }
 
-function makeSupabaseStub(manuscriptContent: string) {
+function makeSupabaseStub(
+  manuscriptContent: string,
+  options?: {
+    manuscriptChunks?: Array<{ chunk_index: number; content: string }>;
+  },
+) {
   const evaluationJobUpdates: Array<Record<string, unknown>> = [];
   const rpcCalls: Array<{ fn: string; args?: Record<string, unknown> }> = [];
+  const manuscriptChunks = options?.manuscriptChunks ?? [];
 
   const now = new Date();
   const leaseUntil = new Date(now.getTime() + 5 * 60_000).toISOString();
@@ -195,6 +201,18 @@ function makeSupabaseStub(manuscriptContent: string) {
         };
       }
 
+      if (table === "manuscript_chunks") {
+        const query = {
+          order: async () => ({ data: manuscriptChunks, error: null }),
+        };
+
+        return {
+          select: () => ({
+            eq: () => query,
+          }),
+        };
+      }
+
       throw new Error(`Unexpected table in chunk routing test stub: ${table}`);
     },
   };
@@ -215,7 +233,14 @@ describe("processEvaluationJob long-form chunk routing", () => {
 
   test("ensures chunks before pipeline for long-form manuscripts and persists chunk routing telemetry", async () => {
     const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
-    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    const supabaseStub = makeSupabaseStub(manuscriptContent, {
+      manuscriptChunks: [
+        { chunk_index: 0, content: "Chunk 0 text" },
+        { chunk_index: 1, content: "Chunk 1 text" },
+        { chunk_index: 2, content: "Chunk 2 text" },
+        { chunk_index: 3, content: "Chunk 3 text" },
+      ],
+    });
     createClientMock.mockReturnValue(supabaseStub);
 
     ensureChunksMock.mockResolvedValue(4);
@@ -267,6 +292,18 @@ describe("processEvaluationJob long-form chunk routing", () => {
     const ensureChunksCallOrder = ensureChunksMock.mock.invocationCallOrder[0];
     const runPipelineCallOrder = runPipelineMock.mock.invocationCallOrder[0];
     expect(ensureChunksCallOrder).toBeLessThan(runPipelineCallOrder);
+
+    const runPipelineArgs = runPipelineMock.mock.calls[0]?.[0];
+    expect(runPipelineArgs).toEqual(
+      expect.objectContaining({
+        manuscriptChunks: [
+          { chunk_index: 0, content: "Chunk 0 text" },
+          { chunk_index: 1, content: "Chunk 1 text" },
+          { chunk_index: 2, content: "Chunk 2 text" },
+          { chunk_index: 3, content: "Chunk 3 text" },
+        ],
+      }),
+    );
 
     const persistCall = supabaseStub.rpcCalls.find(
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",

--- a/lib/evaluation/pipeline/comparisonPacket.ts
+++ b/lib/evaluation/pipeline/comparisonPacket.ts
@@ -136,24 +136,23 @@ export function buildComparisonPacket(
   const pass1ByKey = toCriterionMap(pass1);
   const pass2ByKey = toCriterionMap(pass2);
 
-  const normalizedChunkText = Array.isArray(options.chunks)
-    ? options.chunks
-        .filter(
-          (chunk): chunk is ManuscriptChunkEvidence =>
-            typeof chunk?.chunk_index === "number" && typeof chunk?.content === "string",
-        )
-        .sort((a, b) => a.chunk_index - b.chunk_index)
-        .map((chunk) => chunk.content.trim())
-        .filter((content) => content.length > 0)
-        .join("\n")
-    : "";
+  const getChunkText = (): string => {
+    if (!Array.isArray(options.chunks) || options.chunks.length === 0) return "";
+    return options.chunks
+      .filter(
+        (chunk): chunk is ManuscriptChunkEvidence =>
+          typeof chunk?.chunk_index === "number" && typeof chunk?.content === "string",
+      )
+      .sort((a, b) => a.chunk_index - b.chunk_index)
+      .map((chunk) => chunk.content.trim())
+      .filter((content) => content.length > 0)
+      .join("\n");
+  };
 
   const manuscriptTextForExcerptWindow =
     typeof options.manuscriptText === "string" && options.manuscriptText.length > 0
       ? options.manuscriptText
-      : normalizedChunkText.length > 0
-      ? normalizedChunkText
-      : undefined;
+      : (() => { const t = getChunkText(); return t.length > 0 ? t : undefined; })();
 
   const excerptRadiusChars = options.excerptRadiusChars ?? DEFAULT_EXCERPT_RADIUS_CHARS;
   const maxEvidencePerCriterion =

--- a/lib/evaluation/pipeline/comparisonPacket.ts
+++ b/lib/evaluation/pipeline/comparisonPacket.ts
@@ -1,6 +1,6 @@
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import type { CriterionKey } from "@/schemas/criteria-keys";
-import type { EvidenceAnchor, SinglePassOutput } from "./types";
+import type { EvidenceAnchor, ManuscriptChunkEvidence, SinglePassOutput } from "./types";
 
 export type ComparisonState = "agree" | "soft_divergence" | "hard_divergence" | "missing_or_invalid";
 
@@ -29,6 +29,7 @@ export type ComparisonPacket = {
 
 export type BuildComparisonPacketOptions = {
   manuscriptText?: string;
+  chunks?: ManuscriptChunkEvidence[];
   excerptRadiusChars?: number;
   maxEvidencePerCriterion?: number;
 };
@@ -135,6 +136,25 @@ export function buildComparisonPacket(
   const pass1ByKey = toCriterionMap(pass1);
   const pass2ByKey = toCriterionMap(pass2);
 
+  const normalizedChunkText = Array.isArray(options.chunks)
+    ? options.chunks
+        .filter(
+          (chunk): chunk is ManuscriptChunkEvidence =>
+            typeof chunk?.chunk_index === "number" && typeof chunk?.content === "string",
+        )
+        .sort((a, b) => a.chunk_index - b.chunk_index)
+        .map((chunk) => chunk.content.trim())
+        .filter((content) => content.length > 0)
+        .join("\n")
+    : "";
+
+  const manuscriptTextForExcerptWindow =
+    typeof options.manuscriptText === "string" && options.manuscriptText.length > 0
+      ? options.manuscriptText
+      : normalizedChunkText.length > 0
+      ? normalizedChunkText
+      : undefined;
+
   const excerptRadiusChars = options.excerptRadiusChars ?? DEFAULT_EXCERPT_RADIUS_CHARS;
   const maxEvidencePerCriterion =
     options.maxEvidencePerCriterion ?? DEFAULT_MAX_EVIDENCE_PER_CRITERION;
@@ -159,7 +179,7 @@ export function buildComparisonPacket(
 
     const disputedExcerptWindow = extractDisputedExcerptWindow({
       state,
-      manuscriptText: options.manuscriptText,
+      manuscriptText: manuscriptTextForExcerptWindow,
       evidence: rawPass1Evidence,
       excerptRadiusChars,
     });

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -12,7 +12,15 @@
 import OpenAI from "openai";
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import { PASS3_SYSTEM_PROMPT, PASS3_PROMPT_VERSION, buildPass3UserPrompt } from "./prompts/pass3-synthesis";
-import type { SinglePassOutput, SynthesisOutput, SynthesizedCriterion, EvidenceAnchor, CompletionUsage, PassCompletionCapture } from "./types";
+import type {
+  SinglePassOutput,
+  SynthesisOutput,
+  SynthesizedCriterion,
+  EvidenceAnchor,
+  CompletionUsage,
+  PassCompletionCapture,
+  ManuscriptChunkEvidence,
+} from "./types";
 import type { CanonRegistry } from "@/lib/governance/canonRegistry";
 import {
   buildOpenAIOutputTokenParam,
@@ -206,6 +214,7 @@ export interface RunPass3Options {
   pass1: SinglePassOutput;
   pass2: SinglePassOutput;
   manuscriptText: string;
+  manuscriptChunks?: ManuscriptChunkEvidence[];
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   registry: CanonRegistry;
@@ -231,6 +240,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
 
   const comparisonPacket = buildComparisonPacket(opts.pass1, opts.pass2, {
     manuscriptText: opts.manuscriptText,
+    chunks: opts.manuscriptChunks,
   });
   const promptPacket = buildPromptPacketFromComparison(comparisonPacket);
   const comparisonPacketJson = JSON.stringify(promptPacket);
@@ -251,6 +261,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     schema_version: "1" as const,
     prompt_version: PASS3_PROMPT_VERSION,
     criteria_count_by_state: reducerTelemetry.criteria_count_by_state,
+    chunk_count: Array.isArray(opts.manuscriptChunks) ? opts.manuscriptChunks.length : 0,
     comparison_packet_chars: comparisonPacketJson.length,
     system_prompt_chars: PASS3_SYSTEM_PROMPT.length,
     user_prompt_chars: userPrompt.length,

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -26,7 +26,13 @@ import { buildScoreLedger } from "./buildScoreLedger";
 import { buildExcellenceFilter } from "./buildExcellenceFilter";
 import { buildAdvisoryPlan } from "./buildAdvisoryPlan";
 import { computeCriterionConfidence } from "./criterionConfidence";
-import type { PipelineResult, SinglePassOutput, SynthesisOutput, QualityGateResult } from "./types";
+import type {
+  PipelineResult,
+  SinglePassOutput,
+  SynthesisOutput,
+  QualityGateResult,
+  ManuscriptChunkEvidence,
+} from "./types";
 import type { EvaluationResultV1 } from "@/schemas/evaluation-result-v1";
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
@@ -84,6 +90,7 @@ const ENABLE_SCOPE = process.env.EVAL_SCOPE_PROFILE_ENABLED === "true";
 
 export interface RunPipelineOptions {
   manuscriptText: string;
+  manuscriptChunks?: ManuscriptChunkEvidence[];
   workType: string;
   title: string;
   jobId?: string;
@@ -775,6 +782,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
         pass1: pass1Output,
         pass2: pass2Output,
         manuscriptText: opts.manuscriptText,
+        manuscriptChunks: opts.manuscriptChunks,
         title: opts.title,
         executionMode: opts.executionMode,
         model: opts.model,

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -134,7 +134,7 @@ export interface RunPipelineOptions {
 }
 
 const DEFAULT_PASS_TIMEOUT_MS = 60_000;
-const DEFAULT_MAX_MANUSCRIPT_CHARS = 2_000_000;
+const DEFAULT_MAX_MANUSCRIPT_CHARS = 3_000_000;
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -134,7 +134,7 @@ export interface RunPipelineOptions {
 }
 
 const DEFAULT_PASS_TIMEOUT_MS = 60_000;
-const DEFAULT_MAX_MANUSCRIPT_CHARS = 1_000_000;
+const DEFAULT_MAX_MANUSCRIPT_CHARS = 2_000_000;
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -312,10 +312,16 @@ export type Pass3CriteriaCountByState = {
   missing_or_invalid: number;
 };
 
+export type ManuscriptChunkEvidence = {
+  chunk_index: number;
+  content: string;
+};
+
 export type Pass3ReducerTelemetry = {
   schema_version: "1";
   prompt_version: string;
   criteria_count_by_state: Pass3CriteriaCountByState;
+  chunk_count: number;
   comparison_packet_chars: number;
   system_prompt_chars: number;
   user_prompt_chars: number;

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -102,6 +102,7 @@ import { detectContextContamination } from '@/lib/evaluation/governance/contextC
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
 import { ensureChunks } from '@/lib/manuscripts/chunks';
+import type { ManuscriptChunkEvidence } from '@/lib/evaluation/pipeline/types';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -182,11 +183,6 @@ interface Manuscript {
   work_type: string | null;
   user_id: string;
 }
-
-type ManuscriptChunkEvidence = {
-  chunk_index: number;
-  content: string;
-};
 
 type CriterionEntry = EvaluationResultV1['criteria'][number];
 
@@ -796,11 +792,11 @@ export function normalizeRecommendationsFromAIResult(
 async function resolveManuscriptText(
   supabase: any,
   manuscript: Manuscript,
-): Promise<string> {
+): Promise<{ text: string; loadedChunks?: ManuscriptChunkEvidence[] }> {
   // Priority 1: Direct content column
   const directContent = typeof manuscript.content === 'string' ? manuscript.content.trim() : '';
   if (directContent.length > 0) {
-    return directContent;
+    return { text: directContent };
   }
 
   // Priority 2: Reconstruct from manuscript_chunks
@@ -817,8 +813,13 @@ async function resolveManuscriptText(
   }
 
   if (chunks && chunks.length > 0) {
-    const reconstructed = (chunks as Array<{ content?: unknown }>)
-      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content.trim() : ''))
+    const validChunks = (chunks as Array<{ chunk_index?: unknown; content?: unknown }>)
+      .filter(
+        (c): c is ManuscriptChunkEvidence =>
+          typeof c.chunk_index === 'number' && typeof c.content === 'string',
+      );
+    const reconstructed = validChunks
+      .map((chunk) => chunk.content.trim())
       .filter((part) => part.length > 0)
       .join('\n');
 
@@ -826,7 +827,7 @@ async function resolveManuscriptText(
       evalDebugWarn(
         `[Processor] manuscript ${manuscript.id} missing manuscripts.content; reconstructed text from ${chunks.length} chunk(s)`,
       );
-      return reconstructed;
+      return { text: reconstructed, loadedChunks: validChunks };
     }
   }
 
@@ -842,7 +843,7 @@ async function resolveManuscriptText(
           console.log(
             `[Processor] manuscript ${manuscript.id} resolved text from file_url data URI (${decoded.length} chars)`,
           );
-          return decoded;
+          return { text: decoded };
         }
       }
     } catch (decodeError) {
@@ -853,7 +854,7 @@ async function resolveManuscriptText(
     }
   }
 
-  return '';
+  return { text: '' };
 }
 
 async function maybeEnsureLongFormChunks(args: {
@@ -1653,7 +1654,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     console.log(`[Processor] Manuscript ${manuscript.id} fetched: "${manuscript.title}"`);
 
-    const resolvedManuscriptText = await resolveManuscriptText(supabase, manuscript as Manuscript);
+    const { text: resolvedManuscriptText } = await resolveManuscriptText(supabase, manuscript as Manuscript);
     if (!resolvedManuscriptText || resolvedManuscriptText.trim().length === 0) {
       const contentError = 'Manuscript text unavailable: neither manuscripts.content nor manuscript_chunks.content found';
       await markFailed(contentError);
@@ -1702,7 +1703,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     let manuscriptChunksForPipeline: ManuscriptChunkEvidence[] | undefined;
     if (chunkRouting.route === 'long_form') {
-      const canonicalPostChunkText = await resolveManuscriptText(supabase, {
+      const { text: canonicalPostChunkText, loadedChunks } = await resolveManuscriptText(supabase, {
         ...(manuscript as Manuscript),
         content: null,
       });
@@ -1711,33 +1712,41 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         manuscriptWithContent.content = canonicalPostChunkText;
       }
 
-      const { data: chunkRows, error: chunkRowsError } = await supabase
-        .from('manuscript_chunks')
-        .select('chunk_index, content')
-        .eq('manuscript_id', manuscriptWithContent.id)
-        .order('chunk_index', { ascending: true });
+      if (loadedChunks && loadedChunks.length > 0) {
+        // Reuse chunks already loaded by resolveManuscriptText — no second DB read needed.
+        manuscriptChunksForPipeline = loadedChunks.filter(
+          (row) => row.content.trim().length > 0,
+        );
+      } else {
+        // Fallback: explicit query when resolveManuscriptText did not take chunk-reconstruction path.
+        const { data: chunkRows, error: chunkRowsError } = await supabase
+          .from('manuscript_chunks')
+          .select('chunk_index, content')
+          .eq('manuscript_id', manuscriptWithContent.id)
+          .order('chunk_index', { ascending: true });
 
-      if (chunkRowsError) {
-        const chunkLoadError =
-          `Failed to load chunk evidence for manuscript ${manuscriptWithContent.id}: ${chunkRowsError.message}`;
-        await markFailed(chunkLoadError, 'CHUNK_EVIDENCE_LOAD_FAILED', {
-          pipelineStage: 'phase_1',
-          reasonCodes: ['CHUNK_EVIDENCE_LOAD_FAILED'],
-        });
-        return { success: false, error: chunkLoadError };
+        if (chunkRowsError) {
+          const chunkLoadError =
+            `Failed to load chunk evidence for manuscript ${manuscriptWithContent.id}: ${chunkRowsError.message}`;
+          await markFailed(chunkLoadError, 'CHUNK_EVIDENCE_LOAD_FAILED', {
+            pipelineStage: 'phase_1',
+            reasonCodes: ['CHUNK_EVIDENCE_LOAD_FAILED'],
+          });
+          return { success: false, error: chunkLoadError };
+        }
+
+        manuscriptChunksForPipeline = (chunkRows ?? [])
+          .filter(
+            (row: { chunk_index?: unknown; content?: unknown }): row is ManuscriptChunkEvidence =>
+              typeof row.chunk_index === 'number' &&
+              typeof row.content === 'string' &&
+              row.content.trim().length > 0,
+          )
+          .map((row) => ({
+            chunk_index: row.chunk_index,
+            content: row.content,
+          }));
       }
-
-      manuscriptChunksForPipeline = (chunkRows ?? [])
-        .filter(
-          (row: { chunk_index?: unknown; content?: unknown }): row is ManuscriptChunkEvidence =>
-            typeof row.chunk_index === 'number' &&
-            typeof row.content === 'string' &&
-            row.content.trim().length > 0,
-        )
-        .map((row) => ({
-          chunk_index: row.chunk_index,
-          content: row.content,
-        }));
 
       progressState.chunk_evidence = {
         source: 'manuscript_chunks',

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -183,6 +183,11 @@ interface Manuscript {
   user_id: string;
 }
 
+type ManuscriptChunkEvidence = {
+  chunk_index: number;
+  content: string;
+};
+
 type CriterionEntry = EvaluationResultV1['criteria'][number];
 
 type NormalizationDiagnostics = {
@@ -1695,6 +1700,51 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     });
     progressState.chunk_routing = chunkRouting;
 
+    let manuscriptChunksForPipeline: ManuscriptChunkEvidence[] | undefined;
+    if (chunkRouting.route === 'long_form') {
+      const canonicalPostChunkText = await resolveManuscriptText(supabase, {
+        ...(manuscript as Manuscript),
+        content: null,
+      });
+
+      if (canonicalPostChunkText.trim().length > 0) {
+        manuscriptWithContent.content = canonicalPostChunkText;
+      }
+
+      const { data: chunkRows, error: chunkRowsError } = await supabase
+        .from('manuscript_chunks')
+        .select('chunk_index, content')
+        .eq('manuscript_id', manuscriptWithContent.id)
+        .order('chunk_index', { ascending: true });
+
+      if (chunkRowsError) {
+        const chunkLoadError =
+          `Failed to load chunk evidence for manuscript ${manuscriptWithContent.id}: ${chunkRowsError.message}`;
+        await markFailed(chunkLoadError, 'CHUNK_EVIDENCE_LOAD_FAILED', {
+          pipelineStage: 'phase_1',
+          reasonCodes: ['CHUNK_EVIDENCE_LOAD_FAILED'],
+        });
+        return { success: false, error: chunkLoadError };
+      }
+
+      manuscriptChunksForPipeline = (chunkRows ?? [])
+        .filter(
+          (row: { chunk_index?: unknown; content?: unknown }): row is ManuscriptChunkEvidence =>
+            typeof row.chunk_index === 'number' &&
+            typeof row.content === 'string' &&
+            row.content.trim().length > 0,
+        )
+        .map((row) => ({
+          chunk_index: row.chunk_index,
+          content: row.content,
+        }));
+
+      progressState.chunk_evidence = {
+        source: 'manuscript_chunks',
+        chunk_count: manuscriptChunksForPipeline.length,
+      };
+    }
+
     console.log('[Processor] chunk routing decision', {
       job_id: jobId,
       manuscript_id: manuscriptWithContent.id,
@@ -1762,6 +1812,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     try {
       pipelineResult = await runPipeline({
         manuscriptText: manuscriptWithContent.content || '',
+        manuscriptChunks: manuscriptChunksForPipeline,
         workType: manuscriptWithContent.work_type || 'novel',
         title: manuscriptWithContent.title,
         jobId: String(job.id),

--- a/tests/evaluation/pipeline/comparisonPacket.test.ts
+++ b/tests/evaluation/pipeline/comparisonPacket.test.ts
@@ -161,6 +161,33 @@ describe("buildComparisonPacket", () => {
     expect(concept.disputed_excerpt_window?.char_end).toBe(2009);
   });
 
+  it("uses chunk evidence text for disputed excerpts when manuscriptText is absent", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    const concept1 = pass1.criteria.find((c) => c.key === "concept")!;
+    const concept2 = pass2.criteria.find((c) => c.key === "concept")!;
+    concept1.score_0_10 = 9;
+    concept2.score_0_10 = 5;
+    concept1.evidence = [{ snippet: "Chunk anchor", char_start: 2, char_end: 8 }];
+
+    const packet = buildComparisonPacket(pass1, pass2, {
+      chunks: [
+        { chunk_index: 2, content: "CDEFGH" },
+        { chunk_index: 0, content: "AB" },
+      ],
+      excerptRadiusChars: 1,
+    });
+
+    const concept = packet.criteria.find((c) => c.key === "concept")!;
+    expect(concept.disputed_excerpt_window).toBeDefined();
+    expect(concept.disputed_excerpt_window?.char_start).toBeGreaterThanOrEqual(0);
+    expect(concept.disputed_excerpt_window?.char_end).toBeGreaterThan(
+      concept.disputed_excerpt_window?.char_start ?? 0,
+    );
+    expect(concept.disputed_excerpt_window?.snippet).toContain("CDEFGH");
+  });
+
   it("preserves verbatim snippet spacing while still deduping by normalized text", () => {
     const pass1 = makePass(1, "craft_execution");
     const pass2 = makePass(2, "editorial_literary");

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -755,9 +755,9 @@ describe("runPipeline (e2e with injected runners)", () => {
     expect(mockRunPass3).toHaveBeenCalledTimes(1);
   });
 
-  it("accepts a manuscript at exactly 2,000,000 characters (new ceiling)", async () => {
+  it("accepts a manuscript at exactly 3,000,000 characters (new ceiling)", async () => {
     const result = await runPipeline({
-      manuscriptText: "a".repeat(2_000_000),
+      manuscriptText: "a".repeat(3_000_000),
       workType: "literary_fiction",
       title: "Long Form Test",
       openaiApiKey: "sk-test",
@@ -776,9 +776,9 @@ describe("runPipeline (e2e with injected runners)", () => {
     expect(mockRunPass1).toHaveBeenCalled();
   });
 
-  it("accepts a 1,500,000-character manuscript (within new ceiling)", async () => {
+  it("accepts a 2,000,000-character manuscript (within 3M ceiling)", async () => {
     const result = await runPipeline({
-      manuscriptText: "a".repeat(1_500_000),
+      manuscriptText: "a".repeat(2_000_000),
       workType: "literary_fiction",
       title: "Mid Long Form Test",
       openaiApiKey: "sk-test",
@@ -796,9 +796,9 @@ describe("runPipeline (e2e with injected runners)", () => {
     expect(mockRunPass1).toHaveBeenCalled();
   });
 
-  it("rejects a manuscript over 2,000,000 characters (exceeds new ceiling)", async () => {
+  it("rejects a manuscript over 3,000,000 characters (exceeds new ceiling)", async () => {
     const result = await runPipeline({
-      manuscriptText: "a".repeat(2_000_001),
+      manuscriptText: "a".repeat(3_000_001),
       workType: "literary_fiction",
       title: "Over Ceiling Test",
       openaiApiKey: "sk-test",

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -755,6 +755,70 @@ describe("runPipeline (e2e with injected runners)", () => {
     expect(mockRunPass3).toHaveBeenCalledTimes(1);
   });
 
+  it("accepts a manuscript at exactly 2,000,000 characters (new ceiling)", async () => {
+    const result = await runPipeline({
+      manuscriptText: "a".repeat(2_000_000),
+      workType: "literary_fiction",
+      title: "Long Form Test",
+      openaiApiKey: "sk-test",
+      _runners: {
+        runPass1: mockRunPass1,
+        runPass2: mockRunPass2,
+        runPass3Synthesis: mockRunPass3,
+      },
+    });
+
+    // Must NOT fail with PIPELINE_INPUT_INVALID due to length
+    if (!result.ok) {
+      const r = result as Extract<typeof result, { ok: false }>;
+      expect(r.error_code).not.toBe("PIPELINE_INPUT_INVALID");
+    }
+    expect(mockRunPass1).toHaveBeenCalled();
+  });
+
+  it("accepts a 1,500,000-character manuscript (within new ceiling)", async () => {
+    const result = await runPipeline({
+      manuscriptText: "a".repeat(1_500_000),
+      workType: "literary_fiction",
+      title: "Mid Long Form Test",
+      openaiApiKey: "sk-test",
+      _runners: {
+        runPass1: mockRunPass1,
+        runPass2: mockRunPass2,
+        runPass3Synthesis: mockRunPass3,
+      },
+    });
+
+    if (!result.ok) {
+      const r = result as Extract<typeof result, { ok: false }>;
+      expect(r.error_code).not.toBe("PIPELINE_INPUT_INVALID");
+    }
+    expect(mockRunPass1).toHaveBeenCalled();
+  });
+
+  it("rejects a manuscript over 2,000,000 characters (exceeds new ceiling)", async () => {
+    const result = await runPipeline({
+      manuscriptText: "a".repeat(2_000_001),
+      workType: "literary_fiction",
+      title: "Over Ceiling Test",
+      openaiApiKey: "sk-test",
+      _runners: {
+        runPass1: mockRunPass1,
+        runPass2: mockRunPass2,
+        runPass3Synthesis: mockRunPass3,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (isPipelineFailure(result)) {
+      expect(result.error_code).toBe("PIPELINE_INPUT_INVALID");
+      expect(result.failed_at).toBe("pass1");
+    }
+    expect(mockRunPass1).not.toHaveBeenCalled();
+    expect(mockRunPass2).not.toHaveBeenCalled();
+    expect(mockRunPass3).not.toHaveBeenCalled();
+  });
+
   it("fails closed when governance injection map validation fails", async () => {
     const result = await runPipeline({
       manuscriptText: "test",


### PR DESCRIPTION
## Summary
Implements issue #292 by plumbing chunk evidence into Pass 3 comparison packet construction for long-form jobs, and raises pipeline manuscript input ceiling from 1,000,000 to 3,000,000 characters for 200k-word headroom.

## Scope
- unify long-form text source after `ensureChunks()` in `processor.ts`
- thread `manuscriptChunks` through `runPipeline` -> `runPass3Synthesis`
- allow `buildComparisonPacket()` to derive excerpt-window source from ordered chunks when raw text is absent
- make chunk text normalization lazy in `buildComparisonPacket()` (avoid eager join when `manuscriptText` exists)
- reduce duplicate chunk DB reads by reusing chunks already loaded during manuscript text resolution
- remove duplicate local `ManuscriptChunkEvidence` definition and import shared pipeline type
- raise `DEFAULT_MAX_MANUSCRIPT_CHARS` from 1,000,000 to 3,000,000
- keep/add validation coverage for 3,000,000 accepted and 3,000,001 rejected

## Contract Integrity
- Canonical identifiers and status contracts unchanged.
- No illegal state transition behavior introduced.
- No API/UI progress-state inference introduced.
- Ceiling raise is input-validation only; no pass/gate logic rewritten.

## Behavioral Quality
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3
- Quality Gate disclosure: no prompt semantics, scoring/verdict logic, or gate criteria rewrites.
- Final principle acknowledged: optimization is **not reducing intelligence**.

## Latency Evidence

### Baseline (Pre-change)
| Run | pass3_ms | total_ms | notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Chunk substrate existed; packet construction could still do unnecessary eager chunk text normalization. |
| Run 2 | N/A | N/A | Duplicate chunk DB read possible in long-form path. |

### Post-change Runs
| Run | pass3_ms | total_ms | notes |
|---|---:|---:|---|
| Run 1 | local_test_only | local_test_only | Focused suite passed: `tests/evaluation/pipeline/comparisonPacket.test.ts`. |
| Run 2 | local_test_only | local_test_only | Focused suites passed: `__tests__/lib/evaluation/processor.chunk-routing.test.ts`, `tests/evaluation/pipeline/pipeline-e2e.test.ts`; `npx tsc --noEmit` passed. |

Pass 3 divergence distribution token retained: `criteria_count_by_state`.

## Risks & Anomalies
- Risk: production-like 200k-word latency deltas still require post-merge canary measurement.
- Mitigation: CI + follow-up run telemetry capture after merge window.
- Anomalies observed in focused validation: none (QG_* behavior unchanged).

Closes #292
