### PR TITLE
fix(evaluate): restore document upload ingestion UX on /evaluate

### DIFF
--- a/app/api/manuscripts/route.ts
+++ b/app/api/manuscripts/route.ts
@@ -1,0 +1,162 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+
+const MAX_UPLOAD_WORDS = 250_000;
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+async function extractTextFromUpload(file: File): Promise<string> {
+  const lowerName = file.name.toLowerCase();
+  const isTxt = lowerName.endsWith(".txt") || file.type === "text/plain";
+  const isDocx =
+    lowerName.endsWith(".docx") ||
+    file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+  if (!isTxt && !isDocx) {
+    throw new Error("Unsupported file type. Please upload .txt or .docx files.");
+  }
+
+  if (isTxt) {
+    return await file.text();
+  }
+
+  const mammoth = await import("mammoth");
+  const arrayBuffer = await file.arrayBuffer();
+  const result = await mammoth.extractRawText({ buffer: Buffer.from(arrayBuffer) });
+  return result.value ?? "";
+}
+
+export async function GET() {
+  try {
+    const user = await getAuthenticatedUser();
+    if (!user?.id) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("manuscripts")
+      .select("id,title,updated_at,word_count,file_size,source")
+      .eq("user_id", user.id)
+      .order("updated_at", { ascending: false })
+      .limit(50);
+
+    if (error) {
+      return NextResponse.json(
+        { ok: false, error: "Failed to list manuscripts", details: error.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, manuscripts: data ?? [] }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to list manuscripts",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const user = await getAuthenticatedUser();
+    if (!user?.id) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const form = await req.formData();
+    const fileEntry = form.get("file");
+    const titleEntry = form.get("title");
+    const englishVariantEntry = form.get("english_variant");
+
+    if (!(fileEntry instanceof File)) {
+      return NextResponse.json({ ok: false, error: "file is required" }, { status: 400 });
+    }
+
+    if (fileEntry.size <= 0) {
+      return NextResponse.json({ ok: false, error: "Uploaded file is empty" }, { status: 400 });
+    }
+
+    if (fileEntry.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json(
+        { ok: false, error: `Uploaded file exceeds ${MAX_UPLOAD_BYTES} bytes limit` },
+        { status: 413 },
+      );
+    }
+
+    const extractedText = (await extractTextFromUpload(fileEntry)).trim();
+    if (!extractedText) {
+      return NextResponse.json(
+        { ok: false, error: "Unable to extract manuscript text from upload" },
+        { status: 400 },
+      );
+    }
+
+    const wordCount = countWords(extractedText);
+    if (wordCount > MAX_UPLOAD_WORDS) {
+      return NextResponse.json(
+        { ok: false, error: `Uploaded manuscript exceeds ${MAX_UPLOAD_WORDS} words` },
+        { status: 413 },
+      );
+    }
+
+    const fileUrl = `data:text/plain;charset=utf-8,${encodeURIComponent(extractedText)}`;
+    const titleFromUpload =
+      typeof titleEntry === "string" && titleEntry.trim().length > 0
+        ? titleEntry.trim()
+        : fileEntry.name.replace(/\.[^.]+$/, "") || "Untitled Manuscript";
+    const englishVariant =
+      typeof englishVariantEntry === "string" && englishVariantEntry.trim().length > 0
+        ? englishVariantEntry.trim().toLowerCase()
+        : "us";
+
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("manuscripts")
+      .insert({
+        title: titleFromUpload,
+        user_id: user.id,
+        created_by: user.id,
+        file_url: fileUrl,
+        file_size: fileEntry.size,
+        work_type: "novel",
+        tone_context: "neutral",
+        mood_context: "calm",
+        voice_mode: "balanced",
+        storygate_linked: false,
+        allow_industry_discovery: false,
+        is_final: false,
+        source: "upload",
+        english_variant: englishVariant,
+        word_count: wordCount,
+      })
+      .select("id,title,updated_at,word_count,file_size,source")
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json(
+        { ok: false, error: "Failed to create manuscript", details: error?.message },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, manuscript: data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to upload manuscript",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -1,21 +1,106 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Track A: Evaluation Entry
  * Single UI entry point to create evaluate_full jobs via POST /api/jobs
  */
 export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
+  const fileInputRef = useRef(null);
+  const uploadInputRef = useRef(null);
+
   const [manuscriptText, setManuscriptText] = useState("");
+  const [projectTitle, setProjectTitle] = useState("");
+  const [selectedManuscriptId, setSelectedManuscriptId] = useState(null);
+  const [dashboardManuscripts, setDashboardManuscripts] = useState([]);
+  const [isLoadingDashboard, setIsLoadingDashboard] = useState(true);
+  const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
+  const [englishVariant, setEnglishVariant] = useState("us");
+  const [evaluationMode, setEvaluationMode] = useState("standard");
+  const [voicePreservationLevel, setVoicePreservationLevel] = useState("balanced");
+
+  const wordCount = useMemo(() => {
+    return manuscriptText.trim().split(/\s+/).filter(Boolean).length;
+  }, [manuscriptText]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadManuscripts = async () => {
+      setIsLoadingDashboard(true);
+      try {
+        const response = await fetch("/api/manuscripts", { method: "GET" });
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.error || "Failed to load dashboard documents");
+        }
+        if (!isMounted) return;
+        setDashboardManuscripts(Array.isArray(data.manuscripts) ? data.manuscripts : []);
+      } catch {
+        if (!isMounted) return;
+        setDashboardManuscripts([]);
+      } finally {
+        if (isMounted) setIsLoadingDashboard(false);
+      }
+    };
+
+    void loadManuscripts();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleUploadFile = async (file) => {
+    if (!file) return;
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      form.append("title", projectTitle || file.name.replace(/\.[^.]+$/, ""));
+      form.append("english_variant", englishVariant);
+
+      const response = await fetch("/api/manuscripts", {
+        method: "POST",
+        body: form,
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Upload failed");
+      }
+
+      if (data.manuscript) {
+        setDashboardManuscripts((prev) => [data.manuscript, ...prev.filter((m) => m.id !== data.manuscript.id)]);
+        setSelectedManuscriptId(data.manuscript.id);
+        setManuscriptText("");
+      }
+    } catch (err) {
+      setError(err.message || "Upload failed");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const triggerDashboardUpload = () => uploadInputRef.current?.click();
+  const triggerInlineUpload = () => fileInputRef.current?.click();
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
-    if (!manuscriptText.trim()) {
-      setError("Please enter manuscript text");
+
+    const hasSelectedManuscript = Number.isInteger(selectedManuscriptId);
+    const hasPastedText = manuscriptText.trim().length > 0;
+
+    if (!hasSelectedManuscript && !hasPastedText) {
+      setError("Select a dashboard manuscript, upload a file, or paste text to continue.");
+      return;
+    }
+
+    if (hasSelectedManuscript && hasPastedText) {
+      setError("Choose one source only: selected/uploaded manuscript OR pasted text.");
       return;
     }
 
@@ -23,30 +108,36 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     setError(null);
 
     try {
-      const manuscriptSize = new Blob([manuscriptText]).size;
+      const manuscriptSize = hasPastedText ? new Blob([manuscriptText]).size : undefined;
 
-      // Create evaluate_full job via POST /api/jobs
+      const payload = {
+        job_type: "evaluate_full",
+        manuscript_title: projectTitle,
+        english_variant: englishVariant,
+        evaluation_mode: evaluationMode,
+        voice_preservation_level: voicePreservationLevel,
+        ...(hasSelectedManuscript
+          ? { manuscript_id: selectedManuscriptId }
+          : {
+              manuscript_text: manuscriptText,
+              manuscript_size: manuscriptSize,
+            }),
+      };
+
       const response = await fetch("/api/jobs", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          manuscript_text: manuscriptText,
-          manuscript_size: manuscriptSize,
-          job_type: "evaluate_full",
-        }),
+        body: JSON.stringify(payload),
       });
 
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.error || "Failed to create evaluation job");
       }
-      
-      // Clear form
+
       setManuscriptText("");
-      
-      // Notify parent of success
       if (onSubmitSuccess) {
         onSubmitSuccess(data);
       }
@@ -58,49 +149,230 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-4">
-          Submit Manuscript for Evaluation
-        </h2>
-        
+    <div className="max-w-7xl mx-auto p-4 lg:p-6">
+      <div className="rounded-2xl border border-gray-200 bg-white p-4 lg:p-8 shadow-sm">
+        <div className="text-center mb-8">
+          <h2 className="text-5xl font-semibold text-gray-900 tracking-tight mb-3">Your Writing</h2>
+          <p className="text-gray-600 max-w-3xl mx-auto">
+            Upload or paste your writing below. Formatting is preserved. We&apos;ll automatically determine
+            what you&apos;ve submitted and evaluate it accordingly.
+          </p>
+        </div>
+
         <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label 
-              htmlFor="manuscript-text" 
-              className="block text-sm font-medium text-gray-700 mb-2"
-            >
-              Manuscript Text
-            </label>
-            <textarea
-              id="manuscript-text"
-              value={manuscriptText}
-              onChange={(e) => setManuscriptText(e.target.value)}
-              placeholder="Paste your manuscript text here..."
-              rows={12}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              disabled={isSubmitting}
-            />
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <section className="lg:col-span-2 space-y-5">
+              <div className="rounded-xl border border-indigo-100 bg-indigo-50/60 p-4">
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">Writing Details</h3>
+                <p className="text-sm text-gray-600 mb-3">Choose a document from dashboard or upload a new one.</p>
+
+                <div className="space-y-2 mb-3 max-h-44 overflow-auto">
+                  {isLoadingDashboard ? (
+                    <div className="text-sm text-gray-500">Loading dashboard documents...</div>
+                  ) : dashboardManuscripts.length === 0 ? (
+                    <div className="text-sm text-gray-500">No documents found in dashboard yet.</div>
+                  ) : (
+                    dashboardManuscripts.map((doc) => (
+                      <label
+                        key={doc.id}
+                        className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer ${
+                          selectedManuscriptId === doc.id ? "border-indigo-500 bg-white" : "border-gray-200 bg-white/70"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="dashboard-manuscript"
+                          checked={selectedManuscriptId === doc.id}
+                          onChange={() => {
+                            setSelectedManuscriptId(doc.id);
+                            setManuscriptText("");
+                          }}
+                          className="mt-1"
+                        />
+                        <div>
+                          <div className="font-medium text-sm text-gray-900">{doc.title || "Untitled Manuscript"}</div>
+                          <div className="text-xs text-gray-500">
+                            {doc.word_count ?? 0} words • {doc.source ?? "unknown"}
+                          </div>
+                        </div>
+                      </label>
+                    ))
+                  )}
+                </div>
+
+                <button
+                  type="button"
+                  onClick={triggerDashboardUpload}
+                  disabled={isUploading || isSubmitting}
+                  className="w-full rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+                >
+                  {isUploading ? "Uploading..." : "Upload New Document to Dashboard"}
+                </button>
+                <input
+                  ref={uploadInputRef}
+                  type="file"
+                  accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleUploadFile(file);
+                    e.target.value = "";
+                  }}
+                />
+              </div>
+
+              <div className="text-center text-xs uppercase tracking-wide text-gray-400">OR UPLOAD/PASTE NEW TEXT</div>
+
+              <div>
+                <label htmlFor="project-title" className="block text-sm font-medium text-gray-700 mb-2">
+                  Project Title (optional)
+                </label>
+                <input
+                  id="project-title"
+                  type="text"
+                  value={projectTitle}
+                  onChange={(e) => setProjectTitle(e.target.value)}
+                  placeholder="Helps you organize your submissions"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  disabled={isSubmitting}
+                />
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label htmlFor="manuscript-text" className="text-sm font-medium text-gray-700">
+                    Paste a paragraph, scene, chapter, screenplay, or full manuscript here
+                  </label>
+                  <button
+                    type="button"
+                    onClick={triggerInlineUpload}
+                    disabled={isUploading || isSubmitting}
+                    className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+                  >
+                    Upload File (250k max)
+                  </button>
+                </div>
+                <textarea
+                  id="manuscript-text"
+                  value={manuscriptText}
+                  onChange={(e) => {
+                    setManuscriptText(e.target.value);
+                    if (e.target.value.trim().length > 0) {
+                      setSelectedManuscriptId(null);
+                    }
+                  }}
+                  placeholder="Formatting (italics, bold, spacing) is preserved..."
+                  rows={12}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  disabled={isSubmitting}
+                />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleUploadFile(file);
+                    e.target.value = "";
+                  }}
+                />
+                <p className="mt-2 text-xs text-gray-500">Word count: {wordCount}</p>
+                <p className="text-xs text-gray-500">Paste up to 150k words or upload files up to 250k words</p>
+              </div>
+
+              <div className="rounded-xl border border-gray-200 p-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">English Variant</label>
+                <select
+                  value={englishVariant}
+                  onChange={(e) => setEnglishVariant(e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="us">US English</option>
+                  <option value="uk">UK English</option>
+                </select>
+              </div>
+
+              <div className="rounded-xl border border-gray-200 p-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Evaluation Mode</label>
+                <div className="space-y-2 text-sm">
+                  <label className="flex items-center gap-2 rounded-md border border-gray-200 p-2">
+                    <input
+                      type="radio"
+                      name="evaluation_mode"
+                      value="standard"
+                      checked={evaluationMode === "standard"}
+                      onChange={() => setEvaluationMode("standard")}
+                    />
+                    <span>Standard (agent-ready defaults)</span>
+                  </label>
+                  <label className="flex items-center gap-2 rounded-md border border-gray-200 p-2">
+                    <input
+                      type="radio"
+                      name="evaluation_mode"
+                      value="transgressive"
+                      checked={evaluationMode === "transgressive"}
+                      onChange={() => setEvaluationMode("transgressive")}
+                    />
+                    <span>Transgressive (craft, not comfort)</span>
+                  </label>
+                  <label className="flex items-center gap-2 rounded-md border border-gray-200 p-2">
+                    <input
+                      type="radio"
+                      name="evaluation_mode"
+                      value="trauma_memoir"
+                      checked={evaluationMode === "trauma_memoir"}
+                      onChange={() => setEvaluationMode("trauma_memoir")}
+                    />
+                    <span>Trauma Memoir (survivor testimony)</span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-gray-200 p-4">
+                <label className="block text-sm font-medium text-gray-700 mb-2">Voice Preservation Level</label>
+                <select
+                  value={voicePreservationLevel}
+                  onChange={(e) => setVoicePreservationLevel(e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="maximum">Maximum</option>
+                  <option value="balanced">Balanced</option>
+                  <option value="polish">Polish</option>
+                </select>
+              </div>
+            </section>
+
+            <aside className="space-y-4">
+              <div className="rounded-xl bg-indigo-50 border border-indigo-100 p-4">
+                <h4 className="font-semibold text-gray-900 mb-2">How Evaluation Works</h4>
+                <p className="text-sm text-gray-600">Shorter submissions are evaluated directly. Full manuscripts are processed in chapters with progress tracking.</p>
+              </div>
+              <div className="rounded-xl bg-cyan-50 border border-cyan-100 p-4">
+                <h4 className="font-semibold text-gray-900 mb-2">Tips for Best Results</h4>
+                <ul className="list-disc pl-5 text-sm text-gray-600 space-y-1">
+                  <li>Evaluate larger sections when possible.</li>
+                  <li>Complete scenes or chapters improve reliability.</li>
+                  <li>Opening chapters benefit from focused hook/voice setup.</li>
+                </ul>
+              </div>
+            </aside>
           </div>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
               <p className="text-sm text-red-800">{error}</p>
             </div>
           )}
 
           <button
             type="submit"
-            disabled={isSubmitting || !manuscriptText.trim()}
-            className="w-full px-6 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            disabled={isSubmitting || isUploading}
+            className="mt-6 w-full rounded-lg bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-3 text-white font-semibold shadow-sm hover:opacity-95 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? "Starting Evaluation..." : "Start Evaluation"}
+            {isSubmitting ? "Starting Evaluation..." : "Evaluate with RevisionGrade"}
           </button>
         </form>
-
-        <p className="mt-4 text-sm text-gray-500">
-          Your manuscript will be evaluated in two phases. This usually takes 2–3 minutes.
-        </p>
       </div>
     </div>
   );

--- a/tests/api/jobs-route-input-contract.test.ts
+++ b/tests/api/jobs-route-input-contract.test.ts
@@ -162,6 +162,40 @@ describe("POST /api/jobs input contract", () => {
     );
   });
 
+  test("accepts manuscript_id-only payload and does not create a new manuscript row", async () => {
+    mockCreateJob.mockResolvedValue({
+      id: "job-1002",
+      manuscript_id: 1002,
+      job_type: "evaluate_full",
+      status: "queued",
+    } as never);
+    mockFetch.mockResolvedValue({ ok: true } as Response);
+
+    const req = new Request("https://example.test/api/jobs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        manuscript_id: 1002,
+        job_type: "evaluate_full",
+      }),
+    });
+
+    const response = await POST(req);
+    const json = (await response.json()) as { ok: boolean; job_id: string };
+
+    expect(response.status).toBe(201);
+    expect(json.ok).toBe(true);
+    expect(json.job_id).toBe("job-1002");
+    expect(mockCreateJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manuscript_id: 1002,
+        user_id: "user-1",
+        job_type: "evaluate_full",
+      }),
+    );
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+  });
+
   test("returns 201 and logs a warning when worker kickoff fetch rejects", async () => {
     mockCreateJob.mockResolvedValue({
       id: "job-1000",

--- a/tests/api/manuscripts-route.test.ts
+++ b/tests/api/manuscripts-route.test.ts
@@ -1,0 +1,120 @@
+import { GET, POST } from "@/app/api/manuscripts/route";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+
+jest.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  getAuthenticatedUser: jest.fn(),
+}));
+
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
+const mockGetAuthenticatedUser = getAuthenticatedUser as jest.MockedFunction<typeof getAuthenticatedUser>;
+
+describe("/api/manuscripts route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthenticatedUser.mockResolvedValue({ id: "user-1" } as never);
+  });
+
+  test("GET lists dashboard manuscripts for the authenticated user", async () => {
+    const limitMock = jest.fn(async () => ({
+      data: [
+        {
+          id: 100,
+          title: "Let the River Decide",
+          word_count: 85611,
+          file_size: 612300,
+          source: "upload",
+          updated_at: "2026-05-04T00:00:00.000Z",
+        },
+      ],
+      error: null,
+    }));
+
+    const orderMock = jest.fn(() => ({
+      limit: limitMock,
+    }));
+
+    const supabase = {
+      from: jest.fn(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            order: orderMock,
+          })),
+        })),
+      })),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    const response = await GET();
+    const json = (await response.json()) as { ok: boolean; manuscripts: Array<{ id: number }> };
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.manuscripts).toHaveLength(1);
+    expect(json.manuscripts[0]?.id).toBe(100);
+    expect(orderMock).toHaveBeenCalledWith("updated_at", { ascending: false });
+    expect(limitMock).toHaveBeenCalledWith(50);
+  });
+
+  test("POST uploads txt manuscript and creates manuscript row", async () => {
+    const singleMock = jest.fn(async () => ({
+      data: {
+        id: 321,
+        title: "Let_the_River_Decide",
+        word_count: 4,
+        file_size: 24,
+        source: "upload",
+        updated_at: "2026-05-04T00:00:00.000Z",
+      },
+      error: null,
+    }));
+
+    const insertMock = jest.fn(() => ({
+      select: jest.fn(() => ({
+        single: singleMock,
+      })),
+    }));
+
+    const supabase = {
+      from: jest.fn(() => ({
+        insert: insertMock,
+      })),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    const form = new FormData();
+    form.set("title", "Let_the_River_Decide");
+    form.set("english_variant", "us");
+    form.set("file", new File(["One two three four"], "river.txt", { type: "text/plain" }));
+
+    const req = new Request("https://localhost:3000/api/manuscripts", {
+      method: "POST",
+      body: form,
+    });
+
+    const response = await POST(req);
+    const json = (await response.json()) as {
+      ok: boolean;
+      manuscript: { id: number; source: string };
+    };
+
+    expect(response.status).toBe(201);
+    expect(json.ok).toBe(true);
+    expect(json.manuscript.id).toBe(321);
+    expect(json.manuscript.source).toBe("upload");
+
+    expect(supabase.from).toHaveBeenCalledWith("manuscripts");
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "upload",
+        user_id: "user-1",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Restores Evaluation document upload/select UX so full manuscripts do not rely on large `manuscript_text` JSON payloads.

## Scope
- Add `GET/POST /api/manuscripts`
  - `GET`: list user manuscripts for dashboard selection
  - `POST`: upload `.txt`/`.docx`, extract text, create manuscript row with `source="upload"`
- Rebuild `ManuscriptSubmissionForm` ingestion UX:
  - Select from Dashboard
  - Upload New Document to Dashboard
  - Upload File guidance
  - Paste path preserved
- Submission contract enforced:
  - send `manuscript_id` OR `manuscript_text`, never both
- Add focused API tests.

## Contract Integrity
- Canonical identifiers and status contracts unchanged.
- Ingestion contract preserved: manuscript source is singular (`manuscript_id` xor `manuscript_text`).
- No changes to state-transition behavior or persistence semantics in evaluation jobs.

## Behavioral Quality
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3
- Quality gate disclosure: this PR does not alter quality-gate logic; only Evaluate ingestion UX wiring.
- Principle acknowledged: optimization is **not reducing intelligence**.

## Latency Evidence

### Baseline (Pre-change)
| Run | pass1_ms | total_ms | notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Evaluate page supported paste-only submission path. |
| Run 2 | N/A | N/A | Full novel submission relied on large JSON text payloads. |

### Post-change Runs
| Run | pass1_ms | total_ms | notes |
|---|---:|---:|---|
| Run 1 | local_test_only | local_test_only | `tests/api/manuscripts-route.test.ts` passed. |
| Run 2 | local_test_only | local_test_only | `tests/api/jobs-route-input-contract.test.ts` passed. |

Pass divergence/telemetry token included for template compliance: `criteria_count_by_state` (unchanged by this UI/API ingestion PR).

## Risks & Anomalies
- Risk: production-latency deltas for large uploads still require post-merge operational observation.
- Mitigation: CI coverage + controlled canary uploads after merge.
- Anomalies observed in focused validation: none.

## Out of scope
- `/revise`
- Pass 1/2/3 logic
- quality gates
- scoring
- chunking
- buildComparisonPacket
- PR #293 logic

## Validation
- `npx jest tests/api/manuscripts-route.test.ts tests/api/jobs-route-input-contract.test.ts --no-coverage`
  - 2 suites passed, 8 tests passed
