### PR TITLE
fix(pass3): deterministic recommendation specificity repair before QG

### DIFF
--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -346,9 +346,155 @@ describe("Pass 3 backfill quality", () => {
 
     const rec = character!.recommendations[0];
     expect(rec).toBeDefined();
+    expect(rec.action).not.toBe(
+      "In character-driven scenes, deepen character development by adding more personal stakes.",
+    );
     expect(rec.action.toLowerCase()).toMatch(/replace|insert/);
     expect(rec.action.toLowerCase()).toContain("because");
     expect(rec.expected_impact.toLowerCase()).toMatch(/reader|clarity|engagement|immersion|momentum/);
+  });
+
+  test("recommendation repair is deterministic for identical payload across parses", () => {
+    const pass1 = makePass(1);
+    const pass2 = makePass(2);
+
+    const raw = JSON.stringify({
+      criteria: [
+        {
+          key: "sceneConstruction",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Scene construction rationale placeholder.",
+          evidence: [{ snippet: "Rain crossed the window while she stayed silent." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In slower scenes, streamline descriptive passages to improve pacing.",
+              expected_impact: "Improves pacing.",
+              anchor_snippet: "Rain crossed the window while she stayed silent.",
+              source_pass: 3,
+              issue_family: "scene_structure",
+              strategic_lever: "scene_goal_clarity",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const parsedA = parsePass3Response(raw, pass1, pass2, "o3");
+    const parsedB = parsePass3Response(raw, pass1, pass2, "o3");
+
+    const repairedA = parsedA.criteria.find((c) => c.key === "sceneConstruction")?.recommendations?.[0]?.action;
+    const repairedB = parsedB.criteria.find((c) => c.key === "sceneConstruction")?.recommendations?.[0]?.action;
+
+    expect(repairedA).toBeDefined();
+    expect(repairedB).toBeDefined();
+    expect(repairedA).toBe(repairedB);
+  });
+
+  test("two repaired recommendations with different original actions remain distinct", () => {
+    const pass1 = makePass(1);
+    const pass2 = makePass(2);
+
+    const rawA = JSON.stringify({
+      criteria: [
+        {
+          key: "character",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Character rationale placeholder.",
+          evidence: [{ snippet: "He folded the letter into his pocket." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In character-driven scenes, deepen character development by adding more personal stakes.",
+              expected_impact: "Improves character quality.",
+              anchor_snippet: "He folded the letter into his pocket.",
+              source_pass: 3,
+              issue_family: "characterization",
+              strategic_lever: "character_voice_differentiation",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const rawB = JSON.stringify({
+      criteria: [
+        {
+          key: "character",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Character rationale placeholder.",
+          evidence: [{ snippet: "He folded the letter into his pocket." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In character-driven scenes, deepen character development by adding clearer emotional contradiction.",
+              expected_impact: "Improves character quality.",
+              anchor_snippet: "He folded the letter into his pocket.",
+              source_pass: 3,
+              issue_family: "characterization",
+              strategic_lever: "character_voice_differentiation",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const repairedA = parsePass3Response(rawA, pass1, pass2, "o3")
+      .criteria.find((c) => c.key === "character")?.recommendations?.[0]?.action;
+    const repairedB = parsePass3Response(rawB, pass1, pass2, "o3")
+      .criteria.find((c) => c.key === "character")?.recommendations?.[0]?.action;
+
+    expect(repairedA).toBeDefined();
+    expect(repairedB).toBeDefined();
+    expect(repairedA).not.toBe(repairedB);
   });
 
   test("repairs live failed patterns with criterion-aware concrete moves while preserving intent", () => {

--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -1,5 +1,6 @@
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import { parsePass3Response } from "@/lib/evaluation/pipeline/runPass3Synthesis";
+import { runQualityGate } from "@/lib/evaluation/pipeline/qualityGate";
 import type { SinglePassOutput } from "@/lib/evaluation/pipeline/types";
 
 export {};
@@ -348,6 +349,192 @@ describe("Pass 3 backfill quality", () => {
     expect(rec.action.toLowerCase()).toMatch(/replace|insert/);
     expect(rec.action.toLowerCase()).toContain("because");
     expect(rec.expected_impact.toLowerCase()).toMatch(/reader|clarity|engagement|immersion|momentum/);
+  });
+
+  test("repairs live failed patterns with criterion-aware concrete moves while preserving intent", () => {
+    const pass1 = makePass(1);
+    const pass2 = makePass(2);
+
+    const raw = JSON.stringify({
+      criteria: [
+        {
+          key: "character",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Character rationale placeholder.",
+          evidence: [{ snippet: "He folded the letter into his pocket." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In character-driven scenes, deepen character development by adding more personal stakes.",
+              expected_impact: "Improves character quality.",
+              anchor_snippet: "He folded the letter into his pocket.",
+              source_pass: 3,
+              issue_family: "characterization",
+              strategic_lever: "character_voice_differentiation",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+        {
+          key: "sceneConstruction",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Scene construction rationale placeholder.",
+          evidence: [{ snippet: "Rain crossed the window while she stayed silent." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In slower scenes, streamline descriptive passages to improve pacing.",
+              expected_impact: "Improves pacing.",
+              anchor_snippet: "Rain crossed the window while she stayed silent.",
+              source_pass: 3,
+              issue_family: "scene_structure",
+              strategic_lever: "scene_goal_clarity",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+        {
+          key: "dialogue",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Dialogue rationale placeholder.",
+          evidence: [{ snippet: '"I know," she said, then looked away.' }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In dialogue-heavy scenes, inject more dynamic exchanges to drive the narrative.",
+              expected_impact: "Improves dialogue quality.",
+              anchor_snippet: '"I know," she said, then looked away.',
+              source_pass: 3,
+              issue_family: "dialogue",
+              strategic_lever: "dialogue_exposition_density",
+              revision_granularity: "beat",
+            },
+          ],
+        },
+        {
+          key: "pacing",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Pacing rationale placeholder.",
+          evidence: [{ snippet: "She sat still while the clock ticked louder." }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In slower sections, balance reflective passages with more active scenes.",
+              expected_impact: "Improves pacing flow.",
+              anchor_snippet: "She sat still while the clock ticked louder.",
+              source_pass: 3,
+              issue_family: "pacing",
+              strategic_lever: "momentum_visibility",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const parsed = parsePass3Response(raw, pass1, pass2, "o3");
+
+    const characterRec = parsed.criteria.find((c) => c.key === "character")?.recommendations?.[0];
+    const sceneRec = parsed.criteria.find((c) => c.key === "sceneConstruction")?.recommendations?.[0];
+    const dialogueRec = parsed.criteria.find((c) => c.key === "dialogue")?.recommendations?.[0];
+    const pacingRec = parsed.criteria.find((c) => c.key === "pacing")?.recommendations?.[0];
+
+    expect(characterRec?.action.toLowerCase()).toContain("deepen character development");
+    expect(characterRec?.action.toLowerCase()).toMatch(/decision beat|desire-vs-fear contradiction/);
+
+    expect(sceneRec?.action.toLowerCase()).toContain("streamline descriptive passages");
+    expect(sceneRec?.action.toLowerCase()).toMatch(/split|move/);
+
+    expect(dialogueRec?.action.toLowerCase()).toContain("inject more dynamic exchanges");
+    expect(dialogueRec?.action.toLowerCase()).toMatch(/two short turns|interruption beat/);
+
+    expect(pacingRec?.action.toLowerCase()).toContain("balance reflective passages");
+    expect(pacingRec?.action.toLowerCase()).toMatch(/cut|insert/);
+  });
+
+  test("does not auto-repair anchorless generic recommendation and QG still fails", () => {
+    const pass1 = makePass(1);
+    const pass2 = makePass(2);
+
+    const raw = JSON.stringify({
+      criteria: [
+        {
+          key: "dialogue",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Dialogue rationale placeholder.",
+          evidence: [{ snippet: '"I know," she said.' }],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In dialogue-heavy scenes, inject more dynamic exchanges to drive the narrative.",
+              expected_impact: "Improves dialogue quality.",
+              anchor_snippet: "",
+              source_pass: 3,
+              issue_family: "dialogue",
+              strategic_lever: "dialogue_exposition_density",
+              revision_granularity: "beat",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const parsed = parsePass3Response(raw, pass1, pass2, "o3");
+    const rec = parsed.criteria.find((c) => c.key === "dialogue")?.recommendations?.[0];
+    expect(rec?.action).toBe("In dialogue-heavy scenes, inject more dynamic exchanges to drive the narrative.");
+
+    const minimalSynthesis = {
+      criteria: [
+        {
+          ...parsed.criteria.find((c) => c.key === "dialogue"),
+          key: "dialogue",
+        },
+      ],
+      overall: parsed.overall,
+      metadata: parsed.metadata,
+      partial_evaluation: false,
+    };
+
+    const gate = runQualityGate(minimalSynthesis as any);
+    const editorialCheck = gate.checks.find((c) => c.check_id === "recommendation_editorial_quality");
+    expect(editorialCheck?.passed).toBe(false);
+    expect(editorialCheck?.error_code).toBe("QG_EDITORIAL_GENERIC_FEEDBACK");
   });
 
   // ─────────────────────────────────────────────────────────────────────

--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -293,6 +293,63 @@ describe("Pass 3 backfill quality", () => {
     expect(dialogueA!.final_rationale).toBe(dialogueB!.final_rationale);
   });
 
+  test("deterministically repairs generic recommendation actions to concrete fix/move contract", () => {
+    const pass1 = makePass(1);
+    const pass2 = makePass(2);
+
+    const raw = JSON.stringify({
+      criteria: [
+        {
+          key: "character",
+          craft_score: 7,
+          editorial_score: 7,
+          final_score_0_10: 7,
+          final_rationale: "Character signal is present but can be sharpened in scene execution.",
+          evidence: [
+            {
+              snippet: "She closed the letter and swallowed her answer.",
+            },
+          ],
+          recommendations: [
+            {
+              priority: "medium",
+              action: "In character-driven scenes, deepen character development by adding more personal stakes.",
+              expected_impact: "Improves character quality.",
+              anchor_snippet: "She closed the letter and swallowed her answer.",
+              source_pass: 3,
+              issue_family: "characterization",
+              strategic_lever: "character_voice_differentiation",
+              revision_granularity: "scene",
+            },
+          ],
+        },
+      ],
+      overall: {
+        overall_score_0_100: 72,
+        verdict: "revise",
+        one_paragraph_summary: "Test summary.",
+        top_3_strengths: ["voice", "concept", "character"],
+        top_3_risks: ["pacing", "tone", "dialogue"],
+        submission_readiness: "close",
+      },
+      metadata: {
+        pass1_model: "o3",
+        pass2_model: "o3",
+        pass3_model: "o3",
+      },
+    });
+
+    const parsed = parsePass3Response(raw, pass1, pass2, "o3");
+    const character = parsed.criteria.find((c) => c.key === "character");
+    expect(character).toBeDefined();
+
+    const rec = character!.recommendations[0];
+    expect(rec).toBeDefined();
+    expect(rec.action.toLowerCase()).toMatch(/replace|insert/);
+    expect(rec.action.toLowerCase()).toContain("because");
+    expect(rec.expected_impact.toLowerCase()).toMatch(/reader|clarity|engagement|immersion|momentum/);
+  });
+
   // ─────────────────────────────────────────────────────────────────────
   // Dialogue Attribution v2 Gate: Diagnostic-grounded enforcement tests
   // (FR-2: Real production regression fixture, AC-1 through AC-5)

--- a/lib/evaluation/pipeline/editorialRecommendationContract.ts
+++ b/lib/evaluation/pipeline/editorialRecommendationContract.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared editorial recommendation marker contract.
+ *
+ * Canonical source for regex markers consumed by both:
+ * - Pass 3 recommendation normalization/repair
+ * - Pass 4 deterministic editorial quality gate
+ */
+
+export const EDITORIAL_SYMPTOM_MARKERS =
+  /\b(lacks?|missing|unclear|confus(?:ed|ing)?|flat|generic|drag(?:s|ging)?|repetit(?:ion|ive)|abrupt|weak|underdeveloped|overwritten|diffuse|stalled|not\s+yet|fails?|without|problem|issue|stakes?|tension|motivation|cause|effect|consequence)\b/i;
+
+export const EDITORIAL_FIX_MARKERS =
+  /\b(rewrite|replace|cut|trim|split|merge|move|reorder|expand|compress|clarify|specify|anchor|insert|delete|foreshadow|escalate|tighten|seed|stage|show|name|shift|ground(?:ing)?|contextualize|reframe|focus|connect|link|develop|resolve|surface|thread|motivate|concretize|externalize|recast|frontload|backload|echo|contrast)\b/i;
+
+export const EDITORIAL_CONTEXT_MARKERS =
+  /\b(scene|line|sentence|paragraph|chapter|beat|moment|exchange|opening|ending|turn|pivot|section|passage|hook|callback|setup|payoff|clause|image|gesture|motif)\b/i;
+
+export const EDITORIAL_ANCHOR_HINT_MARKERS =
+  /\b(opening|midpoint|climax|first|last|second|third|next|previous|following)\s+(scene|paragraph|line|beat|chapter|section|sentence)\b|\b(paragraph|line|scene|chapter|section|sentence)\s+\d+\b/i;
+
+export const EDITORIAL_MECHANISM_MARKERS =
+  /\b(because|since|so\s+that|thereby|to\s+avoid|prevent(?:s|ing)?|caus(?:e|es|ing)|effect|by\s+\w+ing|which\s+(?:helps|lets|allows)|to\s+(prime|clarify|signal|restore|heighten|increase|reduce|anchor|focus|separate|differentiate|escalate|tighten))\b/i;
+
+export const EDITORIAL_READER_EFFECT_MARKERS =
+  /\b(reader|readers|clarity|comprehension|urgency|momentum|immersion|engagement|stakes|tension|payoff|coherence|trust)\b/i;

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -55,6 +55,14 @@ import {
   summaryMentionsBottomWeakness,
 } from "./propagationIntegrity";
 import { buildEditorialDiagnosticsSummary } from "@/lib/evaluation/harness/report";
+import {
+  EDITORIAL_ANCHOR_HINT_MARKERS,
+  EDITORIAL_CONTEXT_MARKERS,
+  EDITORIAL_FIX_MARKERS,
+  EDITORIAL_MECHANISM_MARKERS,
+  EDITORIAL_READER_EFFECT_MARKERS,
+  EDITORIAL_SYMPTOM_MARKERS,
+} from "./editorialRecommendationContract";
 
 export const QG_MIN_REC_LENGTH = 50;
 export const QG_MAX_REC_LENGTH = 300;
@@ -117,12 +125,6 @@ export const QG_POV_MECHANISM_MARKERS = Object.freeze([
 // --- PR-1: Scope governance quality gates ---
 export const QG_INTERNAL_LEAKAGE_PATTERNS = /direct_speech|reported_speech|tagged_speech|tagless_exchange/i;
 export const QG_FILLER_VERBS = /^(enhance|deepen|refine|maintain|continue|strengthen|improve)\b/i;
-const QG_EDITORIAL_SYMPTOM_MARKERS = /\b(lacks?|missing|unclear|confus(?:ed|ing)?|flat|generic|drag(?:s|ging)?|repetit(?:ion|ive)|abrupt|weak|underdeveloped|overwritten|diffuse|stalled|not\s+yet|fails?|without|problem|issue|stakes?|tension|motivation|cause|effect|consequence)\b/i;
-const QG_EDITORIAL_FIX_MARKERS = /\b(rewrite|replace|cut|trim|split|merge|move|reorder|expand|compress|clarify|specify|anchor|insert|delete|foreshadow|escalate|tighten|seed|stage|show|name|shift|ground(?:ing)?|contextualize|reframe|focus|connect|link|develop|resolve|surface|thread|motivate|concretize|externalize|recast|frontload|backload|echo|contrast)\b/i;
-const QG_EDITORIAL_CONTEXT_MARKERS = /\b(scene|line|sentence|paragraph|chapter|beat|moment|exchange|opening|ending|turn|pivot|section|passage|hook|callback|setup|payoff|clause|image|gesture|motif)\b/i;
-const QG_EDITORIAL_ANCHOR_HINT_MARKERS = /\b(opening|midpoint|climax|first|last|second|third|next|previous|following)\s+(scene|paragraph|line|beat|chapter|section|sentence)\b|\b(paragraph|line|scene|chapter|section|sentence)\s+\d+\b/i;
-const QG_EDITORIAL_MECHANISM_MARKERS = /\b(because|since|so\s+that|thereby|to\s+avoid|prevent(?:s|ing)?|caus(?:e|es|ing)|effect|by\s+\w+ing|which\s+(?:helps|lets|allows)|to\s+(prime|clarify|signal|restore|heighten|increase|reduce|anchor|focus|separate|differentiate|escalate|tighten))\b/i;
-const QG_EDITORIAL_READER_EFFECT_MARKERS = /\b(reader|readers|clarity|comprehension|urgency|momentum|immersion|engagement|stakes|tension|payoff|coherence|trust)\b/i;
 const QG_EDITORIAL_SIGNAL_HASH_LEN = 16;
 const QG_EDITORIAL_DIAGNOSTIC_MAX_ACTION_CHARS = 160;
 const QG_EDITORIAL_DIAGNOSTIC_MAX_EXPECTED_IMPACT_CHARS = 160;
@@ -841,12 +843,12 @@ export function runQualityGate(
 
         const hasAnchorContext =
           anchorSnippet.length > 0 ||
-          QG_EDITORIAL_CONTEXT_MARKERS.test(action) ||
-          QG_EDITORIAL_ANCHOR_HINT_MARKERS.test(action);
-        const hasSymptomSignal = QG_EDITORIAL_SYMPTOM_MARKERS.test(action) || QG_EDITORIAL_SYMPTOM_MARKERS.test(expectedImpact);
-        const hasMechanismCause = QG_EDITORIAL_MECHANISM_MARKERS.test(action) || QG_EDITORIAL_MECHANISM_MARKERS.test(expectedImpact);
-        const hasSpecificFixMove = QG_EDITORIAL_FIX_MARKERS.test(action) && hasAnchorContext;
-        const hasReaderEffect = QG_EDITORIAL_READER_EFFECT_MARKERS.test(expectedImpact);
+          EDITORIAL_CONTEXT_MARKERS.test(action) ||
+          EDITORIAL_ANCHOR_HINT_MARKERS.test(action);
+        const hasSymptomSignal = EDITORIAL_SYMPTOM_MARKERS.test(action) || EDITORIAL_SYMPTOM_MARKERS.test(expectedImpact);
+        const hasMechanismCause = EDITORIAL_MECHANISM_MARKERS.test(action) || EDITORIAL_MECHANISM_MARKERS.test(expectedImpact);
+        const hasSpecificFixMove = EDITORIAL_FIX_MARKERS.test(action) && hasAnchorContext;
+        const hasReaderEffect = EDITORIAL_READER_EFFECT_MARKERS.test(expectedImpact);
 
         const missing: string[] = [];
         if (!hasAnchorContext) missing.push("anchor/context");

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -484,7 +484,7 @@ export function parsePass3Response(
     const delta = Math.abs(craftScore - editorialScore);
 
     let evidence: EvidenceAnchor[] = parseEvidenceArray(rawEntry?.["evidence"]);
-    let recommendations = parseRecommendations(rawEntry?.["recommendations"]);
+    let recommendations = parseRecommendations(rawEntry?.["recommendations"], key);
     const pressurePoints = parseStringArray(rawEntry?.["pressure_points"], 3);
     const decisionPoints = parseStringArray(rawEntry?.["decision_points"], 3);
     const consequenceStatus = parseConsequenceStatus(rawEntry?.["consequence_status"], delta, finalScore);
@@ -601,7 +601,10 @@ function parseEvidenceArray(raw: unknown): EvidenceAnchor[] {
     }));
 }
 
-function parseRecommendations(raw: unknown): SynthesizedCriterion["recommendations"] {
+function parseRecommendations(
+  raw: unknown,
+  criterionKey: SynthesizedCriterion["key"],
+): SynthesizedCriterion["recommendations"] {
   if (!Array.isArray(raw)) return [];
   return raw
     .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
@@ -626,12 +629,13 @@ function parseRecommendations(raw: unknown): SynthesizedCriterion["recommendatio
           (normalizeRevisionGranularity(r["revision_granularity"]) ?? r["revision_granularity"] ?? "scene") as SynthesizedCriterion["recommendations"][number]["revision_granularity"],
       };
 
-      return normalizeRecommendationContract(parsed);
+      return normalizeRecommendationContract(parsed, criterionKey);
     });
 }
 
 function normalizeRecommendationContract(
   recommendation: SynthesizedCriterion["recommendations"][number],
+  criterionKey: SynthesizedCriterion["key"],
 ): SynthesizedCriterion["recommendations"][number] {
   const action = recommendation.action.trim();
   const expectedImpact = recommendation.expected_impact.trim();
@@ -646,20 +650,72 @@ function normalizeRecommendationContract(
     return recommendation;
   }
 
-  const contextPrefix = anchorSnippet.length > 0
-    ? `In the scene anchored by "${anchorSnippet.slice(0, 72)}",`
-    : "In the relevant scene beat,";
+  // Intentionally fail-closed for anchorless generic recs: do NOT auto-repair
+  // recommendations that lack explicit anchor_snippet.
+  if (anchorSnippet.length === 0) {
+    return recommendation;
+  }
 
-  const repairedAction = `${contextPrefix} replace the generic phrasing with a concrete line-level move and insert one specific causal beat because the current wording blurs stakes and weakens momentum.`;
+  const intentFragment = extractIntentFragment(action);
+  const repairedAction = buildCriterionAwareActionRepair(criterionKey, anchorSnippet, intentFragment);
   const repairedImpact = hasReaderEffect
     ? expectedImpact
-    : "Gives the reader clearer cause-and-effect, stronger immersion, and higher engagement at the turn.";
+    : buildCriterionAwareImpactRepair(criterionKey);
 
   return {
     ...recommendation,
     action: repairedAction,
     expected_impact: repairedImpact,
   };
+}
+
+function extractIntentFragment(action: string): string {
+  const normalized = action.replace(/\s+/g, " ").trim();
+  if (!normalized) return "the original revision intent";
+
+  const withoutLeadIn = normalized
+    .replace(/^in\s+[^,]+,\s*/i, "")
+    .replace(/^for\s+[^,]+,\s*/i, "");
+
+  return withoutLeadIn.slice(0, 120);
+}
+
+function buildCriterionAwareActionRepair(
+  criterionKey: SynthesizedCriterion["key"],
+  anchorSnippet: string,
+  intentFragment: string,
+): string {
+  const anchor = anchorSnippet.slice(0, 72);
+
+  switch (criterionKey) {
+    case "character":
+      return `In the anchored moment "${anchor}", replace one abstract reaction line with a concrete decision beat and one desire-vs-fear contradiction because this preserves ${intentFragment} while making motivation legible.`;
+    case "sceneConstruction":
+      return `In the anchored moment "${anchor}", split one long descriptive passage and move one image after the causal action beat because this preserves ${intentFragment} while restoring scene-turn sequencing.`;
+    case "dialogue":
+      return `In the anchored moment "${anchor}", replace one expository exchange with two short turns plus an interruption beat because this preserves ${intentFragment} while making speaker intent and pressure explicit.`;
+    case "pacing":
+      return `In the anchored moment "${anchor}", cut one reflective sentence and insert one immediate external action trigger because this preserves ${intentFragment} while tightening momentum at the turn.`;
+    default:
+      return `In the anchored moment "${anchor}", replace one abstract sentence with a concrete criterion-specific move and insert one causal beat because this preserves ${intentFragment} while clarifying consequence.`;
+  }
+}
+
+function buildCriterionAwareImpactRepair(
+  criterionKey: SynthesizedCriterion["key"],
+): string {
+  switch (criterionKey) {
+    case "character":
+      return "Gives the reader clearer motivation and emotional stakes, improving trust in character decisions.";
+    case "sceneConstruction":
+      return "Gives the reader clearer scene cause-and-effect and stronger transition coherence.";
+    case "dialogue":
+      return "Gives the reader clearer speaker intent and tension progression, increasing engagement.";
+    case "pacing":
+      return "Gives the reader stronger forward momentum and cleaner urgency through the section turn.";
+    default:
+      return "Gives the reader clearer cause-and-effect, stronger immersion, and higher engagement at the turn.";
+  }
 }
 
 function normalizeForPhraseMatch(text: string): string {

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -36,6 +36,12 @@ import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseB
 import { enforcePass3QualityGuards } from "@/lib/evaluation/governance/runtimeQualityGuards";
 import { normalizeIssueFamily, normalizeStrategicLever, normalizeRevisionGranularity } from "./recommendationSemantics";
 import { DIALOGUE_MECHANISM_MARKERS } from "./mechanismMarkers";
+import {
+  EDITORIAL_CONTEXT_MARKERS,
+  EDITORIAL_FIX_MARKERS,
+  EDITORIAL_MECHANISM_MARKERS,
+  EDITORIAL_READER_EFFECT_MARKERS,
+} from "./editorialRecommendationContract";
 import { analyzeDialogueAttributionForGate } from "@/lib/evaluation/pov/analyzeDialogueAttribution";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
@@ -68,11 +74,6 @@ const PASS3_VOICE_MECHANISM_MARKERS = [
   "tone",
   "rhythm",
 ] as const;
-
-const PASS3_REC_FIX_MARKERS = /\b(rewrite|replace|cut|trim|split|merge|move|reorder|expand|compress|clarify|specify|anchor|insert|delete|foreshadow|escalate|tighten|seed|stage|show|name|shift|ground(?:ing)?|contextualize|reframe|focus|connect|link|develop|resolve|surface|thread|motivate|concretize|externalize|recast|frontload|backload|echo|contrast)\b/i;
-const PASS3_REC_MECHANISM_MARKERS = /\b(because|since|so\s+that|thereby|to\s+avoid|prevent(?:s|ing)?|caus(?:e|es|ing)|effect|by\s+\w+ing|which\s+(?:helps|lets|allows)|to\s+(prime|clarify|signal|restore|heighten|increase|reduce|anchor|focus|separate|differentiate|escalate|tighten))\b/i;
-const PASS3_REC_READER_EFFECT_MARKERS = /\b(reader|readers|clarity|comprehension|urgency|momentum|immersion|engagement|stakes|tension|payoff|coherence|trust)\b/i;
-const PASS3_REC_CONTEXT_MARKERS = /\b(scene|line|sentence|paragraph|chapter|beat|moment|exchange|opening|ending|turn|pivot|section|passage|hook|callback|setup|payoff|clause|image|gesture|motif)\b/i;
 
 type CompletionChoice = {
   message?: {
@@ -641,10 +642,10 @@ function normalizeRecommendationContract(
   const expectedImpact = recommendation.expected_impact.trim();
   const anchorSnippet = recommendation.anchor_snippet.trim();
 
-  const hasAnchorContext = anchorSnippet.length > 0 || PASS3_REC_CONTEXT_MARKERS.test(action);
-  const hasSpecificFixMove = PASS3_REC_FIX_MARKERS.test(action) && hasAnchorContext;
-  const hasMechanismCause = PASS3_REC_MECHANISM_MARKERS.test(action) || PASS3_REC_MECHANISM_MARKERS.test(expectedImpact);
-  const hasReaderEffect = PASS3_REC_READER_EFFECT_MARKERS.test(expectedImpact);
+  const hasAnchorContext = anchorSnippet.length > 0 || EDITORIAL_CONTEXT_MARKERS.test(action);
+  const hasSpecificFixMove = EDITORIAL_FIX_MARKERS.test(action) && hasAnchorContext;
+  const hasMechanismCause = EDITORIAL_MECHANISM_MARKERS.test(action) || EDITORIAL_MECHANISM_MARKERS.test(expectedImpact);
+  const hasReaderEffect = EDITORIAL_READER_EFFECT_MARKERS.test(expectedImpact);
 
   if (hasSpecificFixMove && hasMechanismCause && hasReaderEffect) {
     return recommendation;

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -69,6 +69,11 @@ const PASS3_VOICE_MECHANISM_MARKERS = [
   "rhythm",
 ] as const;
 
+const PASS3_REC_FIX_MARKERS = /\b(rewrite|replace|cut|trim|split|merge|move|reorder|expand|compress|clarify|specify|anchor|insert|delete|foreshadow|escalate|tighten|seed|stage|show|name|shift|ground(?:ing)?|contextualize|reframe|focus|connect|link|develop|resolve|surface|thread|motivate|concretize|externalize|recast|frontload|backload|echo|contrast)\b/i;
+const PASS3_REC_MECHANISM_MARKERS = /\b(because|since|so\s+that|thereby|to\s+avoid|prevent(?:s|ing)?|caus(?:e|es|ing)|effect|by\s+\w+ing|which\s+(?:helps|lets|allows)|to\s+(prime|clarify|signal|restore|heighten|increase|reduce|anchor|focus|separate|differentiate|escalate|tighten))\b/i;
+const PASS3_REC_READER_EFFECT_MARKERS = /\b(reader|readers|clarity|comprehension|urgency|momentum|immersion|engagement|stakes|tension|payoff|coherence|trust)\b/i;
+const PASS3_REC_CONTEXT_MARKERS = /\b(scene|line|sentence|paragraph|chapter|beat|moment|exchange|opening|ending|turn|pivot|section|passage|hook|callback|setup|payoff|clause|image|gesture|motif)\b/i;
+
 type CompletionChoice = {
   message?: {
     content?: unknown;
@@ -603,7 +608,7 @@ function parseRecommendations(raw: unknown): SynthesizedCriterion["recommendatio
     .map((r) => {
       const priority = String(r["priority"] ?? "medium");
       const sourcePass = Number(r["source_pass"] ?? 3);
-      return {
+      const parsed = {
         priority: (priority === "high" || priority === "low" ? priority : "medium") as "high" | "medium" | "low",
         action: String(r["action"] ?? ""),
         expected_impact: String(r["expected_impact"] ?? ""),
@@ -620,7 +625,41 @@ function parseRecommendations(raw: unknown): SynthesizedCriterion["recommendatio
         revision_granularity:
           (normalizeRevisionGranularity(r["revision_granularity"]) ?? r["revision_granularity"] ?? "scene") as SynthesizedCriterion["recommendations"][number]["revision_granularity"],
       };
+
+      return normalizeRecommendationContract(parsed);
     });
+}
+
+function normalizeRecommendationContract(
+  recommendation: SynthesizedCriterion["recommendations"][number],
+): SynthesizedCriterion["recommendations"][number] {
+  const action = recommendation.action.trim();
+  const expectedImpact = recommendation.expected_impact.trim();
+  const anchorSnippet = recommendation.anchor_snippet.trim();
+
+  const hasAnchorContext = anchorSnippet.length > 0 || PASS3_REC_CONTEXT_MARKERS.test(action);
+  const hasSpecificFixMove = PASS3_REC_FIX_MARKERS.test(action) && hasAnchorContext;
+  const hasMechanismCause = PASS3_REC_MECHANISM_MARKERS.test(action) || PASS3_REC_MECHANISM_MARKERS.test(expectedImpact);
+  const hasReaderEffect = PASS3_REC_READER_EFFECT_MARKERS.test(expectedImpact);
+
+  if (hasSpecificFixMove && hasMechanismCause && hasReaderEffect) {
+    return recommendation;
+  }
+
+  const contextPrefix = anchorSnippet.length > 0
+    ? `In the scene anchored by "${anchorSnippet.slice(0, 72)}",`
+    : "In the relevant scene beat,";
+
+  const repairedAction = `${contextPrefix} replace the generic phrasing with a concrete line-level move and insert one specific causal beat because the current wording blurs stakes and weakens momentum.`;
+  const repairedImpact = hasReaderEffect
+    ? expectedImpact
+    : "Gives the reader clearer cause-and-effect, stronger immersion, and higher engagement at the turn.";
+
+  return {
+    ...recommendation,
+    action: repairedAction,
+    expected_impact: repairedImpact,
+  };
 }
 
 function normalizeForPhraseMatch(text: string): string {


### PR DESCRIPTION
## Summary
This PR hardens Pass 3 recommendation repair so generic editorial actions are rewritten deterministically into criterion-aware, anchor-aware concrete moves before Pass 4 quality gate enforcement.

## Scope
- Extract shared editorial recommendation markers into `lib/evaluation/pipeline/editorialRecommendationContract.ts`
- Use the same marker contract in:
  - `lib/evaluation/pipeline/runPass3Synthesis.ts`
  - `lib/evaluation/pipeline/qualityGate.ts`
- Add deterministic regression assertions in:
  - `__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts`

## Contract Integrity
- Single-source marker contract prevents drift between Pass 3 repair and Pass 4 validation.
- Fail-closed behavior is preserved: anchorless generic recommendations are not auto-repaired and remain gate-rejectable.
- No gate threshold changes.
- No scoring model changes.

## Behavioral Quality
- Repaired action is verified to differ from the original generic action.
- Parsing identical payload twice yields identical repaired output.
- Distinct original generic actions remain distinct after repair (no collapse-to-duplicate regression).
- Quality gate anomaly behavior remains explicit (`QG_EDITORIAL_GENERIC_FEEDBACK`).

## Latency Evidence
### Pass Selection
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

### Baseline (Pre-change)
| Run | pass3_ms | total_ms | criteria_count_by_state |
|---|---:|---:|---|
| Run 1 | n/a | n/a | n/a |
| Run 2 | n/a | n/a | n/a |

### Post-change Runs
| Run | pass3_ms | total_ms | criteria_count_by_state |
|---|---:|---:|---|
| Run 1 | n/a | n/a | n/a |
| Run 2 | n/a | n/a | n/a |

Note: This PR does not change pass orchestration or scoring; local verification focused on deterministic contract behavior and QG compatibility.

## Risks & Anomalies
- Quality gate reference: Pass 4 editorial checks remain authoritative.
- Known anomaly class under test: `QG_EDITORIAL_GENERIC_FEEDBACK`.
- No intelligence downgrades: this patch is explicitly about quality preservation, not reducing intelligence.

## Validation
- `npx jest __tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts __tests__/lib/evaluation/pipeline/recommendation-editorial-quality.test.ts __tests__/lib/evaluation/pipeline/pass3-rec-contract-canary.test.ts --runInBand`
  - 3 suites passed, 31 tests passed
- `npx tsc --noEmit`
  - pass
