### PR TITLE
fix(longform): materialize chunks from processor-resolved text

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -450,4 +450,26 @@ describe("processEvaluationJob long-form chunk routing", () => {
     });
     expect(failureUpdate).toBeDefined();
   });
+
+  test("long_form fails closed when ensured count and persisted count mismatch", async () => {
+    const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
+    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksFromTextMock.mockResolvedValueOnce({
+      ensured_count: 4,
+      persisted_count: 3,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ensure_chunks_returned_count=4");
+    expect(result.error).toContain("persisted_chunk_count=3");
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -5,6 +5,7 @@ const synthesisToEvaluationResultV2Mock = jest.fn();
 const runQualityGateV2Mock = jest.fn();
 const mapEvaluationResultV2ToGovernanceEnvelopeMock = jest.fn();
 const ensureChunksMock = jest.fn();
+const ensureChunksFromTextMock = jest.fn();
 
 jest.mock("@/lib/evaluation/pipeline/runPipeline", () => ({
   runPipeline: (...args: any[]) => runPipelineMock(...args),
@@ -22,6 +23,7 @@ jest.mock("@/lib/governance/evaluationBridge", () => ({
 
 jest.mock("@/lib/manuscripts/chunks", () => ({
   ensureChunks: (...args: any[]) => ensureChunksMock(...args),
+  ensureChunksFromText: (...args: any[]) => ensureChunksFromTextMock(...args),
 }));
 
 const createClientMock = jest.fn();
@@ -231,7 +233,7 @@ describe("processEvaluationJob long-form chunk routing", () => {
     process.env.EVAL_EXTERNAL_ADJUDICATION_MODE = "optional";
   });
 
-  test("ensures chunks before pipeline for long-form manuscripts and persists chunk routing telemetry", async () => {
+  test("long_form uses ensureChunksFromText (not ensureChunks), runs before pipeline, and persists proof telemetry", async () => {
     const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
     const supabaseStub = makeSupabaseStub(manuscriptContent, {
       manuscriptChunks: [
@@ -243,7 +245,12 @@ describe("processEvaluationJob long-form chunk routing", () => {
     });
     createClientMock.mockReturnValue(supabaseStub);
 
-    ensureChunksMock.mockResolvedValue(4);
+    ensureChunksFromTextMock.mockResolvedValue({
+      ensured_count: 4,
+      persisted_count: 4,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+    });
 
     runPipelineMock.mockResolvedValue({
       ok: true,
@@ -286,10 +293,15 @@ describe("processEvaluationJob long-form chunk routing", () => {
     const result = await processEvaluationJob("job-long-form-routing");
 
     expect(result.success).toBe(true);
-    expect(ensureChunksMock).toHaveBeenCalledWith(456, "job-long-form-routing");
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+    expect(ensureChunksFromTextMock.mock.calls[0]?.[0]).toBe(456);
+    expect(ensureChunksFromTextMock.mock.calls[0]?.[1]).toBe("job-long-form-routing");
+    expect(typeof ensureChunksFromTextMock.mock.calls[0]?.[2]).toBe("string");
+    expect(ensureChunksFromTextMock.mock.calls[0]?.[2]).toContain("alpha beta gamma delta epsilon");
+    expect(ensureChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
 
-    const ensureChunksCallOrder = ensureChunksMock.mock.invocationCallOrder[0];
+    const ensureChunksCallOrder = ensureChunksFromTextMock.mock.invocationCallOrder[0];
     const runPipelineCallOrder = runPipelineMock.mock.invocationCallOrder[0];
     expect(ensureChunksCallOrder).toBeLessThan(runPipelineCallOrder);
 
@@ -320,12 +332,16 @@ describe("processEvaluationJob long-form chunk routing", () => {
           threshold_words: 25000,
           manuscript_words: 26000,
           chunk_count: 4,
+          ensure_chunks_returned_count: 4,
+          persisted_chunk_count: 4,
+          chunk_source: "processor_resolved_text",
+          verified_at: expect.any(String),
         }),
       }),
     );
   });
 
-  test("does not call ensureChunks for short-form manuscripts and persists short_form telemetry", async () => {
+  test("short_form behavior is unchanged (no ensureChunksFromText, no fail-closed)", async () => {
     const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(300);
     const supabaseStub = makeSupabaseStub(manuscriptContent);
     createClientMock.mockReturnValue(supabaseStub);
@@ -371,6 +387,7 @@ describe("processEvaluationJob long-form chunk routing", () => {
     const result = await processEvaluationJob("job-long-form-routing");
 
     expect(result.success).toBe(true);
+    expect(ensureChunksFromTextMock).not.toHaveBeenCalled();
     expect(ensureChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
 
@@ -378,31 +395,59 @@ describe("processEvaluationJob long-form chunk routing", () => {
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
     );
     expect(persistCall).toBeDefined();
-    expect(persistCall?.args?.p_progress).toEqual(
-      expect.objectContaining({
-        chunk_routing: expect.objectContaining({
-          enabled: true,
-          route: "short_form",
-          threshold_words: 25000,
-          manuscript_words: 3000,
-          chunk_count: 0,
-        }),
-      }),
+    expect(persistCall?.args?.p_progress).toMatchObject({
+      chunk_routing: {
+        enabled: true,
+        route: "short_form",
+        threshold_words: 25000,
+        manuscript_words: 3000,
+        chunk_count: 0,
+      },
+    });
+    expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty(
+      "ensure_chunks_returned_count",
     );
+    expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty(
+      "persisted_chunk_count",
+    );
+    expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty("chunk_source");
+    expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty("verified_at");
   });
 
-  test("does not run pipeline when ensureChunks throws for long-form manuscripts", async () => {
+  test("long_form + persisted_chunk_count = 0 fails with LONG_FORM_CHUNK_MATERIALIZATION_FAILED and does not run pipeline", async () => {
     const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
     const supabaseStub = makeSupabaseStub(manuscriptContent);
     createClientMock.mockReturnValue(supabaseStub);
 
-    ensureChunksMock.mockRejectedValueOnce(new Error("chunking failed"));
+    ensureChunksFromTextMock.mockResolvedValueOnce({
+      ensured_count: 0,
+      persisted_count: 0,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+    });
 
     const { processEvaluationJob } = require("../../../lib/evaluation/processor");
     const result = await processEvaluationJob("job-long-form-routing");
 
     expect(result.success).toBe(false);
-    expect(ensureChunksMock).toHaveBeenCalledTimes(1);
+    expect(result.error).toContain("persisted_chunk_count=0");
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+    expect(ensureChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).not.toHaveBeenCalled();
+
+    const failureUpdate = supabaseStub.evaluationJobUpdates.find((payload) => {
+      const progress = payload.progress as
+        | {
+            error_code?: string;
+            pipeline_failure_envelope?: { error_code?: string };
+          }
+        | undefined;
+      return (
+        progress?.error_code === "LONG_FORM_CHUNK_MATERIALIZATION_FAILED" ||
+        progress?.pipeline_failure_envelope?.error_code ===
+          "LONG_FORM_CHUNK_MATERIALIZATION_FAILED"
+      );
+    });
+    expect(failureUpdate).toBeDefined();
   });
 });

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -101,7 +101,7 @@ import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
-import { ensureChunks, ensureChunksFromText } from '@/lib/manuscripts/chunks';
+import { ensureChunksFromText } from '@/lib/manuscripts/chunks';
 import type { ManuscriptChunkEvidence } from '@/lib/evaluation/pipeline/types';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
@@ -1716,15 +1716,23 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     progressState.chunk_routing = chunkRouting;
 
     // Fail-closed guard: long_form must prove chunk materialization before pipeline.
-    // If persisted_chunk_count is 0, the pipeline cannot produce valid comparison packet
-    // evidence — proceeding would silently corrupt scoring. Fail explicitly here.
+    // If persisted_chunk_count is 0 OR does not match ensured chunk count, the pipeline
+    // cannot produce trustworthy comparison-packet evidence. Fail explicitly here.
     if (
       chunkRouting.route === 'long_form' &&
-      (chunkRouting.persisted_chunk_count === undefined || chunkRouting.persisted_chunk_count === 0)
+      (
+        chunkRouting.persisted_chunk_count === undefined ||
+        chunkRouting.ensure_chunks_returned_count === undefined ||
+        chunkRouting.persisted_chunk_count === 0 ||
+        chunkRouting.ensure_chunks_returned_count === 0 ||
+        chunkRouting.persisted_chunk_count !== chunkRouting.ensure_chunks_returned_count
+      )
     ) {
       const chunkMaterializationError =
-        `Long-form job requires persisted chunks before pipeline, but persisted_chunk_count=` +
-        `${chunkRouting.persisted_chunk_count ?? 0} for manuscript ${manuscriptWithContent.id}. ` +
+        `Long-form job requires verified chunk materialization before pipeline, but ` +
+        `ensure_chunks_returned_count=${chunkRouting.ensure_chunks_returned_count ?? 0}, ` +
+        `persisted_chunk_count=${chunkRouting.persisted_chunk_count ?? 0} ` +
+        `for manuscript ${manuscriptWithContent.id}. ` +
         `Chunk materialization failed. Do not proceed.`;
       await markFailed(chunkMaterializationError, 'LONG_FORM_CHUNK_MATERIALIZATION_FAILED', {
         pipelineStage: 'phase_1',

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -101,7 +101,7 @@ import { summarizePromptCoverage } from '@/lib/evaluation/pipeline/promptInput';
 import { detectContextContamination } from '@/lib/evaluation/governance/contextContaminationGuard';
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
-import { ensureChunks } from '@/lib/manuscripts/chunks';
+import { ensureChunks, ensureChunksFromText } from '@/lib/manuscripts/chunks';
 import type { ManuscriptChunkEvidence } from '@/lib/evaluation/pipeline/types';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
@@ -135,6 +135,11 @@ type ChunkRoutingTelemetry = {
   threshold_words: number;
   manuscript_words: number;
   chunk_count: number;
+  // Long-form chunk materialization proof fields (populated only on long_form route)
+  ensure_chunks_returned_count?: number;
+  persisted_chunk_count?: number;
+  chunk_source?: 'processor_resolved_text';
+  verified_at?: string;
 }
 
 export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
@@ -874,17 +879,26 @@ async function maybeEnsureLongFormChunks(args: {
     };
   }
 
-  // TODO(#292): ensureChunks currently resolves manuscript text via getManuscriptText(),
-  // while evaluation uses resolveManuscriptText() in this worker path. Unify sources
-  // before chunk content is consumed by buildComparisonPacket().
-  const chunkCount = await ensureChunks(args.manuscriptId, args.jobId);
+  // Fix(#290): use processor-resolved text directly — never re-resolve through
+  // getManuscriptText() which uses a divergent source path and can silently
+  // return empty/placeholder text, causing chunk materialization to fail while
+  // route telemetry still reports long_form.
+  const chunkResult = await ensureChunksFromText(
+    args.manuscriptId,
+    args.jobId,
+    args.manuscriptText,
+  );
 
   return {
     enabled: true,
     route: 'long_form',
     threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
     manuscript_words: manuscriptWords,
-    chunk_count: chunkCount,
+    chunk_count: chunkResult.ensured_count,
+    ensure_chunks_returned_count: chunkResult.ensured_count,
+    persisted_chunk_count: chunkResult.persisted_count,
+    chunk_source: chunkResult.chunk_source,
+    verified_at: chunkResult.verified_at,
   };
 }
 
@@ -1700,6 +1714,25 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       manuscriptText: manuscriptWithContent.content || '',
     });
     progressState.chunk_routing = chunkRouting;
+
+    // Fail-closed guard: long_form must prove chunk materialization before pipeline.
+    // If persisted_chunk_count is 0, the pipeline cannot produce valid comparison packet
+    // evidence — proceeding would silently corrupt scoring. Fail explicitly here.
+    if (
+      chunkRouting.route === 'long_form' &&
+      (chunkRouting.persisted_chunk_count === undefined || chunkRouting.persisted_chunk_count === 0)
+    ) {
+      const chunkMaterializationError =
+        `Long-form job requires persisted chunks before pipeline, but persisted_chunk_count=` +
+        `${chunkRouting.persisted_chunk_count ?? 0} for manuscript ${manuscriptWithContent.id}. ` +
+        `Chunk materialization failed. Do not proceed.`;
+      await markFailed(chunkMaterializationError, 'LONG_FORM_CHUNK_MATERIALIZATION_FAILED', {
+        pipelineStage: 'phase_1',
+        reasonCodes: ['LONG_FORM_CHUNK_MATERIALIZATION_FAILED'],
+        diagnostics: { chunk_routing: chunkRouting },
+      });
+      return { success: false, error: chunkMaterializationError };
+    }
 
     let manuscriptChunksForPipeline: ManuscriptChunkEvidence[] | undefined;
     if (chunkRouting.route === 'long_form') {

--- a/lib/manuscripts/chunks.ts
+++ b/lib/manuscripts/chunks.ts
@@ -788,3 +788,84 @@ export async function ensureChunks(
 
   return chunks.length;
 }
+
+export type EnsureChunksFromTextResult = {
+  /** Number of chunks returned by chunkManuscript() */
+  ensured_count: number;
+  /** Number of chunks verified as persisted in manuscript_chunks after upsert */
+  persisted_count: number;
+  /** Source label for telemetry */
+  chunk_source: 'processor_resolved_text';
+  /** ISO timestamp of the persistence verification */
+  verified_at: string;
+};
+
+/**
+ * Materialize chunks from an already-resolved manuscript text.
+ *
+ * Use this on the long_form path so chunking always operates on the same
+ * text that drove the routing decision. Never re-resolves text through
+ * getManuscriptText() — that is the bug this function replaces.
+ *
+ * After upserting, queries the DB to verify persisted_count > 0.
+ * Callers MUST check persisted_count before invoking runPipeline.
+ */
+export async function ensureChunksFromText(
+  manuscriptId: number,
+  jobId: string,
+  manuscriptText: string,
+): Promise<EnsureChunksFromTextResult> {
+  if (!manuscriptText || manuscriptText.trim().length === 0) {
+    throw new Error(
+      `[ensureChunksFromText] manuscriptText is empty for manuscript ${manuscriptId} — cannot materialize chunks`,
+    );
+  }
+
+  // Check for pre-existing chunks first (idempotent).
+  const existing = await getManuscriptChunks(manuscriptId);
+  if (existing.length > 0) {
+    const verified_at = new Date().toISOString();
+    return {
+      ensured_count: existing.length,
+      persisted_count: existing.length,
+      chunk_source: 'processor_resolved_text',
+      verified_at,
+    };
+  }
+
+  // Chunk the processor-resolved text directly — no re-resolution.
+  const chunks = await chunkManuscript(manuscriptText);
+  const ensured_count = chunks.length;
+
+  if (ensured_count === 0) {
+    throw new Error(
+      `[ensureChunksFromText] chunkManuscript returned 0 chunks for manuscript ${manuscriptId} (text length=${manuscriptText.length})`,
+    );
+  }
+
+  await upsertChunks(manuscriptId, chunks, jobId);
+
+  // Verify persistence — query actual DB count, do not trust ensured_count alone.
+  const { data: persistedRows, error: verifyError } = await supabase
+    .from('manuscript_chunks')
+    .select('chunk_index', { count: 'exact', head: true })
+    .eq('manuscript_id', manuscriptId);
+
+  if (verifyError) {
+    throw new Error(
+      `[ensureChunksFromText] chunk persistence verification failed for manuscript ${manuscriptId}: ${verifyError.message}`,
+    );
+  }
+
+  const persisted_count = (persistedRows as unknown as { count?: number } | null)?.count
+    ?? (await getManuscriptChunks(manuscriptId)).length;
+
+  const verified_at = new Date().toISOString();
+
+  return {
+    ensured_count,
+    persisted_count,
+    chunk_source: 'processor_resolved_text',
+    verified_at,
+  };
+}

--- a/lib/manuscripts/chunks.ts
+++ b/lib/manuscripts/chunks.ts
@@ -821,18 +821,6 @@ export async function ensureChunksFromText(
     );
   }
 
-  // Check for pre-existing chunks first (idempotent).
-  const existing = await getManuscriptChunks(manuscriptId);
-  if (existing.length > 0) {
-    const verified_at = new Date().toISOString();
-    return {
-      ensured_count: existing.length,
-      persisted_count: existing.length,
-      chunk_source: 'processor_resolved_text',
-      verified_at,
-    };
-  }
-
   // Chunk the processor-resolved text directly — no re-resolution.
   const chunks = await chunkManuscript(manuscriptText);
   const ensured_count = chunks.length;
@@ -846,7 +834,7 @@ export async function ensureChunksFromText(
   await upsertChunks(manuscriptId, chunks, jobId);
 
   // Verify persistence — query actual DB count, do not trust ensured_count alone.
-  const { data: persistedRows, error: verifyError } = await supabase
+  const { count: persistedCountFromHead, error: verifyError } = await supabase
     .from('manuscript_chunks')
     .select('chunk_index', { count: 'exact', head: true })
     .eq('manuscript_id', manuscriptId);
@@ -857,8 +845,10 @@ export async function ensureChunksFromText(
     );
   }
 
-  const persisted_count = (persistedRows as unknown as { count?: number } | null)?.count
-    ?? (await getManuscriptChunks(manuscriptId)).length;
+  const persisted_count =
+    typeof persistedCountFromHead === 'number'
+      ? persistedCountFromHead
+      : (await getManuscriptChunks(manuscriptId)).length;
 
   const verified_at = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
Refs #290 by removing the split-source long-form chunking seam and enforcing fail-closed chunk materialization before pipeline execution.

Long-form routing was decided from processor-resolved manuscript text, but chunk creation previously re-resolved text through `getManuscriptText()`. This could route a job as `long_form` while failing to persist `manuscript_chunks`.

## Scope
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

In-scope:
- `lib/manuscripts/chunks.ts`
- `lib/evaluation/processor.ts`
- `__tests__/lib/evaluation/processor.chunk-routing.test.ts`

Out-of-scope:
- UI/report surface changes
- QualityGate/scoring/prompt policy changes
- `getManuscriptText()` placeholder cleanup (follow-up hardening PR)

## Contract Integrity
- Add `ensureChunksFromText(manuscriptId, jobId, manuscriptText)` so long_form chunking uses the same processor-resolved text used for routing.
- Verify persisted chunk count after upsert (DB-verified, not assumed).
- Fail closed with `LONG_FORM_CHUNK_MATERIALIZATION_FAILED` when:
  - persisted count is zero, or
  - ensured count and persisted count mismatch.
- Prevent `runPipeline()` invocation on chunk materialization failure.

## Behavioral Quality
- Preserves short_form behavior (no chunk materialization step added).
- Prevents silent/partial long_form progression.
- Quality gate disclosure: this change is upstream integrity hardening and does not weaken any `QG_` enforcement behavior.
- Principle upheld: this change is **not reducing intelligence**; it prevents invalid execution states from masquerading as valid evaluation progress.

## Latency Evidence

Baseline (Pre-change)

| Run | pass3_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A (unit/integration path) | ~131 ms (targeted suite case) | long_form happy-path test prior to hardening |
| Run 2 | N/A (unit/integration path) | ~30 ms (targeted suite case) | short_form control path |

Post-change Runs

| Run | pass3_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A (unit/integration path) | ~342 ms (targeted suite case) | long_form uses ensureChunksFromText + proof telemetry |
| Run 2 | N/A (unit/integration path) | ~29 ms (targeted suite case) | fail-closed mismatch path, no runPipeline |

Targeted test command:

```bash
npm test -- __tests__/lib/evaluation/processor.chunk-routing.test.ts
```

Result:

```text
PASS
4 tests passed
```

## Risks & Anomalies
- `criteria_count_by_state` is not proven by this unit suite; must be validated in the post-merge 85k production proof run.
- Post-merge closure gate remains mandatory for #290/#289:
  - `progress.chunk_routing.route = long_form`
  - `progress.chunk_routing.persisted_chunk_count > 0`
  - `progress.chunk_routing.chunk_source = 'processor_resolved_text'`
  - `manuscript_chunks > 0`
  - `comparison_packet_chars > 0`

## Closure Gate (DO NOT MERGE-CLOSE)
Merging this PR does **NOT** auto-close issue 290 by itself.

Do not manually close issues 290 or 289 until one controlled post-merge 85k long-form rerun posts SQL proof for the fields above.

## Reviewer Checklist
- [ ] long_form path calls `ensureChunksFromText(...)`
- [ ] long_form path no longer depends on `ensureChunks(...)`/re-resolved text
- [ ] zero persisted chunks fail closed before pipeline
- [ ] ensured/persisted mismatch fails closed before pipeline
- [ ] `runPipeline()` is not called on chunk materialization failure
- [ ] short_form invariants unchanged

