### PR TITLE
fix(migrations): canon_rag_schema index → pass_scope

### DIFF
--- a/supabase/migrations/20260501000100_canon_rag_schema.sql
+++ b/supabase/migrations/20260501000100_canon_rag_schema.sql
@@ -58,8 +58,8 @@ CREATE TABLE IF NOT EXISTS public.canon_governance_rules (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS canon_documents_scope_idx
-  ON public.canon_documents USING GIN (scope);
+CREATE INDEX IF NOT EXISTS canon_documents_pass_scope_idx
+  ON public.canon_documents USING GIN (pass_scope);
 
 CREATE INDEX IF NOT EXISTS canon_documents_canon_id_idx
   ON public.canon_documents (canon_id);


### PR DESCRIPTION
Fixes Production Alignment Guard #120 (SQLSTATE 42703 on canon_documents.scope). Production schema has pass_scope text[]; this aligns the index DDL with reality. Proof: information_schema.columns query confirms pass_scope exists, scope does not.