### PR TITLE
fix(evaluation): reconcile low-confidence score cap before gate

### DIFF
--- a/lib/evaluation/signal/criterionObservability.ts
+++ b/lib/evaluation/signal/criterionObservability.ts
@@ -47,6 +47,10 @@ export type RawCriterionInput = {
   insufficient_signal_reason?: InsufficientSignalReason;
 };
 
+export const LOW_CONFIDENCE_SCORE_CAP = 5;
+export const LOW_CONFIDENCE_SCORE_RECONCILIATION_REASON =
+  "LOW_CONFIDENCE_SCORE_RECONCILED_TO_5";
+
 const PATTERN_CRITERIA = new Set<CriterionKey>(["voice", "tone", "pacing", "theme"]);
 const SOFT_FAIL_DIALOGUE_ENABLED = process.env.RG_SOFT_FAIL_DIALOGUE !== "false";
 
@@ -349,8 +353,22 @@ export function normalizeCriterion(
   // Scorability semantics: thin support lowers confidence, it does not erase a scorable score.
   if (hasNumericScore) {
     const rounded = Math.max(0, Math.min(10, Math.round(raw.score_0_10 as number)));
+    const reconciledScore = reconcileLowConfidenceScore({
+      status: "SCORABLE",
+      confidence_level: cappedConfidenceLevel,
+      score_0_10: rounded,
+    });
     const normalizedSignal: "SUFFICIENT" | "STRONG" =
       signalStrength === "STRONG" ? "STRONG" : "SUFFICIENT";
+
+    const reconciledConfidenceReasons = reconciledScore.reconciled
+      ? Array.from(
+          new Set([
+            ...confidenceReasons,
+            LOW_CONFIDENCE_SCORE_RECONCILIATION_REASON,
+          ]),
+        )
+      : confidenceReasons;
 
     return {
       key: raw.key,
@@ -358,11 +376,11 @@ export function normalizeCriterion(
       status: "SCORABLE",
       signal_present: true,
       signal_strength: normalizedSignal,
-      score_0_10: rounded,
+      score_0_10: reconciledScore.score_0_10,
       confidence_band: confidenceBandFromLevel,
       confidence_score_0_100: cappedConfidenceScore,
       confidence_level: cappedConfidenceLevel,
-      confidence_reasons: confidenceReasons,
+      confidence_reasons: reconciledConfidenceReasons,
       scorability_status:
         confidence.scorability_status === "non_scorable"
           ? "scorable_low_confidence"
@@ -392,6 +410,29 @@ export function normalizeCriterion(
     evidence,
     recommendations,
     insufficient_signal_reason: buildStructuredReason(status, raw.insufficient_signal_reason),
+  };
+}
+
+export function reconcileLowConfidenceScore(input: {
+  status: CriterionStatus;
+  confidence_level: "high" | "moderate" | "low";
+  score_0_10: number | null;
+}): { score_0_10: number | null; reconciled: boolean } {
+  if (
+    input.status === "SCORABLE" &&
+    input.confidence_level === "low" &&
+    typeof input.score_0_10 === "number" &&
+    input.score_0_10 > LOW_CONFIDENCE_SCORE_CAP
+  ) {
+    return {
+      score_0_10: LOW_CONFIDENCE_SCORE_CAP,
+      reconciled: true,
+    };
+  }
+
+  return {
+    score_0_10: input.score_0_10,
+    reconciled: false,
   };
 }
 

--- a/tests/lib/evaluation/criterionObservability.reconciliation.test.ts
+++ b/tests/lib/evaluation/criterionObservability.reconciliation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  LOW_CONFIDENCE_SCORE_RECONCILIATION_REASON,
+  normalizeCriterion,
+  reconcileLowConfidenceScore,
+} from "@/lib/evaluation/signal/criterionObservability";
+
+describe("reconcileLowConfidenceScore", () => {
+  test("caps SCORABLE low-confidence score above 5", () => {
+    const result = reconcileLowConfidenceScore({
+      status: "SCORABLE",
+      confidence_level: "low",
+      score_0_10: 7,
+    });
+
+    expect(result).toEqual({
+      score_0_10: 5,
+      reconciled: true,
+    });
+  });
+
+  test("does not cap high-confidence score", () => {
+    const result = reconcileLowConfidenceScore({
+      status: "SCORABLE",
+      confidence_level: "high",
+      score_0_10: 8,
+    });
+
+    expect(result).toEqual({
+      score_0_10: 8,
+      reconciled: false,
+    });
+  });
+
+  test("does not alter low-confidence score at cap boundary", () => {
+    const result = reconcileLowConfidenceScore({
+      status: "SCORABLE",
+      confidence_level: "low",
+      score_0_10: 5,
+    });
+
+    expect(result).toEqual({
+      score_0_10: 5,
+      reconciled: false,
+    });
+  });
+});
+
+describe("normalizeCriterion low-confidence reconciliation", () => {
+  test("reconciles low-confidence SCORABLE score and records reason", () => {
+    const normalized = normalizeCriterion(
+      {
+        key: "proseControl",
+        score_0_10: 8,
+        rationale:
+          "This criterion has enough text for a score but confidence is constrained by thin support.",
+        evidence: [
+          {
+            snippet: "Brief evidence anchor.",
+          },
+        ],
+      },
+      {
+        confidenceCaps: {
+          proseControl: "LOW",
+        },
+      },
+    );
+
+    expect(normalized.status).toBe("SCORABLE");
+    expect(normalized.confidence_level).toBe("low");
+    expect(normalized.score_0_10).toBe(5);
+    expect(normalized.confidence_reasons).toContain(
+      LOW_CONFIDENCE_SCORE_RECONCILIATION_REASON,
+    );
+  });
+
+  test("does not reconcile when confidence is high", () => {
+    const normalized = normalizeCriterion({
+      key: "voice",
+      score_0_10: 8,
+      rationale:
+        "Voice diction and cadence are consistently controlled and evidenced across the passage.",
+      evidence: [
+        {
+          snippet: "The river remembers everything, even when we forget.",
+          location: { char_start: 5, char_end: 60 },
+        },
+        {
+          snippet: "Glass towers caught fire in the dusk.",
+          location: { char_start: 320, char_end: 358 },
+        },
+        {
+          snippet: "Sentences breathed in the cadence of tide.",
+          location: { char_start: 650, char_end: 692 },
+        },
+      ],
+      signal_strength: "STRONG",
+    });
+
+    expect(normalized.status).toBe("SCORABLE");
+    expect(normalized.score_0_10).toBe(8);
+    expect(normalized.confidence_level).not.toBe("low");
+    expect(normalized.confidence_reasons).not.toContain(
+      LOW_CONFIDENCE_SCORE_RECONCILIATION_REASON,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic pre-gate reconciliation for `SCORABLE + confidence_level=low + score_0_10>5`
- cap score to 5 before quality gate evaluation
- append explicit reconciliation reason to `confidence_reasons`
- export reconciler for direct deterministic unit testing

## Files
- `lib/evaluation/signal/criterionObservability.ts`
- `tests/lib/evaluation/criterionObservability.reconciliation.test.ts`

## Validation
- targeted tests pass:
  - `tests/lib/evaluation/criterionObservability.reconciliation.test.ts`
  - `lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts`
