### PR TITLE
db: add user preferences timezone table

### DIFF
--- a/supabase/migrations/20260506170000_add_user_preferences_timezone.sql
+++ b/supabase/migrations/20260506170000_add_user_preferences_timezone.sql
@@ -1,0 +1,49 @@
+-- User display preferences for localized UI rendering.
+-- Canonical storage, logs, governance timestamps, and audit trails remain UTC.
+
+create table if not exists public.user_preferences (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  timezone text,
+  updated_at timestamptz not null default now(),
+
+  constraint user_preferences_timezone_format check (
+    timezone is null
+    or timezone ~ '^[A-Za-z_]+/[A-Za-z0-9_+.-]+(/[A-Za-z0-9_+.-]+)?$'
+  )
+);
+
+alter table public.user_preferences enable row level security;
+
+create policy "Users can read their own preferences"
+  on public.user_preferences
+  for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert their own preferences"
+  on public.user_preferences
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update their own preferences"
+  on public.user_preferences
+  for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create or replace function public.set_user_preferences_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_user_preferences_updated_at
+  on public.user_preferences;
+
+create trigger set_user_preferences_updated_at
+before update on public.user_preferences
+for each row
+execute function public.set_user_preferences_updated_at();

--- a/supabase/migrations/20260506170000_add_user_preferences_timezone.sql
+++ b/supabase/migrations/20260506170000_add_user_preferences_timezone.sql
@@ -8,25 +8,31 @@ create table if not exists public.user_preferences (
 
   constraint user_preferences_timezone_format check (
     timezone is null
-    or timezone ~ '^[A-Za-z_]+/[A-Za-z0-9_+.-]+(/[A-Za-z0-9_+.-]+)?$'
+    or timezone ~ '^[A-Za-z_]+([/+][A-Za-z0-9_+.-]+)*$'
   )
 );
 
 alter table public.user_preferences enable row level security;
 
-create policy "Users can read their own preferences"
+drop policy if exists user_preferences_select_own on public.user_preferences;
+create policy user_preferences_select_own
   on public.user_preferences
   for select
+  to authenticated
   using (auth.uid() = user_id);
 
-create policy "Users can insert their own preferences"
+drop policy if exists user_preferences_insert_own on public.user_preferences;
+create policy user_preferences_insert_own
   on public.user_preferences
   for insert
+  to authenticated
   with check (auth.uid() = user_id);
 
-create policy "Users can update their own preferences"
+drop policy if exists user_preferences_update_own on public.user_preferences;
+create policy user_preferences_update_own
   on public.user_preferences
   for update
+  to authenticated
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 


### PR DESCRIPTION
## Summary
Adds the database foundation for localized datetime rendering by creating `public.user_preferences`.

## Changes
- Adds `public.user_preferences`
- Stores per-user `timezone`
- Enforces timezone shape with an IANA-style check constraint
- Enables RLS
- Adds own-row read/insert/update policies
- Adds `updated_at` maintenance trigger

## Non-goals
- No runtime datetime behavior changes
- No server-side canonical time changes
- UTC remains canonical server-side
- No HeaderNav changes
- No Pipeline Health changes
- No gates, scoring, prompts, or evaluation pipeline changes
- No #322 reconciliation changes
- No route, hook, component, or UI changes in this PR

## Validation
- Migration-only PR
- Scope limited to one SQL migration
