### PR TITLE
feat(qg): per-criterion non-certified downgrade for score/confidence mismatch

### DIFF
--- a/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
+++ b/__tests__/lib/evaluation/processor.canonical-pipeline.test.ts
@@ -450,6 +450,167 @@ describe("processEvaluationJob canonical pipeline integration", () => {
     ).toBe(false);
   });
 
+  test("persists downgradedResult when quality gate provides explicit non-mutating downgrade", async () => {
+    const supabaseStub = makeSupabaseStub();
+    createClientMock.mockReturnValue(supabaseStub);
+
+    runPipelineMock.mockResolvedValue({
+      ok: true,
+      synthesis: {
+        criteria: [],
+        overall: {
+          overall_score_0_100: 82,
+          verdict: "pass",
+          one_paragraph_summary: "Summary",
+          top_3_strengths: [],
+          top_3_risks: [],
+        },
+        metadata: {
+          pass1_model: "gpt-4o",
+          pass2_model: "o3",
+          pass3_model: "o3",
+          generated_at: new Date().toISOString(),
+        },
+      },
+      quality_gate: {
+        pass: true,
+        checks: [],
+        warnings: [],
+      },
+      pass4_governance: { ok: true },
+    });
+
+    const baseEvaluationResult = {
+      schema_version: "evaluation_result_v2",
+      ids: {
+        evaluation_run_id: "run-1",
+        manuscript_id: 456,
+        user_id: "00000000-0000-0000-0000-000000000001",
+      },
+      generated_at: new Date().toISOString(),
+      engine: {
+        model: "o3",
+        provider: "openai",
+        prompt_version: "test",
+      },
+      overview: {
+        verdict: "pass",
+        overall_score_0_100: 82,
+        one_paragraph_summary: "Summary",
+        top_3_strengths: [],
+        top_3_risks: [],
+      },
+      criteria: new Array(13).fill(null).map((_, idx) => ({
+        key: [
+          "concept",
+          "narrativeDrive",
+          "character",
+          "voice",
+          "sceneConstruction",
+          "dialogue",
+          "theme",
+          "worldbuilding",
+          "pacing",
+          "proseControl",
+          "tone",
+          "narrativeClosure",
+          "marketability",
+        ][idx],
+        scorable: true,
+        status: "SCORABLE",
+        signal_present: true,
+        signal_strength: "SUFFICIENT",
+        confidence_band: "MEDIUM",
+        score_0_10: 7,
+        rationale: "Criterion is supported by manuscript evidence and synthesis.",
+        evidence: [{ snippet: "Evidence snippet with sufficient detail for quality gate checks." }],
+        recommendations: [],
+      })),
+      recommendations: {
+        quick_wins: [],
+        strategic_revisions: [],
+      },
+      metrics: {
+        manuscript: {},
+        processing: {},
+      },
+      artifacts: [],
+      governance: {
+        confidence: 0.9,
+        warnings: [],
+        limitations: [],
+        policy_family: "multi-pass-dual-axis",
+      },
+    };
+
+    synthesisToEvaluationResultV2Mock.mockReturnValue(baseEvaluationResult);
+
+    const downgradedResult = {
+      ...baseEvaluationResult,
+      criteria: baseEvaluationResult.criteria.map((criterion: any) =>
+        criterion.key !== "concept"
+          ? criterion
+          : {
+              ...criterion,
+              scorable: false,
+              status: "INSUFFICIENT_SIGNAL",
+              signal_strength: "WEAK",
+              score_0_10: null,
+              scorability_status: "non_scorable",
+              model_emitted_score_unverified: 7,
+              insufficient_signal_reason: {
+                looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
+                not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
+              },
+            },
+      ),
+    };
+
+    runQualityGateV2Mock.mockReturnValue({
+      pass: true,
+      checks: [],
+      warnings: [],
+      downgradedResult,
+    });
+
+    mapEvaluationResultV2ToGovernanceEnvelopeMock.mockReturnValue({
+      evaluation_run_id: "run-1",
+      criteria: [],
+    });
+
+    upsertEvaluationArtifactMock.mockResolvedValue("artifact-1");
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+
+    const result = await processEvaluationJob("job-canonical-pipeline");
+    expect(result.success).toBe(true);
+
+    const persistCall = supabaseStub.rpcCalls.find(
+      (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
+    ) as { fn: string; args?: Record<string, unknown> } | undefined;
+    expect(persistCall).toBeDefined();
+
+    const persistedEvaluationResult = persistCall?.args?.p_evaluation_result as
+      | Record<string, unknown>
+      | undefined;
+    expect(persistedEvaluationResult).toBeDefined();
+
+    const persistedCriteria = persistedEvaluationResult?.criteria as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const persistedConcept = persistedCriteria?.find((criterion) => criterion.key === "concept");
+    expect(persistedConcept).toEqual(
+      expect.objectContaining({
+        status: "INSUFFICIENT_SIGNAL",
+        score_0_10: null,
+        model_emitted_score_unverified: 7,
+      }),
+    );
+
+    expect((baseEvaluationResult.criteria[0] as Record<string, unknown>).status).toBe("SCORABLE");
+    expect((baseEvaluationResult.criteria[0] as Record<string, unknown>).score_0_10).toBe(7);
+  });
+
   test("uncaught processor fallback persists failure metadata when atomic finalization fails", async () => {
     const supabaseStub = makeSupabaseStub();
     createClientMock.mockReturnValue(supabaseStub);

--- a/__tests__/lib/evaluation/processor.real-gate.test.ts
+++ b/__tests__/lib/evaluation/processor.real-gate.test.ts
@@ -490,7 +490,7 @@ describe("processEvaluationJob — real synthesisToEvaluationResultV2 + real run
     expect(finalProgressUpdate).toBeDefined();
   });
 
-  test("V2 GATE DIAGNOSTICS: pass_outputs_diagnostic_v1 and quality_gate_diagnostics_v1 persisted on score-confidence mismatch failure", async () => {
+  test("V2 SCORE-CONFIDENCE DOWNGRADE: mismatch downgrades criterion and persists canonical V2 output", async () => {
     const supabaseStub = makeSupabaseStub();
     createClientMock.mockReturnValue(supabaseStub);
     // Allow fail-soft diagnostic upserts to resolve cleanly.
@@ -546,103 +546,57 @@ describe("processEvaluationJob — real synthesisToEvaluationResultV2 + real run
     const { processEvaluationJob } = require("../../../lib/evaluation/processor");
     const result = await processEvaluationJob("job-real-gate-test");
 
-    // ── Gate must ALWAYS fail ─────────────────────────────────────────────────
+    // ── Gate must pass overall while downgrading the offending criterion ─────
     // proseControl is deterministically low-confidence (snippet "x", 1 char →
     // enforceTextualAnchorConfidence forces confidence_level="low") and score=7 > cap=5.
-    // No conditional branch — the v2_fidelity_score_confidence_alignment check
-    // MUST fire and the job MUST fail.
-    expect(result.success).toBe(false);
+    // Under PR G semantics, that criterion is downgraded to INSUFFICIENT_SIGNAL,
+    // while the overall job remains successful and persists the downgraded V2 result.
+    expect(result.success).toBe(true);
 
-    // ── Acceptance criterion 1: pass_outputs_diagnostic_v1 persisted ──────────
-    const passOutputsCall = (upsertEvaluationArtifactMock.mock.calls as any[]).find(
-      (call: any[]) => call[0]?.artifactType === "pass_outputs_diagnostic_v1",
+    // No fail-soft diagnostic artifacts should be written because this path is no
+    // longer a gate failure.
+    expect(upsertEvaluationArtifactMock).not.toHaveBeenCalled();
+
+    const persistCall = supabaseStub.rpcCalls.find(
+      (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
+    ) as { fn: string; args?: Record<string, unknown> } | undefined;
+    expect(persistCall).toBeDefined();
+
+    const persistedContent = persistCall?.args?.p_artifact_content as Record<string, unknown>;
+    expect(persistedContent).toBeDefined();
+
+    const persistedCriteria = persistedContent.criteria as Array<Record<string, unknown>>;
+    expect(Array.isArray(persistedCriteria)).toBe(true);
+
+    const proseControlCriterion = persistedCriteria.find(
+      (criterion) => criterion.key === "proseControl",
     );
-    expect(passOutputsCall).toBeDefined();
-
-    const passOutputsContent = passOutputsCall[0]?.content as Record<string, unknown>;
-    expect(passOutputsContent.failed_at).toBe("v2_gate");
-    expect(passOutputsContent.error_code).toBe("QG_FAILED");
-    expect(Array.isArray(passOutputsContent.per_criterion)).toBe(true);
-
-    const perCriterionArr = passOutputsContent.per_criterion as Array<Record<string, unknown>>;
-    const proseControlEntry = perCriterionArr.find((e) => e.criterion_key === "proseControl");
-    expect(proseControlEntry).toBeDefined();
-    // score, confidence, and confidence_label must be populated (reconstructable forensics).
-    expect(proseControlEntry!.score).toBe(7);
-    expect(typeof proseControlEntry!.confidence).toBe("number");
-    expect(proseControlEntry!.confidence_label).toBe("low");
-
-    // ── Acceptance criterion 2: quality_gate_diagnostics_v1 persisted ─────────
-    const gateDiagCall = (upsertEvaluationArtifactMock.mock.calls as any[]).find(
-      (call: any[]) => call[0]?.artifactType === "quality_gate_diagnostics_v1",
+    expect(proseControlCriterion).toEqual(
+      expect.objectContaining({
+        key: "proseControl",
+        status: "INSUFFICIENT_SIGNAL",
+        scorable: false,
+        signal_strength: "WEAK",
+        score_0_10: null,
+        scorability_status: "non_scorable",
+        model_emitted_score_unverified: 7,
+        insufficient_signal_reason: {
+          looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
+          not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
+        },
+      }),
     );
-    expect(gateDiagCall).toBeDefined();
 
-    const gateDiagContent = gateDiagCall[0]?.content as Record<string, unknown>;
-    // gate_id is the semantic label for this failure path (score-confidence alignment).
-    // It is correctly hardcoded for this specific failure scenario.
-    expect(gateDiagContent.gate_id).toBe("v2_fidelity_score_confidence_alignment");
-    expect(gateDiagContent.gate_version).toBe("v2");
-    // score_cap_for_low_confidence echoes QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE = 5.
-    expect(gateDiagContent.score_cap_for_low_confidence).toBe(5);
+    const persistedOverview = persistedContent.overview as Record<string, unknown>;
+    expect(persistedOverview.scored_criteria_count).toBe(CRITERIA_KEYS.length - 1);
 
-    // per_criterion must include proseControl with violated=true and reasons populated.
-    const gateDiagPerCriterion = gateDiagContent.per_criterion as Array<Record<string, unknown>>;
-    expect(Array.isArray(gateDiagPerCriterion)).toBe(true);
-    const proseGateEntry = gateDiagPerCriterion.find((e) => e.criterion_key === "proseControl");
-    expect(proseGateEntry).toBeDefined();
-    expect(proseGateEntry!.score).toBe(7);
-    expect(typeof proseGateEntry!.confidence).toBe("number");
-    expect(proseGateEntry!.violated).toBe(true);
-    expect(Array.isArray(proseGateEntry!.reasons)).toBe(true);
-    expect((proseGateEntry!.reasons as string[]).length).toBeGreaterThan(0);
-
-    // failed_criteria must include proseControl with score, confidence, reasons.
-    const gateDiagFailedCriteria = gateDiagContent.failed_criteria as Array<Record<string, unknown>>;
-    expect(Array.isArray(gateDiagFailedCriteria)).toBe(true);
-    expect(gateDiagFailedCriteria.length).toBeGreaterThan(0);
-    const proseInFailed = gateDiagFailedCriteria.find((e) => e.criterion_key === "proseControl");
-    expect(proseInFailed).toBeDefined();
-    expect(proseInFailed!.score).toBe(7);
-    expect(Array.isArray(proseInFailed!.reasons)).toBe(true);
-    expect((proseInFailed!.reasons as string[]).length).toBeGreaterThan(0);
-
-    // failed_checks must preserve the actual QualityGateV2 check IDs from
-    // qualityGateV2.checks so the diagnostics artifact is fully reconstructable.
-    // gate_id is the semantic label; failed_checks contains the real check_id(s).
-    // Each entry is formatted as "check_id: details", so use startsWith for precision.
-    const failedChecks = gateDiagContent.failed_checks as string[];
-    expect(Array.isArray(failedChecks)).toBe(true);
-    expect(failedChecks.length).toBeGreaterThan(0);
-    expect(
-      failedChecks.some((fc: string) => fc.startsWith("v2_fidelity_score_confidence_alignment")),
-    ).toBe(true);
-
-    // ── No user-facing artifact persisted ─────────────────────────────────────
-    // Only diagnostic artifact types must be written — no evaluation_result_v2.
-    expect(
-      (upsertEvaluationArtifactMock.mock.calls as any[]).some(
-        (call: any[]) => call[0]?.artifactType === "evaluation_result_v2",
-      ),
-    ).toBe(false);
-    // No atomic V2 persistence RPC.
-    expect(
-      supabaseStub.rpcCalls.some((call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic"),
-    ).toBe(false);
-    // No "complete" status written to DB.
     expect(
       supabaseStub.evaluationJobUpdates.some(
-        (u: Record<string, unknown>) => u.status === "complete",
+        (u: Record<string, unknown>) =>
+          u.progress !== undefined &&
+          typeof u.progress === "object" &&
+          (u.progress as Record<string, unknown>).v2_gate_status === "failed",
       ),
     ).toBe(false);
-
-    // ── v2_gate_status=failed in progress ─────────────────────────────────────
-    const progressUpdate = supabaseStub.evaluationJobUpdates.find(
-      (u: Record<string, unknown>) =>
-        u.progress !== undefined &&
-        typeof u.progress === "object" &&
-        (u.progress as Record<string, unknown>).v2_gate_status === "failed",
-    );
-    expect(progressUpdate).toBeDefined();
   });
 });

--- a/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
+++ b/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
@@ -57,6 +57,43 @@ function makeValidArtifact(): EvaluationResultV2 {
 }
 
 describe("validateEvaluationArtifact (boundary structural validator)", () => {
+  test("accepts non-scorable V2 criteria with null scores", () => {
+    const artifact = makeValidArtifact();
+    artifact.criteria[0] = {
+      ...artifact.criteria[0],
+      scorable: false,
+      status: "INSUFFICIENT_SIGNAL",
+      signal_strength: "WEAK",
+      score_0_10: null,
+      model_emitted_score_unverified: 7,
+      insufficient_signal_reason: {
+        looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
+        not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
+      },
+    } as EvaluationResultV2["criteria"][number];
+    artifact.overview.scored_criteria_count = CRITERIA_KEYS.length - 1;
+
+    const result = validateEvaluationArtifact(artifact);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects legacy-like criteria missing status at the V2 boundary", () => {
+    const artifact = makeValidArtifact();
+    artifact.criteria[0] = {
+      ...artifact.criteria[0],
+      status: undefined as never,
+      score_0_10: 7,
+    } as unknown as EvaluationResultV2["criteria"][number];
+
+    const result = validateEvaluationArtifact(artifact);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({ code: "CRITERION_SCORE_OUT_OF_RANGE" }),
+      );
+    }
+  });
+
   test("rejects a missing canonical criterion", () => {
     const artifact = makeValidArtifact();
     artifact.criteria = artifact.criteria.filter((criterion) => criterion.key !== "narrativeDrive");

--- a/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
+++ b/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
@@ -349,7 +349,12 @@ describe("runQualityGateV2 integration", () => {
     const conceptIndex = CRITERIA_KEYS.indexOf("concept");
     const dialogueIndex = CRITERIA_KEYS.indexOf("dialogue");
     const originalConceptScore = 8;
-    const originalDialogueCriterion = fixture.criteria[dialogueIndex];
+    // DEFENSIVE: Deep-clone to detect any future regression to in-place mutation.
+    // If this were a direct reference, the test would pass silently even if
+    // runQualityGateV2 mutates the criterion object in place.
+    const originalDialogueCriterion = structuredClone(
+      fixture.criteria[dialogueIndex],
+    );
 
     fixture.criteria[conceptIndex] = {
       ...fixture.criteria[conceptIndex],

--- a/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
+++ b/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
@@ -347,8 +347,9 @@ describe("runQualityGateV2 integration", () => {
   it("downgrades low-confidence criteria exceeding score cap to non-certified without failing the whole job", () => {
     const fixture = makeBaseV2Fixture();
     const conceptIndex = CRITERIA_KEYS.indexOf("concept");
+    const dialogueIndex = CRITERIA_KEYS.indexOf("dialogue");
     const originalConceptScore = 8;
-    const originalDialogueCriterion = fixture.criteria[CRITERIA_KEYS.indexOf("dialogue")];
+    const originalDialogueCriterion = fixture.criteria[dialogueIndex];
 
     fixture.criteria[conceptIndex] = {
       ...fixture.criteria[conceptIndex],
@@ -357,10 +358,16 @@ describe("runQualityGateV2 integration", () => {
       confidence_score_0_100: 22,
     } as EvaluationResultV2["criteria"][number];
 
+    const originalFixtureSnapshot = structuredClone(fixture);
+
     const result = runQualityGateV2(fixture);
     expect(result.pass).toBe(true);
 
-    const downgraded = fixture.criteria[conceptIndex];
+    expect(fixture).toEqual(originalFixtureSnapshot);
+    expect(result.downgradedResult).toBeDefined();
+
+    const downgraded = result.downgradedResult?.criteria[conceptIndex];
+    expect(downgraded).toBeDefined();
     expect(downgraded.status).toBe("INSUFFICIENT_SIGNAL");
     expect(downgraded.scorable).toBe(false);
     expect(downgraded.score_0_10).toBeNull();
@@ -370,7 +377,7 @@ describe("runQualityGateV2 integration", () => {
       not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
     });
 
-    const unchangedDialogue = fixture.criteria[CRITERIA_KEYS.indexOf("dialogue")];
+    const unchangedDialogue = result.downgradedResult?.criteria[dialogueIndex];
     expect(unchangedDialogue).toEqual(originalDialogueCriterion);
     expect(unchangedDialogue.status).toBe("SCORABLE");
     expect(unchangedDialogue.score_0_10).toBe(7);
@@ -392,6 +399,7 @@ describe("runQualityGateV2 integration", () => {
 
     const result = runQualityGateV2(fixture);
     expect(result.pass).toBe(false);
+    expect(result.downgradedResult).toBeUndefined();
     expect(
       result.checks.some(
         (check) => check.check_id === "v2_criteria_count" && !check.passed,

--- a/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
+++ b/lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts
@@ -344,25 +344,57 @@ describe("runQualityGateV2 integration", () => {
     ).toBe(true);
   });
 
-  it("fails on low-confidence criteria exceeding score cap", () => {
+  it("downgrades low-confidence criteria exceeding score cap to non-certified without failing the whole job", () => {
     const fixture = makeBaseV2Fixture();
     const conceptIndex = CRITERIA_KEYS.indexOf("concept");
+    const originalConceptScore = 8;
+    const originalDialogueCriterion = fixture.criteria[CRITERIA_KEYS.indexOf("dialogue")];
 
     fixture.criteria[conceptIndex] = {
       ...fixture.criteria[conceptIndex],
-      score_0_10: 8,
+      score_0_10: originalConceptScore,
       confidence_level: "low",
       confidence_score_0_100: 22,
     } as EvaluationResultV2["criteria"][number];
 
     const result = runQualityGateV2(fixture);
-    expect(result.pass).toBe(false);
+    expect(result.pass).toBe(true);
+
+    const downgraded = fixture.criteria[conceptIndex];
+    expect(downgraded.status).toBe("INSUFFICIENT_SIGNAL");
+    expect(downgraded.scorable).toBe(false);
+    expect(downgraded.score_0_10).toBeNull();
+    expect(downgraded.model_emitted_score_unverified).toBe(originalConceptScore);
+    expect(downgraded.insufficient_signal_reason).toEqual({
+      looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
+      not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
+    });
+
+    const unchangedDialogue = fixture.criteria[CRITERIA_KEYS.indexOf("dialogue")];
+    expect(unchangedDialogue).toEqual(originalDialogueCriterion);
+    expect(unchangedDialogue.status).toBe("SCORABLE");
+    expect(unchangedDialogue.score_0_10).toBe(7);
+
     expect(
       result.checks.some(
         (check) =>
           check.check_id === "v2_fidelity_score_confidence_alignment" &&
           !check.passed &&
           check.error_code === "QG_FIDELITY_SCORE_CONFIDENCE_MISMATCH",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps structural fatal checks fail-closed for missing criteria", () => {
+    const fixture = makeBaseV2Fixture();
+    fixture.criteria = fixture.criteria.slice(0, CRITERIA_KEYS.length - 1);
+    fixture.overview.scored_criteria_count = fixture.criteria.length;
+
+    const result = runQualityGateV2(fixture);
+    expect(result.pass).toBe(false);
+    expect(
+      result.checks.some(
+        (check) => check.check_id === "v2_criteria_count" && !check.passed,
       ),
     ).toBe(true);
   });

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -152,6 +152,7 @@ export type QualityGateFailureTelemetry = {
 
 export interface QualityGateV2Result extends QualityGateResult {
   artifactGate: ArtifactGateDecision;
+  downgradedResult?: EvaluationResultV2;
 }
 
 function normalizeForPhraseMatch(text: string): string {
@@ -999,7 +1000,6 @@ export function runQualityGateV2(
       };
 
   const criteria = result.criteria;
-  const propagation = summarizePropagationIntegrity(criteria);
   const expectedCount = CRITERIA_KEYS.length;
 
   if (criteria.length !== expectedCount) {
@@ -1221,8 +1221,7 @@ export function runQualityGateV2(
   }
 
   const scoreConfidenceMismatchDetails: string[] = [];
-  for (let idx = 0; idx < criteria.length; idx += 1) {
-    const criterion = criteria[idx];
+  const downgradedCriteria: EvaluationResultV2["criteria"] = criteria.map((criterion): EvaluationResultV2["criteria"][number] => {
     if (
       criterion.status === "SCORABLE" &&
       criterion.confidence_level === "low" &&
@@ -1231,13 +1230,13 @@ export function runQualityGateV2(
     ) {
       scoreConfidenceMismatchDetails.push(`${criterion.key}:${criterion.score_0_10}`);
 
-      criteria[idx] = {
+      return {
         ...criterion,
-        scorable: false,
-        status: "INSUFFICIENT_SIGNAL",
-        signal_strength: "WEAK",
+        scorable: false as const,
+        status: "INSUFFICIENT_SIGNAL" as const,
+        signal_strength: "WEAK" as const,
         score_0_10: null,
-        scorability_status: "non_scorable",
+        scorability_status: "non_scorable" as const,
         model_emitted_score_unverified: criterion.score_0_10,
         insufficient_signal_reason: {
           looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
@@ -1245,7 +1244,12 @@ export function runQualityGateV2(
         },
       };
     }
-  }
+
+    return criterion;
+  });
+
+  const criteriaForPostAlignmentChecks =
+    scoreConfidenceMismatchDetails.length > 0 ? downgradedCriteria : criteria;
 
   checks.push({
     check_id: "v2_fidelity_score_confidence_alignment",
@@ -1259,6 +1263,8 @@ export function runQualityGateV2(
         ? `Low-confidence criteria exceeded score cap (${QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE}) and were downgraded to INSUFFICIENT_SIGNAL: ${scoreConfidenceMismatchDetails.join(",")}`
         : "Score-confidence alignment holds",
   });
+
+  const propagation = summarizePropagationIntegrity(criteriaForPostAlignmentChecks);
 
   const summaryMentionsWeakness = summaryMentionsBottomWeakness(
     result.overview.one_paragraph_summary,
@@ -1280,7 +1286,7 @@ export function runQualityGateV2(
         : "Overview summary references low-score weakness cluster or no weak cluster exists",
   });
 
-  const scoredCount = criteria.filter((c) => c.status === "SCORABLE").length;
+  const scoredCount = criteriaForPostAlignmentChecks.filter((c) => c.status === "SCORABLE").length;
 
   const aggregateScoreMismatch =
     (scoredCount === 0 && result.overview.overall_score_0_100 !== null) ||
@@ -1350,10 +1356,20 @@ export function runQualityGateV2(
   const failedHardChecks = checks.filter(
     (c) => !c.passed && c.check_id !== "v2_fidelity_score_confidence_alignment",
   );
+
+  const downgradedResult =
+    scoreConfidenceMismatchDetails.length > 0
+      ? {
+          ...result,
+          criteria: downgradedCriteria,
+        }
+      : undefined;
+
   return {
     pass: failedHardChecks.length === 0,
     checks,
     warnings,
     artifactGate,
+    downgradedResult,
   };
 }

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -1361,6 +1361,12 @@ export function runQualityGateV2(
     scoreConfidenceMismatchDetails.length > 0
       ? {
           ...result,
+          overview: {
+            ...result.overview,
+            scored_criteria_count: scoredCount,
+            overall_score_0_100:
+              scoredCount === 0 ? null : result.overview.overall_score_0_100,
+          },
           criteria: downgradedCriteria,
         }
       : undefined;

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -1220,26 +1220,43 @@ export function runQualityGateV2(
     );
   }
 
-  const scoreConfidenceMismatches = criteria
-    .filter(
-      (c) =>
-        c.status === "SCORABLE" &&
-        c.confidence_level === "low" &&
-        typeof c.score_0_10 === "number" &&
-        c.score_0_10 > QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE,
-    )
-    .map((c) => `${c.key}:${c.score_0_10}`);
+  const scoreConfidenceMismatchDetails: string[] = [];
+  for (let idx = 0; idx < criteria.length; idx += 1) {
+    const criterion = criteria[idx];
+    if (
+      criterion.status === "SCORABLE" &&
+      criterion.confidence_level === "low" &&
+      typeof criterion.score_0_10 === "number" &&
+      criterion.score_0_10 > QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE
+    ) {
+      scoreConfidenceMismatchDetails.push(`${criterion.key}:${criterion.score_0_10}`);
+
+      criteria[idx] = {
+        ...criterion,
+        scorable: false,
+        status: "INSUFFICIENT_SIGNAL",
+        signal_strength: "WEAK",
+        score_0_10: null,
+        scorability_status: "non_scorable",
+        model_emitted_score_unverified: criterion.score_0_10,
+        insufficient_signal_reason: {
+          looked_for: ["CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING"],
+          not_found: ["LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS"],
+        },
+      };
+    }
+  }
 
   checks.push({
     check_id: "v2_fidelity_score_confidence_alignment",
-    passed: scoreConfidenceMismatches.length === 0,
+    passed: scoreConfidenceMismatchDetails.length === 0,
     error_code:
-      scoreConfidenceMismatches.length > 0
+      scoreConfidenceMismatchDetails.length > 0
         ? "QG_FIDELITY_SCORE_CONFIDENCE_MISMATCH"
         : undefined,
     details:
-      scoreConfidenceMismatches.length > 0
-        ? `Low-confidence criteria exceed score cap (${QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE}): ${scoreConfidenceMismatches.join(",")}`
+      scoreConfidenceMismatchDetails.length > 0
+        ? `Low-confidence criteria exceeded score cap (${QG_MAX_HIGH_SCORE_WHEN_LOW_CONFIDENCE}) and were downgraded to INSUFFICIENT_SIGNAL: ${scoreConfidenceMismatchDetails.join(",")}`
         : "Score-confidence alignment holds",
   });
 
@@ -1330,7 +1347,9 @@ export function runQualityGateV2(
     }
   }
 
-  const failedHardChecks = checks.filter((c) => !c.passed);
+  const failedHardChecks = checks.filter(
+    (c) => !c.passed && c.check_id !== "v2_fidelity_score_confidence_alignment",
+  );
   return {
     pass: failedHardChecks.length === 0,
     checks,

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -2305,8 +2305,40 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       enforcementMode: 'enforce' as const,
     };
 
-    evaluationResult.governance.warnings = [
-      ...(evaluationResult.governance.warnings ?? []),
+    const effectiveEvaluationResult =
+      qualityGateV2.downgradedResult ?? evaluationResult;
+
+    const effectiveArtifactCriteria = effectiveEvaluationResult.criteria.map((criterion) => ({
+      key: criterion.key,
+      final_score_0_10: criterion.score_0_10,
+      reasoning: criterion.rationale,
+      evidence: criterion.evidence.map((item) => item.snippet).filter(Boolean).join(' | '),
+      interpretation: '',
+    }));
+    const effectiveScoreLedger =
+      effectiveArtifactCriteria.length > 0
+        ? buildScoreLedger({
+            criteria: effectiveArtifactCriteria.map((criterion) => ({
+              key: criterion.key,
+              final_score_0_10: criterion.final_score_0_10,
+            })),
+          })
+        : {
+            rawTotal: 0,
+            maxTotal: 0,
+            normalized: 0,
+            weighting: 'weighted' as const,
+            authorityComposite: computeAuthorityComposite([]),
+          };
+    const effectiveExcellenceFilter = buildExcellenceFilter({
+      criteria: effectiveArtifactCriteria.map((criterion) => ({
+        key: criterion.key,
+        final_score_0_10: criterion.final_score_0_10,
+      })),
+    });
+
+    effectiveEvaluationResult.governance.warnings = [
+      ...(effectiveEvaluationResult.governance.warnings ?? []),
       ...(qualityGateV2.warnings ?? []),
       ...(artifactGateDecision.reasonCodes.length > 0
         ? [
@@ -2314,24 +2346,26 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
           ]
         : []),
     ];
-    evaluationResult.governance.transparency = {
-      ...(evaluationResult.governance.transparency ?? {}),
+    effectiveEvaluationResult.governance.transparency = {
+      ...(effectiveEvaluationResult.governance.transparency ?? {}),
       artifact_validation_result: artifactGateDecision.verdict,
       artifact_reason_codes: artifactGateDecision.reasonCodes,
       artifact_validated_at: artifactGateDecision.validatedAt,
       score_ledger: {
-        raw_total: scoreLedger.rawTotal,
-        max_total: scoreLedger.maxTotal,
-        normalized_total: scoreLedger.normalized,
-        weighting: scoreLedger.weighting,
+        raw_total: effectiveScoreLedger.rawTotal,
+        max_total: effectiveScoreLedger.maxTotal,
+        normalized_total: effectiveScoreLedger.normalized,
+        weighting: effectiveScoreLedger.weighting,
       },
       excellence_filter: {
-        verdict: excellenceFilter.verdict,
-        blocking_criteria: excellenceFilter.blockingCriteria,
+        verdict: effectiveExcellenceFilter.verdict,
+        blocking_criteria: effectiveExcellenceFilter.blockingCriteria,
       },
     };
 
-    const governanceBridgeProjection = mapEvaluationResultV2ToGovernanceEnvelope(evaluationResult);
+    const governanceBridgeProjection = mapEvaluationResultV2ToGovernanceEnvelope(
+      effectiveEvaluationResult,
+    );
     console.log(
       `[Processor] ${jobId}: governance bridge projected ${governanceBridgeProjection.criteria.length} scorable criterion/criteria`,
     );
@@ -2339,7 +2373,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     if (evalContextContaminationGuardEnabled) {
       const contaminationCheck = detectContextContamination({
         sourceText: manuscriptWithContent.content || '',
-        evaluationResult,
+        evaluationResult: effectiveEvaluationResult,
       });
 
       if (contaminationCheck.contaminated) {
@@ -2359,22 +2393,22 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     }
 
     const promptCoverage = summarizePromptCoverage(manuscriptWithContent.content || '');
-    evaluationResult.metrics.manuscript = {
-      ...evaluationResult.metrics.manuscript,
+    effectiveEvaluationResult.metrics.manuscript = {
+      ...effectiveEvaluationResult.metrics.manuscript,
       word_count: promptCoverage.sourceWords,
       char_count: promptCoverage.sourceChars,
       genre: manuscriptWithContent.work_type || 'Unknown',
     };
-    evaluationResult.metrics.processing = {
-      ...evaluationResult.metrics.processing,
+    effectiveEvaluationResult.metrics.processing = {
+      ...effectiveEvaluationResult.metrics.processing,
       segment_count: promptCoverage.truncated ? 3 : 1,
     };
-    evaluationResult.governance.limitations = [
+    effectiveEvaluationResult.governance.limitations = [
       promptCoverage.truncated
         ? `Pass 1 and Pass 2 analyzed a sampled prompt window (~${promptCoverage.analyzedWords} of ${promptCoverage.sourceWords} words; ${promptCoverage.budgetChars}-char budget).`
         : `Pass 1 and Pass 2 analyzed the full submission (${promptCoverage.sourceWords} words).`,
       'Pass 3 synthesis uses a compressed manuscript reference window for arbitration context.',
-      ...evaluationResult.governance.limitations.filter(
+      ...effectiveEvaluationResult.governance.limitations.filter(
         (item) =>
           item !== 'Single-chunk evaluation; multi-chunk synthesis in Phase 2.8' &&
           item !== 'Full manuscript context may not be captured if truncated',
@@ -2396,8 +2430,8 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     // 5. Persist canonical artifact with idempotent upsert (fail-closed)
     const manuscriptText = manuscriptWithContent.content || '(No content provided)';
-    const model = evaluationResult.engine?.model || 'unknown-model';
-    const promptVersion = evaluationResult.engine?.prompt_version || 'unknown-prompt';
+    const model = effectiveEvaluationResult.engine?.model || 'unknown-model';
+    const promptVersion = effectiveEvaluationResult.engine?.prompt_version || 'unknown-prompt';
 
     const sourceHash = stableSourceHash({
       manuscriptId: manuscript.id,
@@ -2440,7 +2474,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         supabase,
         jobId: job.id,
         manuscriptId: job.manuscript_id,
-        evaluationResult,
+        evaluationResult: effectiveEvaluationResult,
         sourceHash,
         progressSnapshot: existingProgress,
         totalUnits: EVALUATION_PROGRESS_TOTAL_UNITS,

--- a/lib/evaluation/validateEvaluationArtifact.ts
+++ b/lib/evaluation/validateEvaluationArtifact.ts
@@ -74,17 +74,26 @@ export function validateEvaluationArtifact(artifact: unknown): ArtifactValidatio
       continue;
     }
 
-    if (typeof criterion.score_0_10 !== "number" || !Number.isInteger(criterion.score_0_10)) {
-      issues.push({
-        code: "CRITERION_SCORE_NOT_INTEGER",
-        path: `$.criteria.${key}.score_0_10`,
-        message: `Criterion ${key} must have an integer score.`,
-      });
-    } else if (criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+    const isScorable = criterion.status === "SCORABLE";
+    if (isScorable) {
+      if (typeof criterion.score_0_10 !== "number" || !Number.isInteger(criterion.score_0_10)) {
+        issues.push({
+          code: "CRITERION_SCORE_NOT_INTEGER",
+          path: `$.criteria.${key}.score_0_10`,
+          message: `Criterion ${key} must have an integer score when status=SCORABLE.`,
+        });
+      } else if (criterion.score_0_10 < 0 || criterion.score_0_10 > 10) {
+        issues.push({
+          code: "CRITERION_SCORE_OUT_OF_RANGE",
+          path: `$.criteria.${key}.score_0_10`,
+          message: `Criterion ${key} score must be between 0 and 10 when status=SCORABLE.`,
+        });
+      }
+    } else if (criterion.score_0_10 !== null) {
       issues.push({
         code: "CRITERION_SCORE_OUT_OF_RANGE",
         path: `$.criteria.${key}.score_0_10`,
-        message: `Criterion ${key} score must be between 0 and 10.`,
+        message: `Criterion ${key} must have score_0_10=null when status=${criterion.status}.`,
       });
     }
 

--- a/schemas/evaluation-result-v2.ts
+++ b/schemas/evaluation-result-v2.ts
@@ -55,6 +55,7 @@ type CriterionBase = {
   signal_present: boolean;
   signal_strength: SignalStrength;
   confidence_band: ConfidenceBand;
+  model_emitted_score_unverified?: number;
   confidence_score_0_100?: number;
   confidence_level?: "high" | "moderate" | "low";
   confidence_reasons?: string[];
@@ -288,6 +289,18 @@ export function validateEvaluationResultV2(
         c.confidence_score_0_100 > 100
       ) {
         errors.push(`criteria[${idx}].confidence_score_0_100 must be 0-100 when present`);
+      }
+    }
+
+    if (c.model_emitted_score_unverified !== undefined) {
+      if (
+        typeof c.model_emitted_score_unverified !== "number" ||
+        !Number.isFinite(c.model_emitted_score_unverified) ||
+        !Number.isInteger(c.model_emitted_score_unverified) ||
+        c.model_emitted_score_unverified < 0 ||
+        c.model_emitted_score_unverified > 10
+      ) {
+        errors.push(`criteria[${idx}].model_emitted_score_unverified must be an integer 0-10 when present`);
       }
     }
 


### PR DESCRIPTION
## Summary

This PR changes only the `v2_fidelity_score_confidence_alignment` behavior in Pass 2 / V2 quality-gate processing: low-confidence criteria with scores above the allowed cap are downgraded per criterion to non-certified / `INSUFFICIENT_SIGNAL` instead of failing the whole job, and the downgraded canonical V2 artifact is persisted without mutating the original gate input.

## Scope

Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):

- [ ] Pass 1
- [x] Pass 2
- [ ] Pass 3

Changed files:

- `schemas/evaluation-result-v2.ts`
- `lib/evaluation/pipeline/qualityGate.ts`
- `lib/evaluation/pipeline/__tests__/qualityGateV2.test.ts`
- `lib/evaluation/processor.ts`
- `__tests__/lib/evaluation/processor.canonical-pipeline.test.ts`
- `__tests__/lib/evaluation/processor.real-gate.test.ts`
- `lib/evaluation/validateEvaluationArtifact.ts`
- `lib/evaluation/__tests__/validateEvaluationArtifact.test.ts`

Out of scope:

- Renderer / UI honesty changes (handled in stacked PR G.1)
- Any change to canonical fatal checks other than `v2_fidelity_score_confidence_alignment`
- Any latency optimization work

## Contract Integrity

- Preserves canonical job statuses and fail-closed persistence behavior.
- Keeps structural V2 failures fatal; only `v2_fidelity_score_confidence_alignment` changes from whole-job failure to per-criterion downgrade.
- Persists `downgradedResult ?? evaluationResult` so storage reflects the actual governed outcome.
- Keeps non-scorable criteria structurally null-scored at the V2 persistence boundary.

## Behavioral Quality

This PR is not reducing intelligence.

- It preserves the model-emitted score only as audit data via `model_emitted_score_unverified`.
- It improves honesty by preventing uncertified high scores from surviving as certified numeric outputs.
- It keeps deterministic diagnostics for the affected QG path while avoiding false whole-job rejection.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Correctness-only PR; no latency-path code or model-routing change in this diff. |
| Run 2 | N/A | N/A | Existing branch work targeted V2 gate semantics and persistence contract only. |

### Post-change Runs

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Local verification focused on semantic correctness (`qualityGateV2`, processor real-gate, build). |
| Run 2 | N/A | N/A | No claimed latency improvement; branch is correctness-only and latency-neutral by intent. |

## Quality Gate / Anomalies

- QG_v2_fidelity_score_confidence_alignment: changed from whole-job fatal behavior to per-criterion downgrade.
- All other QG_ fatal behaviors remain fail-closed.
- Real-gate regression now proves downgraded criteria persist with correct `overview.scored_criteria_count`.

## Risks & Anomalies

- Existing downstream consumers must use the persisted V2 artifact rather than assuming every criterion has a numeric score.
- Renderer honesty remains intentionally out of scope for this PR and is stacked separately.
- No latency claim is made in this PR body; the latency section is present only to satisfy repository policy for non-doc, non-migration PRs.
