### PR TITLE
feat(renderer): display non-certified criteria honestly

### DIFF
--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -13,6 +13,12 @@ import {
 import { EvaluationPoller } from "@/components/EvaluationPoller";
 import { buildTopRecommendations } from "@/lib/evaluation/reportRecommendations";
 import { classifyEvaluationIntegrityBanner } from "@/lib/evaluation/warningClassification";
+import {
+  getCertifiedCriteriaSummary,
+  getCriterionPrimaryBadge,
+  getCriterionSupportLabel,
+  isCertifiedCriterion,
+} from "@/lib/evaluation/reportCriterionDisplay";
 
 type Job = {
   id: string;
@@ -202,22 +208,13 @@ function isCriterionKey(key: string): key is CriterionKey {
 function isScorableCriterion(
   c: NonNullable<ArtifactContentV1["criteria"]>[number],
 ): boolean {
-  if (typeof c.scorable === "boolean") {
-    return c.scorable;
-  }
-  if (c.status) {
-    return c.status === "SCORABLE";
-  }
-  return typeof c.score_0_10 === "number";
+  return isCertifiedCriterion(c);
 }
 
 function criterionStatusLabel(
   c: NonNullable<ArtifactContentV1["criteria"]>[number],
 ): string | null {
-  if (isScorableCriterion(c)) return null;
-  if (c.status === "NOT_APPLICABLE") return "N/A — Not applicable for this evaluation context";
-  if (c.status === "NO_SIGNAL") return "N/A — No observable evidence";
-  return "N/A — Insufficient manuscript evidence";
+  return getCriterionSupportLabel(c);
 }
 
 function getConfidencePresentation(
@@ -505,20 +502,16 @@ export default async function EvaluationReportPage({
                       <li>Low (&lt;60): limited support from the text</li>
                     </ul>
                   </div>
+                  <p className="mt-3 text-sm font-medium text-gray-700">
+                    {getCertifiedCriteriaSummary(orderedCriteria)}
+                  </p>
                   <div className="mt-4 space-y-4">
                     {orderedCriteria.map((c) => (
                       <div key={c.key} className="rounded-md border bg-white p-5">
                         {(() => {
                           const scorable = isScorableCriterion(c);
-                          const scoreValue = scorable ? c.score_0_10 : null;
                           const confidence = getConfidencePresentation(c);
-                          const badgeClasses = !scorable
-                            ? "bg-slate-100 text-slate-700"
-                            : (typeof scoreValue === "number" && scoreValue >= 8)
-                              ? "bg-green-100 text-green-800"
-                              : (typeof scoreValue === "number" && scoreValue >= 6)
-                                ? "bg-yellow-100 text-yellow-800"
-                                : "bg-red-100 text-red-800";
+                          const primaryBadge = getCriterionPrimaryBadge(c);
 
                           return (
                         <div className="flex items-start justify-between gap-3">
@@ -526,8 +519,8 @@ export default async function EvaluationReportPage({
                             {isCriterionKey(c.key) ? getCriterionDisplayLabel(c.key, evaluationScope) : c.key}
                           </h3>
                           <div className="flex shrink-0 items-center gap-2">
-                            <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${badgeClasses}`}>
-                              {scorable ? `${scoreValue ?? "—"} / 10` : "N/A"}
+                            <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${primaryBadge.classes}`}>
+                              {primaryBadge.label}
                             </span>
                             {confidence && (
                               <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${confidence.classes}`}>

--- a/app/evaluate/[jobId]/report/page.tsx
+++ b/app/evaluate/[jobId]/report/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { sanitizeRenderData } from "@/lib/evaluation/reportCriterionDisplay";
 
 /**
  * Canonical artifact type for Flow 1 one-page summary.
@@ -128,7 +129,7 @@ export default function ReportPage({ params }: { params: { jobId: string } }) {
             <div style={{ marginTop: 16 }}>
               <strong>Raw Result (debug)</strong>
               <pre style={{ whiteSpace: "pre-wrap" }}>
-                {JSON.stringify(data.evaluation_result, null, 2)}
+                {JSON.stringify(sanitizeRenderData(data.evaluation_result), null, 2)}
               </pre>
             </div>
           )}

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -8,6 +8,11 @@ import { EvaluationResultV1, isEvaluationResultV1, hasD2TransparencyFields } fro
 import AgentTrustHeader from '@/components/reports/AgentTrustHeader';
 import { scanObjectForForbiddenMarketClaims } from '@/lib/release/forbiddenMarketClaims';
 import { classifyEvaluationIntegrityBanner } from '@/lib/evaluation/warningClassification';
+import {
+  getCertifiedCriteriaSummary,
+  getCriterionPrimaryBadge,
+  getCriterionSupportLabel,
+} from '@/lib/evaluation/reportCriterionDisplay';
 
 // D1 Boundary: server-only. Service key must not leak to client.
 // Hybrid owner-gate: SSR client for auth identity, admin client for
@@ -247,6 +252,9 @@ export default async function ReportPage({ params }: { params: { jobId: string }
               <li>Low (&lt;60): limited support from the text</li>
             </ul>
           </div>
+          <p className="mb-4 text-sm font-medium text-gray-700">
+            {getCertifiedCriteriaSummary(criteria as Parameters<typeof getCertifiedCriteriaSummary>[0])}
+          </p>
           <div className="grid md:grid-cols-2 gap-4">
             {criteria.map((criterion) => (
               <div key={criterion.key} className="border border-gray-200 rounded-lg p-4">
@@ -255,13 +263,14 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                     {criterion.key}
                   </h3>
                   <div className="flex items-center gap-2">
-                    <span className={`text-lg font-bold ${
-                      criterion.score_0_10 >= 8 ? 'text-green-600' :
-                      criterion.score_0_10 >= 6 ? 'text-yellow-600' :
-                      'text-red-600'
-                    }`}>
-                      {criterion.score_0_10}/10
-                    </span>
+                    {(() => {
+                      const badge = getCriterionPrimaryBadge(criterion as Parameters<typeof getCriterionPrimaryBadge>[0]);
+                      return (
+                        <span className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold ${badge.classes}`}>
+                          {badge.label}
+                        </span>
+                      );
+                    })()}
                     {(() => {
                       const confidence = getConfidenceBadge(criterion);
                       if (!confidence) return null;
@@ -273,6 +282,11 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                     })()}
                   </div>
                 </div>
+                {getCriterionSupportLabel(criterion as Parameters<typeof getCriterionSupportLabel>[0]) && (
+                  <p className="mb-2 text-xs font-medium text-gray-500">
+                    {getCriterionSupportLabel(criterion as Parameters<typeof getCriterionSupportLabel>[0])}
+                  </p>
+                )}
                 <p className="text-sm text-gray-600">
                   {criterion.rationale}
                 </p>

--- a/lib/evaluation/reportCriterionDisplay.ts
+++ b/lib/evaluation/reportCriterionDisplay.ts
@@ -1,0 +1,107 @@
+export type RenderableCriterion = {
+  score_0_10?: number | null;
+  status?: "NOT_APPLICABLE" | "NO_SIGNAL" | "INSUFFICIENT_SIGNAL" | "SCORABLE";
+  scorable?: boolean;
+  scorability_status?: "scorable" | "scorable_low_confidence" | "non_scorable";
+  insufficient_signal_reason?: {
+    looked_for?: string[];
+    not_found?: string[];
+  };
+};
+
+export function isCertifiedCriterion(criterion: RenderableCriterion): boolean {
+  if (typeof criterion.scorable === "boolean") {
+    return criterion.scorable;
+  }
+
+  if (criterion.status) {
+    return criterion.status === "SCORABLE";
+  }
+
+  if (criterion.scorability_status) {
+    return (
+      criterion.scorability_status !== "non_scorable" &&
+      typeof criterion.score_0_10 === "number"
+    );
+  }
+
+  return typeof criterion.score_0_10 === "number";
+}
+
+export function getCriterionPrimaryBadge(criterion: RenderableCriterion): {
+  label: string;
+  classes: string;
+  numeric: boolean;
+} {
+  if (criterion.status === "NOT_APPLICABLE") {
+    return {
+      label: "N/A",
+      classes: "bg-slate-100 text-slate-700",
+      numeric: false,
+    };
+  }
+
+  if (!isCertifiedCriterion(criterion)) {
+    return {
+      label: "Score not certified",
+      classes: "bg-slate-100 text-slate-700",
+      numeric: false,
+    };
+  }
+
+  const scoreValue = criterion.score_0_10;
+  if (typeof scoreValue === "number" && scoreValue >= 8) {
+    return {
+      label: `${scoreValue} / 10`,
+      classes: "bg-green-100 text-green-800",
+      numeric: true,
+    };
+  }
+
+  if (typeof scoreValue === "number" && scoreValue >= 6) {
+    return {
+      label: `${scoreValue} / 10`,
+      classes: "bg-yellow-100 text-yellow-800",
+      numeric: true,
+    };
+  }
+
+  return {
+    label: `${scoreValue ?? "—"} / 10`,
+    classes: "bg-red-100 text-red-800",
+    numeric: true,
+  };
+}
+
+export function getCriterionSupportLabel(criterion: RenderableCriterion): string | null {
+  if (isCertifiedCriterion(criterion)) return null;
+  if (criterion.status === "NOT_APPLICABLE") {
+    return "N/A — Not applicable for this evaluation context";
+  }
+  if (criterion.status === "NO_SIGNAL") {
+    return "Score not certified — no observable evidence";
+  }
+  return "Score not certified — insufficient evidence anchoring";
+}
+
+export function getCertifiedCriteriaSummary(criteria: RenderableCriterion[]): string {
+  const total = criteria.length;
+  const certified = criteria.filter((criterion) => isCertifiedCriterion(criterion)).length;
+  return `${certified} of ${total} criteria certified`;
+}
+
+export function sanitizeRenderData<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeRenderData(entry)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    const sanitizedEntries = Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => key !== "model_emitted_score_unverified")
+      .map(([key, entryValue]) => [key, sanitizeRenderData(entryValue)]);
+
+    return Object.fromEntries(sanitizedEntries) as T;
+  }
+
+  return value;
+}

--- a/tests/lib/evaluation/reportCriterionDisplay.test.ts
+++ b/tests/lib/evaluation/reportCriterionDisplay.test.ts
@@ -1,0 +1,91 @@
+import {
+  getCertifiedCriteriaSummary,
+  getCriterionPrimaryBadge,
+  getCriterionSupportLabel,
+  isCertifiedCriterion,
+  sanitizeRenderData,
+  type RenderableCriterion,
+} from '@/lib/evaluation/reportCriterionDisplay';
+
+describe('reportCriterionDisplay helpers', () => {
+  test('non-certified criterion renders Score not certified without numeric badge', () => {
+    const criterion: RenderableCriterion = {
+      status: 'INSUFFICIENT_SIGNAL',
+      score_0_10: null,
+      scorable: false,
+      insufficient_signal_reason: {
+        looked_for: ['CERTIFIED_ANCHORS_FOR_HIGH_CONFIDENCE_SCORING'],
+        not_found: ['LOW_CONFIDENCE_HIGH_SCORE_WITHOUT_CERTIFIED_ANCHORS'],
+      },
+    };
+
+    expect(isCertifiedCriterion(criterion)).toBe(false);
+    expect(getCriterionPrimaryBadge(criterion)).toEqual(
+      expect.objectContaining({
+        label: 'Score not certified',
+        numeric: false,
+      }),
+    );
+    expect(getCriterionPrimaryBadge(criterion).label).not.toContain('/ 10');
+    expect(getCriterionSupportLabel(criterion)).toBe(
+      'Score not certified — insufficient evidence anchoring',
+    );
+  });
+
+  test('certified-count summary is correct', () => {
+    const criteria: RenderableCriterion[] = [
+      { status: 'SCORABLE', score_0_10: 7, scorable: true },
+      { status: 'SCORABLE', score_0_10: 8, scorable: true },
+      { status: 'INSUFFICIENT_SIGNAL', score_0_10: null, scorable: false },
+    ];
+
+    expect(getCertifiedCriteriaSummary(criteria)).toBe('2 of 3 criteria certified');
+  });
+
+  test('scorable criteria still render numeric score normally', () => {
+    const criterion: RenderableCriterion = {
+      status: 'SCORABLE',
+      score_0_10: 7,
+      scorable: true,
+    };
+
+    expect(getCriterionPrimaryBadge(criterion)).toEqual(
+      expect.objectContaining({
+        label: '7 / 10',
+        numeric: true,
+      }),
+    );
+    expect(getCriterionSupportLabel(criterion)).toBeNull();
+  });
+
+  test('audit-only score is suppressed from rendered/debug data', () => {
+    const sanitized = sanitizeRenderData({
+      criteria: [
+        {
+          key: 'proseControl',
+          status: 'INSUFFICIENT_SIGNAL',
+          score_0_10: null,
+          model_emitted_score_unverified: 7,
+          nested: {
+            model_emitted_score_unverified: 9,
+          },
+        },
+      ],
+    });
+
+    expect(JSON.stringify(sanitized)).not.toContain('model_emitted_score_unverified');
+    expect(JSON.stringify(sanitized)).not.toContain('9');
+  });
+
+  test('NO_SIGNAL criteria surface explicit non-certified support label', () => {
+    const criterion: RenderableCriterion = {
+      status: 'NO_SIGNAL',
+      score_0_10: null,
+      scorable: false,
+    };
+
+    expect(getCriterionSupportLabel(criterion)).toBe(
+      'Score not certified — no observable evidence',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Renderer-only G.1 for Option B honesty: user-facing report surfaces now display non-certified criteria without numeric scores, preserve rationale/reason visibility, and suppress audit-only fields.

## Scope

Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):

- [ ] Pass 1
- [x] Pass 2
- [ ] Pass 3

Changed files:

- `lib/evaluation/reportCriterionDisplay.ts`
- `tests/lib/evaluation/reportCriterionDisplay.test.ts`
- `app/evaluate/[jobId]/page.tsx`
- `app/reports/[jobId]/page.tsx`
- `app/evaluate/[jobId]/report/page.tsx`

Out of scope:

- Any `qualityGate` runtime semantics
- Any persistence or validator boundary logic
- Any job state/contract changes

## Contract Integrity

- Consumes persisted Option B shape from main (`downgradedResult ?? evaluationResult` path already merged via #350).
- Treats non-scorable criteria as non-certified display states, never as numeric-scored display states.
- Keeps audit-only `model_emitted_score_unverified` hidden from rendered/debug output.

## Behavioral Quality

This PR is not reducing intelligence.

- Improves UI truthfulness for non-certified criteria.
- Prevents accidental display of uncertified numeric scores.
- Preserves rationale and insufficient-signal reason context for users.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Renderer/UI-only PR; no Pass 2 pipeline execution path changed. |
| Run 2 | N/A | N/A | No model call, prompt, or pipeline runtime code touched. |

### Post-change Runs

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Verified renderer helper tests and full build pass; no latency contract change claimed. |
| Run 2 | N/A | N/A | Scope remains presentation-only over already persisted V2 data. |

## Quality Gate / Anomalies

- QG_ behavior changes: none (renderer-only PR).
- Quality Gate disclosure: UI now faithfully surfaces non-certified outcomes generated by existing QG/runtime logic.

## Risks & Anomalies

- Depends on #350 merged shape already present on `main`.
- If future renderer surfaces bypass shared helper logic, non-certified display consistency could drift.
- No runtime/persistence risk introduced by this PR’s file scope (5 files).
