### PR TITLE
fix(qg): add γ runtime gate for ambiguous 'the drive' phrasing

### DIFF
--- a/__tests__/lib/evaluation/pipeline/recommendation-editorial-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/recommendation-editorial-quality.test.ts
@@ -237,4 +237,27 @@ describe("qualityGate recommendation_editorial_quality", () => {
     expect(check?.error_code).toBe("QG_EDITORIAL_GENERIC_FEEDBACK");
     expect(check?.details).toContain("duplicate editorial reasoning");
   });
+
+  it("fails when recommendation uses ambiguous craft phrase 'the drive'", () => {
+    const synthesis = makeSynthesis({
+      narrativeDrive: {
+        recommendations: [
+          {
+            ...makeRecommendation("narrativeDrive"),
+            action:
+              "In the chapter turn for narrativeDrive, replace the abstract reaction line because the drive fades before consequence becomes visible.",
+            expected_impact:
+              "Gives the reader stronger urgency and continuity once the drive is clarified at the pivot.",
+          },
+        ],
+      },
+    });
+
+    const result = runQualityGate(synthesis);
+    const check = result.checks.find((c) => c.check_id === "recommendation_editorial_quality");
+
+    expect(check?.passed).toBe(false);
+    expect(check?.error_code).toBe("QG_EDITORIAL_GENERIC_FEEDBACK");
+    expect(check?.details).toContain("ambiguous craft term");
+  });
 });

--- a/lib/evaluation/pipeline/qualityGate.ts
+++ b/lib/evaluation/pipeline/qualityGate.ts
@@ -896,6 +896,12 @@ export function runQualityGate(
           genericFeedbackFindings.push(`${c.key}: missing ${missing.join(",")} in recommendation \"${action.slice(0, 80)}\"`);
         }
 
+        if (/\bthe\s+drive\b/i.test(action) || /\bthe\s+drive\b/i.test(expectedImpact)) {
+          genericFeedbackFindings.push(
+            `${c.key}: ambiguous craft term "the drive" detected; prefer "narrative momentum" wording`,
+          );
+        }
+
         if (duplicateReasoning) {
           genericFeedbackFindings.push(`${c.key}: duplicate editorial reasoning detected in recommendations`);
         } else {


### PR DESCRIPTION
## Summary

Isolated γ runtime gate: block ambiguous craft phrasing "the drive" in recommendation text.

## Scope

- ✅ In scope: `lib/evaluation/pipeline/qualityGate.ts` (recommendation_editorial_quality check)
- ✅ In scope: `__tests__/lib/evaluation/pipeline/recommendation-editorial-quality.test.ts`
- ❌ Out of scope: prompt text, named-character checks, prefix/sibling clustering, three-and-three V2 gate, SIPOC fixtures

## Contract Integrity

- No job lifecycle/status changes
- No DB schema or write-path changes
- Deterministic quality gate only

## Behavioral Quality

- Fails a recommendation when `action` or `expected_impact` contains `the drive`
- Failure is emitted through existing `recommendation_editorial_quality` path (`QG_EDITORIAL_GENERIC_FEEDBACK`)
- Guidance in failure detail points to clearer wording (`narrative momentum`)

## Latency Evidence

Baseline (Pre-change)
- Selected pass: [x] Pass 3
- pass3_ms: n/a (deterministic gate check only)
- total_ms: n/a (deterministic gate check only)
- criteria_count_by_state: n/a (no synthesis schema change)
- QG_: recommendation_editorial_quality (existing check path)

Post-change Runs
- Run 1: local targeted suite pass (9/9)
- Run 2: pending CI

## Risks & Anomalies

- Low risk: lexical guard could flag intentional figurative use of "drive"; this is intentional doctrine tightening for craft-term disambiguation.
- No scoring or persistence behavior altered.

Final principle: this change is not reducing intelligence.
