### PR TITLE
feat(renderer): deterministic Chicago surface normalization

### DIFF
--- a/__tests__/lib/evaluation/reportRecommendations.test.ts
+++ b/__tests__/lib/evaluation/reportRecommendations.test.ts
@@ -21,8 +21,8 @@ describe("buildTopRecommendations", () => {
     });
 
     expect(output).toEqual([
-      "Quick win: Condense the council-profile sequence by combining repeated motive beats. — This preserves the strongest revelations while reducing pattern fatigue.",
-      "Strategic revision: Insert one irreversible discovery before the river meditation closes the chapter. — This converts accumulated pressure into immediate narrative consequence.",
+      "Quick win: Condense the council-profile sequence by combining repeated motive beats.—This preserves the strongest revelations while reducing pattern fatigue.",
+      "Strategic revision: Insert one irreversible discovery before the river meditation closes the chapter.—This converts accumulated pressure into immediate narrative consequence.",
     ]);
   });
 
@@ -42,7 +42,7 @@ describe("buildTopRecommendations", () => {
     });
 
     expect(output).toEqual([
-      "Differentiate Malcolm and Frankie through distinct consequence paths. — This reduces repetitive profile rhythm.",
+      "Differentiate Malcolm and Frankie through distinct consequence paths.—This reduces repetitive profile rhythm.",
     ]);
   });
 });

--- a/__tests__/lib/evaluation/style/chicagoSurface.test.ts
+++ b/__tests__/lib/evaluation/style/chicagoSurface.test.ts
@@ -1,0 +1,22 @@
+const { normalizeChicagoSurfaceText } = require("../../../../lib/evaluation/style/chicagoSurface");
+
+describe("normalizeChicagoSurfaceText", () => {
+  test("normalizes dashed clauses to deterministic em-dash style", () => {
+    expect(normalizeChicagoSurfaceText("Sentence one -- sentence two")).toBe("Sentence one—sentence two");
+    expect(normalizeChicagoSurfaceText("Sentence one — sentence two")).toBe("Sentence one—sentence two");
+  });
+
+  test("normalizes smart quotes and contraction apostrophes", () => {
+    const input = 'In the anchored moment "It\'s okay," I whispered.';
+    const output = normalizeChicagoSurfaceText(input);
+
+    expect(output).toContain("“It’s okay,”");
+    expect(output).not.toContain("\"It's okay,\"");
+  });
+
+  test("handles optional values safely", () => {
+    expect(normalizeChicagoSurfaceText(undefined)).toBe("");
+    expect(normalizeChicagoSurfaceText(null)).toBe("");
+    expect(normalizeChicagoSurfaceText("   ")).toBe("");
+  });
+});

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -13,6 +13,7 @@ import {
   getCriterionPrimaryBadge,
   getCriterionSupportLabel,
 } from '@/lib/evaluation/reportCriterionDisplay';
+import { normalizeChicagoSurfaceText } from '@/lib/evaluation/style/chicagoSurface';
 
 // D1 Boundary: server-only. Service key must not leak to client.
 // Hybrid owner-gate: SSR client for auth identity, admin client for
@@ -206,7 +207,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
             </div>
           </div>
           <p className="text-gray-700 mb-6 leading-relaxed">
-            {overview.one_paragraph_summary}
+            {normalizeChicagoSurfaceText(overview.one_paragraph_summary)}
           </p>
           <div className="grid md:grid-cols-2 gap-6">
             <div>
@@ -217,7 +218,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
               <ul className="space-y-2">
                 {overview.top_3_strengths.map((strength, idx) => (
                   <li key={idx} className="text-gray-700 pl-4 border-l-2 border-green-500">
-                    {strength}
+                    {normalizeChicagoSurfaceText(strength)}
                   </li>
                 ))}
               </ul>
@@ -230,7 +231,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
               <ul className="space-y-2">
                 {overview.top_3_risks.map((risk, idx) => (
                   <li key={idx} className="text-gray-700 pl-4 border-l-2 border-amber-500">
-                    {risk}
+                    {normalizeChicagoSurfaceText(risk)}
                   </li>
                 ))}
               </ul>
@@ -288,7 +289,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                   </p>
                 )}
                 <p className="text-sm text-gray-600">
-                  {criterion.rationale}
+                  {normalizeChicagoSurfaceText(criterion.rationale)}
                 </p>
               </div>
             ))}
@@ -309,7 +310,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                 {recommendations.quick_wins.map((qw, idx) => (
                   <div key={idx} className="border-l-4 border-blue-500 pl-4 py-2">
                     <div className="flex items-center gap-2 mb-1">
-                      <p className="font-semibold text-gray-900">{qw.action}</p>
+                      <p className="font-semibold text-gray-900">{normalizeChicagoSurfaceText(qw.action)}</p>
                       <span className="text-xs px-2 py-1 rounded bg-gray-100 text-gray-600">
                         {qw.effort} effort
                       </span>
@@ -317,7 +318,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                         {qw.impact} impact
                       </span>
                     </div>
-                    <p className="text-sm text-gray-600">{qw.why}</p>
+                    <p className="text-sm text-gray-600">{normalizeChicagoSurfaceText(qw.why)}</p>
                   </div>
                 ))}
               </div>
@@ -334,7 +335,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                 {recommendations.strategic_revisions.map((sr, idx) => (
                   <div key={idx} className="border-l-4 border-purple-500 pl-4 py-2">
                     <div className="flex items-center gap-2 mb-1">
-                      <p className="font-semibold text-gray-900">{sr.action}</p>
+                      <p className="font-semibold text-gray-900">{normalizeChicagoSurfaceText(sr.action)}</p>
                       <span className="text-xs px-2 py-1 rounded bg-gray-100 text-gray-600">
                         {sr.effort} effort
                       </span>
@@ -342,7 +343,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                         {sr.impact} impact
                       </span>
                     </div>
-                    <p className="text-sm text-gray-600">{sr.why}</p>
+                    <p className="text-sm text-gray-600">{normalizeChicagoSurfaceText(sr.why)}</p>
                   </div>
                 ))}
               </div>

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -1,3 +1,5 @@
+import { normalizeChicagoSurfaceText } from "@/lib/evaluation/style/chicagoSurface";
+
 type ArtifactRecommendation = {
   action?: string;
   why?: string;
@@ -31,11 +33,17 @@ function formatCrossCuttingRecommendation(
   recommendation: ArtifactRecommendation,
   label?: string,
 ): string | null {
-  const action = typeof recommendation.action === "string" ? recommendation.action.trim() : "";
+  const action =
+    typeof recommendation.action === "string"
+      ? normalizeChicagoSurfaceText(recommendation.action)
+      : "";
   if (!action) return null;
 
-  const why = typeof recommendation.why === "string" ? recommendation.why.trim() : "";
-  return `${label ? `${label}: ` : ""}${action}${why ? ` — ${why}` : ""}`;
+  const why =
+    typeof recommendation.why === "string"
+      ? normalizeChicagoSurfaceText(recommendation.why)
+      : "";
+  return normalizeChicagoSurfaceText(`${label ? `${label}: ` : ""}${action}${why ? ` — ${why}` : ""}`);
 }
 
 function extractSummaryFallback(summary: string, maxItems: number): string[] {
@@ -46,7 +54,7 @@ function extractSummaryFallback(summary: string, maxItems: number): string[] {
 
   const bullets = lines
     .filter((line) => /^[-•*]\s+/.test(line))
-    .map((line) => line.replace(/^[-•*]\s+/, ""));
+    .map((line) => normalizeChicagoSurfaceText(line.replace(/^[-•*]\s+/, "")));
 
   if (bullets.length > 0) {
     return bullets.slice(0, maxItems);
@@ -54,7 +62,7 @@ function extractSummaryFallback(summary: string, maxItems: number): string[] {
 
   return summary
     .split(/(?<=[.!?])\s+/)
-    .map((line) => line.trim())
+    .map((line) => normalizeChicagoSurfaceText(line))
     .filter(Boolean)
     .slice(0, maxItems);
 }
@@ -78,13 +86,16 @@ export function buildTopRecommendations(artifact: ArtifactLike | null | undefine
   const criteriaDerived = uniq(
     (artifact.criteria ?? []).flatMap((criterion) =>
       (criterion.recommendations ?? []).map((recommendation) => {
-        const action = typeof recommendation.action === "string" ? recommendation.action.trim() : "";
+        const action =
+          typeof recommendation.action === "string"
+            ? normalizeChicagoSurfaceText(recommendation.action)
+            : "";
         if (!action) return "";
         const impact =
           typeof recommendation.expected_impact === "string"
-            ? recommendation.expected_impact.trim()
+            ? normalizeChicagoSurfaceText(recommendation.expected_impact)
             : "";
-        return `${action}${impact ? ` — ${impact}` : ""}`;
+        return normalizeChicagoSurfaceText(`${action}${impact ? ` — ${impact}` : ""}`);
       }),
     ),
   );

--- a/lib/evaluation/style/chicagoSurface.ts
+++ b/lib/evaluation/style/chicagoSurface.ts
@@ -1,0 +1,64 @@
+const DASH_PATTERN = /\s+[—–]\s+/g;
+const DOUBLE_HYPHEN_PATTERN = /\s+--\s+/g;
+const CONTRACTION_APOSTROPHE_PATTERN = /([A-Za-z])'([A-Za-z])/g;
+const MULTISPACE_PATTERN = /[ \t]{2,}/g;
+
+function smartenDoubleQuotes(text: string): string {
+  let out = "";
+  let open = true;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch !== '"') {
+      out += ch;
+      continue;
+    }
+
+    const prev = i > 0 ? text[i - 1] : "";
+    const isLikelyOpening =
+      prev === "" ||
+      /[\s([\{—–-]/.test(prev);
+
+    if (isLikelyOpening) {
+      out += "“";
+      open = false;
+      continue;
+    }
+
+    if (open) {
+      out += "“";
+      open = false;
+    } else {
+      out += "”";
+      open = true;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Deterministic Chicago-style normalization for user-facing prose.
+ * Scope: renderer/report text only (not diagnostics, telemetry, or JSON envelopes).
+ */
+export function normalizeChicagoSurfaceText(input: string | null | undefined): string {
+  const raw = typeof input === "string" ? input : "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+
+  const normalizedDashes = trimmed
+    .replace(DOUBLE_HYPHEN_PATTERN, " — ")
+    .replace(DASH_PATTERN, "—");
+
+  const normalizedApostrophes = normalizedDashes.replace(
+    CONTRACTION_APOSTROPHE_PATTERN,
+    "$1’$2",
+  );
+
+  const smartQuotes = smartenDoubleQuotes(normalizedApostrophes);
+
+  return smartQuotes
+    .replace(MULTISPACE_PATTERN, " ")
+    .replace(/\s+([,.;:!?])/g, "$1")
+    .trim();
+}


### PR DESCRIPTION
## Summary

Adds a deterministic Chicago-style surface normalization layer for user-facing report prose at renderer/report formatting boundaries. This improves quote, apostrophe, and em-dash consistency without mutating internal diagnostics, gate telemetry, or evaluation contract payloads.

## Scope

Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):

- [ ] Pass 1
- [x] Pass 2
- [ ] Pass 3

Changed files:

- `lib/evaluation/style/chicagoSurface.ts`
- `__tests__/lib/evaluation/style/chicagoSurface.test.ts`
- `lib/evaluation/reportRecommendations.ts`
- `__tests__/lib/evaluation/reportRecommendations.test.ts`
- `app/reports/[jobId]/page.tsx`

Out of scope:

- No changes to quality gate decisions or error codes
- No changes to persisted evaluation JSON schema/contracts
- No LLM post-processing pass; deterministic string normalization only

## Contract Integrity

- Style transformation is applied only to user-facing prose surfaces.
- Internal artifacts/diagnostics remain unchanged.
- Canonical job/evaluation status and governance semantics are unchanged.

## Behavioral Quality

This PR is not reducing intelligence.

- Normalizes spaced dashes and double-hyphen sequences to deterministic em-dash style.
- Normalizes contraction apostrophes and smartens double quotes in renderer-facing text.
- Applies normalization consistently to summary/rationale/recommendation display and top recommendation construction.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | renderer/unit-layer only |
| Run 2 | N/A | N/A | renderer/unit-layer only |

### Post-change Runs

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | `style/chicagoSurface.test.ts` + `reportRecommendations.test.ts` passing |
| Run 2 | N/A | N/A | rerun passing |

## Quality Gate / Anomalies

QG_<gate-id>: no QG_ behavior changes

## Risks & Anomalies

- Current pass implements deterministic punctuation/quote normalization, not full CMOS coverage.
- Full CMOS convention coverage (e.g., nested quote policy variants, title styling) can be layered in follow-up rules if needed.
