### PR TITLE
fix(pass3): remove clamp-unsafe preservation parentheses

### DIFF
--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -635,7 +635,8 @@ describe("Pass 3 backfill quality", () => {
           recommendations: [
             {
               priority: "medium",
-              action: "Revise dialogue in Chapter 11 to reduce expository elements and increase dynamic interaction.",
+              action:
+                "Revise dialogue in Chapter 11 to reduce expository elements, increase dynamic interaction, sharpen speaker contrast, and ground the pressure shift in visible reaction beats.",
               expected_impact: "Improves dialogue quality.",
               anchor_snippet: '"It\'s okay," I whispered. But even as I said it, I knew it wasn\'t okay.',
               source_pass: 3,
@@ -664,9 +665,12 @@ describe("Pass 3 backfill quality", () => {
     const parsed = parsePass3Response(raw, pass1, pass2, "o3");
     const repaired = parsed.criteria.find((c) => c.key === "dialogue")?.recommendations?.[0]?.action ?? "";
 
-    expect(repaired).toContain("because this preserves the original revision intent (");
+    expect(repaired).toContain("because this preserves the original revision intent by continuing to revise dialogue");
     expect(repaired).not.toContain("because this preserves Revise dialogue");
+    expect(repaired).not.toMatch(/\([^)]*$/);
+    expect(repaired).not.toContain("(");
     expect(repaired.toLowerCase()).not.toContain("criterion-specific move");
+    expect(repaired.length).toBeLessThanOrEqual(300);
   });
 
   test("does not auto-repair anchorless generic recommendation and QG still fails", () => {

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -902,7 +902,11 @@ function normalizeIntentFragmentForRepair(intentFragment: string): string {
 
 function buildPreservationClause(intentFragment: string): string {
   const normalizedIntent = normalizeIntentFragmentForRepair(intentFragment);
-  return `because this preserves the original revision intent (${normalizedIntent})`;
+  if (normalizedIntent === "original revision intent") {
+    return "because this preserves the original revision intent";
+  }
+
+  return `because this preserves the original revision intent by continuing to ${normalizedIntent}`;
 }
 
 function buildCriterionAwareActionRepair(


### PR DESCRIPTION
## Summary

Fix the follow-up edge case in Pass 3 recommendation repair where the preservation clause used parenthetical wording that could be truncated mid-clamp and leave malformed user-facing prose. This replaces the parenthetical clause with non-parenthetical wording and adds a regression to prove repaired actions remain grammatical, deterministic, and clamp-safe.

## Scope

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Changed files:

- `lib/evaluation/pipeline/runPass3Synthesis.ts`
- `__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts`

Out of scope:

- No prompt changes
- No QG rule changes
- No renderer/CMOS pass changes
- No SIPOC harness/runtime contract changes in this PR

## Contract Integrity

- No job lifecycle/status changes
- No DB schema or persistence changes
- No QualityGateV2 logic changes
- Recommendation envelope shape unchanged
- Deterministic repair path preserved

## Behavioral Quality

This PR is not reducing intelligence.

- Removes clamp-unsafe parenthetical formatting from the preservation clause.
- Preserves the splice-fix intent: repaired actions no longer contain `because this preserves Revise ...` garbage.
- Adds regression coverage for unmatched-parenthesis safety, clamp length, and continued absence of `criterion-specific move` leakage.

## Latency Evidence

Baseline (Pre-change)
- Selected pass: [x] Pass 3
- pass3_ms: n/a (deterministic string-template repair only)
- total_ms: n/a
- criteria_count_by_state: n/a
- QG_: recommendation_editorial_quality (no behavior change)

Post-change Runs
- Run 1: `__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts` passed (15/15)
- Run 2: deterministic rerun expected identical output for repaired action text

## Risks & Anomalies

- Low risk: two-file deterministic follow-up on the merged splice-fix seam
- Follow-on SIPOC work should encode this defect as a governed fixture for `S07_PASS3`
- No scoring, persistence, or release-path behavior changed
