### PR TITLE
fix(pass3): remove preservation scaffolding from action text

### DIFF
--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -619,7 +619,7 @@ describe("Pass 3 backfill quality", () => {
     expect(pacingRec?.action.toLowerCase()).toMatch(/cut|insert/);
   });
 
-  test("repair action keeps preservation clause grammatical for imperative intent fragments", () => {
+  test("repair action excludes internal preservation scaffolding for imperative intent fragments", () => {
     const pass1 = makePass(1);
     const pass2 = makePass(2);
 
@@ -665,11 +665,13 @@ describe("Pass 3 backfill quality", () => {
     const parsed = parsePass3Response(raw, pass1, pass2, "o3");
     const repaired = parsed.criteria.find((c) => c.key === "dialogue")?.recommendations?.[0]?.action ?? "";
 
-    expect(repaired).toContain("because this preserves the original revision intent by continuing to revise dialogue");
-    expect(repaired).not.toContain("because this preserves Revise dialogue");
+    expect(repaired).not.toContain("because this preserves");
+    expect(repaired).not.toContain("original revision intent");
+    expect(repaired).not.toContain("continuing to");
     expect(repaired).not.toMatch(/\([^)]*$/);
     expect(repaired).not.toContain("(");
     expect(repaired.toLowerCase()).not.toContain("criterion-specific move");
+    expect(repaired).toMatch(/[.!?]$/);
     expect(repaired.length).toBeLessThanOrEqual(300);
   });
 

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -591,13 +591,21 @@ export function parsePass3Response(
   };
 }
 
+function ensureTerminalPunctuation(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return trimmed;
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
 function clampRecommendationAction(action: string): string {
   const normalized = action.replace(/\s+/g, " ").trim();
-  if (normalized.length <= 300) return normalized;
+  if (normalized.length <= 300) return ensureTerminalPunctuation(normalized);
 
   const mechanismMatch = normalized.match(/\b(because|since|so that)\b/i);
   if (!mechanismMatch || mechanismMatch.index === undefined) {
-    return normalized.slice(0, 300).replace(/\s+\S*$/, "").trim();
+    return ensureTerminalPunctuation(
+      normalized.slice(0, 300).replace(/\s+\S*$/, "").trim(),
+    );
   }
 
   const mechanismIndex = mechanismMatch.index;
@@ -618,9 +626,11 @@ function clampRecommendationAction(action: string): string {
       : suffix;
 
   const clamped = `${safePrefix} ${safeSuffix}`.trim();
-  return clamped.length <= 300
-    ? clamped
-    : clamped.slice(0, 300).replace(/\s+\S*$/, "").trim();
+  return ensureTerminalPunctuation(
+    clamped.length <= 300
+      ? clamped
+      : clamped.slice(0, 300).replace(/\s+\S*$/, "").trim(),
+  );
 }
 
 function parseEvidenceArray(raw: unknown): EvidenceAnchor[] {
@@ -878,35 +888,25 @@ function buildCriterionAwareReaderEffectDefault(criterionKey: SynthesizedCriteri
 
 function extractIntentFragment(action: string): string {
   const normalized = action.replace(/\s+/g, " ").trim();
-  if (!normalized) return "the original revision intent";
+  if (!normalized) return "";
 
   const withoutLeadIn = normalized
     .replace(/^in\s+[^,]+,\s*/i, "")
-    .replace(/^for\s+[^,]+,\s*/i, "");
+    .replace(/^for\s+[^,]+,\s*/i, "")
+    .replace(/[.;:!?]+$/g, "")
+    .trim();
 
   return withoutLeadIn.slice(0, 120);
 }
 
-function normalizeIntentFragmentForRepair(intentFragment: string): string {
+function normalizeIntentForActionTail(intentFragment: string): string {
   const compact = intentFragment.replace(/\s+/g, " ").trim().replace(/[.;:!?]+$/, "");
-  if (!compact) return "original revision intent";
+  if (!compact) return "";
 
-  const lowered = compact.length > 0
-    ? `${compact.charAt(0).toLowerCase()}${compact.slice(1)}`
-    : compact;
-
-  return lowered.length <= 100
+  const lowered = `${compact.charAt(0).toLowerCase()}${compact.slice(1)}`;
+  return lowered.length <= 65
     ? lowered
-    : lowered.slice(0, 100).replace(/\s+\S*$/, "").trim();
-}
-
-function buildPreservationClause(intentFragment: string): string {
-  const normalizedIntent = normalizeIntentFragmentForRepair(intentFragment);
-  if (normalizedIntent === "original revision intent") {
-    return "because this preserves the original revision intent";
-  }
-
-  return `because this preserves the original revision intent by continuing to ${normalizedIntent}`;
+    : lowered.slice(0, 65).replace(/\s+\S*$/, "").trim();
 }
 
 function buildCriterionAwareActionRepair(
@@ -915,19 +915,22 @@ function buildCriterionAwareActionRepair(
   intentFragment: string,
 ): string {
   const anchor = anchorSnippet.slice(0, 72);
-  const preservationClause = buildPreservationClause(intentFragment);
+  const normalizedIntent = normalizeIntentForActionTail(intentFragment);
+  const intentTail = normalizedIntent.length > 0
+    ? normalizedIntent
+    : "tighten scene-level clarity";
 
   switch (criterionKey) {
     case "character":
-      return `In the anchored moment "${anchor}", replace one abstract reaction line with a concrete decision beat and one desire-vs-fear contradiction ${preservationClause} while making motivation legible.`;
+      return `In the anchored moment "${anchor}", replace one abstract reaction line with a concrete decision beat and a desire-vs-fear contradiction because abstract phrasing blunts motivation; ${intentTail}.`;
     case "sceneConstruction":
-      return `In the anchored moment "${anchor}", split one long descriptive passage and move one image after the causal action beat ${preservationClause} while restoring scene-turn sequencing.`;
+      return `In the anchored moment "${anchor}", split one long descriptive passage and move one image after the causal action beat because sequencing obscures scene turns; ${intentTail}.`;
     case "dialogue":
-      return `In the anchored moment "${anchor}", replace one expository exchange with two short turns plus a brief interruption line ${preservationClause} while making speaker intent and pressure explicit.`;
+      return `In the anchored moment "${anchor}", replace one expository exchange with two short turns plus a brief interruption line because exposition flattens speaker pressure; ${intentTail}.`;
     case "pacing":
-      return `In the anchored moment "${anchor}", cut one reflective sentence and insert one immediate external action trigger ${preservationClause} while tightening momentum at the turn.`;
+      return `In the anchored moment "${anchor}", cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum; ${intentTail}.`;
     default:
-      return `In the anchored moment "${anchor}", replace one abstract sentence with a concrete line-level revision and insert one causal beat ${preservationClause} while clarifying consequence.`;
+      return `In the anchored moment "${anchor}", replace one abstract sentence with a concrete line-level revision and insert one causal beat because abstraction diffuses consequence; ${intentTail}.`;
   }
 }
 


### PR DESCRIPTION
## Summary

Remove internal preservation scaffolding from user-facing Pass 3 recommendation `action` text. This eliminates the leaked phrase family (`because this preserves the original revision intent...`) and keeps repaired actions editorially actionable while preserving criterion-aware intent and deterministic behavior.

## Scope

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Changed files:

- `lib/evaluation/pipeline/runPass3Synthesis.ts`
- `__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts`

Out of scope:

- No prompt changes
- No QG threshold/rule changes
- No schema or persistence changes
- No renderer changes

## Contract Integrity

- No job lifecycle/status changes
- No DB/schema write-path changes
- Recommendation envelope shape unchanged
- Deterministic repair path preserved
- SIPOC fixture contract remains additive and unchanged

## Behavioral Quality

This PR is not reducing intelligence.

- Removes `because this preserves...` scaffolding from user-facing repaired `action` text.
- Keeps mechanism-causal language in repaired actions (`because ...`) without exposing internal rationale scaffolding.
- Preserves intent carry-through and repaired-action distinctness across different source actions.
- Ensures clamped repaired actions end with terminal punctuation.

## Latency Evidence

Baseline (Pre-change)
- Selected pass: [x] Pass 3
- pass3_ms: n/a (deterministic string-template repair only)
- total_ms: n/a
- criteria_count_by_state: n/a
- QG_: recommendation_editorial_quality (no gate rule changes)

Post-change Runs
- Run 1: `__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts` passed (15/15)
- Run 2: deterministic rerun expected identical behavior

## Risks & Anomalies

- Low risk: two-file, seam-localized runtime fix
- Existing console debug output in tests is unchanged
- Production verification still required: rerun Chapter 11 and confirm no `because this preserves` appears in rendered recommendations
