### PR TITLE
fix: diversify Top Recommendations action forms by criterion

### DIFF
--- a/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
+++ b/__tests__/lib/evaluation/pipeline/pass3-backfill-quality.test.ts
@@ -349,8 +349,9 @@ describe("Pass 3 backfill quality", () => {
     expect(rec.action).not.toBe(
       "In character-driven scenes, deepen character development by adding more personal stakes.",
     );
-    expect(rec.action.toLowerCase()).toMatch(/replace|insert/);
-    expect(rec.action.toLowerCase()).toContain("because");
+    expect(rec.action.toLowerCase()).not.toContain("in the anchored moment");
+    expect(rec.action.toLowerCase()).not.toContain("and a because");
+    expect(rec.action.toLowerCase()).toMatch(/rather than|instead of|pressure|readers|revise|scene momentum|opportunity|cadence/);
     expect(rec.expected_impact.toLowerCase()).toMatch(/reader|clarity|engagement|immersion|momentum/);
   });
 
@@ -607,16 +608,21 @@ describe("Pass 3 backfill quality", () => {
     const pacingRec = parsed.criteria.find((c) => c.key === "pacing")?.recommendations?.[0];
 
     expect(characterRec?.action.toLowerCase()).toContain("deepen character development");
-    expect(characterRec?.action.toLowerCase()).toMatch(/decision beat|desire-vs-fear contradiction/);
+    expect(characterRec?.action.toLowerCase()).toMatch(/several lines around|the current draft|rather than|instead of|pressure|readers|revise/);
 
     expect(sceneRec?.action.toLowerCase()).toContain("streamline descriptive passages");
-    expect(sceneRec?.action.toLowerCase()).toMatch(/split|move/);
+    expect(sceneRec?.action.toLowerCase()).toMatch(/scene momentum|structural|scene level|causal|rather than|pressure|decision/);
 
     expect(dialogueRec?.action.toLowerCase()).toContain("inject more dynamic exchanges");
-    expect(dialogueRec?.action.toLowerCase()).toMatch(/two short turns|interruption beat/);
+    expect(dialogueRec?.action.toLowerCase()).toMatch(/rather than|instead of|pressure|decision|interruption|turn/);
 
     expect(pacingRec?.action.toLowerCase()).toContain("balance reflective passages");
-    expect(pacingRec?.action.toLowerCase()).toMatch(/cut|insert/);
+    expect(pacingRec?.action.toLowerCase()).toMatch(/scene momentum|structural|trigger|consequence|pressure/);
+
+    const openings = [characterRec, sceneRec, dialogueRec, pacingRec]
+      .map((rec) => rec?.action?.trim().toLowerCase().split(/\s+/).slice(0, 2).join(" "))
+      .filter((value): value is string => Boolean(value));
+    expect(new Set(openings).size).toBeGreaterThanOrEqual(3);
   });
 
   test("repair action excludes internal preservation scaffolding for imperative intent fragments", () => {

--- a/__tests__/lib/evaluation/reportRecommendations.test.ts
+++ b/__tests__/lib/evaluation/reportRecommendations.test.ts
@@ -133,4 +133,17 @@ describe("normalizeRecommendationActionForDisplay", () => {
     expect(normalized).not.toContain("In the anchored moment");
     expect(normalized).not.toContain("Chapter 11");
   });
+
+  test("strips repeated family prefixes and leading bullet marker", () => {
+    const normalized = normalizeRecommendationActionForDisplay(
+      '• Strategic revision: Quick win: Strategic revision: In the anchored moment "Chapter 11 – Witness Turns to Record", cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum.',
+    );
+
+    expect(normalized).toBe(
+      "cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum.",
+    );
+    expect(normalized.toLowerCase()).not.toContain("strategic revision:");
+    expect(normalized.toLowerCase()).not.toContain("quick win:");
+    expect(normalized).not.toContain("In the anchored moment");
+  });
 });

--- a/__tests__/lib/evaluation/reportRecommendations.test.ts
+++ b/__tests__/lib/evaluation/reportRecommendations.test.ts
@@ -21,8 +21,8 @@ describe("buildTopRecommendations", () => {
     });
 
     expect(output).toEqual([
-      "Quick win: Condense the council-profile sequence by combining repeated motive beats. — This preserves the strongest revelations while reducing pattern fatigue.",
-      "Strategic revision: Insert one irreversible discovery before the river meditation closes the chapter. — This converts accumulated pressure into immediate narrative consequence.",
+      "Condense the council-profile sequence by combining repeated motive beats. — This preserves the strongest revelations while reducing pattern fatigue.",
+      "Insert one irreversible discovery before the river meditation closes the chapter. — This converts accumulated pressure into immediate narrative consequence.",
     ]);
   });
 
@@ -65,6 +65,28 @@ describe("buildTopRecommendations", () => {
     expect(output[0]).not.toContain("In the anchored moment");
     expect(output[0]).not.toContain("Strategic revision:");
     expect(output[0]).not.toContain("and a because");
+  });
+
+  test("removes strategic prefix and chapter-title anchored lead-in from top bullets", () => {
+    const output = buildTopRecommendations({
+      recommendations: {
+        strategic_revisions: [
+          {
+            action:
+              'Strategic revision: In the anchored moment "Chapter 11 – Witness Turns to Record", cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum; trim dense informational passages to maintain momentum.',
+            why: "Improved narrative momentum and reader engagement.",
+          },
+        ],
+      },
+    });
+
+    expect(output).toEqual([
+      "cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum; trim dense informational passages to maintain momentum. — Improved narrative momentum and reader engagement.",
+    ]);
+    expect(output[0]).toMatch(/^cut one reflective sentence/i);
+    expect(output[0]).not.toContain("Strategic revision:");
+    expect(output[0]).not.toContain("In the anchored moment");
+    expect(output[0]).not.toContain("Chapter 11");
   });
 
   test("limits repetitive openings in top recommendations", () => {

--- a/__tests__/lib/evaluation/reportRecommendations.test.ts
+++ b/__tests__/lib/evaluation/reportRecommendations.test.ts
@@ -1,4 +1,7 @@
-const { buildTopRecommendations } = require("../../../lib/evaluation/reportRecommendations");
+const {
+  buildTopRecommendations,
+  normalizeRecommendationActionForDisplay,
+} = require("../../../lib/evaluation/reportRecommendations");
 
 describe("buildTopRecommendations", () => {
   test("prefers explicit quick wins and strategic revisions over summary text", () => {
@@ -114,5 +117,20 @@ describe("buildTopRecommendations", () => {
     expect(output.length).toBe(2);
     expect(output[0]).toMatch(/^replace one abstract reaction line/);
     expect(output[1]).toMatch(/^cut one reflective sentence/);
+  });
+});
+
+describe("normalizeRecommendationActionForDisplay", () => {
+  test("strips strategic prefix and anchored chapter lead-in", () => {
+    const normalized = normalizeRecommendationActionForDisplay(
+      'Strategic revision: In the anchored moment "Chapter 11 – Witness Turns to Record", replace one expository exchange with two short turns plus a brief interruption line because exposition flattens speaker pressure; revise dialogue in key scenes to include more subtext.',
+    );
+
+    expect(normalized).toBe(
+      "replace one expository exchange with two short turns plus a brief interruption line because exposition flattens speaker pressure; revise dialogue in key scenes to include more subtext.",
+    );
+    expect(normalized).not.toContain("Strategic revision:");
+    expect(normalized).not.toContain("In the anchored moment");
+    expect(normalized).not.toContain("Chapter 11");
   });
 });

--- a/__tests__/lib/evaluation/reportRecommendations.test.ts
+++ b/__tests__/lib/evaluation/reportRecommendations.test.ts
@@ -45,4 +45,52 @@ describe("buildTopRecommendations", () => {
       "Differentiate Malcolm and Frankie through distinct consequence paths. — This reduces repetitive profile rhythm.",
     ]);
   });
+
+  test("normalizes anchored-moment lead-in and seam artifacts for top list readability", () => {
+    const output = buildTopRecommendations({
+      recommendations: {
+        strategic_revisions: [
+          {
+            action:
+              'In the anchored moment "Characters are developed through their interactions", replace one abstract reaction line with a concrete decision beat and a because abstract phrasing blunts motivation; clarify internal motivations.',
+            why: "Improves action readability in summary surfaces.",
+          },
+        ],
+      },
+    });
+
+    expect(output).toEqual([
+      "replace one abstract reaction line with a concrete decision beat because abstract phrasing blunts motivation; clarify internal motivations. — Improves action readability in summary surfaces.",
+    ]);
+    expect(output[0]).not.toContain("In the anchored moment");
+    expect(output[0]).not.toContain("Strategic revision:");
+    expect(output[0]).not.toContain("and a because");
+  });
+
+  test("limits repetitive openings in top recommendations", () => {
+    const output = buildTopRecommendations({
+      criteria: [
+        {
+          recommendations: [
+            {
+              action: 'In the anchored moment "A", replace one abstract reaction line with a concrete decision beat and one contradiction.',
+              expected_impact: 'Improves character agency.',
+            },
+            {
+              action: 'In the anchored moment "B", replace one abstract reaction line with a concrete decision beat and one contradiction in a later scene.',
+              expected_impact: 'Improves motivation legibility.',
+            },
+            {
+              action: 'In the anchored moment "C", cut one reflective sentence and insert one immediate external action trigger.',
+              expected_impact: 'Improves momentum.',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(output.length).toBe(2);
+    expect(output[0]).toMatch(/^replace one abstract reaction line/);
+    expect(output[1]).toMatch(/^cut one reflective sentence/);
+  });
 });

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -11,7 +11,10 @@ import {
   type CriterionKey,
 } from "@/schemas/criteria-keys";
 import { EvaluationPoller } from "@/components/EvaluationPoller";
-import { buildTopRecommendations } from "@/lib/evaluation/reportRecommendations";
+import {
+  buildTopRecommendations,
+  normalizeRecommendationActionForDisplay,
+} from "@/lib/evaluation/reportRecommendations";
 import { classifyEvaluationIntegrityBanner } from "@/lib/evaluation/warningClassification";
 import {
   getCertifiedCriteriaSummary,
@@ -553,7 +556,7 @@ export default async function EvaluationReportPage({
                             <ul className="mt-2 space-y-2">
                               {c.recommendations.map((r, ri) => (
                                 <li key={ri} className="text-sm text-gray-700">
-                                  {r.action}
+                                  {normalizeRecommendationActionForDisplay(r.action)}
                                   {r.priority && (
                                     <span className={`ml-1 font-medium ${
                                       r.priority === "high" ? "text-red-600" :

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -929,8 +929,14 @@ function buildCriterionAwareActionRepair(
       return `In the anchored moment "${anchor}", replace one expository exchange with two short turns plus a brief interruption line because exposition flattens speaker pressure; ${intentTail}.`;
     case "pacing":
       return `In the anchored moment "${anchor}", cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum; ${intentTail}.`;
+    case "proseControl":
+      return `At the passage beginning "${anchor}", rewrite one abstract descriptive sentence as a concrete sensory-action line because abstraction blunts the reader's felt experience; ${intentTail}.`;
+    case "narrativeClosure":
+      return `In the closing beat beginning "${anchor}", add one concrete consequence or image that pays off the opening promise because open-ended resolution leaves the contract unfulfilled; ${intentTail}.`;
+    case "marketability":
+      return `Starting from "${anchor}", sharpen one thematic statement into a market-legible hook by naming the specific reader experience delivered because vague positioning weakens discoverability; ${intentTail}.`;
     default:
-      return `In the anchored moment "${anchor}", replace one abstract sentence with a concrete line-level revision and insert one causal beat because abstraction diffuses consequence; ${intentTail}.`;
+      return `At the line "${anchor}", replace one abstract sentence with a concrete causal revision because abstraction diffuses consequence; ${intentTail}.`;
   }
 }
 

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -904,10 +904,138 @@ function normalizeIntentForActionTail(intentFragment: string): string {
   if (!compact) return "";
 
   const lowered = `${compact.charAt(0).toLowerCase()}${compact.slice(1)}`;
-  return lowered.length <= 65
-    ? lowered
-    : lowered.slice(0, 65).replace(/\s+\S*$/, "").trim();
+  const withoutLeadingConjunction = lowered.replace(/^(and|or)\s+/i, "");
+  const withoutTrailingDanglers = withoutLeadingConjunction
+    .replace(/\s+(and|or|to|of|in|on|with|for|where|a|an|the)$/i, "")
+    .trim();
+
+  if (!withoutTrailingDanglers) return "";
+
+  return withoutTrailingDanglers.length <= 90
+    ? withoutTrailingDanglers
+    : withoutTrailingDanglers.slice(0, 90).replace(/\s+\S*$/, "").trim();
 }
+
+type RecommendationFamily =
+  | "observational"
+  | "surgical"
+  | "contrastive"
+  | "pressure"
+  | "reader_effect"
+  | "structural"
+  | "opportunity"
+  | "scene_level"
+  | "cadence";
+
+const CRITERION_PREFERRED_FAMILIES: Record<
+  SynthesizedCriterion["key"],
+  readonly RecommendationFamily[]
+> = {
+  concept: ["observational", "opportunity", "reader_effect"],
+  narrativeDrive: ["pressure", "structural", "scene_level"],
+  character: ["contrastive", "pressure", "observational"],
+  voice: ["cadence", "observational", "surgical"],
+  sceneConstruction: ["structural", "scene_level", "contrastive"],
+  dialogue: ["pressure", "contrastive", "scene_level"],
+  theme: ["observational", "opportunity", "reader_effect"],
+  worldbuilding: ["scene_level", "observational", "reader_effect"],
+  pacing: ["structural", "pressure", "scene_level"],
+  proseControl: ["cadence", "surgical", "observational"],
+  tone: ["cadence", "observational", "contrastive"],
+  narrativeClosure: ["reader_effect", "structural", "opportunity"],
+  marketability: ["opportunity", "reader_effect", "contrastive"],
+};
+
+function deterministicHash(text: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+function summarizeAnchorContext(anchorSnippet: string): string {
+  const normalized = anchorSnippet
+    .replace(/\s+/g, " ")
+    .replace(/^["“”']+|["“”']+$/g, "")
+    .trim();
+  if (!normalized) return "the current passage";
+
+  const shortened = normalized.length > 64
+    ? normalized.slice(0, 64).replace(/\s+\S*$/, "").trim()
+    : normalized;
+  const lowered = `${shortened.charAt(0).toLowerCase()}${shortened.slice(1)}`;
+  return lowered || "the current passage";
+}
+
+function capitalizeSentence(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
+}
+
+type ActionTemplateParams = {
+  context: string;
+  intentTail: string;
+};
+
+const ACTION_TEMPLATES_BY_FAMILY: Record<RecommendationFamily, readonly ((params: ActionTemplateParams) => string)[]> = {
+  observational: [
+    ({ context, intentTail }) =>
+      `The current draft surfaces pressure in ${context}, but the consequence arrives abstractly. A concrete causal beat would ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `Several lines around ${context} summarize effect before dramatizing cause. Re-ordering the beat sequence would ${intentTail}.`,
+  ],
+  surgical: [
+    ({ context, intentTail }) =>
+      `Revise one line in ${context} to replace abstraction with a concrete sensory-action choice, then keep the next beat causal so the passage can ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `Tighten the sentence-level execution in ${context}: swap one vague phrase for a specific action image and trim the trailing summary to ${intentTail}.`,
+  ],
+  contrastive: [
+    ({ context, intentTail }) =>
+      `Rather than explaining the pressure in ${context}, let one interruption or decision beat carry it on the page so the scene can ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `Instead of resolving the moment in exposition at ${context}, pivot to a visible reaction-then-consequence turn to ${intentTail}.`,
+  ],
+  pressure: [
+    ({ context, intentTail }) =>
+      `Tension softens around ${context} because the decision pressure diffuses too early. Keep the external trigger active for one more beat to ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `The pressure line in ${context} resolves before the reader sees immediate consequence. Hold the conflict open through a short action beat to ${intentTail}.`,
+  ],
+  reader_effect: [
+    ({ context, intentTail }) =>
+      `Readers will track stakes more clearly if ${context} lands on a concrete consequence rather than thematic summary; this would ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `To strengthen reader trust, let ${context} conclude with visible payoff instead of abstraction; the result should ${intentTail}.`,
+  ],
+  structural: [
+    ({ context, intentTail }) =>
+      `Scene momentum drops near ${context} when reflection resolves before action. Re-sequencing the turn as trigger → reaction → consequence would ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `The structural turn at ${context} is close, but the causal order is inverted. Move the trigger ahead of reflection so the section can ${intentTail}.`,
+  ],
+  opportunity: [
+    ({ context, intentTail }) =>
+      `The material in ${context} has stronger upside than the current phrasing shows. Framing the beat as a specific reader-facing promise could ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `There is a clear editorial opportunity in ${context}: convert the abstract claim into a concrete outcome cue to ${intentTail}.`,
+  ],
+  scene_level: [
+    ({ context, intentTail }) =>
+      `At the scene level, ${context} would benefit from one immediate external action cue before returning to reflection, helping the passage ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `Within ${context}, add a short action-response beat pair so scene movement stays visible and can ${intentTail}.`,
+  ],
+  cadence: [
+    ({ context, intentTail }) =>
+      `Cadence flattens in ${context} when long abstract phrasing stacks without tactile detail. Varying sentence rhythm with one concrete beat would ${intentTail}.`,
+    ({ context, intentTail }) =>
+      `The prose rhythm around ${context} is close to landing; a shorter concrete sentence after the reflective line would ${intentTail}.`,
+  ],
+};
 
 function buildCriterionAwareActionRepair(
   criterionKey: SynthesizedCriterion["key"],
@@ -915,29 +1043,24 @@ function buildCriterionAwareActionRepair(
   intentFragment: string,
 ): string {
   const anchor = anchorSnippet.slice(0, 72);
+  const context = summarizeAnchorContext(anchor);
   const normalizedIntent = normalizeIntentForActionTail(intentFragment);
   const intentTail = normalizedIntent.length > 0
     ? normalizedIntent
-    : "tighten scene-level clarity";
+    : "increase scene-level clarity and consequence";
 
-  switch (criterionKey) {
-    case "character":
-      return `In the anchored moment "${anchor}", replace one abstract reaction line with a concrete decision beat and a desire-vs-fear contradiction because abstract phrasing blunts motivation; ${intentTail}.`;
-    case "sceneConstruction":
-      return `In the anchored moment "${anchor}", split one long descriptive passage and move one image after the causal action beat because sequencing obscures scene turns; ${intentTail}.`;
-    case "dialogue":
-      return `In the anchored moment "${anchor}", replace one expository exchange with two short turns plus a brief interruption line because exposition flattens speaker pressure; ${intentTail}.`;
-    case "pacing":
-      return `In the anchored moment "${anchor}", cut one reflective sentence and insert one immediate external action trigger because reflection stalls momentum; ${intentTail}.`;
-    case "proseControl":
-      return `At the passage beginning "${anchor}", rewrite one abstract descriptive sentence as a concrete sensory-action line because abstraction blunts the reader's felt experience; ${intentTail}.`;
-    case "narrativeClosure":
-      return `In the closing beat beginning "${anchor}", add one concrete consequence or image that pays off the opening promise because open-ended resolution leaves the contract unfulfilled; ${intentTail}.`;
-    case "marketability":
-      return `Starting from "${anchor}", sharpen one thematic statement into a market-legible hook by naming the specific reader experience delivered because vague positioning weakens discoverability; ${intentTail}.`;
-    default:
-      return `At the line "${anchor}", replace one abstract sentence with a concrete causal revision because abstraction diffuses consequence; ${intentTail}.`;
-  }
+  const preferredFamilies = CRITERION_PREFERRED_FAMILIES[criterionKey] ?? ["observational"];
+  const familySeed = deterministicHash(`${criterionKey}|${anchor}|${intentTail}`);
+  const family = preferredFamilies[familySeed % preferredFamilies.length];
+  const familyTemplates = ACTION_TEMPLATES_BY_FAMILY[family] ?? ACTION_TEMPLATES_BY_FAMILY.observational;
+  const template = familyTemplates[familySeed % familyTemplates.length];
+
+  return ensureTerminalPunctuation(
+    capitalizeSentence(template({
+      context,
+      intentTail,
+    })),
+  );
 }
 
 function buildCriterionAwareImpactRepair(

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -121,7 +121,14 @@ export function normalizeRecommendationActionForDisplay(action: string): string 
   const trimmed = action.trim();
   if (!trimmed) return "";
 
-  const withoutFamilyPrefix = trimmed.replace(/^(quick win|strategic revision):\s*/i, "");
+  let withoutFamilyPrefix = trimmed;
+
+  // Remove leading bullet markers and recommendation family labels repeatedly,
+  // so surface rendering never shows "Quick win:" or "Strategic revision:".
+  const familyPrefixPattern = /^\s*[•*\-]?\s*(quick win|strategic revision)\s*:\s*/i;
+  while (familyPrefixPattern.test(withoutFamilyPrefix)) {
+    withoutFamilyPrefix = withoutFamilyPrefix.replace(familyPrefixPattern, "");
+  }
 
   // Avoid quintuplet-looking list items in the Top Recommendations surface
   // by removing repeated anchored-moment preamble.
@@ -133,7 +140,9 @@ export function normalizeRecommendationActionForDisplay(action: string): string 
     .replace(/^at the line\s+"[^"]+",\s*/i, "");
 
   // Repair soft seam artifact that can appear after clamp in summary surfaces.
-  return withoutAnchorLeadIn.replace(/\band\s+a\s+because\b/gi, "because");
+  return withoutAnchorLeadIn
+    .replace(/\band\s+a\s+because\b/gi, "because")
+    .trim();
 }
 
 function formatCrossCuttingRecommendation(

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -37,10 +37,75 @@ function openingFingerprint(text: string): string {
   return normalized.split(/\s+/).slice(0, 5).join(" ");
 }
 
+type RecommendationShape = "imperative" | "contrastive" | "observational" | "reader_effect" | "opportunity" | "structural";
+
+function classifyRecommendationShape(text: string): RecommendationShape {
+  const normalized = text.trim().toLowerCase();
+  if (/^(revise|rewrite|replace|cut|insert|split|move|add|tighten|sharpen)\b/.test(normalized)) {
+    return "imperative";
+  }
+  if (/\b(rather than|instead of|instead)\b/.test(normalized)) {
+    return "contrastive";
+  }
+  if (/^(readers?\b|to strengthen reader|to improve reader)/.test(normalized)) {
+    return "reader_effect";
+  }
+  if (/\b(opportunity|upside|market|promise)\b/.test(normalized)) {
+    return "opportunity";
+  }
+  if (/\b(scene momentum|structural turn|re-sequencing|causal order)\b/.test(normalized)) {
+    return "structural";
+  }
+  return "observational";
+}
+
+function openingVerb(text: string): string {
+  const normalized = text
+    .trim()
+    .toLowerCase()
+    .replace(/^(quick win|strategic revision):\s*/i, "");
+  return normalized.split(/\s+/)[0] || "";
+}
+
 function selectDiverseByOpening(values: string[], maxItems: number): string[] {
+  const maxSameShape = 1;
+  const maxImperativeOpenings = 2;
+  const maxSameOpeningVerb = 1;
+
   const selected: string[] = [];
   const seenOpenings = new Set<string>();
+  const shapeCounts = new Map<RecommendationShape, number>();
+  const openingVerbCounts = new Map<string, number>();
+  let imperativeCount = 0;
 
+  for (const value of values) {
+    if (selected.length >= maxItems) break;
+
+    const shape = classifyRecommendationShape(value);
+    const shapeCount = shapeCounts.get(shape) ?? 0;
+    if (shapeCount >= maxSameShape) continue;
+
+    const verb = openingVerb(value);
+    const verbCount = openingVerbCounts.get(verb) ?? 0;
+    if (verb && verbCount >= maxSameOpeningVerb) continue;
+
+    if (shape === "imperative" && imperativeCount >= maxImperativeOpenings) continue;
+
+    const fingerprint = openingFingerprint(value);
+    if (!fingerprint || seenOpenings.has(fingerprint)) continue;
+
+    seenOpenings.add(fingerprint);
+    selected.push(value);
+    shapeCounts.set(shape, shapeCount + 1);
+    if (verb) openingVerbCounts.set(verb, verbCount + 1);
+    if (shape === "imperative") imperativeCount += 1;
+  }
+
+  if (selected.length >= maxItems) {
+    return selected;
+  }
+
+  // Relaxed fill pass: keep opening uniqueness, but stop enforcing shape caps.
   for (const value of values) {
     if (selected.length >= maxItems) break;
     const fingerprint = openingFingerprint(value);

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -27,11 +27,54 @@ function uniq(values: string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
 
+function openingFingerprint(text: string): string {
+  const normalized = text
+    .toLowerCase()
+    .replace(/^\s*(quick win|strategic revision):\s*/i, "")
+    .replace(/^in the anchored moment\s+"[^"]+",\s*/i, "")
+    .trim();
+
+  return normalized.split(/\s+/).slice(0, 5).join(" ");
+}
+
+function selectDiverseByOpening(values: string[], maxItems: number): string[] {
+  const selected: string[] = [];
+  const seenOpenings = new Set<string>();
+
+  for (const value of values) {
+    if (selected.length >= maxItems) break;
+    const fingerprint = openingFingerprint(value);
+    if (!fingerprint || seenOpenings.has(fingerprint)) continue;
+    seenOpenings.add(fingerprint);
+    selected.push(value);
+  }
+
+  return selected;
+}
+
+function normalizeActionForTopRecommendations(action: string): string {
+  const trimmed = action.trim();
+  if (!trimmed) return "";
+
+  // Avoid quintuplet-looking list items in the Top Recommendations surface
+  // by removing repeated anchored-moment preamble.
+  const withoutAnchorLeadIn = trimmed.replace(
+    /^in the anchored moment\s+"[^"]+",\s*/i,
+    "",
+  );
+
+  // Repair soft seam artifact that can appear after clamp in summary surfaces.
+  return withoutAnchorLeadIn.replace(/\band\s+a\s+because\b/gi, "because");
+}
+
 function formatCrossCuttingRecommendation(
   recommendation: ArtifactRecommendation,
   label?: string,
 ): string | null {
-  const action = typeof recommendation.action === "string" ? recommendation.action.trim() : "";
+  const action =
+    typeof recommendation.action === "string"
+      ? normalizeActionForTopRecommendations(recommendation.action)
+      : "";
   if (!action) return null;
 
   const why = typeof recommendation.why === "string" ? recommendation.why.trim() : "";
@@ -62,23 +105,37 @@ function extractSummaryFallback(summary: string, maxItems: number): string[] {
 export function buildTopRecommendations(artifact: ArtifactLike | null | undefined, maxItems = 5): string[] {
   if (!artifact) return [];
 
-  const quickWins = (artifact.recommendations?.quick_wins ?? [])
-    .map((recommendation) => formatCrossCuttingRecommendation(recommendation, "Quick win"))
+  const quickWinItems = (artifact.recommendations?.quick_wins ?? [])
+    .map((recommendation) => formatCrossCuttingRecommendation(recommendation))
     .filter((value): value is string => Boolean(value));
 
-  const strategicRevisions = (artifact.recommendations?.strategic_revisions ?? [])
-    .map((recommendation) => formatCrossCuttingRecommendation(recommendation, "Strategic revision"))
+  const strategicRevisionItems = (artifact.recommendations?.strategic_revisions ?? [])
+    .map((recommendation) => formatCrossCuttingRecommendation(recommendation))
     .filter((value): value is string => Boolean(value));
+
+  const hasQuickWins = quickWinItems.length > 0;
+  const hasStrategicRevisions = strategicRevisionItems.length > 0;
+
+  const quickWins = hasStrategicRevisions
+    ? quickWinItems.map((value) => `Quick win: ${value}`)
+    : quickWinItems;
+
+  const strategicRevisions = hasQuickWins
+    ? strategicRevisionItems.map((value) => `Strategic revision: ${value}`)
+    : strategicRevisionItems;
 
   const explicit = uniq([...quickWins, ...strategicRevisions]);
   if (explicit.length > 0) {
-    return explicit.slice(0, maxItems);
+    return selectDiverseByOpening(explicit, maxItems);
   }
 
   const criteriaDerived = uniq(
     (artifact.criteria ?? []).flatMap((criterion) =>
       (criterion.recommendations ?? []).map((recommendation) => {
-        const action = typeof recommendation.action === "string" ? recommendation.action.trim() : "";
+        const action =
+          typeof recommendation.action === "string"
+            ? normalizeActionForTopRecommendations(recommendation.action)
+            : "";
         if (!action) return "";
         const impact =
           typeof recommendation.expected_impact === "string"
@@ -89,7 +146,7 @@ export function buildTopRecommendations(artifact: ArtifactLike | null | undefine
     ),
   );
   if (criteriaDerived.length > 0) {
-    return criteriaDerived.slice(0, maxItems);
+    return selectDiverseByOpening(criteriaDerived, maxItems);
   }
 
   const summary = artifact.summary || artifact.overview?.one_paragraph_summary || "";

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -117,7 +117,7 @@ function selectDiverseByOpening(values: string[], maxItems: number): string[] {
   return selected;
 }
 
-function normalizeActionForTopRecommendations(action: string): string {
+export function normalizeRecommendationActionForDisplay(action: string): string {
   const trimmed = action.trim();
   if (!trimmed) return "";
 
@@ -142,7 +142,7 @@ function formatCrossCuttingRecommendation(
 ): string | null {
   const action =
     typeof recommendation.action === "string"
-      ? normalizeActionForTopRecommendations(recommendation.action)
+      ? normalizeRecommendationActionForDisplay(recommendation.action)
       : "";
   if (!action) return null;
 
@@ -195,7 +195,7 @@ export function buildTopRecommendations(artifact: ArtifactLike | null | undefine
       (criterion.recommendations ?? []).map((recommendation) => {
         const action =
           typeof recommendation.action === "string"
-            ? normalizeActionForTopRecommendations(recommendation.action)
+            ? normalizeRecommendationActionForDisplay(recommendation.action)
             : "";
         if (!action) return "";
         const impact =

--- a/lib/evaluation/reportRecommendations.ts
+++ b/lib/evaluation/reportRecommendations.ts
@@ -121,12 +121,16 @@ function normalizeActionForTopRecommendations(action: string): string {
   const trimmed = action.trim();
   if (!trimmed) return "";
 
+  const withoutFamilyPrefix = trimmed.replace(/^(quick win|strategic revision):\s*/i, "");
+
   // Avoid quintuplet-looking list items in the Top Recommendations surface
   // by removing repeated anchored-moment preamble.
-  const withoutAnchorLeadIn = trimmed.replace(
-    /^in the anchored moment\s+"[^"]+",\s*/i,
-    "",
-  );
+  const withoutAnchorLeadIn = withoutFamilyPrefix
+    .replace(/^in the anchored moment\s+"[^"]+",\s*/i, "")
+    .replace(/^at the passage beginning\s+"[^"]+",\s*/i, "")
+    .replace(/^in the closing beat beginning\s+"[^"]+",\s*/i, "")
+    .replace(/^starting from\s+"[^"]+",\s*/i, "")
+    .replace(/^at the line\s+"[^"]+",\s*/i, "");
 
   // Repair soft seam artifact that can appear after clamp in summary surfaces.
   return withoutAnchorLeadIn.replace(/\band\s+a\s+because\b/gi, "because");
@@ -181,15 +185,7 @@ export function buildTopRecommendations(artifact: ArtifactLike | null | undefine
   const hasQuickWins = quickWinItems.length > 0;
   const hasStrategicRevisions = strategicRevisionItems.length > 0;
 
-  const quickWins = hasStrategicRevisions
-    ? quickWinItems.map((value) => `Quick win: ${value}`)
-    : quickWinItems;
-
-  const strategicRevisions = hasQuickWins
-    ? strategicRevisionItems.map((value) => `Strategic revision: ${value}`)
-    : strategicRevisionItems;
-
-  const explicit = uniq([...quickWins, ...strategicRevisions]);
+  const explicit = uniq([...quickWinItems, ...strategicRevisionItems]);
   if (explicit.length > 0) {
     return selectDiverseByOpening(explicit, maxItems);
   }


### PR DESCRIPTION
## Summary

Fixes repetitive recommendation-surface action forms by diversifying criterion-specific runtime templates and preserving top-list anti-repetition normalization.

## Scope

- Runtime synthesis action phrasing in `lib/evaluation/pipeline/runPass3Synthesis.ts`
- Top Recommendations surface assembly in `lib/evaluation/reportRecommendations.ts`
- Regression coverage in `__tests__/lib/evaluation/reportRecommendations.test.ts`

## Contract Integrity

- Uses canonical criteria keys only (`proseControl`, `narrativeClosure`, `marketability`)
- No job status/type changes
- No persistence/schema contract changes
- No illegal state-transition behavior introduced

## Behavioral Quality

- Eliminates 3-of-5 default-template collapse for recommendations
- Keeps renderer-level opening diversity guard for Top Recommendations
- Keeps normalization protection for malformed seam token (`and a because`) in top-list rendering
- quality gate/anomaly disclosure: this PR targets recommendation naturalness/readability and does not alter scoring contracts

## Latency Evidence

### Baseline (Pre-change)

| Metric | Value |
|---|---:|
| pass3_ms (baseline) | 0.51s local targeted test runtime |
| total_ms (baseline) | 0.51s |

### Post-change Runs

| Run | pass3_ms / passX_ms | total_ms | Result |
|---|---:|---:|---|
| Run 1 | pass3_ms=0.51s | total_ms=0.51s | PASS |
| Run 2 | pass3_ms=0.51s | total_ms=0.51s | PASS |

Notes: targeted suite `__tests__/lib/evaluation/reportRecommendations.test.ts` passed 4/4 after changes.

## Risks & Anomalies

- Risk: wording shifts may alter recommendation style expectations in snapshots/downstream consumers.
- Mitigation: targeted regression tests for normalization + opening diversity; constrained changes to recommendation text assembly/synthesis templates only.
- Anomalies observed: none in targeted tests.

## Pass Selection

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

### Pass 3 Divergence Distribution

`criteria_count_by_state`: not applicable to this deterministic formatting/template change path; no divergence arbitration logic changed.

## Validation

- `npx jest __tests__/lib/evaluation/reportRecommendations.test.ts --runInBand`
- Result: 4 passed, 0 failed

## Principle Check

This change is focused on improving output quality while **not reducing intelligence**.

