### PR TITLE
chore(canon-guard): convert Section 4 WARN to FAIL — PR-2a

### DIFF
--- a/scripts/verify-canon-authority.sh
+++ b/scripts/verify-canon-authority.sh
@@ -79,11 +79,11 @@ while IFS= read -r f; do
   if ! head -20 "$f" 2>/dev/null | grep -qE '^canon_status:\s*(authoritative|secondary|deprecated|draft|meta)'; then
     echo "MISSING canon_status: $f"
     warn_missing_frontmatter_count=$((warn_missing_frontmatter_count + 1))
+    fail=1
   fi
 done < <(find "$CONTROL" "$VOLUMES" -type f -name '*.md' 2>/dev/null || true)
 
-# TODO(PR-2): convert to fail=1 after classification baseline lands
-echo "WARN ONLY in PR-0. Hard enforcement deferred to PR-1."
+# Hard enforcement landed in PR-2a (all 26 registered files normalized in PR-2 #375).
 
 section "5. Non-authoritative zones claiming authority"
 forbidden='source of truth|canonical authority|binding canon|runtime ownership|authoritative canon'


### PR DESCRIPTION
## Summary

Single-line enforcement upgrade in `scripts/verify-canon-authority.sh`. Converts Section 4 (`missing_canon_status_registered`) from WARN-only to hard FAIL. Safe because PR-2 (#375) landed all 26 registered files with `canon_status` — the counter is verified at 0 on main.

This change adds enforcement without reducing intelligence — the guard already detects violations; now it acts on them.

## Scope

1 file changed, +2 / -2 in `scripts/verify-canon-authority.sh` Section 4 only.

No logic changes to any other section. No runtime behaviour changes (zero registered files are missing frontmatter — guard fires only on future regressions).

```diff
-    warn_missing_frontmatter_count=$((warn_missing_frontmatter_count + 1))
+    warn_missing_frontmatter_count=$((warn_missing_frontmatter_count + 1))
+    fail=1
-# TODO(PR-2): convert to fail=1 after classification baseline lands
-echo "WARN ONLY in PR-0. Hard enforcement deferred to PR-1."
+# Hard enforcement landed in PR-2a (all 26 registered files normalized in PR-2 #375).
```

## Contract Integrity

| Counter | Pre-PR-2a | Post-PR-2a | Δ |
|---|---|---|---|
| md_md_typos | 15 | 15 | 0 |
| duplicate_basenames_inside_canon | 0 | 0 | 0 |
| authoritative_out_of_zone | 0 | 0 | 0 |
| missing_canon_status_registered | 0 | 0 | 0 |
| non_authoritative_claims | 14 | 14 | 0 |

Guard PASSES on actual main (all 26 registered files have `canon_status`).
Guard FAILS on synthetic file without `canon_status` (FAIL path verified pre-commit).

QG_CONTRACT: all counters unchanged post-change.

## Behavioral Quality

- [x] Pass 1

Script-only change. No data model, no API, no scoring pipeline touched. Guard enforces structural invariant only.

Pass 1 acceptance: guard triggers `fail=1` when a registered file lacks `canon_status`. Accepted because the invariant is already met on main.

## Latency Evidence

This PR does not touch any evaluation pipeline, scoring path, or latency-sensitive code. The changed file is a CI enforcement shell script.

### Baseline (Pre-change)

| Run | pass1_ms | total_ms |
|---|---|---|
| Run 1 | N/A — script-only guard | N/A |
| Run 2 | N/A — script-only guard | N/A |

Latency is not applicable. The guard script runs in CI only, not in the evaluation runtime. No latency regression is possible from this change.

### Post-change Runs

| Run | pass1_ms | total_ms |
|---|---|---|
| Run 1 | N/A | N/A |
| Run 2 | N/A | N/A |

## Risks & Anomalies

**Risk**: If a future PR adds a registered file without frontmatter, CI will now FAIL rather than WARN.
**Assessment**: This is the intended behaviour. All 26 existing registered files satisfy the requirement.

**Quality Gate**: QG_PASS — no anomalies. Zero registered files missing `canon_status` on main at time of merge. This PR is hardening only — not reducing intelligence, only promoting existing detection to enforcement.

## Rollback

`git revert 289c43fe` — restores WARN-only behaviour. No data loss.