### PR TITLE
ci(latency-enforcement): recognize pr-c/ as docs-only scope for skip-gate

### DIFF
--- a/.github/workflows/latency-pr-enforcement.yml
+++ b/.github/workflows/latency-pr-enforcement.yml
@@ -26,9 +26,14 @@ jobs:
             );
 
             const changed = files.map((f) => f.filename);
+            // Doc surfaces exempt from runtime-PR proforma enforcement.
+            // Extend this list (do not weaken the predicate) when new
+            // contract/design artifact directories are introduced.
+            const DOC_PREFIXES = ["docs/", "pr-c/"];
+            const isDocPath = (name) =>
+              DOC_PREFIXES.some((p) => name.startsWith(p));
             const docsOnly =
-              changed.length > 0 &&
-              changed.every((name) => name.startsWith("docs/"));
+              changed.length > 0 && changed.every(isDocPath);
             const migrationsOnly =
               changed.length > 0 &&
               changed.every((name) => name.startsWith("supabase/migrations/"));


### PR DESCRIPTION
## Summary

The `Latency PR Enforcement` workflow's docs-only skip detector previously matched only files under `docs/`. PR-C introduced a new contract/design artifact surface at `pr-c/` (`seam-map.md`, `baseline-6041-pre-prc.md`, `design-doc.md`), which the gate misclassified as runtime — falling through to the proforma validator and demanding Latency Evidence tables, Pass 1/2/3 selection, and `total_ms` metrics that do not apply to design artifacts.

This is exactly the mistake-proofing gap [#318](https://github.com/Mmeraw/literary-ai-partner/issues/318) flagged: scope detection too narrow.

## Fix

Extract `DOC_PREFIXES = ["docs/", "pr-c/"]` and use `every(isDocPath)` instead of a single hardcoded prefix. Predicate semantics preserved — a PR mixing runtime code with `pr-c/` files still hits the validator (because `every()` requires *all* paths to match), so this is not a backdoor for skipping latency enforcement on real runtime PRs.

## Diff size

One file, +5 / -2 lines. No behavior change for any existing PR scope.

## Tests

- ✅ Pure-doc PR with files under `docs/` → still skipped (unchanged behavior).
- ✅ Pure-doc PR with files under `pr-c/` → now skipped (was incorrectly enforced).
- ✅ Mixed PR (`pr-c/` + `lib/...`) → still enforced (correct — runtime change present).
- ✅ Pure-migration PR under `supabase/migrations/` → still skipped (unchanged).

## Closes

- Partially closes #318 — adds `pr-c/` to docs-only scope. The broader `enforce-latency-template` mistake-proofing in #318 (e.g., Pass 3 misclassification) is **not** addressed here and remains open.

## Related

- Unblocks #386 (`docs/pr-c-design`) without forcing its design-doc PR body to fabricate latency proforma scaffolding.

---

This is a CI-only change. No runtime code, no migrations, no canon files touched.
