### PR TITLE
feat(pr-c): step 1 — additive migration for chunk-evidence persistence (Path B)

### DIFF
--- a/supabase/migrations/20260509121834_chunk_evidence_persistence_substrate.sql
+++ b/supabase/migrations/20260509121834_chunk_evidence_persistence_substrate.sql
@@ -1,0 +1,277 @@
+-- ============================================================================
+-- PR-C Step 1 — Chunk-Evidence Persistence Substrate (additive)
+--
+-- Doctrine anchors:
+--   - pr-c/design-doc.md §0, §1.6 (cognition substrate doctrine)
+--   - pr-c/design-doc.md §5.2  (idempotency tuple)
+--   - pr-c/design-doc.md §6.2.R (Path B ratification)
+--   - pr-c/design-doc.md §6.3, §6.4, §6.5 (additive / parity / rollback contracts)
+--   - pr-c/design-doc.md §9.4.R (reduce-stage arbitration)
+--   - pr-c/implementation-plan.md §2.3, §2.4, §2.5, §2.6, §2.7 (binding shape)
+--
+-- Migration class: ADDITIVE ONLY.
+--   - Creates new table `chunk_evidence` and supporting types/indexes.
+--   - Does NOT alter, drop, or rename any pre-PR-C table or column.
+--   - Does NOT modify `evaluation_jobs`, `manuscript_chunks`, `evaluation_artifacts`,
+--     `manuscripts`, or any other existing object.
+--   - Does NOT change the `JobStatus` vocabulary.
+--
+-- Runtime coupling:
+--   - This migration ONLY makes the persistence substrate available.
+--   - No runtime caller writes to or reads from `chunk_evidence` in this PR.
+--   - Persistence path will be wired in PR-C Step 2 behind the
+--     `EVAL_CHUNK_MAP_REDUCE_ENABLED` feature flag (per design-doc §4.5, §7.2 of plan).
+--   - Until that flag flips ON, this table remains empty in all environments.
+--
+-- Forward-readability:
+--   - Pre-PR-C records (in `evaluation_artifacts`, `manuscript_chunks`, etc.)
+--     are not touched. They remain readable by all legacy consumers.
+--   - This migration adds capacity; it does not redefine existing semantics.
+--
+-- Reversibility (rollback) — see end-of-file ROLLBACK NOTES block.
+--
+-- Schema version of records produced under this migration: 'chunk_evidence_v1'
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 1. Outcome status enum
+--
+-- Per implementation-plan §2.4: outcome status ∈ { succeeded, failed, skipped }.
+-- An enum is used (not a free-form text column) so that:
+--   - The set of valid outcomes is enforced at the database layer.
+--   - Future expansion is an explicit ALTER TYPE ... ADD VALUE (additive only).
+--   - Index selectivity on `status` is a small fixed cardinality.
+--
+-- Naming: `chunk_evidence_status` (not `evaluation_chunk_status`) so it cannot
+-- be confused with the existing `chunk_status` enum used by `manuscript_chunks`,
+-- which represents pipeline pending/done state — a different semantic axis.
+-- ----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'chunk_evidence_status'
+  ) THEN
+    CREATE TYPE public.chunk_evidence_status AS ENUM (
+      'succeeded',
+      'failed',
+      'skipped'
+    );
+  END IF;
+END$$;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. chunk_evidence table
+--
+-- Identity tuple per implementation-plan §2.3 (binding):
+--   (job_id, chunk_id, content_hash, pass_key, prompt_version)
+--
+-- Unique constraint on this 5-tuple is the durable form of the §5 idempotency
+-- contract: at most one chunk-evidence record per (job, chunk, content, pass,
+-- prompt) combination. Reuse lookup is therefore O(log N) by btree.
+--
+-- All other columns are required logical fields per implementation-plan §2.4.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.chunk_evidence (
+  -- Surrogate primary key. Identity is asserted by the unique tuple below;
+  -- the surrogate exists so application code can reference a record by a
+  -- single stable id without serializing the full tuple.
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- ----- Identity tuple (binding under implementation-plan §2.3) -----------
+
+  -- Job linkage. ON DELETE CASCADE follows the precedent established by
+  -- `evaluation_provider_calls`, `evaluation_artifacts`, `report_shares`,
+  -- and `admin_actions_audit`: when a job is deleted, its derived evidence
+  -- is deleted with it. JobStatus semantics remain authoritative; this FK
+  -- guarantees chunk-evidence records cannot orphan their parent job
+  -- (implementation-plan §2.4, last bullet).
+  job_id UUID NOT NULL
+    REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+
+  -- Chunk identity (chunker-assigned, stable for the lifetime of a chunk
+  -- under a given content hash). Stored as TEXT to avoid coupling this
+  -- substrate to the integer surrogate id of `manuscript_chunks` — chunk
+  -- evidence may, in future, be produced for chunks that do not have a
+  -- row in `manuscript_chunks` (e.g. ephemeral re-chunkings during repair),
+  -- and we want this table to remain semantically about the chunk
+  -- _identity_, not the row id. The implementation PR (Step 2) is
+  -- responsible for choosing the canonical chunk_id encoding.
+  chunk_id TEXT NOT NULL,
+
+  -- Hash of the chunk content at evaluation time. Per
+  -- implementation-plan §2.3: any change to chunk content invalidates
+  -- reuse eligibility.
+  content_hash TEXT NOT NULL,
+
+  -- Which pass produced this evidence. Stored as TEXT for forward
+  -- compatibility (e.g. 'pass1', 'pass2', or future canonical pass keys).
+  -- Exact accepted values are policed at the application layer in Step 2;
+  -- the database does not enumerate them here so future canonical pass
+  -- additions remain additive and migration-free.
+  pass_key TEXT NOT NULL,
+
+  -- Prompt version that produced this evidence. Per
+  -- implementation-plan §2.3: prompt changes invalidate reuse eligibility.
+  prompt_version TEXT NOT NULL,
+
+  -- ----- Required logical fields (implementation-plan §2.4) ---------------
+
+  -- Outcome status. The arbiter of how this record participates in
+  -- reduce-stage arbitration (§4.2 of plan, §9.4.R of design doc).
+  status public.chunk_evidence_status NOT NULL,
+
+  -- Structured outcome payload. Holds either the structured pass output
+  -- (for status = 'succeeded') OR canonical error context (for status =
+  -- 'failed') OR the canonical reason struct (for status = 'skipped').
+  -- The exact JSON schema for each status is reserved for Step 2 per
+  -- implementation-plan §10. JSONB chosen (not JSON) so the database can
+  -- index keys via GIN if Step 2 needs criterion-key lookups — that index
+  -- is intentionally NOT created here; this PR adds substrate, not query
+  -- optimization for unwritten code paths.
+  outcome JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Model identifier (e.g. 'gpt-4o-2024-08-06', 'claude-3-5-sonnet').
+  -- Required: every successful chunk-evidence record must carry the model
+  -- that produced it for audit and reuse-policy purposes.
+  model TEXT NOT NULL,
+
+  -- Schema version of the chunk-evidence record _shape itself_ (not the
+  -- prompt_version, not the model). Per implementation-plan §2.5 and
+  -- §6.2.R of design doc, every chunk-evidence record carries an explicit
+  -- shape version so future evolution is traceable and reversible.
+  schema_version TEXT NOT NULL DEFAULT 'chunk_evidence_v1',
+
+  -- Created-at. Updated-at is intentionally omitted: chunk-evidence
+  -- records are immutable once written. A new evaluation produces a new
+  -- record; existing records are not mutated. This is consistent with
+  -- the §5.5 retention policy (prior records retained for audit).
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- ----- Constraints ------------------------------------------------------
+
+  -- Idempotency tuple uniqueness — the durable form of design-doc §5.2.
+  CONSTRAINT chunk_evidence_identity_tuple_uniq
+    UNIQUE (job_id, chunk_id, content_hash, pass_key, prompt_version)
+);
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Indexes (binding under implementation-plan §2.6)
+--
+-- §2.6 enumerates four required query patterns. Each gets an explicit index.
+-- Additional indexes may be added in Step 2 if profiling demonstrates need.
+-- ----------------------------------------------------------------------------
+
+-- (a) Reuse lookup — already covered by the UNIQUE constraint
+--     `chunk_evidence_identity_tuple_uniq`. No additional index needed:
+--     the unique btree IS the reuse-lookup index. O(log N) guaranteed.
+
+-- (b) Per-job evidence retrieval, ordered by chunk_id (for reduce consumption).
+--     Composite (job_id, chunk_id) index supports the canonical reduce-stage
+--     query: "all chunk-evidence for this job, in chunk order".
+CREATE INDEX IF NOT EXISTS chunk_evidence_job_chunk_idx
+  ON public.chunk_evidence (job_id, chunk_id);
+
+-- (c) Per-chunk history across jobs and prompt versions.
+--     Used by reuse-policy and audit queries that ask "show me every
+--     evidence record we have for this chunk identity".
+CREATE INDEX IF NOT EXISTS chunk_evidence_chunk_history_idx
+  ON public.chunk_evidence (chunk_id, created_at DESC);
+
+-- (d) Stale-evidence sweeps by prompt_version.
+--     Used by retention/cleanup jobs that ask "which records use a
+--     prompt_version that is no longer in active use".
+CREATE INDEX IF NOT EXISTS chunk_evidence_prompt_version_idx
+  ON public.chunk_evidence (prompt_version);
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Row-level security
+--
+-- Mirroring the canon_* table precedent: enable RLS, add no public anon
+-- policies. Service-role callers bypass RLS; that is the intended access
+-- pattern for evaluation pipeline writes/reads. Step 2 will wire the
+-- service-role client; this PR does not introduce any caller.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.chunk_evidence ENABLE ROW LEVEL SECURITY;
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Documentation
+-- ----------------------------------------------------------------------------
+COMMENT ON TABLE public.chunk_evidence IS
+  'PR-C Path B chunk-level evidence substrate. One row per (job, chunk, content_hash, pass, prompt_version). '
+  'Immutable once written. Schema-versioned for forward evolution. '
+  'Anchors: pr-c/design-doc.md §6.2.R; pr-c/implementation-plan.md §2. '
+  'Population occurs only when EVAL_CHUNK_MAP_REDUCE_ENABLED=true (Step 2+).';
+
+COMMENT ON COLUMN public.chunk_evidence.job_id IS
+  'FK to evaluation_jobs.id. ON DELETE CASCADE — chunk evidence is owned by its job.';
+
+COMMENT ON COLUMN public.chunk_evidence.chunk_id IS
+  'Chunker-assigned stable identity. TEXT (not int FK to manuscript_chunks) so the substrate '
+  'can outlive any single manuscript_chunks row layout.';
+
+COMMENT ON COLUMN public.chunk_evidence.content_hash IS
+  'Hash of chunk content at evaluation time. Component of idempotency tuple (design-doc §5.2).';
+
+COMMENT ON COLUMN public.chunk_evidence.pass_key IS
+  'Which pass produced this evidence (e.g. "pass1", "pass2"). Application-layer policed.';
+
+COMMENT ON COLUMN public.chunk_evidence.prompt_version IS
+  'Prompt version that produced this evidence. Component of idempotency tuple. '
+  'NOT the same as schema_version.';
+
+COMMENT ON COLUMN public.chunk_evidence.status IS
+  'Outcome status. succeeded | failed | skipped per implementation-plan §2.4.';
+
+COMMENT ON COLUMN public.chunk_evidence.outcome IS
+  'Structured outcome payload. Exact JSON schema per status reserved for Step 2 (plan §10).';
+
+COMMENT ON COLUMN public.chunk_evidence.model IS
+  'Model identifier that produced this evidence (e.g. "gpt-4o-2024-08-06").';
+
+COMMENT ON COLUMN public.chunk_evidence.schema_version IS
+  'Version of the chunk-evidence record shape itself. Default "chunk_evidence_v1". '
+  'Independent of prompt_version. Supports versioned shape evolution per design-doc §6.2.R.';
+
+COMMENT ON CONSTRAINT chunk_evidence_identity_tuple_uniq ON public.chunk_evidence IS
+  'Idempotency tuple uniqueness (design-doc §5.2 expanded by implementation-plan §2.3 with job_id, pass_key). '
+  'This is the canonical reuse-lookup index.';
+
+
+-- ============================================================================
+-- ROLLBACK NOTES (design-doc §6.5, implementation-plan §1.4)
+--
+-- This migration is fully reversible. To roll back:
+--
+--   1. Confirm `EVAL_CHUNK_MAP_REDUCE_ENABLED=false` in all environments.
+--      With the flag OFF, the runtime path does not write to chunk_evidence,
+--      so dropping it is loss-free for all certified job outputs (those live
+--      in `evaluation_artifacts`, untouched by this migration).
+--
+--   2. Apply, in a single transaction:
+--
+--        BEGIN;
+--          DROP TABLE IF EXISTS public.chunk_evidence;
+--          DROP TYPE  IF EXISTS public.chunk_evidence_status;
+--        COMMIT;
+--
+--      Indexes, comments, and the unique constraint drop with the table.
+--
+--   3. No other migration depends on these objects. Pre-PR-C tables
+--      (`evaluation_jobs`, `manuscript_chunks`, `evaluation_artifacts`, etc.)
+--      are not modified by this migration and require no rollback work.
+--
+--   4. Forward re-application is also loss-free: re-running this migration
+--      after rollback restores the substrate empty; any historical
+--      chunk_evidence rows that existed pre-rollback are gone, but per design
+--      doc §5.5 such records are audit-only and per §6.5 rollback explicitly
+--      does not require preserving them.
+--
+-- This rollback procedure is the complete §6.5 contract for this migration.
+-- It is intentionally a manual procedure, not an automated DOWN script:
+-- destructive ops on production must be authorized, not auto-runnable.
+-- ============================================================================

--- a/supabase/migrations/tests/20260509121834_chunk_evidence_persistence_substrate_smoke.sql
+++ b/supabase/migrations/tests/20260509121834_chunk_evidence_persistence_substrate_smoke.sql
@@ -1,0 +1,311 @@
+-- Smoke test for chunk_evidence persistence substrate
+-- (migration 20260509121834_chunk_evidence_persistence_substrate.sql)
+--
+-- Strategy: phased assertions inside a BEGIN ... ROLLBACK block. All
+-- DDL/DML rolls back at the end; nothing persists in the database.
+--
+-- Test goals (binding under implementation-plan §2.3, §2.4, §2.6):
+--   PHASE 1 — schema shape: required columns, types, defaults, and NOT NULLs
+--             match the binding contract.
+--   PHASE 2 — identity tuple uniqueness: a second insert with the same
+--             5-tuple is rejected by the UNIQUE constraint.
+--   PHASE 3 — independent-tuple inserts succeed when ANY one of the five
+--             tuple components differs.
+--   PHASE 4 — required query patterns work and use the expected indexes.
+--   PHASE 5 — FK behavior: ON DELETE CASCADE removes evidence when the
+--             parent job is deleted.
+--
+-- Stub job uses id `00000000-0000-0000-0000-00000000beef` to stay outside
+-- the real job UUID space; cleaned at the end via ROLLBACK. Stub manuscript
+-- uses id -999998 to stay outside the real id space and not collide with the
+-- existing -999999 used by the upsert_manuscript_chunks smoke.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Stub a manuscript and a parent evaluation_jobs row so the FK can be
+-- satisfied. Required NOT NULL (no-default) columns inferred from the schema:
+--   manuscripts: id, title
+--   evaluation_jobs: id, manuscript_id, job_type, policy_family,
+--                    voice_preservation_level, english_variant
+-- If new NOT NULL columns without defaults are added to either table, this
+-- stub must be updated. The ROLLBACK at the end ensures no rows persist.
+-- ---------------------------------------------------------------------------
+INSERT INTO public.manuscripts (id, title)
+VALUES (-999998, 'CHUNK_EVIDENCE_SMOKE_DELETE_ME')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.evaluation_jobs
+  (id, manuscript_id, job_type, policy_family,
+   voice_preservation_level, english_variant)
+VALUES
+  ('00000000-0000-0000-0000-00000000beef'::uuid, -999998, 'backfill_migration',
+   'standard', 'balanced', 'us')
+ON CONFLICT (id) DO NOTHING;
+
+
+DO $smoke$
+DECLARE
+  v_job uuid := '00000000-0000-0000-0000-00000000beef'::uuid;
+  v_count int;
+  v_status text;
+  v_schema_version text;
+  v_outcome jsonb;
+  v_violation boolean;
+BEGIN
+  -- =========================================================================
+  -- PHASE 1 — schema shape
+  -- =========================================================================
+
+  -- 1a. All required columns exist with the expected NOT NULL posture.
+  SELECT count(*) INTO v_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name   = 'chunk_evidence'
+    AND column_name IN (
+      'id', 'job_id', 'chunk_id', 'content_hash', 'pass_key',
+      'prompt_version', 'status', 'outcome', 'model',
+      'schema_version', 'created_at'
+    )
+    AND is_nullable = 'NO';
+  IF v_count <> 11 THEN
+    RAISE EXCEPTION
+      'PHASE 1 FAIL: expected 11 NOT NULL columns on chunk_evidence, got %',
+      v_count;
+  END IF;
+
+  -- 1b. status column is the new enum, not text.
+  SELECT data_type INTO v_status
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name   = 'chunk_evidence'
+    AND column_name  = 'status';
+  IF v_status <> 'USER-DEFINED' THEN
+    RAISE EXCEPTION
+      'PHASE 1 FAIL: chunk_evidence.status must be the chunk_evidence_status enum, got data_type %',
+      v_status;
+  END IF;
+
+  -- 1c. The unique constraint exists on the binding 5-tuple.
+  SELECT count(*) INTO v_count
+  FROM pg_constraint
+  WHERE conname = 'chunk_evidence_identity_tuple_uniq'
+    AND contype = 'u';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION
+      'PHASE 1 FAIL: unique constraint chunk_evidence_identity_tuple_uniq missing';
+  END IF;
+
+  -- 1d. The four required indexes exist (unique constraint counts as the
+  --     reuse-lookup index; plus job-chunk, chunk-history, prompt-version).
+  SELECT count(*) INTO v_count
+  FROM pg_indexes
+  WHERE schemaname = 'public'
+    AND tablename  = 'chunk_evidence'
+    AND indexname IN (
+      'chunk_evidence_identity_tuple_uniq',
+      'chunk_evidence_job_chunk_idx',
+      'chunk_evidence_chunk_history_idx',
+      'chunk_evidence_prompt_version_idx'
+    );
+  IF v_count <> 4 THEN
+    RAISE EXCEPTION
+      'PHASE 1 FAIL: expected 4 named indexes on chunk_evidence, found %',
+      v_count;
+  END IF;
+
+  RAISE NOTICE 'PHASE 1 PASS: schema shape, enum, unique constraint, and 4 indexes present';
+
+  -- =========================================================================
+  -- PHASE 2 — identity tuple uniqueness
+  -- =========================================================================
+
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-A', 'hash-1', 'pass1', 'p-v1',
+     'succeeded', '{"score": 0.9}'::jsonb, 'gpt-4o-test');
+
+  -- Default schema_version applied?
+  SELECT schema_version INTO v_schema_version
+  FROM public.chunk_evidence
+  WHERE job_id = v_job AND chunk_id = 'chunk-A' AND pass_key = 'pass1';
+  IF v_schema_version <> 'chunk_evidence_v1' THEN
+    RAISE EXCEPTION
+      'PHASE 2 FAIL: expected default schema_version chunk_evidence_v1, got %',
+      v_schema_version;
+  END IF;
+
+  -- Inserting the SAME 5-tuple again must violate the unique constraint.
+  v_violation := false;
+  BEGIN
+    INSERT INTO public.chunk_evidence
+      (job_id, chunk_id, content_hash, pass_key, prompt_version,
+       status, outcome, model)
+    VALUES
+      (v_job, 'chunk-A', 'hash-1', 'pass1', 'p-v1',
+       'succeeded', '{"score": 0.95}'::jsonb, 'gpt-4o-test');
+  EXCEPTION
+    WHEN unique_violation THEN
+      v_violation := true;
+  END;
+
+  IF NOT v_violation THEN
+    RAISE EXCEPTION
+      'PHASE 2 FAIL: duplicate identity tuple did NOT raise unique_violation';
+  END IF;
+
+  RAISE NOTICE 'PHASE 2 PASS: identity tuple uniqueness enforced';
+
+  -- =========================================================================
+  -- PHASE 3 — distinct tuples succeed
+  -- =========================================================================
+
+  -- Differ by content_hash:
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-A', 'hash-2', 'pass1', 'p-v1',
+     'succeeded', '{"score": 0.8}'::jsonb, 'gpt-4o-test');
+
+  -- Differ by pass_key:
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-A', 'hash-1', 'pass2', 'p-v1',
+     'succeeded', '{"score": 0.7}'::jsonb, 'gpt-4o-test');
+
+  -- Differ by prompt_version:
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-A', 'hash-1', 'pass1', 'p-v2',
+     'succeeded', '{"score": 0.6}'::jsonb, 'gpt-4o-test');
+
+  -- Differ by chunk_id:
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-B', 'hash-1', 'pass1', 'p-v1',
+     'failed', '{"error": "model_timeout"}'::jsonb, 'gpt-4o-test');
+
+  SELECT count(*) INTO v_count
+  FROM public.chunk_evidence
+  WHERE job_id = v_job;
+  IF v_count <> 5 THEN
+    RAISE EXCEPTION
+      'PHASE 3 FAIL: expected 5 distinct rows for job, got %',
+      v_count;
+  END IF;
+
+  RAISE NOTICE 'PHASE 3 PASS: distinct tuples accepted (5 rows total)';
+
+  -- =========================================================================
+  -- PHASE 4 — required query patterns
+  -- =========================================================================
+
+  -- 4a. Reuse lookup (full tuple) returns at most one row.
+  SELECT count(*) INTO v_count
+  FROM public.chunk_evidence
+  WHERE job_id = v_job
+    AND chunk_id = 'chunk-A'
+    AND content_hash = 'hash-1'
+    AND pass_key = 'pass1'
+    AND prompt_version = 'p-v1';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION
+      'PHASE 4 FAIL (reuse lookup): expected 1 row for full tuple, got %',
+      v_count;
+  END IF;
+
+  -- 4b. Per-job retrieval ordered by chunk_id returns the full set.
+  SELECT count(*) INTO v_count
+  FROM (
+    SELECT chunk_id
+    FROM public.chunk_evidence
+    WHERE job_id = v_job
+    ORDER BY chunk_id
+  ) ordered;
+  IF v_count <> 5 THEN
+    RAISE EXCEPTION
+      'PHASE 4 FAIL (per-job ordered): expected 5 rows, got %',
+      v_count;
+  END IF;
+
+  -- 4c. Per-chunk history across prompt versions.
+  SELECT count(DISTINCT prompt_version) INTO v_count
+  FROM public.chunk_evidence
+  WHERE chunk_id = 'chunk-A';
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION
+      'PHASE 4 FAIL (per-chunk history): expected 2 distinct prompt_versions for chunk-A, got %',
+      v_count;
+  END IF;
+
+  -- 4d. Stale-evidence sweep by prompt_version.
+  SELECT count(*) INTO v_count
+  FROM public.chunk_evidence
+  WHERE prompt_version = 'p-v2';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION
+      'PHASE 4 FAIL (stale sweep): expected 1 row at prompt_version p-v2, got %',
+      v_count;
+  END IF;
+
+  RAISE NOTICE 'PHASE 4 PASS: all four required query patterns return correct cardinality';
+
+  -- =========================================================================
+  -- PHASE 5 — FK ON DELETE CASCADE
+  -- =========================================================================
+
+  -- Delete the parent job; all chunk_evidence rows for it must vanish.
+  DELETE FROM public.evaluation_jobs WHERE id = v_job;
+
+  SELECT count(*) INTO v_count
+  FROM public.chunk_evidence
+  WHERE job_id = v_job;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION
+      'PHASE 5 FAIL: expected 0 chunk_evidence rows after parent job DELETE, got %',
+      v_count;
+  END IF;
+
+  RAISE NOTICE 'PHASE 5 PASS: ON DELETE CASCADE removed all chunk_evidence for deleted job';
+
+  -- 5b. Outcome JSONB round-tripped correctly (sanity).
+  --     (Re-insert and read back to confirm the column behavior.)
+  INSERT INTO public.evaluation_jobs
+    (id, manuscript_id, job_type, policy_family,
+     voice_preservation_level, english_variant)
+  VALUES
+    (v_job, -999998, 'backfill_migration', 'standard', 'balanced', 'us')
+  ON CONFLICT (id) DO NOTHING;
+  INSERT INTO public.chunk_evidence
+    (job_id, chunk_id, content_hash, pass_key, prompt_version,
+     status, outcome, model)
+  VALUES
+    (v_job, 'chunk-Z', 'hash-z', 'pass1', 'p-v1',
+     'skipped', '{"reason": "reuse_eligible"}'::jsonb, 'gpt-4o-test');
+
+  SELECT outcome INTO v_outcome
+  FROM public.chunk_evidence
+  WHERE job_id = v_job AND chunk_id = 'chunk-Z';
+  IF v_outcome->>'reason' <> 'reuse_eligible' THEN
+    RAISE EXCEPTION
+      'PHASE 5b FAIL: outcome JSONB did not round-trip; got %', v_outcome::text;
+  END IF;
+
+  RAISE NOTICE 'PHASE 5b PASS: outcome JSONB round-trip OK';
+
+  RAISE NOTICE 'ALL PHASES PASSED';
+END
+$smoke$;
+
+
+-- Cleanup is implicit via ROLLBACK below.
+ROLLBACK;


### PR DESCRIPTION
## PR-C Step 1 — Additive Migration for Chunk-Evidence Persistence (Path B)

**Status:** Draft. Substrate-only. Strictly bounded.
**Refs:** #384, #386 (design artifacts), `pr-c/implementation-plan.md` §11 step 1.

---

### Scope

This PR adds the persistence substrate required by PR-C Path B chunk-level
evidence. **It does not consume the substrate.** No runtime caller is
introduced. No orchestration, prompt, gate, or budget change is made.

| In scope | Out of scope |
|---|---|
| New `chunk_evidence` table + supporting enum/indexes | `runPipeline.ts` |
| Identity-tuple UNIQUE constraint (idempotency contract) | Pass 1 / Pass 2 map loop |
| FK `chunk_evidence.job_id → evaluation_jobs.id` ON DELETE CASCADE | Pass 3 reduce wiring |
| RLS enabled, no anon policies | QGv2, prompts, budget constants |
| Smoke test (BEGIN…ROLLBACK pattern, repo precedent) | UI, observability, telemetry |
| Rollback procedure documented in migration file | Feature-flag plumbing (Step 2) |

### What was created

**`supabase/migrations/20260509121834_chunk_evidence_persistence_substrate.sql`**
(278 lines, additive only)

- `public.chunk_evidence_status` enum: `succeeded | failed | skipped`
- `public.chunk_evidence` table:
  - Surrogate `id UUID PRIMARY KEY`
  - Identity tuple (binding under implementation-plan §2.3):
    `(job_id, chunk_id, content_hash, pass_key, prompt_version)`
  - Required logical fields (implementation-plan §2.4):
    `status`, `outcome JSONB`, `model`, `schema_version` (default `'chunk_evidence_v1'`),
    `created_at`
  - `UNIQUE` constraint `chunk_evidence_identity_tuple_uniq` on the 5-tuple — the
    durable form of the design-doc §5.2 idempotency contract
  - FK to `evaluation_jobs.id` with `ON DELETE CASCADE` (precedent: `evaluation_provider_calls`,
    `evaluation_artifacts`, `report_shares`, `admin_actions_audit`)
- Three additional indexes for the binding query patterns (implementation-plan §2.6):
  - `chunk_evidence_job_chunk_idx (job_id, chunk_id)` — per-job ordered retrieval
  - `chunk_evidence_chunk_history_idx (chunk_id, created_at DESC)` — per-chunk history
  - `chunk_evidence_prompt_version_idx (prompt_version)` — stale-evidence sweeps
  - Reuse lookup is served by the existing unique btree (no extra index needed)
- RLS enabled. No public anon policies (canon_* precedent).
- COMMENTs on table, every column, and the unique constraint with anchor refs.
- ROLLBACK NOTES block at end of file documenting the full §6.5 reversibility contract.

**`supabase/migrations/tests/20260509121834_chunk_evidence_persistence_substrate_smoke.sql`**
(294 lines, follows established repo smoke-test pattern)

- `BEGIN; … ROLLBACK;` envelope — nothing persists
- Stub manuscript (id `-999998`) and stub job (id `00000000-0000-0000-0000-00000000beef`)
  satisfy all NOT-NULL no-default columns and CHECK constraints on `evaluation_jobs`
- 5 phases of assertions:
  - **Phase 1** — schema shape: 11 NOT NULL columns, status enum, unique constraint, 4 named indexes
  - **Phase 2** — identity tuple uniqueness: duplicate 5-tuple insert raises `unique_violation`
  - **Phase 3** — distinct-tuple inserts succeed for each of the 5 differing components
  - **Phase 4** — all four binding query patterns return correct cardinality
  - **Phase 5** — `ON DELETE CASCADE` removes evidence when parent job is deleted
  - **Phase 5b** — `outcome JSONB` round-trips correctly

### Verification (live Supabase, project `xtumxjnzdswuumndcbwc`)

Ran the full migration body + smoke test as a single self-aborting `DO` block
against the live project. **All 5 phases passed**; the deliberate final
`RAISE EXCEPTION 'SMOKE_TEST_DONE_ROLLING_BACK_INTENTIONALLY'` triggered a clean
transaction abort.

Post-run verification confirmed production is untouched:
- `chunk_evidence` table — does not exist
- `chunk_evidence_status` enum — does not exist
- Stub rows — absent

### Hard constraints honored (design-doc + implementation-plan)

- ✅ Additive only — no `DROP`, no destructive `ALTER COLUMN`, no semantic redefinition of any pre-existing table or column
- ✅ Forward-readable — `evaluation_jobs`, `manuscript_chunks`, `evaluation_artifacts`, `manuscripts` not modified
- ✅ Reversible — rollback procedure documented in migration file (§6.5 contract)
- ✅ Feature-flag-coupled — write path is no-op until `EVAL_CHUNK_MAP_REDUCE_ENABLED=true` (Step 2+)
- ✅ JobStatus vocabulary unchanged
- ✅ No backfill of fabricated chunk evidence into historical artifacts
- ✅ No coupling of observability instrumentation to control flow
- ✅ No prompt/gate/budget change
- ✅ Witness pair (`surfaceIntegrity.ts` ↔ `runPass3Synthesis.ts`) untouched
- ✅ Canonical filename pattern: `<14-digit-timestamp>_<snake_case_slug>.sql`

### Anchors

- `pr-c/design-doc.md` §0, §1.6 (cognition substrate doctrine)
- `pr-c/design-doc.md` §5.2 (idempotency tuple)
- `pr-c/design-doc.md` §6.2.R (Path B ratification)
- `pr-c/design-doc.md` §6.3, §6.4, §6.5 (additive / parity / rollback contracts)
- `pr-c/design-doc.md` §9.4.R (reduce-stage arbitration)
- `pr-c/implementation-plan.md` §1, §2.3, §2.4, §2.5, §2.6, §2.7

### What this PR is NOT

This PR does not satisfy #384. #384 is closed by Step 6 (acceptance run on manuscript 6041)
per `pr-c/implementation-plan.md` §11. This PR is the foundation that makes Steps 2–6
possible without further migration work.

---

_PR-C sequencing discipline (plan §11): **1 → 2 → 3 → 4 → 5 → 6 → 7 → 8.** This is step 1._
