### PR TITLE
fix(admin): improve pipeline health job links and failure visibility

### DIFF
--- a/app/admin/pipeline-health/page.tsx
+++ b/app/admin/pipeline-health/page.tsx
@@ -112,6 +112,11 @@ function fmtDate(iso: string) {
   }
 }
 
+function truncateStr(s: string | null, maxLen: number = 50): string {
+  if (!s) return "—";
+  return s.length > maxLen ? s.substring(0, maxLen) + "…" : s;
+}
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -363,8 +368,11 @@ export default function PipelineHealthPage() {
                   {[
                     "Job ID",
                     "Manuscript",
+                    "Created",
+                    "Updated",
                     "Stage",
                     "Error Code",
+                    "Failure Detail",
                     "Phase",
                     "Phase Status",
                     "Words",
@@ -372,7 +380,6 @@ export default function PipelineHealthPage() {
                     "Chunks",
                     "Duration",
                     "Diagnostics",
-                    "Updated",
                   ].map((h) => (
                     <th
                       key={h}
@@ -388,7 +395,7 @@ export default function PipelineHealthPage() {
                   <tr key={job.jobId} className="hover:bg-gray-50">
                     <td className="px-3 py-2 font-mono text-xs">
                       <Link
-                        href={`/admin/jobs/${job.jobId}`}
+                        href={`/evaluate/${job.jobId}`}
                         className="text-blue-600 underline"
                       >
                         {job.jobId.slice(0, 8)}…
@@ -396,6 +403,12 @@ export default function PipelineHealthPage() {
                     </td>
                     <td className="px-3 py-2 text-xs text-gray-700">
                       {job.manuscriptId ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                      {fmtDate(job.createdAt)}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                      {fmtDate(job.updatedAt)}
                     </td>
                     <td className="px-3 py-2 font-mono text-xs">{job.pipelineStage}</td>
                     <td className="px-3 py-2">
@@ -413,6 +426,11 @@ export default function PipelineHealthPage() {
                         <span className="text-gray-400 text-xs">—</span>
                       )}
                     </td>
+                    <td className="px-3 py-2 text-xs">
+                      <span title={job.lastError ?? "No detail available"}>
+                        {truncateStr(job.lastError)}
+                      </span>
+                    </td>
                     <td className="px-3 py-2 text-xs">{job.phase ?? "—"}</td>
                     <td className="px-3 py-2 text-xs">{job.phaseStatus ?? "—"}</td>
                     <td className="px-3 py-2 text-xs">
@@ -427,9 +445,6 @@ export default function PipelineHealthPage() {
                       <span className={diagBadge(job.diagnosticStatus)}>
                         {job.diagnosticStatus}
                       </span>
-                    </td>
-                    <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
-                      {fmtDate(job.updatedAt)}
                     </td>
                   </tr>
                 ))}
@@ -451,7 +466,7 @@ export default function PipelineHealthPage() {
           <table className="min-w-full text-sm border border-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                {["Job ID", "Status", "Stage", "Error Code", "Diagnostics", "Duration", "Updated"].map(
+                {["Job ID", "Status", "Created", "Updated", "Stage", "Error Code", "Failure Detail", "Diagnostics", "Duration"].map(
                   (h) => (
                     <th
                       key={h}
@@ -468,7 +483,7 @@ export default function PipelineHealthPage() {
                 <tr key={job.jobId} className="hover:bg-gray-50">
                   <td className="px-3 py-2 font-mono text-xs">
                     <Link
-                      href={`/admin/jobs/${job.jobId}`}
+                      href={`/evaluate/${job.jobId}`}
                       className="text-blue-600 underline"
                     >
                       {job.jobId.slice(0, 8)}…
@@ -478,6 +493,12 @@ export default function PipelineHealthPage() {
                     <span className={statusBadge(String(job.status ?? ""))}>
                       {String(job.status ?? "")}
                     </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                    {fmtDate(job.createdAt)}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                    {fmtDate(job.updatedAt)}
                   </td>
                   <td className="px-3 py-2 font-mono text-xs">{job.pipelineStage}</td>
                   <td className="px-3 py-2">
@@ -495,15 +516,17 @@ export default function PipelineHealthPage() {
                       <span className="text-gray-400 text-xs">—</span>
                     )}
                   </td>
+                  <td className="px-3 py-2 text-xs">
+                    <span title={job.lastError ?? "No detail available"}>
+                      {truncateStr(job.lastError)}
+                    </span>
+                  </td>
                   <td className="px-3 py-2">
                     <span className={diagBadge(job.diagnosticStatus)}>
                       {job.diagnosticStatus}
                     </span>
                   </td>
                   <td className="px-3 py-2 text-xs">{fmtMs(job.durationMs)}</td>
-                  <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
-                    {fmtDate(job.updatedAt)}
-                  </td>
                 </tr>
               ))}
             </tbody>

--- a/app/admin/pipeline-health/page.tsx
+++ b/app/admin/pipeline-health/page.tsx
@@ -105,11 +105,10 @@ function fmtMs(ms: number | null) {
 }
 
 function fmtDate(iso: string) {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
 }
 
 function truncateStr(s: string | null, maxLen: number = 50): string {


### PR DESCRIPTION
## Summary

UI/read-path fix for `/admin/pipeline-health`.

Changes:
1. Job links now go to `/evaluate/{jobId}` instead of `/admin/jobs/{jobId}`.
2. Added visible `Created` + `Updated` columns in both `Recent Failed Jobs` and `Recent Jobs`.
3. Added `Failure Detail` column from `lastError` (truncated with tooltip).
4. Hardened `fmtDate()` to return `—` for empty/invalid values (fixes `Invalid Date` edge case).

## Scope

- Single file: `app/admin/pipeline-health/page.tsx`
- UI/read-path only
- No runtime changes
- No gate changes
- No prompt/scoring changes
- No API/backend mutation
- No DB/schema/migration changes

## Contract Integrity

- No SIPOC stage behavior changed
- No QualityGate behavior changed
- No scoring/prompt behavior changed
- API payload is consumed only; not modified
- Governance doctrine unchanged

## Behavioral Quality

- Better operator usability (correct links, visible timestamps, in-table failure detail)
- More truthful rendering under missing timestamp edge cases (`fmtDate` guard)
- No behavior regression expected outside dashboard presentation

## Risks & Anomalies

Low risk, presentation-only:
- Column order/visibility updates
- Link target correction to existing route
- Pure string/date formatting guard

No runtime-path anomalies.
No quality gate implications.

---

### Note on latency check
This PR is admin UI-only and currently blocked by over-scoped latency enforcement. Governance fix is in **#394** (`ci(governance): exempt admin-ui-only diffs from latency template enforcement`). After #394 merges, latency enforcement should skip cleanly for this PR category.
