### PR TITLE
fix(ui): scrub remaining running/queued wording from evaluation progress

### DIFF
--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -376,7 +376,7 @@ export default async function EvaluationReportPage({
             job.status === "running" ? "bg-blue-100 text-blue-800" :
             "bg-gray-100 text-gray-700"
           }`}>
-            {job.status === "complete" ? "✓ Complete" : job.status === "failed" ? "✗ Failed" : job.status === "running" ? "⟳ Running" : "Queued"}
+            {job.status === "complete" ? "✓ Report ready" : job.status === "failed" ? "⚠ Needs attention" : job.status === "running" ? "⟳ In progress" : "Waiting in queue"}
           </span>
           {job.created_at && (
             <span className="text-sm text-gray-600">

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -337,10 +337,10 @@ export function EvaluationPoller({
   }
 
   const statusLabel = {
-    queued: 'Queued',
-    running: 'Running',
-    complete: '✅ Complete',
-    failed: '❌ Failed',
+    queued: 'Waiting in queue',
+    running: 'In progress',
+    complete: '✅ Report ready',
+    failed: '⚠ Needs attention',
   }[job.status];
 
   const statusColor = {

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -37,7 +37,7 @@ export function getProgressDisplay(
     return {
       label: stageLabel,
       valueLabel: `${percentage}%`,
-      helperText: "This page refreshes automatically while your evaluation is running.",
+      helperText: "This page refreshes automatically while your report is being prepared.",
       indeterminate: false,
       percentage,
     };

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -16,7 +16,7 @@ describe("getProgressDisplay", () => {
     expect(getProgressDisplay({ status: "running", progress: 42 })).toEqual({
       label: "Building diagnosis",
       valueLabel: "42%",
-      helperText: "This page refreshes automatically while your evaluation is running.",
+      helperText: "This page refreshes automatically while your report is being prepared.",
       indeterminate: false,
       percentage: 42,
     });


### PR DESCRIPTION
## Summary

Complete the user-facing progress copy scrub by removing remaining `Running/Queued` labels from the evaluation report surfaces while keeping canonical backend status values unchanged.

## Scope

- Updated: `components/EvaluationPoller.tsx`
- Updated: `app/evaluate/[jobId]/page.tsx`
- Updated: `components/evaluation-poller-display.ts`
- Updated: `tests/evaluation-poller-display.test.ts`
- UI text only; no API/runtime/database changes

## Contract Integrity

- Canonical status values remain unchanged in data flow: `queued`, `running`, `complete`, `failed`.
- No status transition logic changed.
- No DB writes/reads changed.

## Behavioral Quality

Changes visible to user:
- `Queued` → `Waiting in queue`
- `Running` → `In progress`
- `Complete` badge text → `Report ready`
- `Failed` badge text → `Needs attention`
- Helper copy now says report is being prepared.

This aligns all progress UI wording with non-revealing language.

## Latency Evidence

### Baseline (Pre-change)

UI string rendering only.

| Metric | Value |
|---|---|
| passX_ms | 0 |
| total_ms | 0 |

### Post-change Runs

- Run 1: passX_ms=0, total_ms=0
- Run 2: passX_ms=0, total_ms=0

Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

Quality/anomaly disclosure:
- No QG_ behavior changes.
- This change is not reducing intelligence.

## Risks & Anomalies

Low risk presentation-only change; validated by focused test suite for progress display mapping and helper text.
