### PR TITLE
docs(readme): link Reliability Doctrine from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Read first:
 - `docs/JOB_CONTRACT_v1.md` — canonical job status contract
 - `docs/CANONICAL_RUNTIME_OPERATIONS.md` — canonical runtime authority
 
+## Reliability doctrine
+
+The canonical reliability governance artifacts now live under `docs/reliability/`:
+
+- `docs/reliability/REVISIONGRADE_RELIABILITY_DOCTRINE_v1.md` — reliability kernel, architecture generations, coverage semantics, replay governance
+- `docs/reliability/README.md` — reliability index, program scaffolding, and incident ledger entry point
+
 ## What must be true before new feature work
 
 Before adding behavior to the evaluation pipeline, the system must prove:


### PR DESCRIPTION
## Summary
Adds a root `README.md` discoverability link to the canonical Reliability Doctrine and reliability index so governance artifacts are reachable from the repository entry point.

## Scope

Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):

- [ ] Pass 1
- [x] Pass 2
- [ ] Pass 3

Changed files:

- `README.md`

Out of scope:

- runtime behavior
- evaluation pipeline
- quality gates / scoring
- CI workflows
- doctrine content changes

## Contract Integrity

- No canonical identifiers were added, renamed, or removed.
- No job contract behavior or persistence boundaries were changed.
- This is a docs/discoverability-only change in `README.md`.

## Behavioral Quality

This PR is not reducing intelligence.

- No prompt, evaluation, or artifact-generation behavior changes.
- No QG_ behavior changes.
- The change only improves discoverability of already-landed canonical governance artifacts.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Docs-only README change; no executable path affected |
| Run 2 | N/A | N/A | Docs-only README change; no executable path affected |

### Post-change Runs

| Run | pass2_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Docs-only README change; no executable path affected |
| Run 2 | N/A | N/A | Docs-only README change; no executable path affected |

## Quality Gate / Anomalies

QG_none: no QG_ behavior changes; docs-only discoverability update.

## Risks & Anomalies

- Root `README.md` is outside the `docs/**` exemption, so this PR intentionally uses the full mandatory template to satisfy repository policy.
- No known runtime or governance risk beyond ordinary documentation drift.

## Architecture Alignment
- **alignment**: governance-artifact-discoverability (docs-only, no substrate assumptions)
- **mitigation_expiry**: N/A
- **dependent_architecture**: none
- **expected_revisit**: yes — if reliability docs paths change
- **replay_ids_at_risk**: none
- **replay_ids_targeted**: none