### PR TITLE
fix(evaluation): close #291 provenance bundle (final_text_source, post_chunk_reresolved)

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -306,6 +306,12 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(ensureChunksCallOrder).toBeLessThan(runPipelineCallOrder);
 
     const runPipelineArgs = runPipelineMock.mock.calls[0]?.[0];
+    const expectedCanonicalPostChunkText = [
+      "Chunk 0 text",
+      "Chunk 1 text",
+      "Chunk 2 text",
+      "Chunk 3 text",
+    ].join("\n");
     expect(runPipelineArgs).toEqual(
       expect.objectContaining({
         manuscriptChunks: [
@@ -316,8 +322,7 @@ describe("processEvaluationJob long-form chunk routing", () => {
         ],
       }),
     );
-    expect(runPipelineArgs.manuscriptText).toContain("Chunk 0 text");
-    expect(runPipelineArgs.manuscriptText).toContain("Chunk 1 text");
+    expect(runPipelineArgs.manuscriptText).toBe(expectedCanonicalPostChunkText);
     expect(runPipelineArgs.manuscriptText).not.toBe(manuscriptContent);
 
     const persistCall = supabaseStub.rpcCalls.find(
@@ -326,6 +331,9 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(persistCall).toBeDefined();
     expect(persistCall?.args?.p_progress).toEqual(
       expect.objectContaining({
+        final_text_source: "long_form_post_chunk_canonical",
+        post_chunk_reresolved: true,
+        canonical_path_used: "resolveManuscriptText.post_chunk_reconstruct",
         chunk_routing: expect.objectContaining({
           enabled: true,
           route: "long_form",
@@ -396,6 +404,9 @@ describe("processEvaluationJob long-form chunk routing", () => {
     );
     expect(persistCall).toBeDefined();
     expect(persistCall?.args?.p_progress).toMatchObject({
+      final_text_source: "short_form_initial_text",
+      post_chunk_reresolved: false,
+      canonical_path_used: "resolveManuscriptText.initial",
       chunk_routing: {
         enabled: true,
         route: "short_form",

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -142,6 +142,12 @@ type ChunkRoutingTelemetry = {
   verified_at?: string;
 }
 
+type FinalTextProvenance = {
+  final_text_source: 'long_form_post_chunk_canonical' | 'short_form_initial_text';
+  post_chunk_reresolved: boolean;
+  canonical_path_used: 'resolveManuscriptText.post_chunk_reconstruct' | 'resolveManuscriptText.initial';
+};
+
 export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number {
   const parsed =
     typeof raw === 'number'
@@ -1743,6 +1749,11 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     }
 
     let manuscriptChunksForPipeline: ManuscriptChunkEvidence[] | undefined;
+    let finalTextProvenance: FinalTextProvenance = {
+      final_text_source: 'short_form_initial_text',
+      post_chunk_reresolved: false,
+      canonical_path_used: 'resolveManuscriptText.initial',
+    };
     if (chunkRouting.route === 'long_form') {
       const { text: canonicalPostChunkText, loadedChunks } = await resolveManuscriptText(supabase, {
         ...(manuscript as Manuscript),
@@ -1793,7 +1804,17 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         source: 'manuscript_chunks',
         chunk_count: manuscriptChunksForPipeline.length,
       };
+
+      finalTextProvenance = {
+        final_text_source: 'long_form_post_chunk_canonical',
+        post_chunk_reresolved: true,
+        canonical_path_used: 'resolveManuscriptText.post_chunk_reconstruct',
+      };
     }
+
+    progressState.final_text_source = finalTextProvenance.final_text_source;
+    progressState.post_chunk_reresolved = finalTextProvenance.post_chunk_reresolved;
+    progressState.canonical_path_used = finalTextProvenance.canonical_path_used;
 
     console.log('[Processor] chunk routing decision', {
       job_id: jobId,


### PR DESCRIPTION
## Summary

Close #291's missing provenance bundle with a narrow follow-up patch:
- add runtime provenance fields in processor progress (`final_text_source`, `post_chunk_reresolved`, `canonical_path_used`)
- keep long-form post-chunk canonical re-resolution before `runPipeline()`
- strengthen processor test assertions so final text equality is strict provenance proof (not contains-based)

## Scope

- In scope:
  - `lib/evaluation/processor.ts`
  - `__tests__/lib/evaluation/processor.chunk-routing.test.ts`
- Out of scope:
  - packet redesign
  - scoring/prompt/WAVE changes
  - pass architecture changes

## Contract Integrity

- Canonical job status contract unchanged (`queued`/`running`/`complete`/`failed`).
- No illegal transition handling changes.
- Change is additive telemetry in progress payload only.
- Long-form canonical source semantics are explicit and auditable:
  - `final_text_source = long_form_post_chunk_canonical`
  - `post_chunk_reresolved = true`
- Short-form negative case explicitly emitted:
  - `final_text_source = short_form_initial_text`
  - `post_chunk_reresolved = false`

## Behavioral Quality

- Provenance assertion upgraded from weak containment to strict equality:
  - `runPipeline.manuscriptText === canonical post-chunk reconstructed text`
  - `runPipeline.manuscriptText !== pre-chunk manuscriptContent`
- Focused verification run from this session:
  - `npm test -- __tests__/lib/evaluation/processor.chunk-routing.test.ts --runInBand`
  - Result: PASS (4/4)

## Latency Evidence

This PR is provenance/instrumentation + test-hardening, not latency optimization. No runtime latency path redesign was introduced.

### Pass selection

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

### Baseline (Pre-change)

| Metric | Value | Notes |
|---|---:|---|
| pass1_ms | N/A | Not measured for this provenance-only PR |
| total_ms | N/A | No baseline latency benchmark was run in this PR thread |
| quality gate signal | QG_unchanged | Quality gate behavior not modified |

### Post-change Runs

| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Focused correctness run only; no latency benchmark |
| Run 2 | N/A | N/A | Focused correctness run only; no latency benchmark |

### Observed execution artifact from this session

- Jest focused suite duration (correctness run): `Time: 0.541 s` for `processor.chunk-routing.test.ts`.
- This is test-suite runtime, not pipeline latency.

## Risks & Anomalies

- Risk: provenance fields are additive and could be misread as performance metrics.
  - Mitigation: explicit naming and explicit short-form negative case.
- Risk: no dedicated latency benchmark in this PR.
  - Mitigation: PR scoped to provenance closure only; latency behavior intentionally unchanged.
- Quality/anomaly disclosure: no new QG_ failures introduced by this patch in focused test execution.

Final principle: this patch is intentionally **not reducing intelligence**; it strengthens traceability and source-lineage proof without degrading evaluation quality.

---

Refs: #291, #292
