### PR TITLE
feat(governance): calibration analysis tooling for Phase 2 distributional artifact

### DIFF
--- a/docs/governance/phase-2-calibration-template.md
+++ b/docs/governance/phase-2-calibration-template.md
@@ -1,0 +1,82 @@
+# 293 Phase 2 Calibration Data Template
+
+> Purpose: Fill this document with output from `scripts/governance/analyze-phase-2-calibration.ts` once the calibration window prerequisites are met.
+
+## Inputs
+
+- Observation window start:
+- Observation window end:
+- Long-form jobs analyzed:
+- Short-form jobs observed (excluded from long-form ratio analytics):
+- Distinct manuscript genres/types represented:
+
+## Compression Ratio Distribution (Long-form)
+
+- Include histogram of `representation_compression_ratio`.
+- Include notes on shape (clustered, multimodal, skewed).
+
+## Statistical Summary (Long-form)
+
+- mean:
+- median:
+- p10:
+- p25:
+- p75:
+- p90:
+- p95:
+- p99:
+
+## Governance Band Coverage (Long-form)
+
+| Band | Count | Percent |
+| --- | ---: | ---: |
+| pass |  |  |
+| warn |  |  |
+| observe |  |  |
+| null |  |  |
+
+## Per-Genre / Manuscript-Class Breakdown
+
+- Provide summary table for each available grouping.
+- Call out class-conditional drift if present.
+
+## Dark Criteria Frequency
+
+- Count jobs with any `criteria_with_zero_evidence`.
+- List top criteria by zero-evidence frequency.
+- Describe recurring dark-criteria patterns.
+
+## Evidence Density by Criterion
+
+- Average evidence count per long-form job by criterion.
+- Median/p90 evidence counts by criterion.
+- Criteria with consistently low evidence density.
+
+## Outlier Patterns
+
+- Jobs below p1 and above p99.
+- Root-cause hypothesis for each outlier cluster.
+- False-positive risk notes for threshold derivation.
+
+## Threshold Derivation Proposal (Prerequisite 3)
+
+- Proposed threshold(s):
+- Distributional rationale:
+- Stress-test notes against outliers:
+- Why this avoids false hard-fail on legitimate runs:
+
+## Reversal Mechanism Plan (Prerequisite 4)
+
+- Runtime override mechanism:
+- Audit log contract for override invocation:
+- Monitoring signal for hard-fail rate:
+
+## Decision
+
+- [ ] Not ready for Phase 2 lock (insufficient evidence)
+- [ ] Ready to draft Phase 2 governance lock
+
+## References
+
+- `PR_293_PHASE_2_PREVIEW_BRIEF.md`
+- `CALIBRATION_ANALYSIS_TOOLING_GOVERNANCE_BRIEF.md`

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "gate:replay:strict": "npx tsx -r tsconfig-paths/register scripts/pipeline/gate-replay-check.ts --fail-on-any",
     "sipoc:validate": "npx tsx -r tsconfig-paths/register scripts/validate-sipoc-fixtures.ts",
     "sipoc:harness": "npx tsx -r tsconfig-paths/register scripts/run-sipoc-harness.ts",
-    "sipoc:analyze": "npx tsx -r tsconfig-paths/register scripts/analyze-sipoc-results.ts"
+    "sipoc:analyze": "npx tsx -r tsconfig-paths/register scripts/analyze-sipoc-results.ts",
+    "governance:calibration:analyze": "npx tsx -r tsconfig-paths/register scripts/governance/analyze-phase-2-calibration.ts"
   },
   "dependencies": {
     "@base44/sdk": "^0.8.27",

--- a/scripts/governance/analyze-phase-2-calibration.ts
+++ b/scripts/governance/analyze-phase-2-calibration.ts
@@ -180,31 +180,33 @@ function detectOutliers(
 ): OutlierRecord[] {
   if (!summary) return [];
 
-  return longForm
-    .map((record) => {
-      const ratio = record.representation_compression_ratio;
-      if (ratio === null || !Number.isFinite(ratio)) return null;
+  const outliers: OutlierRecord[] = [];
 
-      let reason: OutlierRecord["reason"] | null = null;
-      if (ratio < summary.p1) {
-        reason = "below_p1";
-      } else if (ratio > summary.p99) {
-        reason = "above_p99";
-      }
+  for (const record of longForm) {
+    const ratio = record.representation_compression_ratio;
+    if (ratio === null || !Number.isFinite(ratio)) continue;
 
-      if (!reason) return null;
+    let reason: OutlierRecord["reason"] | null = null;
+    if (ratio < summary.p1) {
+      reason = "below_p1";
+    } else if (ratio > summary.p99) {
+      reason = "above_p99";
+    }
 
-      return {
-        job_id: record.job_id,
-        ratio,
-        reason,
-        manuscript_words: record.manuscript_words,
-        manuscript_genre: record.manuscript_genre,
-        manuscript_type: record.manuscript_type,
-        manuscript_class: record.manuscript_class,
-      };
-    })
-    .filter((record): record is OutlierRecord => record !== null);
+    if (!reason) continue;
+
+    outliers.push({
+      job_id: record.job_id,
+      ratio,
+      reason,
+      manuscript_words: record.manuscript_words,
+      manuscript_genre: record.manuscript_genre,
+      manuscript_type: record.manuscript_type,
+      manuscript_class: record.manuscript_class,
+    });
+  }
+
+  return outliers;
 }
 
 function computePerGenreBreakdown(

--- a/scripts/governance/analyze-phase-2-calibration.ts
+++ b/scripts/governance/analyze-phase-2-calibration.ts
@@ -1,0 +1,431 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { CRITERIA_KEYS, CriterionKey } from "../../schemas/criteria-keys";
+import {
+  CalibrationAnalysisResult,
+  ClassCoverageEntry,
+  CompressionGovernanceBand,
+  DarkCriteriaFrequencyEntry,
+  EvidenceDensityEntry,
+  HistogramBucket,
+  ManuscriptClassGroupingEntry,
+  OutlierRecord,
+  StatisticalSummary,
+  TelemetryInputRecord,
+} from "./types";
+
+const HISTOGRAM_BUCKET_EDGES = [
+  0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.15, 0.2, 0.3, 0.5, 1.0, Infinity,
+];
+
+const BAND_ORDER: CompressionGovernanceBand[] = ["pass", "warn", "observe", null];
+
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const idx = (p / 100) * (sortedAsc.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sortedAsc[lo];
+  const frac = idx - lo;
+  return sortedAsc[lo] * (1 - frac) + sortedAsc[hi] * frac;
+}
+
+function fixed(value: number, decimals = 6): number {
+  return Number(value.toFixed(decimals));
+}
+
+function computeStatisticalSummary(values: number[]): StatisticalSummary | null {
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mean = sorted.reduce((s, v) => s + v, 0) / n;
+  const variance = sorted.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+
+  return {
+    n,
+    mean: fixed(mean),
+    median: fixed(percentile(sorted, 50)),
+    p1: fixed(percentile(sorted, 1)),
+    p10: fixed(percentile(sorted, 10)),
+    p25: fixed(percentile(sorted, 25)),
+    p50: fixed(percentile(sorted, 50)),
+    p75: fixed(percentile(sorted, 75)),
+    p90: fixed(percentile(sorted, 90)),
+    p95: fixed(percentile(sorted, 95)),
+    p99: fixed(percentile(sorted, 99)),
+    min: fixed(sorted[0]),
+    max: fixed(sorted[n - 1]),
+    stddev: fixed(Math.sqrt(variance)),
+  };
+}
+
+function buildHistogram(values: number[]): HistogramBucket[] {
+  const buckets: HistogramBucket[] = [];
+  for (let i = 0; i < HISTOGRAM_BUCKET_EDGES.length - 1; i++) {
+    buckets.push({
+      range_lo: HISTOGRAM_BUCKET_EDGES[i],
+      range_hi: HISTOGRAM_BUCKET_EDGES[i + 1],
+      count: 0,
+    });
+  }
+
+  for (const value of values) {
+    for (const bucket of buckets) {
+      if (value >= bucket.range_lo && value < bucket.range_hi) {
+        bucket.count += 1;
+        break;
+      }
+    }
+  }
+
+  return buckets;
+}
+
+function computeClassCoverage(longForm: TelemetryInputRecord[]): ClassCoverageEntry[] {
+  const total = longForm.length;
+  return BAND_ORDER.map((band) => {
+    const count = longForm.filter((r) => r.compression_governance_state === band).length;
+    return {
+      band,
+      count,
+      pct_of_long_form: total === 0 ? 0 : fixed((count / total) * 100, 2),
+    };
+  });
+}
+
+function computeManuscriptClassGrouping(
+  longForm: TelemetryInputRecord[],
+): ManuscriptClassGroupingEntry[] {
+  const total = longForm.length;
+  const counts = new Map<string, number>();
+
+  for (const record of longForm) {
+    const key =
+      record.manuscript_class ?? record.manuscript_genre ?? record.manuscript_type ?? "unspecified";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([manuscript_class, count]) => ({
+      manuscript_class,
+      count,
+      pct_of_long_form: total === 0 ? 0 : fixed((count / total) * 100, 2),
+    }));
+}
+
+function computeDarkCriteriaFrequency(longForm: TelemetryInputRecord[]): {
+  frequency: DarkCriteriaFrequencyEntry[];
+  jobsWithAnyDarkCriteria: number;
+} {
+  const total = longForm.length;
+  const counts = new Map<CriterionKey, number>(CRITERIA_KEYS.map((k) => [k, 0]));
+  let jobsWithAnyDarkCriteria = 0;
+
+  for (const record of longForm) {
+    const raw = record.criteria_with_zero_evidence ?? [];
+    const keys = new Set(raw.filter((key): key is CriterionKey => CRITERIA_KEYS.includes(key as CriterionKey)));
+    if (keys.size > 0) {
+      jobsWithAnyDarkCriteria += 1;
+    }
+    for (const key of keys) {
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+
+  const frequency = CRITERIA_KEYS.map((criterion_key) => {
+    const count = counts.get(criterion_key) ?? 0;
+    return {
+      criterion_key,
+      long_form_jobs_with_zero_evidence: count,
+      pct_of_long_form: total === 0 ? 0 : fixed((count / total) * 100, 2),
+    };
+  });
+
+  return { frequency, jobsWithAnyDarkCriteria };
+}
+
+function computeEvidenceDensityByCriterion(
+  longForm: TelemetryInputRecord[],
+): EvidenceDensityEntry[] {
+  const total = longForm.length;
+
+  return CRITERIA_KEYS.map((criterion_key) => {
+    const values = longForm.map((record) => {
+      const raw = record.evidence_count_by_criterion?.[criterion_key];
+      return typeof raw === "number" && Number.isFinite(raw) && raw >= 0 ? raw : 0;
+    });
+
+    const sorted = [...values].sort((a, b) => a - b);
+    const jobsWithEvidence = values.filter((v) => v > 0).length;
+
+    return {
+      criterion_key,
+      avg_evidence_count_per_long_form_job:
+        values.length === 0 ? 0 : fixed(values.reduce((s, v) => s + v, 0) / values.length, 4),
+      median_evidence_count_per_long_form_job: sorted.length === 0 ? 0 : fixed(percentile(sorted, 50), 4),
+      p90_evidence_count_per_long_form_job: sorted.length === 0 ? 0 : fixed(percentile(sorted, 90), 4),
+      long_form_jobs_with_evidence: jobsWithEvidence,
+      pct_long_form_jobs_with_evidence: total === 0 ? 0 : fixed((jobsWithEvidence / total) * 100, 2),
+    };
+  });
+}
+
+function detectOutliers(
+  longForm: TelemetryInputRecord[],
+  summary: StatisticalSummary | null,
+): OutlierRecord[] {
+  if (!summary) return [];
+
+  return longForm
+    .map((record) => {
+      const ratio = record.representation_compression_ratio;
+      if (ratio === null || !Number.isFinite(ratio)) return null;
+
+      let reason: OutlierRecord["reason"] | null = null;
+      if (ratio < summary.p1) {
+        reason = "below_p1";
+      } else if (ratio > summary.p99) {
+        reason = "above_p99";
+      }
+
+      if (!reason) return null;
+
+      return {
+        job_id: record.job_id,
+        ratio,
+        reason,
+        manuscript_words: record.manuscript_words,
+        manuscript_genre: record.manuscript_genre,
+        manuscript_type: record.manuscript_type,
+        manuscript_class: record.manuscript_class,
+      };
+    })
+    .filter((record): record is OutlierRecord => record !== null);
+}
+
+function computePerGenreBreakdown(
+  longForm: TelemetryInputRecord[],
+): Record<string, StatisticalSummary> {
+  const byGenre = new Map<string, number[]>();
+
+  for (const record of longForm) {
+    const ratio = record.representation_compression_ratio;
+    if (ratio === null || !Number.isFinite(ratio)) continue;
+
+    const genre = record.manuscript_genre ?? "unspecified";
+    if (!byGenre.has(genre)) byGenre.set(genre, []);
+    byGenre.get(genre)!.push(ratio);
+  }
+
+  const output: Record<string, StatisticalSummary> = {};
+  for (const [genre, ratios] of byGenre.entries()) {
+    const summary = computeStatisticalSummary(ratios);
+    if (summary) {
+      output[genre] = summary;
+    }
+  }
+
+  return output;
+}
+
+function buildMarkdownSummary(result: CalibrationAnalysisResult): string {
+  const lines: string[] = [];
+  const summary = result.statistical_summary;
+  const topDarkCriteria = [...result.dark_criteria_frequency]
+    .sort((a, b) => b.long_form_jobs_with_zero_evidence - a.long_form_jobs_with_zero_evidence)
+    .slice(0, 5);
+
+  lines.push("# Phase 2 Calibration Summary Artifact");
+  lines.push("");
+  lines.push(`Generated at: ${result.generated_at}`);
+  lines.push("");
+  lines.push("## Coverage");
+  lines.push(`- Total input records: ${result.total_input_records}`);
+  lines.push(`- Long-form analyzed: ${result.long_form_record_count}`);
+  lines.push(`- Short-form excluded: ${result.short_form_record_count_excluded}`);
+  lines.push("");
+
+  lines.push("## Compression Ratio Distribution");
+  if (!summary) {
+    lines.push("- No long-form finite ratio data available.");
+  } else {
+    lines.push(`- mean: ${summary.mean}`);
+    lines.push(`- median: ${summary.median}`);
+    lines.push(`- p10: ${summary.p10}`);
+    lines.push(`- p25: ${summary.p25}`);
+    lines.push(`- p75: ${summary.p75}`);
+    lines.push(`- p90: ${summary.p90}`);
+    lines.push(`- p95: ${summary.p95}`);
+    lines.push(`- p99: ${summary.p99}`);
+  }
+  lines.push("");
+
+  lines.push("## Governance Band Coverage (Long-form)");
+  for (const entry of result.class_coverage) {
+    lines.push(`- ${entry.band ?? "null"}: ${entry.count} (${entry.pct_of_long_form}%)`);
+  }
+  lines.push("");
+
+  lines.push("## Manuscript Class Grouping");
+  if (result.manuscript_class_grouping.length === 0) {
+    lines.push("- No class metadata available.");
+  } else {
+    for (const entry of result.manuscript_class_grouping) {
+      lines.push(`- ${entry.manuscript_class}: ${entry.count} (${entry.pct_of_long_form}%)`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Dark Criteria Frequency");
+  lines.push(
+    `- Jobs with any dark criteria: ${result.long_form_jobs_with_any_dark_criteria} / ${result.long_form_record_count}`,
+  );
+  for (const entry of topDarkCriteria) {
+    lines.push(
+      `- ${entry.criterion_key}: ${entry.long_form_jobs_with_zero_evidence} (${entry.pct_of_long_form}%)`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Evidence Density by Criterion (Top 5 by average)");
+  const topEvidence = [...result.evidence_density_by_criterion]
+    .sort((a, b) => b.avg_evidence_count_per_long_form_job - a.avg_evidence_count_per_long_form_job)
+    .slice(0, 5);
+  for (const entry of topEvidence) {
+    lines.push(
+      `- ${entry.criterion_key}: avg=${entry.avg_evidence_count_per_long_form_job}, median=${entry.median_evidence_count_per_long_form_job}, p90=${entry.p90_evidence_count_per_long_form_job}`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Outliers");
+  lines.push(`- Total outliers: ${result.outliers.length}`);
+  if (result.outliers.length > 0) {
+    lines.push(
+      `- Example: ${result.outliers[0].job_id} (${result.outliers[0].reason}, ratio=${result.outliers[0].ratio})`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Decision Support Notes");
+  lines.push(
+    "- This artifact is observational input for Phase 2 threshold derivation; it does not change runtime enforcement.",
+  );
+  lines.push("- Validate outlier root causes before proposing any threshold lock.");
+
+  return lines.join("\n");
+}
+
+export function analyzeCalibration(records: TelemetryInputRecord[]): CalibrationAnalysisResult {
+  const longForm = records.filter((r) => r.packet_source === "long_form_chunks_canonical");
+  const shortForm = records.filter((r) => r.packet_source === "short_form_initial_text");
+
+  const longFormRatios = longForm
+    .map((r) => r.representation_compression_ratio)
+    .filter((ratio): ratio is number => ratio !== null && Number.isFinite(ratio));
+
+  const statisticalSummary = computeStatisticalSummary(longFormRatios);
+  const histogram = buildHistogram(longFormRatios);
+  const classCoverage = computeClassCoverage(longForm);
+  const manuscriptClassGrouping = computeManuscriptClassGrouping(longForm);
+  const darkCriteria = computeDarkCriteriaFrequency(longForm);
+  const evidenceDensityByCriterion = computeEvidenceDensityByCriterion(longForm);
+  const outliers = detectOutliers(longForm, statisticalSummary);
+  const perGenreBreakdown = computePerGenreBreakdown(longForm);
+
+  const provisional: CalibrationAnalysisResult = {
+    total_input_records: records.length,
+    long_form_record_count: longForm.length,
+    short_form_record_count_excluded: shortForm.length,
+    histogram,
+    statistical_summary: statisticalSummary,
+    class_coverage: classCoverage,
+    manuscript_class_grouping: manuscriptClassGrouping,
+    dark_criteria_frequency: darkCriteria.frequency,
+    long_form_jobs_with_any_dark_criteria: darkCriteria.jobsWithAnyDarkCriteria,
+    evidence_density_by_criterion: evidenceDensityByCriterion,
+    outliers,
+    per_genre_breakdown: perGenreBreakdown,
+    generated_at: new Date().toISOString(),
+    phase_2_summary_markdown: "",
+  };
+
+  return {
+    ...provisional,
+    phase_2_summary_markdown: buildMarkdownSummary(provisional),
+  };
+}
+
+function parseArgs(argv: string[]): {
+  inputPath: string;
+  outputPath: string;
+  markdownOutputPath?: string;
+} {
+  if (argv.length < 1) {
+    console.error(
+      "Usage: analyze-phase-2-calibration.ts <input.json|-> [output.json|/dev/stdout] [--markdown output.md]",
+    );
+    process.exit(2);
+  }
+
+  const inputPath = argv[0];
+  const outputPath = argv[1] ?? "/dev/stdout";
+
+  let markdownOutputPath: string | undefined;
+  const markdownFlagIndex = argv.indexOf("--markdown");
+  if (markdownFlagIndex >= 0) {
+    const markdownPath = argv[markdownFlagIndex + 1];
+    if (!markdownPath) {
+      console.error("--markdown flag requires a path argument");
+      process.exit(2);
+    }
+    markdownOutputPath = markdownPath;
+  }
+
+  return { inputPath, outputPath, markdownOutputPath };
+}
+
+function loadInputRecords(inputPath: string): TelemetryInputRecord[] {
+  const raw = inputPath === "-" ? readFileSync(0, "utf-8") : readFileSync(inputPath, "utf-8");
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("Input must be a JSON array of TelemetryInputRecord");
+  }
+
+  return parsed as TelemetryInputRecord[];
+}
+
+async function main(): Promise<void> {
+  const { inputPath, outputPath, markdownOutputPath } = parseArgs(process.argv.slice(2));
+  const records = loadInputRecords(inputPath);
+  const result = analyzeCalibration(records);
+  const outputJson = JSON.stringify(result, null, 2);
+
+  if (outputPath === "/dev/stdout") {
+    console.log(outputJson);
+  } else {
+    writeFileSync(outputPath, outputJson, "utf-8");
+    console.error(`Wrote JSON analysis to ${outputPath}`);
+  }
+
+  if (markdownOutputPath) {
+    writeFileSync(markdownOutputPath, result.phase_2_summary_markdown, "utf-8");
+    console.error(`Wrote Markdown summary to ${markdownOutputPath}`);
+  }
+}
+
+const isMain = process.argv[1]
+  ? resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/governance/types.ts
+++ b/scripts/governance/types.ts
@@ -1,0 +1,96 @@
+import type { CriterionKey } from "../../schemas/criteria-keys";
+
+export type CompressionGovernanceBand = "pass" | "warn" | "observe" | null;
+
+export type PacketSource = "long_form_chunks_canonical" | "short_form_initial_text";
+
+export interface TelemetryInputRecord {
+  job_id: string;
+  manuscript_words: number;
+  packet_source: PacketSource;
+  representation_compression_ratio: number | null;
+  compression_governance_state: CompressionGovernanceBand;
+  manuscript_genre?: string;
+  manuscript_type?: string;
+  manuscript_class?: string;
+  criteria_with_zero_evidence?: string[];
+  evidence_count_by_criterion?: Partial<Record<CriterionKey, number>>;
+  emitted_at: string; // ISO 8601
+}
+
+export interface HistogramBucket {
+  range_lo: number;
+  range_hi: number;
+  count: number;
+}
+
+export interface StatisticalSummary {
+  n: number;
+  mean: number;
+  median: number;
+  p1: number;
+  p10: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  min: number;
+  max: number;
+  stddev: number;
+}
+
+export interface ClassCoverageEntry {
+  band: CompressionGovernanceBand;
+  count: number;
+  pct_of_long_form: number;
+}
+
+export interface ManuscriptClassGroupingEntry {
+  manuscript_class: string;
+  count: number;
+  pct_of_long_form: number;
+}
+
+export interface DarkCriteriaFrequencyEntry {
+  criterion_key: CriterionKey;
+  long_form_jobs_with_zero_evidence: number;
+  pct_of_long_form: number;
+}
+
+export interface EvidenceDensityEntry {
+  criterion_key: CriterionKey;
+  avg_evidence_count_per_long_form_job: number;
+  median_evidence_count_per_long_form_job: number;
+  p90_evidence_count_per_long_form_job: number;
+  long_form_jobs_with_evidence: number;
+  pct_long_form_jobs_with_evidence: number;
+}
+
+export interface OutlierRecord {
+  job_id: string;
+  ratio: number;
+  reason: "below_p1" | "above_p99";
+  manuscript_words: number;
+  manuscript_genre?: string;
+  manuscript_type?: string;
+  manuscript_class?: string;
+}
+
+export interface CalibrationAnalysisResult {
+  total_input_records: number;
+  long_form_record_count: number;
+  short_form_record_count_excluded: number;
+  histogram: HistogramBucket[];
+  statistical_summary: StatisticalSummary | null;
+  class_coverage: ClassCoverageEntry[];
+  manuscript_class_grouping: ManuscriptClassGroupingEntry[];
+  dark_criteria_frequency: DarkCriteriaFrequencyEntry[];
+  long_form_jobs_with_any_dark_criteria: number;
+  evidence_density_by_criterion: EvidenceDensityEntry[];
+  outliers: OutlierRecord[];
+  per_genre_breakdown: Record<string, StatisticalSummary>;
+  generated_at: string;
+  phase_2_summary_markdown: string;
+}

--- a/tests/scripts/analyze-phase-2-calibration.test.ts
+++ b/tests/scripts/analyze-phase-2-calibration.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "@jest/globals";
+import { analyzeCalibration } from "../../scripts/governance/analyze-phase-2-calibration";
+import { TelemetryInputRecord } from "../../scripts/governance/types";
+
+let jobCounter = 0;
+
+function makeRecord(overrides: Partial<TelemetryInputRecord> = {}): TelemetryInputRecord {
+  jobCounter += 1;
+  return {
+    job_id: `job-${jobCounter}`,
+    manuscript_words: 30000,
+    packet_source: "long_form_chunks_canonical",
+    representation_compression_ratio: 0.15,
+    compression_governance_state: "pass",
+    manuscript_genre: "fantasy",
+    manuscript_type: "novel",
+    emitted_at: "2026-05-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("analyzeCalibration", () => {
+  describe("empty input handling", () => {
+    it("handles empty input gracefully", () => {
+      const result = analyzeCalibration([]);
+      expect(result.total_input_records).toBe(0);
+      expect(result.long_form_record_count).toBe(0);
+      expect(result.short_form_record_count_excluded).toBe(0);
+      expect(result.statistical_summary).toBeNull();
+      expect(result.outliers).toEqual([]);
+      expect(result.class_coverage).toHaveLength(4);
+      expect(result.histogram.length).toBeGreaterThan(0);
+      expect(result.per_genre_breakdown).toEqual({});
+      expect(result.phase_2_summary_markdown).toContain("Phase 2 Calibration Summary Artifact");
+    });
+  });
+
+  describe("distribution and band coverage", () => {
+    it("produces correct band counts and ratio summary", () => {
+      const records: TelemetryInputRecord[] = [
+        ...Array(5)
+          .fill(0)
+          .map(() =>
+            makeRecord({ representation_compression_ratio: 0.2, compression_governance_state: "pass" }),
+          ),
+        ...Array(3)
+          .fill(0)
+          .map(() =>
+            makeRecord({ representation_compression_ratio: 0.07, compression_governance_state: "warn" }),
+          ),
+        ...Array(2)
+          .fill(0)
+          .map(() =>
+            makeRecord({ representation_compression_ratio: 0.03, compression_governance_state: "observe" }),
+          ),
+      ];
+
+      const result = analyzeCalibration(records);
+      const passEntry = result.class_coverage.find((c) => c.band === "pass");
+      const warnEntry = result.class_coverage.find((c) => c.band === "warn");
+      const observeEntry = result.class_coverage.find((c) => c.band === "observe");
+
+      expect(passEntry?.count).toBe(5);
+      expect(warnEntry?.count).toBe(3);
+      expect(observeEntry?.count).toBe(2);
+      expect(passEntry?.pct_of_long_form).toBe(50);
+      expect(warnEntry?.pct_of_long_form).toBe(30);
+      expect(observeEntry?.pct_of_long_form).toBe(20);
+
+      expect(result.statistical_summary).not.toBeNull();
+      expect(result.statistical_summary?.n).toBe(10);
+      expect(result.statistical_summary?.min).toBeCloseTo(0.03, 4);
+      expect(result.statistical_summary?.max).toBeCloseTo(0.2, 4);
+    });
+  });
+
+  describe("mixed long-form + short-form handling", () => {
+    it("excludes short-form from long-form analytics", () => {
+      const records: TelemetryInputRecord[] = [
+        ...Array(5)
+          .fill(0)
+          .map(() => makeRecord({ packet_source: "long_form_chunks_canonical" })),
+        ...Array(3)
+          .fill(0)
+          .map(() =>
+            makeRecord({
+              packet_source: "short_form_initial_text",
+              compression_governance_state: null,
+              representation_compression_ratio: null,
+              manuscript_words: 1200,
+            }),
+          ),
+      ];
+
+      const result = analyzeCalibration(records);
+      expect(result.total_input_records).toBe(8);
+      expect(result.long_form_record_count).toBe(5);
+      expect(result.short_form_record_count_excluded).toBe(3);
+
+      const totalBandCounts = result.class_coverage.reduce((sum, entry) => sum + entry.count, 0);
+      expect(totalBandCounts).toBe(5);
+    });
+  });
+
+  describe("manuscript grouping and dark criteria", () => {
+    it("groups by manuscript class metadata and computes dark criteria frequency", () => {
+      const records: TelemetryInputRecord[] = [
+        makeRecord({ manuscript_class: "epic_fantasy", criteria_with_zero_evidence: ["sceneConstruction"] }),
+        makeRecord({ manuscript_class: "epic_fantasy", criteria_with_zero_evidence: ["sceneConstruction", "voice"] }),
+        makeRecord({ manuscript_genre: "mystery", manuscript_class: undefined, criteria_with_zero_evidence: ["voice"] }),
+      ];
+
+      const result = analyzeCalibration(records);
+      expect(result.manuscript_class_grouping[0].manuscript_class).toBe("epic_fantasy");
+      expect(result.manuscript_class_grouping[0].count).toBe(2);
+
+      const sceneConstruction = result.dark_criteria_frequency.find(
+        (entry) => entry.criterion_key === "sceneConstruction",
+      );
+      const voice = result.dark_criteria_frequency.find((entry) => entry.criterion_key === "voice");
+      expect(sceneConstruction?.long_form_jobs_with_zero_evidence).toBe(2);
+      expect(voice?.long_form_jobs_with_zero_evidence).toBe(2);
+      expect(result.long_form_jobs_with_any_dark_criteria).toBe(3);
+    });
+  });
+
+  describe("evidence density and outlier detection", () => {
+    it("computes criterion evidence density and detects percentile outliers", () => {
+      const records: TelemetryInputRecord[] = [
+        makeRecord({
+          representation_compression_ratio: 0.001,
+          evidence_count_by_criterion: { concept: 0, sceneConstruction: 0, voice: 0 },
+        }),
+        ...Array(98)
+          .fill(0)
+          .map(() =>
+            makeRecord({
+              representation_compression_ratio: 0.15,
+              evidence_count_by_criterion: { concept: 3, sceneConstruction: 2, voice: 1 },
+            }),
+          ),
+        makeRecord({
+          representation_compression_ratio: 0.99,
+          evidence_count_by_criterion: { concept: 1, sceneConstruction: 0, voice: 0 },
+        }),
+      ];
+
+      const result = analyzeCalibration(records);
+      const conceptDensity = result.evidence_density_by_criterion.find(
+        (entry) => entry.criterion_key === "concept",
+      );
+
+      expect(conceptDensity).toBeDefined();
+      expect(conceptDensity!.avg_evidence_count_per_long_form_job).toBeGreaterThan(2.8);
+      expect(conceptDensity!.pct_long_form_jobs_with_evidence).toBeGreaterThan(95);
+
+      const hasLowOutlier = result.outliers.some((o) => o.reason === "below_p1");
+      const hasHighOutlier = result.outliers.some((o) => o.reason === "above_p99");
+      expect(hasLowOutlier).toBe(true);
+      expect(hasHighOutlier).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the calibration analysis tooling lane per the locked governance brief (`CALIBRATION_ANALYSIS_TOOLING_GOVERNANCE_BRIEF.md`, merged via #414). Adds:

- `scripts/governance/types.ts` — typed contracts for calibration analysis input/output
- `scripts/governance/analyze-phase-2-calibration.ts` — CLI + library analyzer (JSON file path or stdin input; JSON + optional markdown output)
- `tests/scripts/analyze-phase-2-calibration.test.ts` — 5 unit tests covering empty input, distribution/band correctness, long-form vs short-form exclusion, manuscript grouping + dark-criteria frequency, evidence density + outlier detection
- `docs/governance/phase-2-calibration-template.md` — export-ready template scaffold for the Phase 2 calibration artifact required by `PR_293_PHASE_2_PREVIEW_BRIEF.md` Prerequisite 2
- `package.json` — adds `governance:calibration:analyze` npm script for repeatable operator invocation

This is observation infrastructure only. No production runtime changes. No threshold derivation. No fail-closed enforcement.

## Scope

In:
- `scripts/governance/types.ts`
- `scripts/governance/analyze-phase-2-calibration.ts`
- `tests/scripts/analyze-phase-2-calibration.test.ts`
- `docs/governance/phase-2-calibration-template.md`
- `package.json` (additive script entry only)

Out:
- ❌ No production prompt/scoring/QG/UI/SIPOC/evaluation pass changes
- ❌ No #293 Phase 2 threshold derivation (that requires its own governance lock per `PR_293_PHASE_2_PREVIEW_BRIEF.md` prerequisites)
- ❌ No fail-closed enforcement
- ❌ No automatic Phase 2 promotion (analysis informs Phase 2 governance, doesn't trigger it)
- ❌ No Supabase/database query layer (input is JSON; query layer is intentionally a separate concern)
- ❌ No visualization frontend

## Contract Integrity

Implements verbatim against `CALIBRATION_ANALYSIS_TOOLING_GOVERNANCE_BRIEF.md` (locked via #414). All five gates from `CALIBRATION_ANALYSIS_TOOLING_ADJUDICATION_TEMPLATE.md` addressed:

- Gate 1 — Analysis script implemented ✅
- Gate 2 — Typed interfaces defined ✅
- Gate 3 — Unit tests cover required cases ✅
- Gate 4 — Markdown calibration template complete ✅
- Gate 5 — No production scope leakage + CI green ✅

Canonical criterion keys used throughout (`schemas/criteria-keys.ts`): `concept`, `narrativeDrive`, `character`, `voice`, `sceneConstruction`, `dialogue`, `theme`, `worldbuilding`, `pacing`, `proseControl`, `tone`, `narrativeClosure`, `marketability`. Per the canon hygiene lesson from PR #414, no banned aliases used.

## Behavioral Quality

- Pass 1, Pass 2, Pass 3 evaluation logic unchanged.
- `criteria_count_by_state` semantics unchanged.
- Short-form behavior unchanged.
- All prior tests continue to pass.
- Quality gate: not reducing intelligence — additive analysis tooling only.

[x] Pass 1 unchanged
[x] Pass 2 unchanged
[x] Pass 3 unchanged
[x] Replay harness unchanged
[x] SIPOC instrument unchanged
[x] Phase 1 governance state unchanged

## Latency Evidence

This is an observation/tooling PR. No production latency-sensitive path modified.

Baseline (Pre-change): N/A — additive analysis tooling
Post-change Runs: N/A
Run 1: N/A
Run 2: N/A

pass1_ms: N/A
pass2_ms: N/A
pass3_ms: N/A
total_ms: N/A

quality gate: not reducing intelligence

## Risks & Anomalies

- **Synthesized data shape risk averted**: tooling consumes the exact `RepresentationTelemetry` shape established by #406 (SIPOC) and extended by #411 (`compression_governance_state`). No assumed fields beyond the locked contract.
- **Phase 2 lockability boundary preserved**: tooling outputs are descriptive (histograms, percentiles, dark-criteria frequency, evidence density) and do not derive thresholds. Phase 2 lock requires its own governance PR per `PR_293_PHASE_2_PREVIEW_BRIEF.md` prerequisites.
- **Operator workflow**: `npm run governance:calibration:analyze -- <input.json> --markdown <output.md>` is the canonical invocation. Smoke-tested locally with stdin input and both output paths.
- **CLI surface stability**: arguments and flags are documented in the script header. Schema version field reserved for future format evolution.

## Refs

Refs #291, #292, #293, #404, #405, #406, #407, #409, #411, #412, #413, #414
