### PR TITLE
governance(meta): lock disclosure-audit cycle and asymmetric disclosure principle

### DIFF
--- a/docs/governance/governance-before-implementation.md
+++ b/docs/governance/governance-before-implementation.md
@@ -2,6 +2,14 @@
 
 **Status**: Canonical RevisionGrade engineering pattern (proven 4× as of 2026-05-09).
 
+## Document Visibility Classification
+
+This document is classified **[PROTECTED]**.
+
+It specifies the cognition-governance sequencing methodology: the meta-discipline that determines what gets locked, in what order, under what causal assumptions, with what disclosure posture, and under what enforcement boundary.
+
+Specific cycle internals, registry contents, ontology signatures, and implementation patterns are intentionally omitted or referenced by category only.
+
 ## What this is
 
 A repeatable two-phase PR workflow that separates **architectural contracts** from **runtime implementation**. The contract lands first, in a governance PR. Implementation lands second, against the locked contract.
@@ -93,6 +101,39 @@ For each major lane, maintain four artifacts in repo root:
 - **Telemetry as future work**: telemetry deferred is telemetry never built. The contract must require it land in the same PR as the runtime change.
 - **Premature hard-fail enforcement**: governance gates without distributional data block legitimate runs. Use observation phases first (see #293 Phase 1).
 - **Scope expansion mid-implementation**: open a follow-up governance PR instead.
+
+## Disclosure-audit cycle (required before lock)
+
+Every governance brief that touches protected architecture passes through this five-stage maturation cycle:
+
+1. **Initial doctrine** — first draft defines boundary, enforcement intent, and causal position.
+2. **Review pressure** — independent review tests scope, abstraction level, and disclosure posture.
+3. **Disclosure audit** — explicit pass for canon enumeration, ontology leakage, registry duplication, and architectural disclosure surface.
+4. **Abstraction tightening** — concrete identifiers become categories; structural examples become placeholders; implementation signatures move out of doctrine briefs.
+5. **Governance lock** — brief merges with clear [PROTECTED] posture and binary adjudication.
+
+The disclosure audit is non-optional. A governance brief that protects an ontology must not enumerate that ontology.
+
+Boundary ownership pattern:
+
+- The **brief** defines boundary doctrine.
+- The **registry** defines protected contents.
+- The **enforcement mechanism** reads the registry and applies the boundary.
+
+If a brief fails disclosure audit, it returns to stage 4 before lock.
+
+## Asymmetric disclosure principle
+
+RevisionGrade maintains deliberate asymmetry between operational and architectural intelligibility:
+
+- **Operationally inspectable**: users can understand outputs, explanations, revision rationale, consequences, and evidence.
+- **Architecturally irreducible**: users cannot reconstruct cognition topology, governance orchestration, ontology depth, internal abstraction layers, or canonical doctrine structures.
+
+This is not security theater. It is boundary integrity.
+
+The system can be sophisticated and explainable simultaneously because what is explained (outputs) and what is sophisticated (mechanism) are different surfaces.
+
+All future user-facing lanes inherit this asymmetry.
 
 ## Pattern naming convention
 


### PR DESCRIPTION
## Meta-Governance Lock (Cycle 11.5)

This PR updates `docs/governance/governance-before-implementation.md` to codify the sequencing doctrine that now governs downstream lanes.

### What this locks

1. **Document Visibility Classification**
   - Classifies the meta-governance workflow document as **[PROTECTED]**
   - Clarifies that sequencing methodology is an architectural asset

2. **Disclosure-Audit Cycle (Required Before Lock)**
   - Canonical five-stage maturation pattern:
     1) initial doctrine
     2) review pressure
     3) disclosure audit
     4) abstraction tightening
     5) governance lock
   - Explicitly requires disclosure-audit pass for governance briefs touching protected architecture

3. **Asymmetric Disclosure Principle**
   - Codifies the operating doctrine:
     - operationally inspectable
     - architecturally irreducible
   - States boundary integrity objective for all user-facing lanes

### Why now

Cycle 12 (CI Guard Governance Lock) should **inherit** this meta-doctrine, not define it retroactively. This PR ensures doctrine scope remains general at the framework layer, while CI guard remains lane-specific.

### Scope constraints

- Governance-only markdown update
- No runtime changes
- No registry contents introduced
- No protected ontology enumeration

### Decision intent

Merge this meta-doctrine lock before authoring cycle 12 so CI guard brief applies an already-locked disclosure and asymmetry framework.