### PR TITLE
feat(registry): add protected registry scaffold and read-only consumer contract

### DIFF
--- a/protected/README.md
+++ b/protected/README.md
@@ -1,0 +1,26 @@
+# Protected Directory
+
+## Visibility Classification
+
+This directory is classified [PROTECTED].
+
+Contents under this path are governed ontology artifacts. They are
+read-only to all consumers and modifiable only through registry-scoped
+pull requests that pass the disclosure-audit cycle.
+
+The shape of artifacts under this path is documentable. The contents
+are not.
+
+## Boundary
+
+- Consumers read from `protected/registry/` exclusively through the
+	read-only consumer contract exported by `protected/registry/index.ts`.
+- No code outside this directory may define ontology categories inline.
+- Modifications to files under this path require a registry-scoped PR.
+- The CI guard reads from this directory; it does not write to it.
+
+## References
+
+- `docs/governance/PROTECTED_REGISTRY_SCAFFOLD_GOVERNANCE_BRIEF.md` (#420)
+- `docs/governance/CI_GUARD_IMPLEMENTATION_GOVERNANCE_BRIEF.md` (#421)
+- `docs/governance/governance-before-implementation.md`

--- a/protected/registry/categories/.gitkeep
+++ b/protected/registry/categories/.gitkeep
@@ -1,0 +1,3 @@
+[PROTECTED]
+This directory exists to hold category files added by registry PRs.
+At scaffold time it is intentionally empty.

--- a/protected/registry/categories/README.md
+++ b/protected/registry/categories/README.md
@@ -1,0 +1,29 @@
+# Registry Categories
+
+## Visibility Classification
+
+This directory is classified [PROTECTED].
+
+Each file under this directory declares a [PROTECTED] category of
+boundary-crossing references. Files in this directory are governed
+ontology artifacts; their contents are not documentable outside this
+directory.
+
+At scaffold time, this directory contains no category files. Categories
+are added through registry-scoped pull requests that pass the
+disclosure-audit cycle.
+
+## File Contract
+
+Each category file:
+
+1. Carries a `[PROTECTED]` header comment
+2. Exports an array conforming to `RegistryEntry[]` from `../types`
+3. Records its audit origin via `RegistryAuditOrigin`
+4. Contains no comments, examples, or documentation disclosing its contents
+
+## Aggregation
+
+Category files are aggregated by `protected/registry/index.ts`. The
+aggregation is internal; consumers do not reference category files
+directly.

--- a/protected/registry/index.ts
+++ b/protected/registry/index.ts
@@ -1,0 +1,79 @@
+// [PROTECTED]
+//
+// Protected registry consumer-facing entry point.
+
+import type {
+  RegistryEntry,
+  ReadOnlyRegistryConsumer,
+  RegistryQueryResult,
+  RegistryValidationResult,
+  EscapeAnnotationPattern,
+} from "./types";
+import { validateRegistryContents } from "./schema";
+
+export type {
+  BoundaryCrossingCategory,
+  RegistryEntry,
+  RegistryAuditOrigin,
+  EscapeAnnotationPattern,
+  RegistryQueryResult,
+  RegistryValidationResult,
+  RegistryValidationError,
+  ReadOnlyRegistryConsumer,
+} from "./types";
+
+/**
+ * At scaffold time, category files contain no entries.
+ */
+function loadEntries(): ReadonlyArray<RegistryEntry> {
+  return Object.freeze([]);
+}
+
+function buildConsumer(): ReadOnlyRegistryConsumer {
+  const entries = loadEntries();
+  const validated = validateRegistryContents(entries);
+  const validation: RegistryValidationResult = Object.freeze({
+    schemaValid: validated.schemaValid,
+    categoryCount: validated.categoryCount,
+    entryCount: validated.entryCount,
+    errors: Object.freeze([...validated.errors]),
+  });
+
+  if (!validation.schemaValid) {
+    throw new Error(
+      `[protected/registry] Registry failed self-validation at load time. ` +
+        `Errors: ${validation.errors.length}. Refusing to expose consumer contract.`,
+    );
+  }
+
+  const escapeAnnotation: EscapeAnnotationPattern = Object.freeze({
+    markerToken: "@InternalOnly",
+    requiredValidatorCheck: "path-classification",
+    auditLogShape: "ci-summary",
+  });
+
+  return Object.freeze({
+    hasCategoryMatch(_candidate: string): RegistryQueryResult {
+      return Object.freeze({
+        matched: false,
+        category: null,
+        classificationDepth: null,
+      });
+    },
+    getEscapeAnnotationContract(): EscapeAnnotationPattern {
+      return escapeAnnotation;
+    },
+    validateRegistry(): RegistryValidationResult {
+      return validation;
+    },
+    getCategoryCount(): number {
+      return validation.categoryCount;
+    },
+  });
+}
+
+const consumer: ReadOnlyRegistryConsumer = buildConsumer();
+
+export function getRegistryConsumer(): ReadOnlyRegistryConsumer {
+  return consumer;
+}

--- a/protected/registry/schema.ts
+++ b/protected/registry/schema.ts
@@ -1,0 +1,88 @@
+// [PROTECTED]
+//
+// Schema validation for the protected registry.
+
+import type {
+  RegistryEntry,
+  RegistryValidationResult,
+  RegistryValidationError,
+} from "./types";
+
+export function validateEntry(
+  entry: unknown,
+  entryIndex: number,
+): ReadonlyArray<RegistryValidationError> {
+  const errors: RegistryValidationError[] = [];
+
+  if (typeof entry !== "object" || entry === null) {
+    errors.push({
+      errorKind: "schema",
+      entryIndex,
+      message: "Entry must be an object.",
+    });
+    return errors;
+  }
+
+  const candidate = entry as Partial<RegistryEntry>;
+
+  if (typeof candidate.category !== "string" || candidate.category.length === 0) {
+    errors.push({
+      errorKind: "schema",
+      entryIndex,
+      message: "Entry must have a non-empty category.",
+    });
+  }
+
+  if (
+    candidate.classificationDepth !== "literal" &&
+    candidate.classificationDepth !== "pattern-class" &&
+    candidate.classificationDepth !== "structural"
+  ) {
+    errors.push({
+      errorKind: "classification",
+      entryIndex,
+      message: "Entry classificationDepth must be one of the locked enum values.",
+    });
+  }
+
+  if (
+    typeof candidate.auditOrigin !== "object" ||
+    candidate.auditOrigin === null ||
+    typeof candidate.auditOrigin.registryPrNumber !== "number" ||
+    typeof candidate.auditOrigin.mergedAt !== "string"
+  ) {
+    errors.push({
+      errorKind: "schema",
+      entryIndex,
+      message: "Entry must have a valid auditOrigin with registryPrNumber and mergedAt.",
+    });
+  }
+
+  return errors;
+}
+
+export function validateRegistryContents(entries: ReadonlyArray<unknown>): RegistryValidationResult {
+  const allErrors: RegistryValidationError[] = [];
+  const categoriesSeen = new Set<string>();
+  let categoryCount = 0;
+
+  entries.forEach((entry, index) => {
+    const entryErrors = validateEntry(entry, index);
+    allErrors.push(...entryErrors);
+
+    if (entryErrors.length === 0) {
+      const validEntry = entry as RegistryEntry;
+      if (!categoriesSeen.has(validEntry.category)) {
+        categoriesSeen.add(validEntry.category);
+        categoryCount++;
+      }
+    }
+  });
+
+  return {
+    schemaValid: allErrors.length === 0,
+    categoryCount,
+    entryCount: entries.length,
+    errors: allErrors,
+  };
+}

--- a/protected/registry/types.ts
+++ b/protected/registry/types.ts
@@ -1,0 +1,48 @@
+// [PROTECTED]
+//
+// Type definitions for the protected registry consumer contract.
+
+export type BoundaryCrossingCategory = string & { readonly __brand: unique symbol };
+
+export interface RegistryEntry {
+  readonly category: BoundaryCrossingCategory;
+  readonly classificationDepth: "literal" | "pattern-class" | "structural";
+  readonly auditOrigin: RegistryAuditOrigin;
+}
+
+export interface RegistryAuditOrigin {
+  readonly registryPrNumber: number;
+  readonly mergedAt: string;
+}
+
+export interface EscapeAnnotationPattern {
+  readonly markerToken: string;
+  readonly requiredValidatorCheck: "path-classification" | "scope-annotation";
+  readonly auditLogShape: "ci-summary" | "workflow-artifact";
+}
+
+export interface RegistryQueryResult {
+  readonly matched: boolean;
+  readonly category: BoundaryCrossingCategory | null;
+  readonly classificationDepth: RegistryEntry["classificationDepth"] | null;
+}
+
+export interface RegistryValidationResult {
+  readonly schemaValid: boolean;
+  readonly categoryCount: number;
+  readonly entryCount: number;
+  readonly errors: ReadonlyArray<RegistryValidationError>;
+}
+
+export interface RegistryValidationError {
+  readonly errorKind: "schema" | "reference" | "duplicate" | "classification";
+  readonly entryIndex: number;
+  readonly message: string;
+}
+
+export interface ReadOnlyRegistryConsumer {
+  hasCategoryMatch(candidate: string): RegistryQueryResult;
+  getEscapeAnnotationContract(): EscapeAnnotationPattern;
+  validateRegistry(): RegistryValidationResult;
+  getCategoryCount(): number;
+}

--- a/tests/protected/registry/consumer-contract.test.ts
+++ b/tests/protected/registry/consumer-contract.test.ts
@@ -1,0 +1,32 @@
+// [PROTECTED]
+
+import { describe, it, expect } from "@jest/globals";
+import { getRegistryConsumer } from "@/protected/registry";
+import type { ReadOnlyRegistryConsumer } from "@/protected/registry";
+
+describe("Protected registry consumer contract", () => {
+  it("exposes the read-only consumer interface", () => {
+    const consumer: ReadOnlyRegistryConsumer = getRegistryConsumer();
+    expect(typeof consumer.hasCategoryMatch).toBe("function");
+    expect(typeof consumer.getEscapeAnnotationContract).toBe("function");
+    expect(typeof consumer.validateRegistry).toBe("function");
+    expect(typeof consumer.getCategoryCount).toBe("function");
+  });
+
+  it("returns no match for any candidate at scaffold time", () => {
+    const consumer = getRegistryConsumer();
+    const result = consumer.hasCategoryMatch("arbitrary-test-string");
+    expect(result.matched).toBe(false);
+    expect(result.category).toBeNull();
+    expect(result.classificationDepth).toBeNull();
+  });
+
+  it("returns frozen result objects and contract payloads", () => {
+    const consumer = getRegistryConsumer();
+    const result = consumer.hasCategoryMatch("test");
+    const contract = consumer.getEscapeAnnotationContract();
+
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(contract)).toBe(true);
+  });
+});

--- a/tests/protected/registry/readonly-mutation.test.ts
+++ b/tests/protected/registry/readonly-mutation.test.ts
@@ -1,0 +1,26 @@
+// [PROTECTED]
+
+import { describe, it, expect } from "@jest/globals";
+import { getRegistryConsumer } from "@/protected/registry";
+
+describe("Protected registry read-only guarantees", () => {
+  it("exposes a frozen consumer that cannot be extended", () => {
+    const consumer = getRegistryConsumer();
+
+    expect(Object.isFrozen(consumer)).toBe(true);
+    expect(() => {
+      (consumer as unknown as { mutate?: () => void }).mutate = () => undefined;
+    }).toThrow();
+  });
+
+  it("returns immutable validation payload", () => {
+    const validation = getRegistryConsumer().validateRegistry();
+
+    expect(Object.isFrozen(validation)).toBe(true);
+    expect(Object.isFrozen(validation.errors)).toBe(true);
+
+    expect(() => {
+      (validation as unknown as { schemaValid: boolean }).schemaValid = false;
+    }).toThrow();
+  });
+});

--- a/tests/protected/registry/schema-validation.test.ts
+++ b/tests/protected/registry/schema-validation.test.ts
@@ -1,0 +1,32 @@
+// [PROTECTED]
+
+import { describe, it, expect } from "@jest/globals";
+import { validateEntry, validateRegistryContents } from "@/protected/registry/schema";
+
+describe("Protected registry schema validation", () => {
+  it("accepts an empty scaffold registry as valid", () => {
+    const result = validateRegistryContents([]);
+    expect(result.schemaValid).toBe(true);
+    expect(result.categoryCount).toBe(0);
+    expect(result.entryCount).toBe(0);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns schema errors for malformed entries", () => {
+    const malformed = {
+      category: "",
+      classificationDepth: "invalid-depth",
+      auditOrigin: { registryPrNumber: "NaN", mergedAt: 42 },
+    };
+
+    const errors = validateEntry(malformed, 0);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.errorKind === "schema" || e.errorKind === "classification")).toBe(true);
+  });
+
+  it("fails closed when malformed entries are present", () => {
+    const result = validateRegistryContents([{}]);
+    expect(result.schemaValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "pages/**/*",
     "components/**/*",
     "lib/**/*",
+    "protected/**/*",
     "scripts/**/*",
     "tests/**/*",
     "middleware.ts",


### PR DESCRIPTION
## Summary

Implements Cycle 13A-impl: protected registry scaffold only.

This PR adds the protected registry path, typed read-only consumer contract, schema validation, and bounded tests. It contains no registry contents and no CI guard implementation logic.

## Scope

In:
- `protected/README.md`
- `protected/registry/index.ts`
- `protected/registry/schema.ts`
- `protected/registry/types.ts`
- `protected/registry/categories/.gitkeep`
- `protected/registry/categories/README.md`
- `tests/protected/registry/consumer-contract.test.ts`
- `tests/protected/registry/schema-validation.test.ts`
- `tests/protected/registry/readonly-mutation.test.ts`
- `tsconfig.json` (include `protected/**/*`)

Out:
- ❌ No CI guard implementation
- ❌ No GitHub Actions workflow
- ❌ No branch protection changes
- ❌ No registry contents

## Contract Integrity

- [x] Registry path exists under `protected/`
- [x] `[PROTECTED]` classification present
- [x] Typed read-only consumer contract exists
- [x] No registry contents
- [x] No CI guard logic
- [x] Schema validates and fails closed on malformed entries
- [x] Read-only mutation attempts are blocked
- [x] Disclosure audit passes

## Behavioral Quality

- [x] Narrow scaffold-only implementation
- [x] No ontology contents exposed
- [x] No guard behavior introduced
- [x] Category directory intentionally empty at scaffold time
- [x] quality gate: not reducing intelligence

## Latency Evidence

Baseline (Pre-change)
- pass1_ms: N/A (docs + scaffold only)
- pass2_ms: N/A
- pass3_ms: N/A
- total_ms: N/A

Post-change Runs
- Run 1: N/A (no runtime path change)
- Run 2: N/A (no runtime path change)

Pass selection
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

Metrics
- pass1_ms: N/A
- total_ms: N/A

quality gate: not reducing intelligence

## Risks & Anomalies

- Scope intentionally narrow: scaffold + contract only.
- Category directory remains intentionally empty at scaffold time.
- Disclosure audit passed 11/11 (including fixture-content check).

## Refs

Refs #416, #417, #418, #419, #420, #421
