### PR TITLE
feat(ci-guard): implement registry-consuming merge-time guard

### DIFF
--- a/.github/workflows/ci-guard.yml
+++ b/.github/workflows/ci-guard.yml
@@ -1,0 +1,35 @@
+name: CI Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run CI Guard
+        run: npm run ci-guard -- --base origin/${{ github.base_ref }} --head ${{ github.sha }} --artifact artifacts/ci-guard-report.json
+
+      - name: Upload CI Guard Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-guard-report
+          path: artifacts/ci-guard-report.json

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "sipoc:validate": "npx tsx -r tsconfig-paths/register scripts/validate-sipoc-fixtures.ts",
     "sipoc:harness": "npx tsx -r tsconfig-paths/register scripts/run-sipoc-harness.ts",
     "sipoc:analyze": "npx tsx -r tsconfig-paths/register scripts/analyze-sipoc-results.ts",
-    "governance:calibration:analyze": "npx tsx -r tsconfig-paths/register scripts/governance/analyze-phase-2-calibration.ts"
+    "governance:calibration:analyze": "npx tsx -r tsconfig-paths/register scripts/governance/analyze-phase-2-calibration.ts",
+    "ci-guard": "npx tsx scripts/ci-guard/index.ts"
   },
   "dependencies": {
     "@base44/sdk": "^0.8.27",

--- a/scripts/ci-guard/README.md
+++ b/scripts/ci-guard/README.md
@@ -1,0 +1,10 @@
+# CI Guard Implementation
+
+This module implements procedural boundary enforcement that **consumes** ontology from `protected/registry/`.
+
+Principles:
+- No inline ontology definitions.
+- No local category authority.
+- Scanner handles structural tokenization only.
+- Registry consumer provides semantic classification.
+- Reporter handles merge-time enforcement outputs.

--- a/scripts/ci-guard/annotation-validator.ts
+++ b/scripts/ci-guard/annotation-validator.ts
@@ -1,0 +1,67 @@
+import type { EscapeAnnotationPattern } from "../../protected/registry";
+import type { EscapeValidatorOutcome, MatchSpan } from "./types";
+import { classifyPath } from "./scope-rules";
+
+const ANNOTATION_PROXIMITY_LINES = 1;
+
+interface AnnotationLookupResult {
+  readonly found: boolean;
+  readonly lineNumber: number | null;
+  readonly malformed: boolean;
+}
+
+function findNearbyAnnotation(content: string, span: MatchSpan, marker: string): AnnotationLookupResult {
+  const lines = content.split("\n");
+  const matchLineIndex = Math.max(0, span.lineNumber - 1);
+  const minLineIndex = Math.max(0, matchLineIndex - ANNOTATION_PROXIMITY_LINES);
+
+  for (let i = minLineIndex; i <= matchLineIndex; i++) {
+    const line = lines[i];
+    if (!line || !line.includes(marker)) {
+      continue;
+    }
+
+    const markerOffset = line.indexOf(marker);
+    const beforeMarker = line.slice(0, markerOffset);
+    const inLineComment = /\/\//.test(beforeMarker);
+    const inBlockComment = /\/\*/.test(beforeMarker);
+
+    if (!inLineComment && !inBlockComment) {
+      return { found: true, lineNumber: i + 1, malformed: true };
+    }
+
+    return { found: true, lineNumber: i + 1, malformed: false };
+  }
+
+  return { found: false, lineNumber: null, malformed: false };
+}
+
+export function validateEscapeAnnotation(
+  relativePath: string,
+  content: string,
+  span: MatchSpan,
+  contract: EscapeAnnotationPattern,
+): EscapeValidatorOutcome {
+  const lookup = findNearbyAnnotation(content, span, contract.markerToken);
+
+  if (!lookup.found) {
+    return "rejected-no-path-classification";
+  }
+
+  if (lookup.malformed) {
+    return "rejected-malformed-annotation";
+  }
+
+  if (contract.requiredValidatorCheck === "path-classification") {
+    const classification = classifyPath(relativePath);
+    if (classification.inScope) {
+      return "rejected-out-of-scope-path";
+    }
+  }
+
+  return "accepted";
+}
+
+export function hasNearbyEscapeAnnotation(content: string, span: MatchSpan, marker: string): boolean {
+  return findNearbyAnnotation(content, span, marker).found;
+}

--- a/scripts/ci-guard/index.ts
+++ b/scripts/ci-guard/index.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { getRegistryConsumer } from "../../protected/registry";
+import { buildScanTarget, scanTarget } from "./scanner";
+import { buildReport, writeOutputs } from "./reporter";
+import type { RawMatch, ScanTarget } from "./types";
+
+interface Args {
+  base: string;
+  head: string;
+  artifact: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { base: "origin/main", head: "HEAD", artifact: "artifacts/ci-guard-report.json" };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--base") args.base = argv[++i] ?? args.base;
+    else if (argv[i] === "--head") args.head = argv[++i] ?? args.head;
+    else if (argv[i] === "--artifact") args.artifact = argv[++i] ?? args.artifact;
+  }
+  return args;
+}
+
+function getChangedFiles(base: string, head: string): string[] {
+  const out = execSync(`git diff --name-only ${base}...${head}`, { encoding: "utf8" });
+  return out
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function readTextFileSafe(relativePath: string): string | null {
+  const absolute = path.resolve(relativePath);
+  if (!fs.existsSync(absolute)) return null;
+  try {
+    const content = fs.readFileSync(absolute, "utf8");
+    if (content.includes("\u0000")) return null;
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+export function runGuard(filePaths: readonly string[], artifactPath = "artifacts/ci-guard-report.json"): number {
+  const registry = getRegistryConsumer();
+  const validation = registry.validateRegistry();
+  const targets: ScanTarget[] = [];
+  const rawMatches: RawMatch[] = [];
+  const contentByPath = new Map<string, string>();
+
+  for (const relativePath of filePaths) {
+    const content = readTextFileSafe(relativePath);
+    if (content === null) continue;
+
+    const target = buildScanTarget(relativePath, content);
+    targets.push(target);
+    contentByPath.set(relativePath, content);
+    rawMatches.push(...scanTarget(target, registry));
+  }
+
+  const report = buildReport({
+    targets,
+    rawMatches,
+    registryValidationOk: validation.schemaValid,
+    escapeContract: registry.getEscapeAnnotationContract(),
+    contentByPath,
+  });
+
+  writeOutputs(report, artifactPath);
+
+  if (!validation.schemaValid || report.outcome === "fail") {
+    return 1;
+  }
+
+  return 0;
+}
+
+function main(): void {
+  const { base, head, artifact } = parseArgs(process.argv);
+  const files = getChangedFiles(base, head);
+
+  const exitCode = runGuard(files, artifact);
+
+  process.exit(exitCode);
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+
+if (invokedPath === currentFilePath) {
+  main();
+}

--- a/scripts/ci-guard/reporter.ts
+++ b/scripts/ci-guard/reporter.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import path from "node:path";
+import { validateEscapeAnnotation } from "./annotation-validator";
+import type { RawMatch, ScanReport, ScanTarget, Violation } from "./types";
+import type { EscapeAnnotationPattern } from "../../protected/registry";
+
+interface BuildReportInput {
+  readonly targets: ReadonlyArray<ScanTarget>;
+  readonly rawMatches: ReadonlyArray<RawMatch>;
+  readonly registryValidationOk: boolean;
+  readonly escapeContract: EscapeAnnotationPattern;
+  readonly contentByPath: ReadonlyMap<string, string>;
+}
+
+export function buildReport(input: BuildReportInput): ScanReport {
+  let acceptedExceptionCount = 0;
+  let rejectedExceptionCount = 0;
+  const violations: Violation[] = [];
+
+  for (const match of input.rawMatches) {
+    let escapeValidatorOutcome = null;
+
+    if (match.hasNearbyEscapeAnnotation) {
+      const content = input.contentByPath.get(match.relativePath) ?? "";
+      const outcome = validateEscapeAnnotation(
+        match.relativePath,
+        content,
+        match.span,
+        input.escapeContract,
+      );
+      escapeValidatorOutcome = outcome;
+
+      if (outcome === "accepted") {
+        acceptedExceptionCount++;
+        continue;
+      }
+
+      rejectedExceptionCount++;
+    }
+
+    violations.push({
+      relativePath: match.relativePath,
+      category: match.result.category!,
+      classificationDepth: match.result.classificationDepth!,
+      span: match.span,
+      hasNearbyEscapeAnnotation: match.hasNearbyEscapeAnnotation,
+      escapeValidatorOutcome,
+    });
+  }
+
+  const inScopeTargetCount = input.targets.filter((t) => t.inScope).length;
+  const outcome = input.registryValidationOk && violations.length === 0 ? "pass" : "fail";
+
+  return {
+    outcome,
+    scanTargetCount: input.targets.length,
+    inScopeTargetCount,
+    violationCount: violations.length,
+    acceptedExceptionCount,
+    rejectedExceptionCount,
+    violations: Object.freeze(violations),
+    registryValidationOk: input.registryValidationOk,
+    escapeContract: input.escapeContract,
+  };
+}
+
+export function renderSummary(report: ScanReport): string {
+  const lines: string[] = [];
+  lines.push("## CI Guard Summary");
+  lines.push("");
+  lines.push(`Outcome: **${report.outcome.toUpperCase()}**`);
+  lines.push(`Registry validation: **${report.registryValidationOk ? "OK" : "FAILED"}**`);
+  lines.push(`Scanned targets: ${report.scanTargetCount} (in-scope: ${report.inScopeTargetCount})`);
+  lines.push(`Violations: ${report.violationCount}`);
+  lines.push(`Accepted exceptions: ${report.acceptedExceptionCount}`);
+  lines.push(`Rejected exceptions: ${report.rejectedExceptionCount}`);
+  lines.push("");
+
+  if (report.violations.length > 0) {
+    lines.push("### Violations");
+    for (const violation of report.violations) {
+      lines.push(
+        `- [${violation.relativePath}:${violation.span.lineNumber}] category=${String(
+          violation.category,
+        )} depth=${violation.classificationDepth} annotated=${violation.hasNearbyEscapeAnnotation}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function writeOutputs(report: ScanReport, artifactPath = "artifacts/ci-guard-report.json"): void {
+  const summary = renderSummary(report);
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${summary}\n`, "utf8");
+  }
+
+  const resolved = path.resolve(artifactPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, JSON.stringify(report, null, 2), "utf8");
+}

--- a/scripts/ci-guard/scanner.ts
+++ b/scripts/ci-guard/scanner.ts
@@ -1,0 +1,65 @@
+import type { ReadOnlyRegistryConsumer } from "../../protected/registry";
+import type { ScanTarget, RawMatch } from "./types";
+import { classifyPath } from "./scope-rules";
+import { hasNearbyEscapeAnnotation } from "./annotation-validator";
+
+const TOKEN_PATTERN = /[A-Za-z][A-Za-z0-9_-]{2,}/g;
+
+function computeLineNumber(content: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset; i++) {
+    if (content.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
+
+function* iterateCandidateTokens(content: string): Generator<{ token: string; offset: number; lineNumber: number }> {
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_PATTERN.exec(content)) !== null) {
+    const offset = match.index;
+    yield {
+      token: match[0],
+      offset,
+      lineNumber: computeLineNumber(content, offset),
+    };
+  }
+}
+
+export function buildScanTarget(relativePath: string, content: string): ScanTarget {
+  const classification = classifyPath(relativePath);
+  return {
+    relativePath,
+    content,
+    inScope: classification.inScope,
+    scopeRationale: classification.rationale,
+  };
+}
+
+export function scanTarget(target: ScanTarget, registry: ReadOnlyRegistryConsumer): ReadonlyArray<RawMatch> {
+  if (!target.inScope) return [];
+
+  const annotation = registry.getEscapeAnnotationContract();
+  const matches: RawMatch[] = [];
+
+  for (const { token, offset, lineNumber } of iterateCandidateTokens(target.content)) {
+    const result = registry.hasCategoryMatch(token);
+    if (!result.matched || result.category === null || result.classificationDepth === null) {
+      continue;
+    }
+
+    const span = {
+      startOffset: offset,
+      endOffset: offset + token.length,
+      lineNumber,
+    };
+
+    matches.push({
+      relativePath: target.relativePath,
+      span,
+      result,
+      hasNearbyEscapeAnnotation: hasNearbyEscapeAnnotation(target.content, span, annotation.markerToken),
+    });
+  }
+
+  return matches;
+}

--- a/scripts/ci-guard/scope-rules.ts
+++ b/scripts/ci-guard/scope-rules.ts
@@ -1,0 +1,91 @@
+export type PathCategory =
+  | "user-facing"
+  | "internal"
+  | "governance"
+  | "protected"
+  | "tooling"
+  | "test"
+  | "unknown";
+
+export interface PathClassification {
+  readonly relativePath: string;
+  readonly category: PathCategory;
+  readonly inScope: boolean;
+  readonly rationale: string;
+}
+
+export function classifyPath(relativePath: string): PathClassification {
+  if (relativePath.startsWith("protected/")) {
+    return {
+      relativePath,
+      category: "protected",
+      inScope: false,
+      rationale: "Protected ontology path; scanner does not inspect ontology files.",
+    };
+  }
+
+  if (relativePath.startsWith("docs/governance/") || relativePath.startsWith("docs/")) {
+    return {
+      relativePath,
+      category: "governance",
+      inScope: false,
+      rationale: "Governance/documentation path; out of runtime user-facing scope.",
+    };
+  }
+
+  if (
+    relativePath.startsWith("tests/") ||
+    relativePath.startsWith("test/") ||
+    relativePath.endsWith(".test.ts") ||
+    relativePath.endsWith(".test.tsx") ||
+    relativePath.endsWith(".spec.ts") ||
+    relativePath.endsWith(".spec.tsx")
+  ) {
+    return {
+      relativePath,
+      category: "test",
+      inScope: false,
+      rationale: "Test path; out of user-facing enforcement scope.",
+    };
+  }
+
+  if (
+    relativePath.startsWith("scripts/") ||
+    relativePath.startsWith(".github/") ||
+    relativePath === "package.json" ||
+    relativePath === "tsconfig.json" ||
+    relativePath.endsWith(".config.ts") ||
+    relativePath.endsWith(".config.js") ||
+    relativePath.endsWith(".config.mjs")
+  ) {
+    return {
+      relativePath,
+      category: "tooling",
+      inScope: false,
+      rationale: "Tooling/CI path; not a wire-crossing surface.",
+    };
+  }
+
+  if (
+    relativePath.startsWith("app/") ||
+    relativePath.startsWith("components/") ||
+    relativePath.startsWith("public/") ||
+    relativePath.startsWith("lib/api/") ||
+    relativePath.startsWith("lib/export/") ||
+    relativePath.startsWith("lib/ui/")
+  ) {
+    return {
+      relativePath,
+      category: "user-facing",
+      inScope: true,
+      rationale: "Wire-crossing surface; subject to boundary integrity enforcement.",
+    };
+  }
+
+  return {
+    relativePath,
+    category: "internal",
+    inScope: false,
+    rationale: "Internal logic path; out of user-facing scope.",
+  };
+}

--- a/scripts/ci-guard/types.ts
+++ b/scripts/ci-guard/types.ts
@@ -1,0 +1,54 @@
+import type {
+  BoundaryCrossingCategory,
+  RegistryQueryResult,
+  EscapeAnnotationPattern,
+} from "../../protected/registry";
+
+export type GuardOutcome = "pass" | "fail";
+
+export interface ScanTarget {
+  readonly relativePath: string;
+  readonly content: string;
+  readonly inScope: boolean;
+  readonly scopeRationale: string;
+}
+
+export interface MatchSpan {
+  readonly startOffset: number;
+  readonly endOffset: number;
+  readonly lineNumber: number;
+}
+
+export type EscapeValidatorOutcome =
+  | "accepted"
+  | "rejected-no-path-classification"
+  | "rejected-malformed-annotation"
+  | "rejected-out-of-scope-path";
+
+export interface Violation {
+  readonly relativePath: string;
+  readonly category: BoundaryCrossingCategory;
+  readonly classificationDepth: NonNullable<RegistryQueryResult["classificationDepth"]>;
+  readonly span: MatchSpan;
+  readonly hasNearbyEscapeAnnotation: boolean;
+  readonly escapeValidatorOutcome: EscapeValidatorOutcome | null;
+}
+
+export interface RawMatch {
+  readonly relativePath: string;
+  readonly span: MatchSpan;
+  readonly result: RegistryQueryResult;
+  readonly hasNearbyEscapeAnnotation: boolean;
+}
+
+export interface ScanReport {
+  readonly outcome: GuardOutcome;
+  readonly scanTargetCount: number;
+  readonly inScopeTargetCount: number;
+  readonly violationCount: number;
+  readonly acceptedExceptionCount: number;
+  readonly rejectedExceptionCount: number;
+  readonly violations: ReadonlyArray<Violation>;
+  readonly registryValidationOk: boolean;
+  readonly escapeContract: EscapeAnnotationPattern;
+}

--- a/tests/scripts/ci-guard/annotation-validator.test.ts
+++ b/tests/scripts/ci-guard/annotation-validator.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { validateEscapeAnnotation, hasNearbyEscapeAnnotation } from "@/scripts/ci-guard/annotation-validator";
+
+const fixture = (name: string) =>
+  fs.readFileSync(path.join(process.cwd(), "tests/scripts/ci-guard/fixtures", name), "utf8");
+
+const contract = {
+  markerToken: "@InternalOnly",
+  requiredValidatorCheck: "path-classification" as const,
+  auditLogShape: "ci-summary" as const,
+};
+
+describe("ci-guard annotation validator", () => {
+  it("detects nearby annotation marker", () => {
+    const content = fixture("in-scope-annotated-exception.txt");
+    const has = hasNearbyEscapeAnnotation(content, { startOffset: 0, endOffset: 10, lineNumber: 2 }, contract.markerToken);
+    expect(has).toBe(true);
+  });
+
+  it("rejects annotation on in-scope path under strict path-classification contract", () => {
+    const content = fixture("in-scope-annotated-exception.txt");
+    const outcome = validateEscapeAnnotation(
+      "app/example/page.tsx",
+      content,
+      { startOffset: 0, endOffset: 10, lineNumber: 2 },
+      contract,
+    );
+    expect(outcome).toBe("rejected-out-of-scope-path");
+  });
+
+  it("accepts validator-confirmed annotation on non-user-facing path", () => {
+    const content = fixture("in-scope-annotated-exception.txt");
+    const outcome = validateEscapeAnnotation(
+      "lib/internal/tool.ts",
+      content,
+      { startOffset: 0, endOffset: 10, lineNumber: 2 },
+      contract,
+    );
+    expect(outcome).toBe("accepted");
+  });
+});

--- a/tests/scripts/ci-guard/fixtures/in-scope-annotated-exception.txt
+++ b/tests/scripts/ci-guard/fixtures/in-scope-annotated-exception.txt
@@ -1,0 +1,2 @@
+// @InternalOnly validator-confirmed, not user-facing
+SyntheticInternalToken appears in annotated context.

--- a/tests/scripts/ci-guard/fixtures/in-scope-clean.txt
+++ b/tests/scripts/ci-guard/fixtures/in-scope-clean.txt
@@ -1,0 +1,2 @@
+This user-facing content is clean and contains only normal prose tokens.
+No protected ontology entries are represented here.

--- a/tests/scripts/ci-guard/fixtures/in-scope-violation.txt
+++ b/tests/scripts/ci-guard/fixtures/in-scope-violation.txt
@@ -1,0 +1,1 @@
+This in-scope fixture contains SyntheticInternalToken for scanner validation.

--- a/tests/scripts/ci-guard/fixtures/out-of-scope.txt
+++ b/tests/scripts/ci-guard/fixtures/out-of-scope.txt
@@ -1,0 +1,1 @@
+SyntheticInternalToken in tests path should be out of scanner scope by path topology.

--- a/tests/scripts/ci-guard/integration.test.ts
+++ b/tests/scripts/ci-guard/integration.test.ts
@@ -1,0 +1,8 @@
+import { runGuard } from "@/scripts/ci-guard/index";
+
+describe("ci-guard integration", () => {
+  it("passes with current empty protected registry scaffold", () => {
+    const exitCode = runGuard(["app/page.tsx", "tests/scripts/ci-guard/fixtures/out-of-scope.txt"]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/tests/scripts/ci-guard/reporter.test.ts
+++ b/tests/scripts/ci-guard/reporter.test.ts
@@ -1,0 +1,53 @@
+import { buildReport, renderSummary } from "@/scripts/ci-guard/reporter";
+import type { RawMatch, ScanTarget } from "@/scripts/ci-guard/types";
+import type { BoundaryCrossingCategory } from "@/protected/registry";
+
+const target: ScanTarget = {
+  relativePath: "app/example/page.tsx",
+  content: "SyntheticInternalToken",
+  inScope: true,
+  scopeRationale: "wire crossing",
+};
+
+const rawMatch: RawMatch = {
+  relativePath: target.relativePath,
+  span: { startOffset: 0, endOffset: 22, lineNumber: 1 },
+  result: {
+    matched: true,
+    category: "synthetic" as unknown as BoundaryCrossingCategory,
+    classificationDepth: "literal",
+  },
+  hasNearbyEscapeAnnotation: false,
+};
+
+const escapeContract = {
+  markerToken: "@InternalOnly",
+  requiredValidatorCheck: "path-classification" as const,
+  auditLogShape: "ci-summary" as const,
+};
+
+describe("ci-guard reporter", () => {
+  it("builds fail report when violations exist", () => {
+    const report = buildReport({
+      targets: [target],
+      rawMatches: [rawMatch],
+      registryValidationOk: true,
+      escapeContract,
+      contentByPath: new Map([[target.relativePath, target.content]]),
+    });
+
+    expect(report.outcome).toBe("fail");
+    expect(report.violationCount).toBe(1);
+  });
+
+  it("renders summary containing outcome", () => {
+    const report = buildReport({
+      targets: [],
+      rawMatches: [],
+      registryValidationOk: true,
+      escapeContract,
+      contentByPath: new Map(),
+    });
+    expect(renderSummary(report)).toContain("Outcome:");
+  });
+});

--- a/tests/scripts/ci-guard/scanner.test.ts
+++ b/tests/scripts/ci-guard/scanner.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+import { buildScanTarget, scanTarget } from "@/scripts/ci-guard/scanner";
+import { BoundaryCrossingCategory, type ReadOnlyRegistryConsumer } from "@/protected/registry";
+
+const fixture = (name: string) =>
+  fs.readFileSync(path.join(process.cwd(), "tests/scripts/ci-guard/fixtures", name), "utf8");
+
+const registry: ReadOnlyRegistryConsumer = {
+  hasCategoryMatch(candidate: string) {
+    const matched = candidate.includes("SyntheticInternalToken");
+    return {
+      matched,
+      category: matched ? ("synthetic" as unknown as BoundaryCrossingCategory) : null,
+      classificationDepth: matched ? "literal" : null,
+    };
+  },
+  getEscapeAnnotationContract() {
+    return {
+      markerToken: "@InternalOnly",
+      requiredValidatorCheck: "path-classification",
+      auditLogShape: "ci-summary",
+    };
+  },
+  validateRegistry() {
+    return {
+      schemaValid: true,
+      categoryCount: 1,
+      entryCount: 1,
+      errors: [],
+    };
+  },
+  getCategoryCount() {
+    return 1;
+  },
+};
+
+describe("ci-guard scanner", () => {
+  it("scans in-scope files and finds synthetic match", () => {
+    const target = buildScanTarget("app/example/page.tsx", fixture("in-scope-violation.txt"));
+    const matches = scanTarget(target, registry);
+
+    expect(target.inScope).toBe(true);
+    expect(matches.length).toBe(1);
+    expect(matches[0].result.matched).toBe(true);
+  });
+
+  it("ignores out-of-scope files", () => {
+    const target = buildScanTarget("tests/example.test.ts", fixture("out-of-scope.txt"));
+    const matches = scanTarget(target, registry);
+
+    expect(target.inScope).toBe(false);
+    expect(matches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements 13B-impl: CI guard procedural enforcement that consumes the protected registry substrate.

This PR adds the guard runtime modules, workflow wiring, and bounded tests. It keeps ontology authority in `protected/registry/` and keeps enforcement procedural in `scripts/ci-guard/`.

## Scope

In:
- `scripts/ci-guard/*` (scanner, validator, reporter, entrypoint, types, scope rules)
- `.github/workflows/ci-guard.yml`
- `tests/scripts/ci-guard/*` (+ fixtures)
- `package.json` (`ci-guard` script)

Out:
- ❌ No registry content population
- ❌ No ontology expansion
- ❌ No branch protection setting changes (manual repo step)

## Contract Integrity

- [x] Guard consumes ontology via `getRegistryConsumer()` only
- [x] No inline ontology categories in guard modules
- [x] No registry mutation paths in guard modules
- [x] Scanner = structural tokenization; registry = semantic classification
- [x] Reporter owns enforcement output assembly
- [x] Validator enforces `@InternalOnly` as validator-confirmed (not comment-only)

## Behavioral Quality

- [x] In-scope path topology isolated in `scope-rules.ts`
- [x] Out-of-scope paths excluded from scanning
- [x] Fail-closed behavior preserved when registry validation fails or violations exist
- [x] Structured artifact output emitted (`artifacts/ci-guard-report.json`)
- [x] quality gate: not reducing intelligence

## Latency Evidence

Baseline (Pre-change)
- pass1_ms: N/A (new CI guard lane)
- pass2_ms: N/A
- pass3_ms: N/A
- total_ms: N/A

Post-change Runs
- Run 1: `npm test -- tests/scripts/ci-guard` (4 suites, 8 tests, pass)
- Run 2: `npm run ci-guard -- --base HEAD --head HEAD --artifact artifacts/ci-guard-report.json` (pass)

Pass selection
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

Metrics
- pass1_ms: N/A
- total_ms: N/A

quality gate: not reducing intelligence

## Risks & Anomalies

- Branch protection required-check binding for `CI Guard` workflow is a manual repository configuration step post-merge.
- Registry currently scaffold-empty by design; guard behavior remains contract-valid with zero ontology entries.
- Fixtures remain synthetic and ontology-light (no canon disclosures).

## Refs

Refs #416, #417, #418, #419, #420, #421, #422
