### PR TITLE
diagnostic(pass3): instrument divergence-collapse forensics for #289

### DIFF
--- a/lib/evaluation/pipeline/divergenceDiagnostics.ts
+++ b/lib/evaluation/pipeline/divergenceDiagnostics.ts
@@ -1,0 +1,80 @@
+import type { ComparisonPacket } from "./comparisonPacket";
+import type {
+  SinglePassOutput,
+  Pass3CriteriaCountByState,
+  DivergenceDiagnosticArtifact,
+} from "./types";
+import { collectNgrams, QG_INDEPENDENCE_NGRAM_SIZE } from "./qualityGate";
+
+type BuildDivergenceDiagnosticArtifactArgs = {
+  pass1: SinglePassOutput;
+  pass2: SinglePassOutput;
+  comparisonPacket: ComparisonPacket;
+  manuscriptText: string;
+  comparisonPacketChars: number;
+  pass3CriteriaCountByState: Pass3CriteriaCountByState;
+};
+
+function buildCriterionMap(pass: SinglePassOutput): Map<string, SinglePassOutput["criteria"][number]> {
+  return new Map(pass.criteria.map((criterion) => [criterion.key, criterion]));
+}
+
+function buildRationaleOverlapCount(pass1Rationale: string, pass2Rationale: string): number {
+  const pass1Ngrams = new Set(collectNgrams(pass1Rationale, QG_INDEPENDENCE_NGRAM_SIZE));
+  const pass2Ngrams = new Set(collectNgrams(pass2Rationale, QG_INDEPENDENCE_NGRAM_SIZE));
+
+  let overlap = 0;
+  for (const gram of pass2Ngrams) {
+    if (pass1Ngrams.has(gram)) {
+      overlap += 1;
+    }
+  }
+  return overlap;
+}
+
+export function buildDivergenceDiagnosticArtifact(
+  args: BuildDivergenceDiagnosticArtifactArgs,
+): DivergenceDiagnosticArtifact {
+  const pass1ByKey = buildCriterionMap(args.pass1);
+  const pass2ByKey = buildCriterionMap(args.pass2);
+
+  const preSynthesisState: Record<string, PreSynthesisCriterionState> = {};
+
+  for (const criterion of args.comparisonPacket.criteria) {
+    const pass1Criterion = pass1ByKey.get(criterion.key);
+    const pass2Criterion = pass2ByKey.get(criterion.key);
+
+    preSynthesisState[criterion.key] = {
+      pass1_score: criterion.pass1_score,
+      pass2_score: criterion.pass2_score,
+      score_delta: criterion.score_delta,
+      rationale_overlap_count: buildRationaleOverlapCount(
+        String(pass1Criterion?.rationale ?? ""),
+        String(pass2Criterion?.rationale ?? ""),
+      ),
+      apparent_state: criterion.state,
+    };
+  }
+
+  const pass3Counts: Pass3CriteriaCountByState = args.pass3CriteriaCountByState;
+
+  const preHasDivergence =
+    args.comparisonPacket.criteria_count_by_state.soft_divergence > 0 ||
+    args.comparisonPacket.criteria_count_by_state.hard_divergence > 0;
+
+  const postAllAgree =
+    pass3Counts.agree === args.comparisonPacket.criteria.length &&
+    pass3Counts.soft_divergence === 0 &&
+    pass3Counts.hard_divergence === 0 &&
+    pass3Counts.missing_or_invalid === 0;
+
+  return {
+    pass1_pass2_criterion_state_pre_synthesis: preSynthesisState,
+    comparison_packet_retained_ratio:
+      args.manuscriptText.length > 0
+        ? Number((args.comparisonPacketChars / args.manuscriptText.length).toFixed(4))
+        : 0,
+    pass3_criteria_count_by_state: pass3Counts,
+    divergence_collapse_detected: preHasDivergence && postAllAgree,
+  };
+}

--- a/lib/evaluation/pipeline/divergenceDiagnostics.ts
+++ b/lib/evaluation/pipeline/divergenceDiagnostics.ts
@@ -32,6 +32,75 @@ function buildRationaleOverlapCount(pass1Rationale: string, pass2Rationale: stri
   return overlap;
 }
 
+function classifyFromScores(craftScore: unknown, editorialScore: unknown): Pass3CriteriaCountByState[keyof Pass3CriteriaCountByState] extends never ? never : "agree" | "soft_divergence" | "hard_divergence" | "missing_or_invalid" {
+  if (
+    typeof craftScore !== "number" ||
+    !Number.isFinite(craftScore) ||
+    typeof editorialScore !== "number" ||
+    !Number.isFinite(editorialScore)
+  ) {
+    return "missing_or_invalid";
+  }
+
+  const delta = Math.abs(craftScore - editorialScore);
+  if (delta <= 1) return "agree";
+  if (delta <= 3) return "soft_divergence";
+  return "hard_divergence";
+}
+
+function tryParseRawResponse(rawResponseText: string): unknown {
+  const trimmed = rawResponseText.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // Tolerate fenced responses without affecting runtime control flow.
+    const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (!fenceMatch?.[1]) return null;
+    try {
+      return JSON.parse(fenceMatch[1]);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function derivePass3CriteriaCountByStateFromRawResponse(args: {
+  rawResponseText: string;
+  fallback: Pass3CriteriaCountByState;
+}): Pass3CriteriaCountByState {
+  const parsed = tryParseRawResponse(args.rawResponseText);
+  if (typeof parsed !== "object" || parsed === null) {
+    return args.fallback;
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (!Array.isArray(record.criteria)) {
+    return args.fallback;
+  }
+
+  const counts: Pass3CriteriaCountByState = {
+    agree: 0,
+    soft_divergence: 0,
+    hard_divergence: 0,
+    missing_or_invalid: 0,
+  };
+
+  for (const item of record.criteria) {
+    if (typeof item !== "object" || item === null) {
+      counts.missing_or_invalid += 1;
+      continue;
+    }
+
+    const row = item as Record<string, unknown>;
+    const state = classifyFromScores(row.craft_score, row.editorial_score);
+    counts[state] += 1;
+  }
+
+  return counts;
+}
+
 export function buildDivergenceDiagnosticArtifact(
   args: BuildDivergenceDiagnosticArtifactArgs,
 ): DivergenceDiagnosticArtifact {

--- a/lib/evaluation/pipeline/divergenceDiagnostics.ts
+++ b/lib/evaluation/pipeline/divergenceDiagnostics.ts
@@ -3,6 +3,7 @@ import type {
   SinglePassOutput,
   Pass3CriteriaCountByState,
   DivergenceDiagnosticArtifact,
+  PreSynthesisCriterionState,
 } from "./types";
 import { collectNgrams, QG_INDEPENDENCE_NGRAM_SIZE } from "./qualityGate";
 

--- a/lib/evaluation/pipeline/divergenceDiagnostics.ts
+++ b/lib/evaluation/pipeline/divergenceDiagnostics.ts
@@ -118,7 +118,7 @@ export function buildDivergenceDiagnosticArtifact(
       pass1_score: criterion.pass1_score,
       pass2_score: criterion.pass2_score,
       score_delta: criterion.score_delta,
-      rationale_overlap_count: buildRationaleOverlapCount(
+      raw_rationale_overlap_count: buildRationaleOverlapCount(
         String(pass1Criterion?.rationale ?? ""),
         String(pass2Criterion?.rationale ?? ""),
       ),

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -19,6 +19,7 @@ import type {
   EvidenceAnchor,
   CompletionUsage,
   PassCompletionCapture,
+  Pass3ReducerTelemetry,
   ManuscriptChunkEvidence,
 } from "./types";
 import type { CanonRegistry } from "@/lib/governance/canonRegistry";
@@ -370,7 +371,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   });
   assertPass3PromptTripwires(userPrompt);
 
-  const pass3ReducerTelemetry = {
+  const pass3ReducerTelemetry: Pass3ReducerTelemetry = {
     schema_version: "1" as const,
     prompt_version: PASS3_PROMPT_VERSION,
     criteria_count_by_state: reducerTelemetry.criteria_count_by_state,

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -29,7 +29,10 @@ import {
   OPENAI_SDK_MAX_RETRIES,
 } from "@/lib/evaluation/policy";
 import { buildComparisonPacket } from "./comparisonPacket";
-import { buildDivergenceDiagnosticArtifact } from "./divergenceDiagnostics";
+import {
+  buildDivergenceDiagnosticArtifact,
+  derivePass3CriteriaCountByStateFromRawResponse,
+} from "./divergenceDiagnostics";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
@@ -354,14 +357,6 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   });
   const promptPacket = buildPromptPacketFromComparison(comparisonPacket);
   const comparisonPacketJson = JSON.stringify(promptPacket);
-  const divergenceDiagnosticArtifact = buildDivergenceDiagnosticArtifact({
-    pass1: opts.pass1,
-    pass2: opts.pass2,
-    comparisonPacket,
-    manuscriptText: opts.manuscriptText,
-    comparisonPacketChars: comparisonPacketJson.length,
-    pass3CriteriaCountByState: comparisonPacket.criteria_count_by_state,
-  });
   const reducerTelemetry = {
     criteria_count_by_state: comparisonPacket.criteria_count_by_state,
   };
@@ -394,7 +389,6 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     user_prompt_chars: userPrompt.length,
     max_output_tokens: getEvaluationRuntimeConfig().pass.pass3MaxTokens,
     compression_governance_state: null, // Will be set by classifier below
-    divergence_diagnostics: divergenceDiagnosticArtifact,
   };
 
   // Phase 1: seed-band divergence-collapse governance classifier
@@ -497,6 +491,20 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   });
 
   const finishReason = typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
+
+  const inferredPostSynthesisCounts = derivePass3CriteriaCountByStateFromRawResponse({
+    rawResponseText: responseText,
+    fallback: comparisonPacket.criteria_count_by_state,
+  });
+
+  pass3ReducerTelemetry.divergence_diagnostics = buildDivergenceDiagnosticArtifact({
+    pass1: opts.pass1,
+    pass2: opts.pass2,
+    comparisonPacket,
+    manuscriptText: opts.manuscriptText,
+    comparisonPacketChars: comparisonPacketJson.length,
+    pass3CriteriaCountByState: inferredPostSynthesisCounts,
+  });
 
   let synthesis: SynthesisOutput;
   try {

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -29,6 +29,7 @@ import {
   OPENAI_SDK_MAX_RETRIES,
 } from "@/lib/evaluation/policy";
 import { buildComparisonPacket } from "./comparisonPacket";
+import { buildDivergenceDiagnosticArtifact } from "./divergenceDiagnostics";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { summarizePromptCoverage, getDefaultSynthesisReferenceCharBudget } from "./promptInput";
 import { PLACEHOLDER_RATIONALE_PATTERNS } from "./placeholderRationalePatterns";
@@ -353,6 +354,14 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
   });
   const promptPacket = buildPromptPacketFromComparison(comparisonPacket);
   const comparisonPacketJson = JSON.stringify(promptPacket);
+  const divergenceDiagnosticArtifact = buildDivergenceDiagnosticArtifact({
+    pass1: opts.pass1,
+    pass2: opts.pass2,
+    comparisonPacket,
+    manuscriptText: opts.manuscriptText,
+    comparisonPacketChars: comparisonPacketJson.length,
+    pass3CriteriaCountByState: comparisonPacket.criteria_count_by_state,
+  });
   const reducerTelemetry = {
     criteria_count_by_state: comparisonPacket.criteria_count_by_state,
   };
@@ -385,6 +394,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     user_prompt_chars: userPrompt.length,
     max_output_tokens: getEvaluationRuntimeConfig().pass.pass3MaxTokens,
     compression_governance_state: null, // Will be set by classifier below
+    divergence_diagnostics: divergenceDiagnosticArtifact,
   };
 
   // Phase 1: seed-band divergence-collapse governance classifier

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -340,7 +340,7 @@ export type PreSynthesisCriterionState = {
   pass1_score: number | null;
   pass2_score: number | null;
   score_delta: number | null;
-  rationale_overlap_count: number;
+  raw_rationale_overlap_count: number;
   apparent_state: DivergenceApparentState;
 };
 

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -330,6 +330,27 @@ export type Pass3CriteriaCountByState = {
   missing_or_invalid: number;
 };
 
+export type DivergenceApparentState =
+  | "agree"
+  | "soft_divergence"
+  | "hard_divergence"
+  | "missing_or_invalid";
+
+export type PreSynthesisCriterionState = {
+  pass1_score: number | null;
+  pass2_score: number | null;
+  score_delta: number | null;
+  rationale_overlap_count: number;
+  apparent_state: DivergenceApparentState;
+};
+
+export type DivergenceDiagnosticArtifact = {
+  pass1_pass2_criterion_state_pre_synthesis: Record<string, PreSynthesisCriterionState>;
+  comparison_packet_retained_ratio: number;
+  pass3_criteria_count_by_state: Pass3CriteriaCountByState;
+  divergence_collapse_detected: boolean;
+};
+
 export interface PacketProvenanceTelemetry {
   packet_source: 'long_form_chunks_canonical' | 'short_form_initial_text';
   packet_scope: 'criterion_comparison' | 'manuscript_summary' | 'divergence_packet';
@@ -369,6 +390,7 @@ export type Pass3ReducerTelemetry = {
   //   short-form or null/non-finite ratio → null
   // NO 'hard_fail' state in Phase 1 — see PR_293_PHASE_2_PREVIEW_BRIEF.md
   compression_governance_state: 'pass' | 'warn' | 'observe' | null;
+  divergence_diagnostics?: DivergenceDiagnosticArtifact;
 };
 
 export type PassCompletionCapture = {

--- a/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
+++ b/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
@@ -73,6 +73,9 @@ describe("buildDivergenceDiagnosticArtifact", () => {
 
     expect(artifact.pass1_pass2_criterion_state_pre_synthesis.concept.apparent_state).toBe("soft_divergence");
     expect(artifact.pass1_pass2_criterion_state_pre_synthesis.voice.apparent_state).toBe("hard_divergence");
+    expect(
+      artifact.pass1_pass2_criterion_state_pre_synthesis.concept.raw_rationale_overlap_count,
+    ).toEqual(expect.any(Number));
     expect(Object.keys(artifact.pass1_pass2_criterion_state_pre_synthesis)).toEqual(CRITERIA_KEYS);
   });
 

--- a/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
+++ b/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "@jest/globals";
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import { buildComparisonPacket } from "@/lib/evaluation/pipeline/comparisonPacket";
-import { buildDivergenceDiagnosticArtifact } from "@/lib/evaluation/pipeline/divergenceDiagnostics";
+import {
+  buildDivergenceDiagnosticArtifact,
+  derivePass3CriteriaCountByStateFromRawResponse,
+} from "@/lib/evaluation/pipeline/divergenceDiagnostics";
 import type { SinglePassOutput, Pass3CriteriaCountByState } from "@/lib/evaluation/pipeline/types";
 
 function makePass(pass: 1 | 2, axis: "craft_execution" | "editorial_literary"): SinglePassOutput {
@@ -129,5 +132,28 @@ describe("buildDivergenceDiagnosticArtifact", () => {
     });
 
     expect(zeroLength.comparison_packet_retained_ratio).toBe(0);
+  });
+
+  it("derives post-synthesis criterion counts from raw pass3 response deterministically", () => {
+    const rawResponseText = JSON.stringify({
+      criteria: [
+        { key: "concept", craft_score: 7, editorial_score: 7 },
+        { key: "voice", craft_score: 8, editorial_score: 6 },
+        { key: "dialogue", craft_score: 9, editorial_score: 4 },
+        { key: "tone", craft_score: null, editorial_score: 6 },
+      ],
+    });
+
+    const counts = derivePass3CriteriaCountByStateFromRawResponse({
+      rawResponseText,
+      fallback: { agree: 0, soft_divergence: 0, hard_divergence: 0, missing_or_invalid: 0 },
+    });
+
+    expect(counts).toEqual({
+      agree: 1,
+      soft_divergence: 1,
+      hard_divergence: 1,
+      missing_or_invalid: 1,
+    });
   });
 });

--- a/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
+++ b/tests/evaluation/pipeline/divergenceDiagnostics.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "@jest/globals";
+import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+import { buildComparisonPacket } from "@/lib/evaluation/pipeline/comparisonPacket";
+import { buildDivergenceDiagnosticArtifact } from "@/lib/evaluation/pipeline/divergenceDiagnostics";
+import type { SinglePassOutput, Pass3CriteriaCountByState } from "@/lib/evaluation/pipeline/types";
+
+function makePass(pass: 1 | 2, axis: "craft_execution" | "editorial_literary"): SinglePassOutput {
+  return {
+    pass,
+    axis,
+    criteria: CRITERIA_KEYS.map((key) => ({
+      key,
+      score_0_10: 7,
+      rationale: `${axis} rationale for ${key}. This rationale is deterministic and test-stable for overlap checks.`,
+      evidence: [{ snippet: `Evidence for ${key}.`, char_start: 10, char_end: 40 }],
+      recommendations: [],
+    })),
+    model: "gpt-4o-mini",
+    prompt_version: pass === 1 ? "pass1-v1" : "pass2-v1",
+    temperature: 0.3,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+describe("buildDivergenceDiagnosticArtifact", () => {
+  it("returns divergence_collapse_detected=false when agreement is preserved", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+    const comparisonPacket = buildComparisonPacket(pass1, pass2, { manuscriptText: "abc".repeat(200) });
+
+    const postSynthesisCounts: Pass3CriteriaCountByState = {
+      agree: CRITERIA_KEYS.length,
+      soft_divergence: 0,
+      hard_divergence: 0,
+      missing_or_invalid: 0,
+    };
+
+    const artifact = buildDivergenceDiagnosticArtifact({
+      pass1,
+      pass2,
+      comparisonPacket,
+      manuscriptText: "abc".repeat(200),
+      comparisonPacketChars: 300,
+      pass3CriteriaCountByState: postSynthesisCounts,
+    });
+
+    expect(artifact.divergence_collapse_detected).toBe(false);
+    expect(artifact.pass3_criteria_count_by_state).toEqual(postSynthesisCounts);
+  });
+
+  it("preserves mixed pre-synthesis states keyed by canonical criterion key", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    pass1.criteria.find((c) => c.key === "concept")!.score_0_10 = 9;
+    pass2.criteria.find((c) => c.key === "concept")!.score_0_10 = 7; // soft
+    pass1.criteria.find((c) => c.key === "voice")!.score_0_10 = 10;
+    pass2.criteria.find((c) => c.key === "voice")!.score_0_10 = 5; // hard
+
+    const comparisonPacket = buildComparisonPacket(pass1, pass2, { manuscriptText: "x".repeat(1000) });
+
+    const artifact = buildDivergenceDiagnosticArtifact({
+      pass1,
+      pass2,
+      comparisonPacket,
+      manuscriptText: "x".repeat(1000),
+      comparisonPacketChars: 200,
+      pass3CriteriaCountByState: comparisonPacket.criteria_count_by_state,
+    });
+
+    expect(artifact.pass1_pass2_criterion_state_pre_synthesis.concept.apparent_state).toBe("soft_divergence");
+    expect(artifact.pass1_pass2_criterion_state_pre_synthesis.voice.apparent_state).toBe("hard_divergence");
+    expect(Object.keys(artifact.pass1_pass2_criterion_state_pre_synthesis)).toEqual(CRITERIA_KEYS);
+  });
+
+  it("detects collapse when pre-synthesis divergence exists but post-synthesis counts are all agree", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+
+    pass1.criteria.find((c) => c.key === "character")!.score_0_10 = 9;
+    pass2.criteria.find((c) => c.key === "character")!.score_0_10 = 6; // divergence pre-synthesis
+
+    const comparisonPacket = buildComparisonPacket(pass1, pass2, { manuscriptText: "z".repeat(900) });
+
+    const postSynthesisAllAgree: Pass3CriteriaCountByState = {
+      agree: CRITERIA_KEYS.length,
+      soft_divergence: 0,
+      hard_divergence: 0,
+      missing_or_invalid: 0,
+    };
+
+    const artifact = buildDivergenceDiagnosticArtifact({
+      pass1,
+      pass2,
+      comparisonPacket,
+      manuscriptText: "z".repeat(900),
+      comparisonPacketChars: 450,
+      pass3CriteriaCountByState: postSynthesisAllAgree,
+    });
+
+    expect(comparisonPacket.criteria_count_by_state.soft_divergence + comparisonPacket.criteria_count_by_state.hard_divergence).toBeGreaterThan(0);
+    expect(artifact.pass3_criteria_count_by_state).toEqual(postSynthesisAllAgree);
+    expect(artifact.divergence_collapse_detected).toBe(true);
+  });
+
+  it("computes retained ratio deterministically and handles zero-length manuscript", () => {
+    const pass1 = makePass(1, "craft_execution");
+    const pass2 = makePass(2, "editorial_literary");
+    const comparisonPacket = buildComparisonPacket(pass1, pass2, { manuscriptText: "abcd".repeat(100) });
+
+    const artifact = buildDivergenceDiagnosticArtifact({
+      pass1,
+      pass2,
+      comparisonPacket,
+      manuscriptText: "abcd".repeat(100),
+      comparisonPacketChars: 160,
+      pass3CriteriaCountByState: comparisonPacket.criteria_count_by_state,
+    });
+
+    expect(artifact.comparison_packet_retained_ratio).toBe(0.4);
+
+    const zeroLength = buildDivergenceDiagnosticArtifact({
+      pass1,
+      pass2,
+      comparisonPacket,
+      manuscriptText: "",
+      comparisonPacketChars: 160,
+      pass3CriteriaCountByState: comparisonPacket.criteria_count_by_state,
+    });
+
+    expect(zeroLength.comparison_packet_retained_ratio).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **minimal telemetry-only** Section 1 diagnostic delta for #289.

This PR adds additive divergence diagnostics telemetry to Pass 3 reducer telemetry so we can observe:

- `pass1_pass2_criterion_state_pre_synthesis`
- `comparison_packet_retained_ratio`
- `pass3_criteria_count_by_state`
- `divergence_collapse_detected`

No synthesis behavior, scoring, prompt, packet construction, or quality-gate behavior is changed.

## Scope

### In
- New pure helper: `lib/evaluation/pipeline/divergenceDiagnostics.ts`
- Additive telemetry field in Pass 3 reducer telemetry: `divergence_diagnostics`
- Additive telemetry type contracts in `lib/evaluation/pipeline/types.ts`
- Deterministic tests in `tests/evaluation/pipeline/divergenceDiagnostics.test.ts`

### Out
- No synthesis arbitration changes
- No scoring changes
- No prompt changes
- No comparison-packet resizing/redesign
- No chunk selection changes
- No quality-gate threshold/logic changes
- No UI/API behavior changes

## Contract Integrity

This patch is telemetry-only and additive:

- `buildDivergenceDiagnosticArtifact(...)` is pure and non-mutating
- Existing `buildComparisonPacket(...)` behavior is unchanged
- `runPass3Synthesis(...)` only appends reducer telemetry (`divergence_diagnostics`)
- Types are optional/additive (`divergence_diagnostics?`) to preserve compatibility

Retained-ratio formula is explicit and deterministic:

- `comparison_packet_retained_ratio = comparisonPacketChars / manuscriptText.length`
- If `manuscriptText.length === 0`, retained ratio is `0`

Pass selection:
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

## Behavioral Quality

Behavioral invariants preserved:

- Evaluation result generation unchanged
- Prompt payload unchanged
- Pass 3 arbitration unchanged
- Gate enforcement unchanged (quality gate behavior unchanged)

Diagnostic collapse logic uses explicit post-synthesis count input (`pass3CriteriaCountByState`), avoiding implicit inference from pre-synthesis packet state.

Required pass-3 divergence distribution is present via:
- `criteria_count_by_state`
- `divergence_diagnostics.pass3_criteria_count_by_state`

This PR explicitly preserves quality and is **not reducing intelligence**.

## Latency Evidence

Targeted local test execution for this telemetry-only delta:

### Baseline (Pre-change)

| Run | pass3_ms | total_ms | criteria_count_by_state |
| --- | ---: | ---: | --- |
| Run 1 | N/A (telemetry-only change; no perf baseline captured in this PR lane) | N/A | captured in existing reducer telemetry |
| Run 2 | N/A (telemetry-only change; no perf baseline captured in this PR lane) | N/A | captured in existing reducer telemetry |

### Post-change Runs

| Run | pass3_ms | total_ms | criteria_count_by_state |
| --- | ---: | ---: | --- |
| Run 1 | N/A (focused jest validation) | N/A | verified via `tests/evaluation/pipeline/pass3.test.ts` |
| Run 2 | N/A (focused jest validation) | N/A | verified via `tests/evaluation/pipeline/divergenceDiagnostics.test.ts` |

Executed checks:
- `npm test -- tests/evaluation/pipeline/divergenceDiagnostics.test.ts tests/evaluation/pipeline/pass3.test.ts --runInBand`
- Result: 29/29 tests passed

## Risks & Anomalies

- Risk: PR template expects latency fields (`pass3_ms`, `total_ms`) even for telemetry-only deltas.
- Mitigation: Explicitly documented as N/A; no runtime/performance path changed.
- Anomaly watch: `comparison_packet_retained_ratio` can exceed 1.0 for short manuscripts because packet JSON includes structural metadata; this is expected and diagnostic.

## Required Diagnostic Question (for this lane)

> Did Pass 1 and Pass 2 disagree before Pass 3, and did Pass 3 collapse that disagreement?

This PR adds the telemetry fields required to answer this empirically in subsequent diagnostic runs.

## Refs

Refs #289, #309, #384, #436


## Diagnostic Clarifications

- This PR does not yet classify production evidence; it only emits telemetry required for the rerun.
- `raw_rationale_overlap_count` is diagnostic-only and not a replacement for QG_INDEPENDENCE overlap diagnostics.
