### PR TITLE
fix(evaluation): bound chunk-native pass execution to avoid timeout

### DIFF
--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -328,6 +328,8 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     }
 
     const chunkEvalTotalMs = nowMs() - chunkEvalStartMs;
+    const chunkCoveragePct =
+      chunksTotal > 0 ? Number(((chunkResults.length / chunksTotal) * 100).toFixed(2)) : 0;
     emitLatencyTrace({
       job_id: opts.jobId ?? "unknown",
       stage: "pass1",
@@ -337,6 +339,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
         chunks_attempted: selectedChunks.length,
         chunks_succeeded: chunkResults.length,
         chunks_failed: failures.length,
+        chunk_coverage_pct: chunkCoveragePct,
         chunk_concurrency: chunkConcurrency,
         chunk_eval_total_ms: chunkEvalTotalMs,
         chunk_cap_applied: chunkCap ? true : false,

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -31,6 +31,7 @@ const PASS1_LIMITS = {
   maxEvidencePerCriterion: 1,
   maxEvidenceSnippetChars: 180,
 } as const;
+const DEFAULT_CHUNK_PASS_CONCURRENCY = 10;
 
 /**
  * RCA-PASS1-TOKEN-001: Pass1 model is strictly authoritative.
@@ -126,6 +127,52 @@ function buildEmptyResponseDiagnostic(params: {
     `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
     `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""})`
   );
+}
+
+function getChunkPassConcurrency(): number {
+  const raw = process.env.EVAL_CHUNK_PASS_CONCURRENCY;
+  if (!raw) return DEFAULT_CHUNK_PASS_CONCURRENCY;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CHUNK_PASS_CONCURRENCY;
+  return Math.min(24, Math.max(1, parsed));
+}
+
+function getChunkPassMaxPerPass(): number | null {
+  const raw = process.env.EVAL_CHUNK_MAX_PER_PASS;
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+async function runChunksWithConcurrency<T>(
+  chunks: ManuscriptChunkEvidence[],
+  concurrency: number,
+  worker: (chunk: ManuscriptChunkEvidence) => Promise<T>,
+): Promise<Array<PromiseSettledResult<T>>> {
+  const settled: Array<PromiseSettledResult<T>> = new Array(chunks.length);
+  let cursor = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= chunks.length) {
+        return;
+      }
+
+      try {
+        const value = await worker(chunks[index]);
+        settled[index] = { status: "fulfilled", value };
+      } catch (reason) {
+        settled[index] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, chunks.length) }, () => runWorker());
+  await Promise.all(workers);
+  return settled;
 }
 
 /** Function signature for creating a chat completion (enables DI for testing). */
@@ -244,23 +291,69 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
   // and aggregate results. Otherwise, fall through to single-pass window path.
   const hasChunks = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 1;
   if (hasChunks) {
-    console.log(`[Pass1] Chunk-native path: evaluating ${opts.manuscriptChunks!.length} chunks`);
-    
+    const chunksTotal = opts.manuscriptChunks!.length;
+    const chunkConcurrency = getChunkPassConcurrency();
+    const chunkCap = getChunkPassMaxPerPass();
+    const selectedChunks = chunkCap ? opts.manuscriptChunks!.slice(0, chunkCap) : opts.manuscriptChunks!;
+    const chunkEvalStartMs = nowMs();
+
+    console.log(
+      `[Pass1] Chunk-native path: total=${chunksTotal} attempted=${selectedChunks.length} concurrency=${chunkConcurrency}`,
+    );
+
+    const settled = await runChunksWithConcurrency(
+      selectedChunks,
+      chunkConcurrency,
+      async (chunk) =>
+        runPass1({
+          ...opts,
+          manuscriptText: chunk.content,
+          manuscriptChunks: undefined, // Prevent recursive chunking
+        }),
+    );
+
     const chunkResults: SinglePassOutput[] = [];
-    for (const chunk of opts.manuscriptChunks!) {
-      try {
-        const chunkResult = await runPass1(
-          {
-            ...opts,
-            manuscriptText: chunk.content,
-            manuscriptChunks: undefined, // Prevent recursive chunking
-          },
-        );
-        chunkResults.push(chunkResult);
-      } catch (error) {
-        console.error(`[Pass1] Chunk ${chunk.chunk_index} evaluation failed:`, error);
-        throw error;
+    const failures: Array<{ chunkIndex: number; reason: string }> = [];
+    for (let i = 0; i < settled.length; i += 1) {
+      const result = settled[i];
+      if (!result) continue;
+      if (result.status === "fulfilled") {
+        chunkResults.push(result.value);
+      } else {
+        failures.push({
+          chunkIndex: selectedChunks[i].chunk_index,
+          reason: String(result.reason instanceof Error ? result.reason.message : result.reason),
+        });
       }
+    }
+
+    const chunkEvalTotalMs = nowMs() - chunkEvalStartMs;
+    emitLatencyTrace({
+      job_id: opts.jobId ?? "unknown",
+      stage: "pass1",
+      state: "pass1_chunk_eval",
+      metadata: {
+        chunks_total: chunksTotal,
+        chunks_attempted: selectedChunks.length,
+        chunks_succeeded: chunkResults.length,
+        chunks_failed: failures.length,
+        chunk_concurrency: chunkConcurrency,
+        chunk_eval_total_ms: chunkEvalTotalMs,
+        chunk_cap_applied: chunkCap ? true : false,
+      },
+    });
+
+    if (chunkCap && selectedChunks.length < chunksTotal) {
+      console.warn(
+        `[Pass1] Partial chunk coverage due to EVAL_CHUNK_MAX_PER_PASS=${chunkCap} (attempted ${selectedChunks.length}/${chunksTotal})`,
+      );
+    }
+
+    if (failures.length > 0) {
+      const firstFailure = failures[0];
+      throw new Error(
+        `[Pass1] Chunk evaluation failures: failed=${failures.length}/${selectedChunks.length}; first_chunk=${firstFailure.chunkIndex}; first_error=${firstFailure.reason}`,
+      );
     }
 
     const aggregated = aggregateChunkResults(chunkResults);

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -318,6 +318,8 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     }
 
     const chunkEvalTotalMs = nowMs() - chunkEvalStartMs;
+    const chunkCoveragePct =
+      chunksTotal > 0 ? Number(((chunkResults.length / chunksTotal) * 100).toFixed(2)) : 0;
     emitLatencyTrace({
       job_id: opts.jobId ?? "unknown",
       stage: "pass2",
@@ -327,6 +329,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
         chunks_attempted: selectedChunks.length,
         chunks_succeeded: chunkResults.length,
         chunks_failed: failures.length,
+        chunk_coverage_pct: chunkCoveragePct,
         chunk_concurrency: chunkConcurrency,
         chunk_eval_total_ms: chunkEvalTotalMs,
         chunk_cap_applied: chunkCap ? true : false,

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -22,10 +22,12 @@ import {
   OPENAI_SDK_MAX_RETRIES,
 } from "@/lib/evaluation/policy";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
+import { emitLatencyTrace } from "@/lib/observability/latencyTrace";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
 
 const PASS2_TEMPERATURE = 0.3;
+const DEFAULT_CHUNK_PASS_CONCURRENCY = 10;
 // Pass 2 model is resolved exclusively via getCanonicalPipelineModel(opts.model). The central resolver in policy.ts enforces the production reasoning-model invariant (forbids o-series unless EVAL_ALLOW_REASONING_MODELS=true).
 
 function getRetryPass2MaxTokens(currentMaxTokens: number): number {
@@ -101,6 +103,52 @@ function buildEmptyResponseDiagnostic(params: {
     `${typeof usage?.total_tokens === "number" ? ` total_tokens=${usage.total_tokens}` : ""}` +
     `${refusal ? ` refusal=${JSON.stringify(refusal).slice(0, 120)}` : ""})`
   );
+}
+
+function getChunkPassConcurrency(): number {
+  const raw = process.env.EVAL_CHUNK_PASS_CONCURRENCY;
+  if (!raw) return DEFAULT_CHUNK_PASS_CONCURRENCY;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CHUNK_PASS_CONCURRENCY;
+  return Math.min(24, Math.max(1, parsed));
+}
+
+function getChunkPassMaxPerPass(): number | null {
+  const raw = process.env.EVAL_CHUNK_MAX_PER_PASS;
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+async function runChunksWithConcurrency<T>(
+  chunks: ManuscriptChunkEvidence[],
+  concurrency: number,
+  worker: (chunk: ManuscriptChunkEvidence) => Promise<T>,
+): Promise<Array<PromiseSettledResult<T>>> {
+  const settled: Array<PromiseSettledResult<T>> = new Array(chunks.length);
+  let cursor = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= chunks.length) {
+        return;
+      }
+
+      try {
+        const value = await worker(chunks[index]);
+        settled[index] = { status: "fulfilled", value };
+      } catch (reason) {
+        settled[index] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, chunks.length) }, () => runWorker());
+  await Promise.all(workers);
+  return settled;
 }
 
 /** Function signature for creating a chat completion (enables DI for testing). */
@@ -233,23 +281,69 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
   // and aggregate results. Otherwise, fall through to single-pass window path.
   const hasChunks = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 1;
   if (hasChunks) {
-    console.log(`[Pass2] Chunk-native path: evaluating ${opts.manuscriptChunks!.length} chunks`);
-    
+    const chunksTotal = opts.manuscriptChunks!.length;
+    const chunkConcurrency = getChunkPassConcurrency();
+    const chunkCap = getChunkPassMaxPerPass();
+    const selectedChunks = chunkCap ? opts.manuscriptChunks!.slice(0, chunkCap) : opts.manuscriptChunks!;
+    const chunkEvalStartMs = nowMs();
+
+    console.log(
+      `[Pass2] Chunk-native path: total=${chunksTotal} attempted=${selectedChunks.length} concurrency=${chunkConcurrency}`,
+    );
+
+    const settled = await runChunksWithConcurrency(
+      selectedChunks,
+      chunkConcurrency,
+      async (chunk) =>
+        runPass2({
+          ...opts,
+          manuscriptText: chunk.content,
+          manuscriptChunks: undefined, // Prevent recursive chunking
+        }),
+    );
+
     const chunkResults: SinglePassOutput[] = [];
-    for (const chunk of opts.manuscriptChunks!) {
-      try {
-        const chunkResult = await runPass2(
-          {
-            ...opts,
-            manuscriptText: chunk.content,
-            manuscriptChunks: undefined, // Prevent recursive chunking
-          },
-        );
-        chunkResults.push(chunkResult);
-      } catch (error) {
-        console.error(`[Pass2] Chunk ${chunk.chunk_index} evaluation failed:`, error);
-        throw error;
+    const failures: Array<{ chunkIndex: number; reason: string }> = [];
+    for (let i = 0; i < settled.length; i += 1) {
+      const result = settled[i];
+      if (!result) continue;
+      if (result.status === "fulfilled") {
+        chunkResults.push(result.value);
+      } else {
+        failures.push({
+          chunkIndex: selectedChunks[i].chunk_index,
+          reason: String(result.reason instanceof Error ? result.reason.message : result.reason),
+        });
       }
+    }
+
+    const chunkEvalTotalMs = nowMs() - chunkEvalStartMs;
+    emitLatencyTrace({
+      job_id: opts.jobId ?? "unknown",
+      stage: "pass2",
+      state: "pass2_chunk_eval",
+      metadata: {
+        chunks_total: chunksTotal,
+        chunks_attempted: selectedChunks.length,
+        chunks_succeeded: chunkResults.length,
+        chunks_failed: failures.length,
+        chunk_concurrency: chunkConcurrency,
+        chunk_eval_total_ms: chunkEvalTotalMs,
+        chunk_cap_applied: chunkCap ? true : false,
+      },
+    });
+
+    if (chunkCap && selectedChunks.length < chunksTotal) {
+      console.warn(
+        `[Pass2] Partial chunk coverage due to EVAL_CHUNK_MAX_PER_PASS=${chunkCap} (attempted ${selectedChunks.length}/${chunksTotal})`,
+      );
+    }
+
+    if (failures.length > 0) {
+      const firstFailure = failures[0];
+      throw new Error(
+        `[Pass2] Chunk evaluation failures: failed=${failures.length}/${selectedChunks.length}; first_chunk=${firstFailure.chunkIndex}; first_error=${firstFailure.reason}`,
+      );
     }
 
     const aggregated = aggregateChunkResults(chunkResults);


### PR DESCRIPTION
## Summary

Urgent hotfix for post-#439 timeout failures on long-form manuscripts (`PASS1_TIMEOUT` / `PASS2_TIMEOUT`).

Chunk-native routing is correct, but prior implementation executed chunk calls sequentially. This PR adds bounded parallel execution and explicit chunk coverage telemetry for Pass 1 and Pass 2.

## Scope

Included files:
- `lib/evaluation/pipeline/runPass1.ts`
- `lib/evaluation/pipeline/runPass2.ts`

No changes to:
- prompts
- scoring weights
- quality gate semantics
- short-form fallback behavior

Pass selection:
- [x] Pass 1
- [x] Pass 2
- [ ] Pass 3

## Contract Integrity

- Pass 2 independence remains intact (no Pass 1 data input added).
- Short-form path remains unchanged when chunks are absent.
- Chunk-native path now executes with bounded concurrency; recursive chunk calls still disable nested chunking (`manuscriptChunks: undefined`).
- Fail-closed behavior preserved: chunk failures still fail pass execution.

## Behavioral Quality

- Added bounded parallel chunk execution (default concurrency = 10; configurable via `EVAL_CHUNK_PASS_CONCURRENCY`).
- Full chunk coverage by default (no cap unless explicitly set via `EVAL_CHUNK_MAX_PER_PASS`).
- Added telemetry for honest coverage reporting:
  - `chunks_total`
  - `chunks_attempted`
  - `chunks_succeeded`
  - `chunks_failed`
  - `chunk_coverage_pct` (`succeeded / total * 100`)
  - `chunk_concurrency`
  - `chunk_eval_total_ms`

This preserves evaluation intelligence (not reducing intelligence) while making chunk-native execution operationally viable.

## Latency Evidence

Baseline (Pre-change)

| Metric | Value |
|---|---|
| pass1_ms | timed out on long-form chunk path in production run |
| pass2_ms | timed out on long-form chunk path in production run |
| total_ms | failed before completion |

Post-change Runs

| Run | pass1_ms | pass2_ms | total_ms | Notes |
|---|---:|---:|---:|---|
| Run 1 | pending CI/runtime evidence | pending CI/runtime evidence | pending CI/runtime evidence | bounded concurrency active |
| Run 2 | pending production re-run | pending production re-run | pending production re-run | coverage telemetry emitted |

## Risks & Anomalies

- Risk: higher concurrent call volume (5–10) increases provider burst load.
- Mitigation: bounded concurrency and fail-closed semantics retained.
- Risk: optional cap env var can produce partial coverage if enabled.
- Mitigation: telemetry now reports coverage honestly (`chunk_coverage_pct`).
- Quality gate behavior remains unchanged.

## Corrected Directive Applied

- Production path targets full chunk coverage (no artificial 24-chunk production cap).
- 24-chunk cap is smoke-test only if explicitly configured.
- Parallel batches + proper timeout sizing are required for long-form workloads.

## Timeout sizing required in deployment (Vercel)

Set in **Production + Preview** and redeploy:
- `EVAL_PASS_TIMEOUT_MS=600000`
- `EVAL_WORKER_MAX_EXECUTION_MS=900000`

These values align timeout policy to chunk-native workload size.

## Validation Checklist

- [x] Chunk-native routing remains enabled
- [x] Pass 1/2 chunk execution now bounded-parallel
- [x] Full chunk coverage default retained
- [x] Chunk coverage telemetry emitted
- [x] Short-form path unchanged
- [x] Targeted tests pass (`chunk-native-routing`)
- [ ] CI fully green
- [ ] Production 133k re-run completed and compared vs `fd1fd073`

## References

Refs #289, #384, #438, #439
