### PR TITLE
fix(timeout): enforce 600s floor for multi_chapter/full_manuscript

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -314,6 +314,8 @@ describe("processEvaluationJob long-form chunk routing", () => {
     ].join("\n");
     expect(runPipelineArgs).toEqual(
       expect.objectContaining({
+        _passTimeoutMs: 600000,
+        _openAiTimeoutMs: 600000,
         manuscriptChunks: [
           { chunk_index: 0, content: "Chunk 0 text" },
           { chunk_index: 1, content: "Chunk 1 text" },
@@ -398,6 +400,9 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(ensureChunksFromTextMock).not.toHaveBeenCalled();
     expect(ensureChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
+    const runPipelineArgs = runPipelineMock.mock.calls[0]?.[0];
+    expect(runPipelineArgs?._passTimeoutMs).toBe(runPipelineArgs?._openAiTimeoutMs);
+    expect(runPipelineArgs?._passTimeoutMs).toBeLessThanOrEqual(600000);
 
     const persistCall = supabaseStub.rpcCalls.find(
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",

--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -314,8 +314,6 @@ describe("processEvaluationJob long-form chunk routing", () => {
     ].join("\n");
     expect(runPipelineArgs).toEqual(
       expect.objectContaining({
-        _passTimeoutMs: 600000,
-        _openAiTimeoutMs: 600000,
         manuscriptChunks: [
           { chunk_index: 0, content: "Chunk 0 text" },
           { chunk_index: 1, content: "Chunk 1 text" },
@@ -336,6 +334,13 @@ describe("processEvaluationJob long-form chunk routing", () => {
         final_text_source: "long_form_post_chunk_canonical",
         post_chunk_reresolved: true,
         canonical_path_used: "resolveManuscriptText.post_chunk_reconstruct",
+        timeout_resolution: expect.objectContaining({
+          input_scale: "full_manuscript",
+          floor_applied: true,
+          floor_ms: 600000,
+          resolved_pass_timeout_ms: 600000,
+          resolved_openai_timeout_ms: 600000,
+        }),
         chunk_routing: expect.objectContaining({
           enabled: true,
           route: "long_form",
@@ -400,9 +405,6 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(ensureChunksFromTextMock).not.toHaveBeenCalled();
     expect(ensureChunksMock).not.toHaveBeenCalled();
     expect(runPipelineMock).toHaveBeenCalledTimes(1);
-    const runPipelineArgs = runPipelineMock.mock.calls[0]?.[0];
-    expect(runPipelineArgs?._passTimeoutMs).toBe(runPipelineArgs?._openAiTimeoutMs);
-    expect(runPipelineArgs?._passTimeoutMs).toBeLessThanOrEqual(600000);
 
     const persistCall = supabaseStub.rpcCalls.find(
       (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
@@ -412,6 +414,10 @@ describe("processEvaluationJob long-form chunk routing", () => {
       final_text_source: "short_form_initial_text",
       post_chunk_reresolved: false,
       canonical_path_used: "resolveManuscriptText.initial",
+      timeout_resolution: {
+        input_scale: "standard_chapter",
+        floor_applied: false,
+      },
       chunk_routing: {
         enabled: true,
         route: "short_form",
@@ -428,6 +434,18 @@ describe("processEvaluationJob long-form chunk routing", () => {
     );
     expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty("chunk_source");
     expect(persistCall?.args?.p_progress?.chunk_routing).not.toHaveProperty("verified_at");
+
+    const timeoutResolution = persistCall?.args?.p_progress?.timeout_resolution as
+      | {
+          base_pass_timeout_ms?: number;
+          resolved_pass_timeout_ms?: number;
+          base_openai_timeout_ms?: number;
+          resolved_openai_timeout_ms?: number;
+        }
+      | undefined;
+
+    expect(timeoutResolution?.resolved_pass_timeout_ms).toBe(timeoutResolution?.base_pass_timeout_ms);
+    expect(timeoutResolution?.resolved_openai_timeout_ms).toBe(timeoutResolution?.base_openai_timeout_ms);
   });
 
   test("long_form + persisted_chunk_count = 0 fails with LONG_FORM_CHUNK_MATERIALIZATION_FAILED and does not run pipeline", async () => {

--- a/lib/config/__tests__/evaluationRuntimeConfig.test.ts
+++ b/lib/config/__tests__/evaluationRuntimeConfig.test.ts
@@ -192,6 +192,30 @@ describe("resolveScopedEvaluationTimeouts", () => {
     expect(resolved.openAiTimeoutMs).toBe(600000);
   });
 
+  it("preserves configured values above the floor for full_manuscript", () => {
+    const resolved = resolveScopedEvaluationTimeouts({
+      inputScale: "full_manuscript",
+      passTimeoutMs: 900000,
+      openAiTimeoutMs: 900000,
+    });
+
+    expect(resolved.floorApplied).toBe(false);
+    expect(resolved.passTimeoutMs).toBe(900000);
+    expect(resolved.openAiTimeoutMs).toBe(900000);
+  });
+
+  it("raises long-form provider timeout to match long-form pass timeout when needed", () => {
+    const resolved = resolveScopedEvaluationTimeouts({
+      inputScale: "multi_chapter",
+      passTimeoutMs: 720000,
+      openAiTimeoutMs: 180000,
+    });
+
+    expect(resolved.floorApplied).toBe(true);
+    expect(resolved.passTimeoutMs).toBe(720000);
+    expect(resolved.openAiTimeoutMs).toBe(720000);
+  });
+
   it("does not apply floor for standard_chapter inputs", () => {
     const resolved = resolveScopedEvaluationTimeouts({
       inputScale: "standard_chapter",

--- a/lib/config/__tests__/evaluationRuntimeConfig.test.ts
+++ b/lib/config/__tests__/evaluationRuntimeConfig.test.ts
@@ -1,5 +1,7 @@
 import {
   EvaluationRuntimeConfigError,
+  LONG_FORM_TIMEOUT_FLOOR_MS,
+  resolveScopedEvaluationTimeouts,
   resolveEvaluationRuntimeConfig,
 } from "@/lib/config/evaluationRuntimeConfig";
 
@@ -162,5 +164,43 @@ describe("resolveEvaluationRuntimeConfig", () => {
         USE_REAL_LLM: "true",
       }, {}),
     ).toThrow(EvaluationRuntimeConfigError);
+  });
+});
+
+describe("resolveScopedEvaluationTimeouts", () => {
+  it("applies 600000ms floor for multi_chapter inputs", () => {
+    const resolved = resolveScopedEvaluationTimeouts({
+      inputScale: "multi_chapter",
+      passTimeoutMs: 180000,
+      openAiTimeoutMs: 180000,
+    });
+
+    expect(resolved.floorApplied).toBe(true);
+    expect(resolved.passTimeoutMs).toBe(LONG_FORM_TIMEOUT_FLOOR_MS);
+    expect(resolved.openAiTimeoutMs).toBe(LONG_FORM_TIMEOUT_FLOOR_MS);
+  });
+
+  it("keeps existing larger values for full_manuscript inputs", () => {
+    const resolved = resolveScopedEvaluationTimeouts({
+      inputScale: "full_manuscript",
+      passTimeoutMs: 600000,
+      openAiTimeoutMs: 600000,
+    });
+
+    expect(resolved.floorApplied).toBe(false);
+    expect(resolved.passTimeoutMs).toBe(600000);
+    expect(resolved.openAiTimeoutMs).toBe(600000);
+  });
+
+  it("does not apply floor for standard_chapter inputs", () => {
+    const resolved = resolveScopedEvaluationTimeouts({
+      inputScale: "standard_chapter",
+      passTimeoutMs: 180000,
+      openAiTimeoutMs: 180000,
+    });
+
+    expect(resolved.floorApplied).toBe(false);
+    expect(resolved.passTimeoutMs).toBe(180000);
+    expect(resolved.openAiTimeoutMs).toBe(180000);
   });
 });

--- a/lib/config/evaluationRuntimeConfig.ts
+++ b/lib/config/evaluationRuntimeConfig.ts
@@ -72,6 +72,58 @@ export interface EvaluationRuntimeConfig {
   routing: EvaluationPassRouting;
 }
 
+export type TimeoutScopeInputScale =
+  | "micro_excerpt"
+  | "light_chapter"
+  | "standard_chapter"
+  | "multi_chapter"
+  | "full_manuscript";
+
+export const LONG_FORM_TIMEOUT_FLOOR_MS = 600_000;
+
+export interface ScopedTimeoutResolution {
+  inputScale: TimeoutScopeInputScale;
+  floorMs: number;
+  floorApplied: boolean;
+  basePassTimeoutMs: number;
+  baseOpenAiTimeoutMs: number;
+  passTimeoutMs: number;
+  openAiTimeoutMs: number;
+}
+
+function isLongFormTimeoutScale(inputScale: TimeoutScopeInputScale): boolean {
+  return inputScale === "multi_chapter" || inputScale === "full_manuscript";
+}
+
+export function resolveScopedEvaluationTimeouts(args: {
+  inputScale: TimeoutScopeInputScale;
+  passTimeoutMs: number;
+  openAiTimeoutMs: number;
+  floorMs?: number;
+}): ScopedTimeoutResolution {
+  const floorMs = args.floorMs ?? LONG_FORM_TIMEOUT_FLOOR_MS;
+  const longFormScale = isLongFormTimeoutScale(args.inputScale);
+
+  const passTimeoutMs = longFormScale
+    ? Math.max(args.passTimeoutMs, floorMs)
+    : args.passTimeoutMs;
+
+  // Keep provider timeout >= pass timeout after scoped floor application.
+  const openAiTimeoutMs = longFormScale
+    ? Math.max(args.openAiTimeoutMs, passTimeoutMs, floorMs)
+    : args.openAiTimeoutMs;
+
+  return {
+    inputScale: args.inputScale,
+    floorMs,
+    floorApplied: passTimeoutMs !== args.passTimeoutMs || openAiTimeoutMs !== args.openAiTimeoutMs,
+    basePassTimeoutMs: args.passTimeoutMs,
+    baseOpenAiTimeoutMs: args.openAiTimeoutMs,
+    passTimeoutMs,
+    openAiTimeoutMs,
+  };
+}
+
 function parseStrictInteger(raw: string, name: string): number {
   const trimmed = raw.trim();
   if (!/^-?\d+$/u.test(trimmed)) {

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -343,6 +343,8 @@ export interface RunPass1Options {
    * Omit (undefined) to fall back to getEvaluationRuntimeConfig().openaiApiKey.
    */
   openaiApiKey?: string | null;
+  /** Optional provider timeout override from pipeline-level scoped resolution. */
+  openAiTimeoutMs?: number;
   /** Job ID forwarded from the processor for latency trace correlation. */
   jobId?: string;
   /** Override the completion function (for testing). Production callers omit this. */
@@ -497,7 +499,8 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
   // Falls back to building a sampled window when chunks are not available
   // or when manuscript is small enough to fit in single evaluation.
 
-  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
+  const effectiveOpenAiTimeoutMs = opts.openAiTimeoutMs ?? getEvalOpenAiTimeoutMs();
+  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey, effectiveOpenAiTimeoutMs);
 
   const promptAssemblyStartMs = nowMs();
 
@@ -632,7 +635,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
         model_call_ms: modelCallMs,
         parse_validation_ms: parseValidationMs,
         total_ms: totalMs,
-        configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+        configured_timeout_ms: effectiveOpenAiTimeoutMs,
         configured_max_tokens: configuredMaxTokens,
         active_max_tokens: activeMaxTokens,
         retried_for_length: retriedForLength,
@@ -712,7 +715,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
       model_call_ms: modelCallMs,
       parse_validation_ms: parseValidationMs,
       total_ms: totalMs,
-      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+      configured_timeout_ms: effectiveOpenAiTimeoutMs,
       configured_max_tokens: configuredMaxTokens,
       active_max_tokens: activeMaxTokens,
       retried_for_length: retriedForLength,
@@ -729,14 +732,14 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
  * Build the default OpenAI completion function.
  * Separated so the constructor is only called when no DI override is provided.
  */
-function defaultCreateCompletion(openaiApiKey?: string | null): CreateCompletionFn {
+function defaultCreateCompletion(openaiApiKey?: string | null, openAiTimeoutMs?: number): CreateCompletionFn {
   // null = explicit "no key" (test sentinel). undefined = fall back to runtime config.
   const apiKey =
     openaiApiKey === null ? undefined : (openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey);
   if (!apiKey) {
     throw new Error("[Pass1] OPENAI_API_KEY is not configured");
   }
-  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const timeoutMs = openAiTimeoutMs ?? getEvalOpenAiTimeoutMs();
   const openai = new OpenAI({ apiKey, maxRetries: OPENAI_SDK_MAX_RETRIES, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -308,6 +308,8 @@ export interface RunPass2Options {
   registry: CanonRegistry;
   model?: string;
   openaiApiKey?: string;
+  /** Optional provider timeout override from pipeline-level scoped resolution. */
+  openAiTimeoutMs?: number;
   manuscriptId?: string;
   jobId?: string;
   /** Override the completion function (for testing). Production callers omit this. */
@@ -475,7 +477,8 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
   // Falls back to building a sampled window when chunks are not available
   // or when manuscript is small enough to fit in single evaluation.
 
-  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
+  const effectiveOpenAiTimeoutMs = opts.openAiTimeoutMs ?? getEvalOpenAiTimeoutMs();
+  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey, effectiveOpenAiTimeoutMs);
 
   const promptAssemblyStartMs = nowMs();
 
@@ -585,7 +588,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
       model_call_ms: modelCallMs,
       parse_validation_ms: parseValidationMs,
       total_ms: totalMs,
-      configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+      configured_timeout_ms: effectiveOpenAiTimeoutMs,
       configured_max_tokens: configuredMaxTokens,
       usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
       usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -659,7 +662,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     model_call_ms: modelCallMs,
     parse_validation_ms: parseValidationMs,
     total_ms: totalMs,
-    configured_timeout_ms: getEvalOpenAiTimeoutMs(),
+    configured_timeout_ms: effectiveOpenAiTimeoutMs,
     configured_max_tokens: configuredMaxTokens,
     usage_prompt_tokens: completion.usage?.prompt_tokens ?? null,
     usage_completion_tokens: completion.usage?.completion_tokens ?? null,
@@ -673,12 +676,12 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
  * Build the default OpenAI completion function.
  * Separated so the constructor is only called when no DI override is provided.
  */
-function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
+function defaultCreateCompletion(openaiApiKey?: string, openAiTimeoutMs?: number): CreateCompletionFn {
   const apiKey = openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey;
   if (!apiKey) {
     throw new Error("[Pass2] OPENAI_API_KEY is not configured");
   }
-  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const timeoutMs = openAiTimeoutMs ?? getEvalOpenAiTimeoutMs();
   const openai = new OpenAI({ apiKey, maxRetries: OPENAI_SDK_MAX_RETRIES, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -333,6 +333,8 @@ export interface RunPass3Options {
   registry: CanonRegistry;
   model?: string;
   openaiApiKey?: string;
+  /** Optional provider timeout override from pipeline-level scoped resolution. */
+  openAiTimeoutMs?: number;
   /** Override the completion function (for testing). Production callers omit this. */
   _createCompletion?: CreateCompletionFn;
   _onCompletion?: (capture: PassCompletionCapture) => void;
@@ -348,7 +350,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     throw new Error("[Pass3] Canonical registry binding missing");
   }
 
-  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey);
+  const createCompletion = opts._createCompletion ?? defaultCreateCompletion(opts.openaiApiKey, opts.openAiTimeoutMs);
   const selectedModel = getCanonicalPass3Model(opts.model);
 
   const comparisonPacket = buildComparisonPacket(opts.pass1, opts.pass2, {
@@ -552,12 +554,12 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
  * Build the default OpenAI completion function.
  * Separated so the constructor is only called when no DI override is provided.
  */
-function defaultCreateCompletion(openaiApiKey?: string): CreateCompletionFn {
+function defaultCreateCompletion(openaiApiKey?: string, openAiTimeoutMs?: number): CreateCompletionFn {
   const apiKey = openaiApiKey ?? getEvaluationRuntimeConfig().openaiApiKey;
   if (!apiKey) {
     throw new Error("[Pass3] OPENAI_API_KEY is not configured");
   }
-  const timeoutMs = getEvalOpenAiTimeoutMs();
+  const timeoutMs = openAiTimeoutMs ?? getEvalOpenAiTimeoutMs();
   const openai = new OpenAI({ apiKey, maxRetries: OPENAI_SDK_MAX_RETRIES, timeout: timeoutMs });
   return (params) =>
     openai.chat.completions.create(

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -111,6 +111,8 @@ export interface RunPipelineOptions {
   perplexityApiKey?: string;
   /** Per-pass timeout. Defaults to 60s. */
   _passTimeoutMs?: number;
+  /** Per-pass provider timeout override forwarded to pass runners. */
+  _openAiTimeoutMs?: number;
   /** Maximum accepted manuscript size. Defaults to 1,000,000 chars. */
   _maxManuscriptChars?: number;
   /**
@@ -319,6 +321,10 @@ function validatePipelineInput(opts: RunPipelineOptions): string | null {
 
   if (opts._passTimeoutMs !== undefined && (!Number.isInteger(opts._passTimeoutMs) || opts._passTimeoutMs <= 0)) {
     return "_passTimeoutMs must be a positive integer";
+  }
+
+  if (opts._openAiTimeoutMs !== undefined && (!Number.isInteger(opts._openAiTimeoutMs) || opts._openAiTimeoutMs <= 0)) {
+    return "_openAiTimeoutMs must be a positive integer";
   }
 
   return null;
@@ -592,6 +598,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       executionMode: opts.executionMode,
       openaiApiKey: opts.openaiApiKey,
       jobId: opts.jobId,
+      openAiTimeoutMs: opts._openAiTimeoutMs,
       registry,
             scopeProfile: scopeProfile ?? undefined,
     }),
@@ -633,6 +640,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       openaiApiKey: opts.openaiApiKey,
       manuscriptId: opts.manuscriptId,
       jobId: opts.jobId,
+      openAiTimeoutMs: opts._openAiTimeoutMs,
       registry,
             scopeProfile: scopeProfile ?? undefined,
     }),
@@ -870,6 +878,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
         executionMode: opts.executionMode,
         model: opts.model,
         openaiApiKey: opts.openaiApiKey,
+        openAiTimeoutMs: opts._openAiTimeoutMs,
         registry,
               scopeProfile: scopeProfile ?? undefined,
       }),

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -88,6 +88,11 @@ import {
 } from '@/lib/evaluation/config';
 import { getEvaluationRuntimeConfig } from '@/lib/config/evaluationRuntimeConfig';
 import {
+  LONG_FORM_TIMEOUT_FLOOR_MS,
+  resolveScopedEvaluationTimeouts,
+  type TimeoutScopeInputScale,
+} from '@/lib/config/evaluationRuntimeConfig';
+import {
   emitLatencyTrace,
   finishLatencyStage,
   startLatencyStage,
@@ -1822,6 +1827,41 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       ...chunkRouting,
     });
 
+    const timeoutScopeProfile = classifySubmissionScope(
+      resolvedManuscriptText,
+      chunkRouting.chunk_count,
+    );
+
+    const timeoutResolution = resolveScopedEvaluationTimeouts({
+      inputScale: timeoutScopeProfile.inputScale as TimeoutScopeInputScale,
+      passTimeoutMs: evalPassTimeoutMs,
+      openAiTimeoutMs: evalOpenAiTimeoutMs,
+      floorMs: LONG_FORM_TIMEOUT_FLOOR_MS,
+    });
+
+    progressState.timeout_resolution = {
+      input_scale: timeoutResolution.inputScale,
+      floor_applied: timeoutResolution.floorApplied,
+      floor_ms: timeoutResolution.floorMs,
+      base_pass_timeout_ms: timeoutResolution.basePassTimeoutMs,
+      base_openai_timeout_ms: timeoutResolution.baseOpenAiTimeoutMs,
+      resolved_pass_timeout_ms: timeoutResolution.passTimeoutMs,
+      resolved_openai_timeout_ms: timeoutResolution.openAiTimeoutMs,
+    };
+
+    console.log('[Processor][TimeoutResolution]', {
+      job_id: jobId,
+      manuscript_id: manuscriptWithContent.id,
+      input_scale: timeoutResolution.inputScale,
+      manuscript_words: timeoutScopeProfile.wordCount,
+      floor_applied: timeoutResolution.floorApplied,
+      floor_ms: timeoutResolution.floorMs,
+      base_pass_timeout_ms: timeoutResolution.basePassTimeoutMs,
+      base_openai_timeout_ms: timeoutResolution.baseOpenAiTimeoutMs,
+      resolved_pass_timeout_ms: timeoutResolution.passTimeoutMs,
+      resolved_openai_timeout_ms: timeoutResolution.openAiTimeoutMs,
+    });
+
     // 4. Canonical evaluation via governed multi-pass pipeline (fail-closed)
     await markRunning('Running canonical evaluation pipeline', 1, executionPhase);
 
@@ -1846,7 +1886,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       return { success: false, error: missingCrossCheckConfigError };
     }
 
-    console.log(`[Processor] ${jobId}: ENTER runPipeline model=${getCanonicalPipelineModel(openAiModel)} passTimeoutMs=${evalPassTimeoutMs}`);
+    console.log(`[Processor] ${jobId}: ENTER runPipeline model=${getCanonicalPipelineModel(openAiModel)} passTimeoutMs=${timeoutResolution.passTimeoutMs}`);
     const runPipelineStartedAt = startLatencyStage({
       jobId,
       stage: 'pipeline_run',
@@ -1892,7 +1932,8 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         perplexityApiKey: perplexityApiKey || undefined,
         manuscriptId: String(manuscriptWithContent.id),
         executionMode: 'TRUSTED_PATH',
-        _passTimeoutMs: evalPassTimeoutMs,
+        _passTimeoutMs: timeoutResolution.passTimeoutMs,
+        _openAiTimeoutMs: timeoutResolution.openAiTimeoutMs,
         onHeartbeat: async (stage) => {
           await assertJobWithinSla({
             supabase,


### PR DESCRIPTION
## Summary
Enforces a scope-aware long-form timeout floor so `multi_chapter` and `full_manuscript` evaluations resolve to a minimum of `600000ms` for both pass timeout and provider timeout, with explicit timeout-resolution telemetry persisted into processor progress.

## Scope
- Added scoped timeout resolver in `lib/config/evaluationRuntimeConfig.ts` (`resolveScopedEvaluationTimeouts`, `LONG_FORM_TIMEOUT_FLOOR_MS`).
- Applied scoped timeout resolution in `lib/evaluation/processor.ts` on the runtime path used before `runPipeline` execution.
- Threaded provider timeout override through `runPipeline` into `runPass1` / `runPass2` / `runPass3Synthesis`.
- Hardened tests in:
  - `lib/config/__tests__/evaluationRuntimeConfig.test.ts`
  - `__tests__/lib/evaluation/processor.chunk-routing.test.ts`

## Contract Integrity
- Long-form contract:
  - `multi_chapter` / `full_manuscript` => floor to `600000ms` when configured values are lower.
  - If long-form pass timeout is higher than floor, preserve the higher value.
  - Long-form provider timeout is uplifted to at least resolved pass timeout.
- Short-form contract:
  - No floor coercion; resolved values remain equal to base values.
- Timeout resolution is now observable via persisted `progress.timeout_resolution`.

## Behavioral Quality
- Prevents regression where long-form jobs resolve to sub-floor pass/provider timeouts.
- Avoids brittle test coupling by asserting persisted timeout-resolution telemetry contract rather than underscore-prefixed internal transport fields.
- Quality Gate relevance: this PR does **not** alter QG scoring or editorial criteria logic, but preserves end-to-end evaluation reliability required for downstream QG execution.

## Latency Evidence

### Baseline (Pre-change)
| Run | Context | pass1_ms | pass2_ms | pass3_ms | total_ms | Note |
|---|---|---:|---:|---:|---:|---|
| Run 1 | Long-form timeout resolution path | N/A (unit test path) | N/A | N/A | N/A | Pre-change could resolve below intended long-form floor |
| Run 2 | Short-form timeout resolution path | N/A (unit test path) | N/A | N/A | N/A | Expected to remain unchanged |

### Post-change Runs
| Run | Command | pass1_ms | pass2_ms | pass3_ms | total_ms | Outcome |
|---|---|---:|---:|---:|---:|---|
| Run 1 | `npx jest lib/config/__tests__/evaluationRuntimeConfig.test.ts __tests__/lib/evaluation/processor.chunk-routing.test.ts --runInBand --ci --forceExit` | N/A (unit test path) | N/A | N/A | N/A | Pass |
| Run 2 | Same command after test-hardening refactor commit | N/A (unit test path) | N/A | N/A | N/A | Pass |

Pass selection:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Risks & Anomalies
- CI policy gate currently enforces strict PR-body template; this body update addresses that blocker.
- No evidence of functional regressions in targeted suites.
- Remaining risk is broader CI surface outside targeted tests (tracked by required status checks).

Final principle: this change improves runtime reliability while **not reducing intelligence** or weakening governance semantics.

