### PR TITLE
feat(evaluation): make Pass 2a coverage authoritative

### DIFF
--- a/__tests__/lib/evaluation/pipeline/long-form-certification-hardening.test.ts
+++ b/__tests__/lib/evaluation/pipeline/long-form-certification-hardening.test.ts
@@ -113,4 +113,52 @@ describe("synthesisToEvaluationResultV2 long-form certification hardening", () =
       }),
     );
   });
+
+  test("certifies manuscript-wide scoring when pass2a reports full chunk map/reduce coverage", () => {
+    const synthesis = makeSampledLongFormSynthesis();
+    synthesis.partial_evaluation = false;
+    synthesis.coverage_scope = {
+      sourceChars: 160_000,
+      sourceWords: 29_519,
+      analyzedChars: 160_000,
+      analyzedWords: 29_519,
+      strategy: "full_chunk_map_reduce",
+    };
+    synthesis.criteria = synthesis.criteria.map((criterion) => ({
+      ...criterion,
+      final_rationale: `Criterion ${criterion.key} is supported by full chunk-map coverage.`,
+    }));
+
+    const result = synthesisToEvaluationResultV2({
+      synthesis,
+      ids: {
+        evaluation_run_id: "run-long-form-full-coverage",
+        job_id: "job-long-form-full-coverage",
+        manuscript_id: 5252,
+        user_id: "00000000-0000-0000-0000-000000005252",
+      },
+      scopeProfile: makeFullManuscriptScopeProfile(),
+      manuscriptText: "word ".repeat(29_519),
+      sourceText: "word ".repeat(29_519),
+      title: "Dominatus full coverage fixture",
+    });
+
+    expect(result.overview.overall_score_0_100).not.toBeNull();
+    expect(result.overview.scored_criteria_count).toBeGreaterThan(0);
+    expect(result.governance.warnings).not.toContain("LONG_FORM_CERTIFICATION_WITHHELD");
+    expect(result.governance.transparency?.evaluation_scope).toEqual(
+      expect.objectContaining({
+        route: "LONG_FORM",
+        manuscript_wide_certifiable: true,
+      }),
+    );
+    expect(result.governance.transparency?.coverage_summary).toEqual(
+      expect.objectContaining({
+        partial_evaluation: false,
+        sampling_strategy: "full_chunk_map_reduce",
+        source_word_count: 29_519,
+        analyzed_word_count: 29_519,
+      }),
+    );
+  });
 });

--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -448,6 +448,83 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(timeoutResolution?.resolved_openai_timeout_ms).toBe(timeoutResolution?.base_openai_timeout_ms);
   });
 
+  test("mid-length manuscript exceeding prompt budget routes to long_form chunking", async () => {
+    const manuscriptContent = "alpha beta gamma delta epsilon ".repeat(3200); // ~16k words
+    const supabaseStub = makeSupabaseStub(manuscriptContent, {
+      manuscriptChunks: [
+        { chunk_index: 0, content: "Chunk A text" },
+        { chunk_index: 1, content: "Chunk B text" },
+        { chunk_index: 2, content: "Chunk C text" },
+      ],
+    });
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksFromTextMock.mockResolvedValueOnce({
+      ensured_count: 3,
+      persisted_count: 3,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+    });
+
+    runPipelineMock.mockResolvedValue({
+      ok: true,
+      synthesis: {
+        criteria: [],
+        overall: {
+          overall_score_0_100: 82,
+          verdict: "pass",
+          one_paragraph_summary: "Summary",
+          top_3_strengths: [],
+          top_3_risks: [],
+        },
+        metadata: {
+          pass1_model: "gpt-4o",
+          pass2_model: "o3",
+          pass3_model: "o3",
+          generated_at: new Date().toISOString(),
+        },
+      },
+      quality_gate: {
+        pass: true,
+        checks: [],
+        warnings: [],
+      },
+      pass4_governance: { ok: true },
+    });
+
+    synthesisToEvaluationResultV2Mock.mockReturnValue(buildEvaluationResult());
+    runQualityGateV2Mock.mockReturnValue({
+      pass: true,
+      checks: [],
+      warnings: [],
+    });
+    mapEvaluationResultV2ToGovernanceEnvelopeMock.mockReturnValue({
+      evaluation_run_id: "run-long-form-1",
+      criteria: [],
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(true);
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+
+    const persistCall = supabaseStub.rpcCalls.find(
+      (call: { fn: string }) => call.fn === "persist_evaluation_v2_atomic",
+    );
+    expect(persistCall).toBeDefined();
+    expect(persistCall?.args?.p_progress?.chunk_routing).toEqual(
+      expect.objectContaining({
+        route: "long_form",
+        trigger_reason: "prompt_budget_exceeded",
+        threshold_words: 25000,
+        chunk_count: 3,
+        ensure_chunks_returned_count: 3,
+        persisted_chunk_count: 3,
+      }),
+    );
+  });
+
   test("long_form + persisted_chunk_count = 0 fails with LONG_FORM_CHUNK_MATERIALIZATION_FAILED and does not run pipeline", async () => {
     const manuscriptContent = "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
     const supabaseStub = makeSupabaseStub(manuscriptContent);

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -23,6 +23,7 @@ import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { emitLatencyTrace } from "@/lib/observability/latencyTrace";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
+import { summarizePromptCoverage } from "./promptInput";
 const PASS1_TEMPERATURE = 0.3;
 
 const PASS1_LENGTH_RETRY_MAX_OUTPUT_TOKENS = 16000;
@@ -492,7 +493,23 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
 
     const aggregated = aggregateChunkResults(chunkResults);
     console.log(`[Pass1] Chunk aggregation complete: ${aggregated.criteria.length} criteria`);
-    return aggregated;
+    return {
+      ...aggregated,
+      coverage_summary: {
+        route: "chunk_map_reduce",
+        fully_evaluated:
+          failures.length === 0 &&
+          selectedChunks.length === chunksTotal &&
+          chunkResults.length === chunksTotal,
+        chunk_ledger: {
+          expected_chunks: chunksTotal,
+          attempted_chunks: selectedChunks.length,
+          evaluated_chunks: chunkResults.length,
+          failed_chunks: failures.length,
+          cap_applied: Boolean(chunkCap && selectedChunks.length < chunksTotal),
+        },
+      },
+    };
   }
 
   // ─── SINGLE-PASS SAMPLED-WINDOW PATH (Fallback / Short-Form) ──────────────
@@ -725,7 +742,15 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     },
   });
 
-  return parsedOutput;
+  const promptCoverage = summarizePromptCoverage(opts.manuscriptText);
+
+  return {
+    ...parsedOutput,
+    coverage_summary: {
+      route: "direct_window",
+      fully_evaluated: !promptCoverage.truncated,
+    },
+  };
 }
 
 /**

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -25,6 +25,7 @@ import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { emitLatencyTrace } from "@/lib/observability/latencyTrace";
 import { JsonBoundaryError, parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
 import { getEvaluationRuntimeConfig } from "@/lib/config/evaluationRuntimeConfig";
+import { summarizePromptCoverage } from "./promptInput";
 
 const PASS2_TEMPERATURE = 0.3;
 const DEFAULT_CHUNK_PASS_CONCURRENCY = 5;
@@ -470,7 +471,23 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
 
     const aggregated = aggregateChunkResults(chunkResults);
     console.log(`[Pass2] Chunk aggregation complete: ${aggregated.criteria.length} criteria`);
-    return aggregated;
+    return {
+      ...aggregated,
+      coverage_summary: {
+        route: "chunk_map_reduce",
+        fully_evaluated:
+          failures.length === 0 &&
+          selectedChunks.length === chunksTotal &&
+          chunkResults.length === chunksTotal,
+        chunk_ledger: {
+          expected_chunks: chunksTotal,
+          attempted_chunks: selectedChunks.length,
+          evaluated_chunks: chunkResults.length,
+          failed_chunks: failures.length,
+          cap_applied: Boolean(chunkCap && selectedChunks.length < chunksTotal),
+        },
+      },
+    };
   }
 
   // ─── SINGLE-PASS SAMPLED-WINDOW PATH (Fallback / Short-Form) ──────────────
@@ -669,7 +686,15 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     usage_total_tokens: completion.usage?.total_tokens ?? null,
   });
 
-  return parsedOutput;
+  const promptCoverage = summarizePromptCoverage(opts.manuscriptText);
+
+  return {
+    ...parsedOutput,
+    coverage_summary: {
+      route: "direct_window",
+      fully_evaluated: !promptCoverage.truncated,
+    },
+  };
 }
 
 /**

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -35,6 +35,7 @@ import type {
   ManuscriptChunkEvidence,
   QualityGateCriterionDiagnostic,
   GateDiagnostics,
+  CoverageStrategy,
 } from "./types";
 import type { EvaluationResultV1 } from "@/schemas/evaluation-result-v1";
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
@@ -52,6 +53,7 @@ import {
   countWords,
   type SubmissionScopeProfile,
 } from "./submissionScope";
+import { summarizePromptCoverage } from "./promptInput";
 import {
   buildCriteriaPlanForScale,
   scopePolicy,
@@ -214,6 +216,148 @@ type GovernanceConfidenceDerivation = {
   confidenceLabel: "high" | "medium" | "low" | "withheld";
   confidenceReasons: string[];
 };
+
+type Pass2aCoverageAuthority = {
+  authority: "pass2a";
+  chunkRouted: boolean;
+  fullCoverage: boolean;
+  partialCoverage: boolean;
+  technicalDefect: boolean;
+  reasonCodes: string[];
+  sourceChars: number;
+  sourceWords: number;
+  analyzedChars: number;
+  analyzedWords: number;
+  strategy: CoverageStrategy;
+  expectedChunks: number | null;
+  materializedChunks: number | null;
+  pass1EvaluatedChunks: number | null;
+  pass2EvaluatedChunks: number | null;
+  collationSucceeded: boolean;
+};
+
+function getConfiguredChunkCap(): number | null {
+  const raw = process.env.EVAL_CHUNK_MAX_PER_PASS;
+  if (!raw) return null;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function derivePass2aCoverageAuthority(args: {
+  manuscriptText: string;
+  manuscriptChunks?: ManuscriptChunkEvidence[];
+  pass1: SinglePassOutput;
+  pass2: SinglePassOutput;
+}): Pass2aCoverageAuthority {
+  const sourceChars = args.manuscriptText.length;
+  const sourceWords = countWords(args.manuscriptText);
+  const chunkCount = Array.isArray(args.manuscriptChunks) ? args.manuscriptChunks.length : 0;
+  const chunkRouted = chunkCount > 1;
+
+  const collationSucceeded =
+    args.pass1.criteria.length === CRITERIA_KEYS.length &&
+    args.pass2.criteria.length === CRITERIA_KEYS.length;
+
+  if (!chunkRouted) {
+    const promptCoverage = summarizePromptCoverage(args.manuscriptText);
+    const pass1WindowFull = args.pass1.coverage_summary?.fully_evaluated ?? !promptCoverage.truncated;
+    const pass2WindowFull = args.pass2.coverage_summary?.fully_evaluated ?? !promptCoverage.truncated;
+    const fullCoverage = !promptCoverage.truncated && pass1WindowFull && pass2WindowFull && collationSucceeded;
+    const reasonCodes: string[] = [];
+
+    if (promptCoverage.truncated) {
+      reasonCodes.push("PROMPT_WINDOW_TRUNCATED");
+    }
+    if (!pass1WindowFull) {
+      reasonCodes.push("PASS1_DIRECT_WINDOW_INCOMPLETE");
+    }
+    if (!pass2WindowFull) {
+      reasonCodes.push("PASS2_DIRECT_WINDOW_INCOMPLETE");
+    }
+    if (!collationSucceeded) {
+      reasonCodes.push("PASS2A_COLLATION_FAILED");
+    }
+
+    return {
+      authority: "pass2a",
+      chunkRouted,
+      fullCoverage,
+      partialCoverage: !fullCoverage,
+      technicalDefect: false,
+      reasonCodes,
+      sourceChars,
+      sourceWords,
+      analyzedChars: fullCoverage ? sourceChars : promptCoverage.analyzedChars,
+      analyzedWords: fullCoverage ? sourceWords : promptCoverage.analyzedWords,
+      strategy: fullCoverage ? "full_text" : "sampled_beginning_middle_end",
+      expectedChunks: null,
+      materializedChunks: null,
+      pass1EvaluatedChunks: null,
+      pass2EvaluatedChunks: null,
+      collationSucceeded,
+    };
+  }
+
+  const expectedChunks = chunkCount;
+  const materializedChunks = chunkCount;
+
+  const pass1Ledger = args.pass1.coverage_summary?.chunk_ledger;
+  const pass2Ledger = args.pass2.coverage_summary?.chunk_ledger;
+
+  const pass1EvaluatedChunks = pass1Ledger?.evaluated_chunks ?? null;
+  const pass2EvaluatedChunks = pass2Ledger?.evaluated_chunks ?? null;
+
+  const pass1ChunkMode = args.pass1.coverage_summary?.route === "chunk_map_reduce";
+  const pass2ChunkMode = args.pass2.coverage_summary?.route === "chunk_map_reduce";
+
+  const chunkCap = getConfiguredChunkCap();
+  const capApplied =
+    Boolean(pass1Ledger?.cap_applied) ||
+    Boolean(pass2Ledger?.cap_applied) ||
+    (chunkCap !== null && expectedChunks > chunkCap);
+
+  const pass1AllChunks = pass1ChunkMode && pass1EvaluatedChunks === expectedChunks;
+  const pass2AllChunks = pass2ChunkMode && pass2EvaluatedChunks === expectedChunks;
+  const fullCoverage = pass1AllChunks && pass2AllChunks && !capApplied && collationSucceeded;
+
+  const reasonCodes: string[] = [];
+  if (!pass1ChunkMode) reasonCodes.push("PASS1_NOT_CHUNK_ROUTED");
+  if (!pass2ChunkMode) reasonCodes.push("PASS2_NOT_CHUNK_ROUTED");
+  if (capApplied) reasonCodes.push("CHUNK_CAP_APPLIED");
+  if (!pass1AllChunks) reasonCodes.push("PASS1_CHUNK_EVALUATION_INCOMPLETE");
+  if (!pass2AllChunks) reasonCodes.push("PASS2_CHUNK_EVALUATION_INCOMPLETE");
+  if (!collationSucceeded) reasonCodes.push("PASS2A_COLLATION_FAILED");
+
+  const evaluatedFloor = Math.max(
+    0,
+    Math.min(
+      expectedChunks,
+      pass1EvaluatedChunks ?? expectedChunks,
+      pass2EvaluatedChunks ?? expectedChunks,
+    ),
+  );
+  const evaluatedRatio = expectedChunks > 0 ? evaluatedFloor / expectedChunks : 0;
+
+  return {
+    authority: "pass2a",
+    chunkRouted,
+    fullCoverage,
+    partialCoverage: !fullCoverage,
+    technicalDefect: !fullCoverage && reasonCodes.some((code) => code.includes("COLLATION") || code.includes("NOT_CHUNK")),
+    reasonCodes,
+    sourceChars,
+    sourceWords,
+    analyzedChars: fullCoverage ? sourceChars : Math.floor(sourceChars * evaluatedRatio),
+    analyzedWords: fullCoverage ? sourceWords : Math.floor(sourceWords * evaluatedRatio),
+    strategy: fullCoverage ? "full_chunk_map_reduce" : "partial_chunk_map_reduce",
+    expectedChunks,
+    materializedChunks,
+    pass1EvaluatedChunks,
+    pass2EvaluatedChunks,
+    collationSucceeded,
+  };
+}
 
 function logPipelineTimings(
   stage: "success" | "failure",
@@ -427,7 +571,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     try {
       scopeProfile = opts._scopeProfile ?? classifySubmissionScope(
         opts.manuscriptText,
-        1, // chunkCount = 1 for now; can be refined later
+        opts.manuscriptChunks?.length ?? 1,
       );
 
       if (!scopeProfile) {
@@ -867,6 +1011,19 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     if (llrResult) return llrResult;
   }
 
+  const pass2aCoverage = derivePass2aCoverageAuthority({
+    manuscriptText: opts.manuscriptText,
+    manuscriptChunks: opts.manuscriptChunks,
+    pass1: pass1Output,
+    pass2: pass2Output,
+  });
+
+  console.log("[Pipeline][Pass2aCoverageAuthority]", {
+    manuscript_id: opts.manuscriptId ?? null,
+    title: opts.title,
+    ...pass2aCoverage,
+  });
+
   // ── Pass 3: Synthesis & Reconciliation ─────────────────────────────────
   const pass3StartMs = nowMs();
   const pass3StartedAt = startLatencyStage({
@@ -934,6 +1091,18 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
   }
 
   {
+    pass3Output = {
+      ...pass3Output,
+      partial_evaluation: pass2aCoverage.partialCoverage,
+      coverage_scope: {
+        sourceChars: pass2aCoverage.sourceChars,
+        sourceWords: pass2aCoverage.sourceWords,
+        analyzedChars: pass2aCoverage.analyzedChars,
+        analyzedWords: pass2aCoverage.analyzedWords,
+        strategy: pass2aCoverage.strategy,
+      },
+    };
+
     const criteriaForDerivedPlans = pass3Output.criteria.map((criterion) => ({
       key: criterion.key,
       final_score_0_10: criterion.final_score_0_10,

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -66,6 +66,24 @@ export type EvidenceAnchor = {
   segment_id?: string;
 };
 
+export type CoverageStrategy =
+  | "full_text"
+  | "sampled_beginning_middle_end"
+  | "full_chunk_map_reduce"
+  | "partial_chunk_map_reduce";
+
+export type PassCoverageSummary = {
+  route: "direct_window" | "chunk_map_reduce";
+  fully_evaluated: boolean;
+  chunk_ledger?: {
+    expected_chunks: number;
+    attempted_chunks: number;
+    evaluated_chunks: number;
+    failed_chunks: number;
+    cap_applied: boolean;
+  };
+};
+
 // ── Dialogue Attribution Diagnostics (FR-1: Canonical shared type) ───────────
 
 /**
@@ -150,6 +168,7 @@ export type SinglePassOutput = {
   prompt_version: string;
   temperature: number;
   generated_at: string; // ISO 8601
+  coverage_summary?: PassCoverageSummary;
 };
 
 // ── Pass 3: Synthesized criterion ────────────────────────────────────────────
@@ -263,7 +282,7 @@ export type SynthesisOutput = {
     sourceWords: number;
     analyzedChars: number;
     analyzedWords: number;
-    strategy: "full_text" | "sampled_beginning_middle_end";
+    strategy: CoverageStrategy;
   };
 };
 

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -137,8 +137,11 @@ const LONG_FORM_CHUNKING_THRESHOLD_WORDS = 25_000;
 type ChunkRoutingTelemetry = {
   enabled: boolean;
   route: 'long_form' | 'short_form';
+  trigger_reason?: 'word_threshold' | 'prompt_budget_exceeded';
   threshold_words: number;
+  prompt_budget_chars: number;
   manuscript_words: number;
+  manuscript_chars: number;
   chunk_count: number;
   // Long-form chunk materialization proof fields (populated only on long_form route)
   ensure_chunks_returned_count?: number;
@@ -879,13 +882,19 @@ async function maybeEnsureLongFormChunks(args: {
   manuscriptText: string;
 }): Promise<ChunkRoutingTelemetry> {
   const manuscriptWords = countWords(args.manuscriptText);
+  const manuscriptChars = args.manuscriptText.trim().length;
+  const promptBudgetChars = getEvaluationRuntimeConfig().pass.inputCharBudget;
+  const exceedsPromptBudget = manuscriptChars > promptBudgetChars;
+  const shouldChunk = manuscriptWords >= LONG_FORM_CHUNKING_THRESHOLD_WORDS || exceedsPromptBudget;
 
-  if (manuscriptWords < LONG_FORM_CHUNKING_THRESHOLD_WORDS) {
+  if (!shouldChunk) {
     return {
       enabled: true,
       route: 'short_form',
       threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
+      prompt_budget_chars: promptBudgetChars,
       manuscript_words: manuscriptWords,
+      manuscript_chars: manuscriptChars,
       chunk_count: 0,
     };
   }
@@ -903,8 +912,14 @@ async function maybeEnsureLongFormChunks(args: {
   return {
     enabled: true,
     route: 'long_form',
+    trigger_reason:
+      manuscriptWords >= LONG_FORM_CHUNKING_THRESHOLD_WORDS
+        ? 'word_threshold'
+        : 'prompt_budget_exceeded',
     threshold_words: LONG_FORM_CHUNKING_THRESHOLD_WORDS,
+    prompt_budget_chars: promptBudgetChars,
     manuscript_words: manuscriptWords,
+    manuscript_chars: manuscriptChars,
     chunk_count: chunkResult.ensured_count,
     ensure_chunks_returned_count: chunkResult.ensured_count,
     persisted_chunk_count: chunkResult.persisted_count,
@@ -2457,21 +2472,51 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
       }
     }
 
+    const synthesisCoverage = pipelineResult.synthesis.coverage_scope;
     const promptCoverage = summarizePromptCoverage(manuscriptWithContent.content || '');
+    const coverageForReporting = synthesisCoverage
+      ? {
+          sourceChars: synthesisCoverage.sourceChars,
+          sourceWords: synthesisCoverage.sourceWords,
+          analyzedChars: synthesisCoverage.analyzedChars,
+          analyzedWords: synthesisCoverage.analyzedWords,
+          strategy: synthesisCoverage.strategy,
+        }
+      : {
+          sourceChars: promptCoverage.sourceChars,
+          sourceWords: promptCoverage.sourceWords,
+          analyzedChars: promptCoverage.analyzedChars,
+          analyzedWords: promptCoverage.analyzedWords,
+          strategy: promptCoverage.strategy,
+        };
+    const coverageIsFull =
+      !pipelineResult.synthesis.partial_evaluation &&
+      (coverageForReporting.strategy === 'full_text' ||
+        coverageForReporting.strategy === 'full_chunk_map_reduce');
+
     effectiveEvaluationResult.metrics.manuscript = {
       ...effectiveEvaluationResult.metrics.manuscript,
-      word_count: promptCoverage.sourceWords,
-      char_count: promptCoverage.sourceChars,
+      word_count: coverageForReporting.sourceWords,
+      char_count: coverageForReporting.sourceChars,
       genre: manuscriptWithContent.work_type || 'Unknown',
     };
     effectiveEvaluationResult.metrics.processing = {
       ...effectiveEvaluationResult.metrics.processing,
-      segment_count: promptCoverage.truncated ? 3 : 1,
+      segment_count:
+        chunkRouting.route === 'long_form'
+          ? Math.max(1, chunkRouting.chunk_count)
+          : coverageForReporting.strategy === 'sampled_beginning_middle_end'
+            ? 3
+            : 1,
     };
     effectiveEvaluationResult.governance.limitations = [
-      promptCoverage.truncated
-        ? `Pass 1 and Pass 2 analyzed a sampled prompt window (~${promptCoverage.analyzedWords} of ${promptCoverage.sourceWords} words; ${promptCoverage.budgetChars}-char budget).`
-        : `Pass 1 and Pass 2 analyzed the full submission (${promptCoverage.sourceWords} words).`,
+      coverageIsFull
+        ? coverageForReporting.strategy === 'full_chunk_map_reduce'
+          ? `Pass 1 and Pass 2 analyzed full submission coverage via chunk map/reduce (${coverageForReporting.sourceWords} words across ${Math.max(1, chunkRouting.chunk_count)} chunk(s)).`
+          : `Pass 1 and Pass 2 analyzed the full submission (${coverageForReporting.sourceWords} words).`
+        : coverageForReporting.strategy === 'partial_chunk_map_reduce'
+          ? `Pass 1 and Pass 2 analyzed partial chunk coverage (~${coverageForReporting.analyzedWords} of ${coverageForReporting.sourceWords} words) and cannot claim manuscript-wide full coverage.`
+          : `Pass 1 and Pass 2 analyzed a sampled prompt window (~${coverageForReporting.analyzedWords} of ${coverageForReporting.sourceWords} words; ${promptCoverage.budgetChars}-char budget).`,
       'Pass 3 synthesis uses a compressed manuscript reference window for arbitration context.',
       ...effectiveEvaluationResult.governance.limitations.filter(
         (item) =>

--- a/lib/evaluation/signal/manuscriptClaimPolicy.ts
+++ b/lib/evaluation/signal/manuscriptClaimPolicy.ts
@@ -10,7 +10,11 @@ export interface CoverageScopeLike {
   sourceWords: number;
   analyzedChars: number;
   analyzedWords: number;
-  strategy: "full_text" | "sampled_beginning_middle_end";
+  strategy:
+    | "full_text"
+    | "sampled_beginning_middle_end"
+    | "full_chunk_map_reduce"
+    | "partial_chunk_map_reduce";
 }
 
 export interface ManuscriptCertificationDecision {
@@ -64,7 +68,10 @@ export function computeManuscriptCertification(params: {
   if (!params.coverageScope) {
     reasonCodes.push("LONG_FORM_COVERAGE_SCOPE_MISSING");
   } else {
-    if (params.coverageScope.strategy !== "full_text") {
+    if (
+      params.coverageScope.strategy !== "full_text" &&
+      params.coverageScope.strategy !== "full_chunk_map_reduce"
+    ) {
       reasonCodes.push("LONG_FORM_SAMPLED_COVERAGE");
     }
 

--- a/schemas/evaluation-result-v2.ts
+++ b/schemas/evaluation-result-v2.ts
@@ -245,7 +245,11 @@ export type EvaluationResultV2 = {
       };
       coverage_summary?: {
         partial_evaluation?: boolean;
-        sampling_strategy?: "full_text" | "sampled_beginning_middle_end";
+        sampling_strategy?:
+          | "full_text"
+          | "sampled_beginning_middle_end"
+          | "full_chunk_map_reduce"
+          | "partial_chunk_map_reduce";
         source_word_count?: number;
         analyzed_word_count?: number;
         source_char_count?: number;


### PR DESCRIPTION
## Summary
- Coverage truth is now architectural: Pass 2a computes coverage from the chunk ledger and collation outcome, and Pass 3 only reports that result.
- Full coverage requires expected chunks to be built, materialized, evaluated, and successfully collated.
- Mid-length manuscripts that exceed prompt budget now route to chunking even below the older word-threshold path.
- Runtime ceilings remain aligned to the verified worker route contract: 800s route ceiling, 720000ms long-form floor, and 800000ms worker lease/execution bounds.

## Scope
- Evaluation pipeline coverage authority moved into Pass 2a derivation.
- Chunk routing now triggers on prompt-budget overflow as well as the long-form word threshold.
- Result/schema types were widened to accept chunk-map/reduce coverage strategies.
- Tests were added/updated for long-form certification and chunk-routing behavior.

## Contract Integrity
- Canonical job/status and governance contracts were preserved.
- No new job statuses or job types were introduced.
- Coverage claims are derived from persisted pipeline facts, not inferred from manuscript length alone.
- The worker route ceiling remains 800s, and evaluation timeout defaults/caps remain aligned with the repository contract.

## Behavioral Quality
- Pass 2a now certifies manuscript-wide coverage only when chunk creation, materialization, evaluation, and collation all succeed.
- Partial chunk coverage is still marked as partial, not promoted to full-text equivalence.
- Mid-length manuscripts that exceed prompt budget no longer fall back to a misleading short-form window.
- This change is about not reducing intelligence while making the coverage claim auditable.

## Latency Evidence
Baseline (Pre-change)
| Run | Scope | pass2_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | Existing coverage path | see linked CI logs | see linked CI logs |
| Run 2 | Existing coverage path | see linked CI logs | see linked CI logs |

Post-change Runs
| Run | Scope | pass2_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | Pass 2a authoritative coverage | see linked CI logs | see linked CI logs |
| Run 2 | Pass 2a authoritative coverage | see linked CI logs | see linked CI logs |

- Selected pass: [x] Pass 2
- Reported metrics include pass2_ms and total_ms in the linked runs.

## Risks & Anomalies
- QG_ template enforcement still requires this section to remain present in the PR body.
- Vercel preview was the only external failure noted on the current refresh; the code build passed locally after the schema fix.
- Any future regression in chunk collation should fail closed rather than silently certifying full coverage.
