### PR TITLE
fix(ui): remove stray markdown markers from JobStatusPoll phase display

### DIFF
--- a/app/evaluate/[jobId]/JobStatusPoll.tsx
+++ b/app/evaluate/[jobId]/JobStatusPoll.tsx
@@ -113,12 +113,12 @@ export function JobStatusPoll({ jobId, initialJob }: JobStatusPollProps) {
             )}
           </div>
 
-          **{job.progress?.phase && (
+          {job.progress?.phase && (
             <div>
               <span className="text-gray-600">Phase:</span>{" "}
               <span className="font-mono font-medium">{job.progress.phase}</span>
             </div>
-          )}**
+          )}
 
           {/* GOVERNANCE: phase_status is display-only */}
           {job.progress?.phase_status && (


### PR DESCRIPTION
## Summary

Remove two stray `**` markers wrapping the `job.progress?.phase` JSX block in `JobStatusPoll.tsx`. These rendered as literal asterisks in UI output.

## Scope

- `app/evaluate/[jobId]/JobStatusPoll.tsx` — remove two stray text characters
- UI rendering only; no evaluator pipeline or backend behavior touched

No-Pipeline-Impact: UI-only render change; no pipeline pass execution, scoring, persistence, or job-state semantics changed.

## Visual Evidence

- Before: phase line could display literal `**` around text.
- After: phase line renders clean text with no stray markdown markers.

## Accessibility

- No semantic markup changes.
- No focus-order, keyboard, ARIA, or contrast behavior changes.
- Screen-reader output for phase label remains unchanged except removal of extraneous `*` characters.

## Browser Targets

- Chromium (latest)
- Firefox (latest)
- Safari/WebKit baseline

## Risks & Anomalies

- Very low risk: two-character deletion in JSX text context.
- No logic/state/network/schema changes.
- No known anomalies.
