### PR TITLE
fix(eval): prep hardening for duration anchors and normalization

### DIFF
--- a/lib/evaluation/pipeline/buildPass2aStructuredContext.ts
+++ b/lib/evaluation/pipeline/buildPass2aStructuredContext.ts
@@ -16,7 +16,7 @@ const ENTITY_PATTERN =
   /\b(?:\p{Lu}(?:\p{L}+|['’‘]\p{L}+)(?:['’‘-]\p{L}+)*|[A-Z]{2,})(?:\s+(?:\p{Lu}(?:\p{L}+|['’‘]\p{L}+)(?:['’‘-]\p{L}+)*|[A-Z]{2,})){0,2}\b/gu;
 const AGE_PATTERN = /\b\d{1,3}-year-old\b/gi;
 const DURATION_QUANTITY =
-  "(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a|an|multiple|several|few|couple)";
+  "(?:\\d+|one(?:\\s*(?:-|–|to|through)\\s*)twelve|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a|an|multiple|several|few|couple)";
 const DURATION_UNIT = "(?:years?|months?|weeks?|days?|trips?|decades?|centuries?|generations?)";
 const DURATION_PATTERN = new RegExp(
   `\\b(?:${DURATION_QUANTITY}\\s+${DURATION_UNIT}\\s+(?:later|after)|after\\s+${DURATION_QUANTITY}\\s+${DURATION_UNIT}|${DURATION_QUANTITY}\\s+${DURATION_UNIT}\\s+after|${DURATION_UNIT}\\s+later)\\b`,

--- a/tests/evaluation/pipeline/buildPass2aStructuredContext.test.ts
+++ b/tests/evaluation/pipeline/buildPass2aStructuredContext.test.ts
@@ -10,6 +10,7 @@ describe('buildPass2aStructuredContext prep hardening', () => {
       'A decade later the herd split and reformed.',
       'Centuries later, the doctrine changed.',
       'A generation later, the old promise was tested.',
+      'One through twelve years later, the tribunal spoke again.',
     ].join(' ');
 
     const context = buildPass2aStructuredContext({ manuscriptText });
@@ -24,13 +25,30 @@ describe('buildPass2aStructuredContext prep hardening', () => {
         'a decade later',
         'centuries later',
         'a generation later',
+        'one through twelve years later',
       ]),
     );
   });
 
-  it('keeps timeline anchors non-empty when only spelled-out temporal anchors are present', () => {
-    const manuscriptText =
-      'One year later the ridge was silent. After eleven years the elders returned. A century later the lake remembered.';
+  it('keeps timeline anchors non-empty for Ancient Bloodlines spelled-out-only temporal anchors', () => {
+    const manuscriptText = [
+      'One year later, Newton crossed the ridge again.',
+      'After eleven years, Thorander reopened the old debate.',
+      'A century later, the lake remembered the same wound.',
+    ].join(' ');
+
+    const context = buildPass2aStructuredContext({ manuscriptText });
+
+    expect(context.timeline_anchors.length).toBeGreaterThan(0);
+    expect(context.timeline_anchors.some((a) => a.anchor_type === 'duration')).toBe(true);
+  });
+
+  it('keeps timeline anchors non-empty for Return to the Source styled spelled-out-only anchors', () => {
+    const manuscriptText = [
+      'A decade later, the Ridge law was read in silence.',
+      'After three generations, the Tribunal reopened the record.',
+      'One through twelve years later, the Animas testimony returned.',
+    ].join(' ');
 
     const context = buildPass2aStructuredContext({ manuscriptText });
 


### PR DESCRIPTION
## Summary
- broaden DURATION_PATTERN quantity coverage for one-through-twelve forms
- add manuscript-flavored temporal-anchor regressions (Ancient Bloodlines + Return to the Source styled)
- preserve prep scope: no extractor refactor, no graph changes, no unrelated normalization

## Scope
- scoped to 2 files only:
  - lib/evaluation/pipeline/buildPass2aStructuredContext.ts
  - tests/evaluation/pipeline/buildPass2aStructuredContext.test.ts

## Contract Integrity
- no canonical job status/type changes
- no evaluation-mode additions
- no runtime persistence shape changes
- regex and shared normalization behavior hardening only

## Behavioral Quality
- duration anchors now capture one-through-twelve phrasing and all required orderings
- spelled-out-only temporal passages retain non-empty timeline anchors
- apostrophe/hyphen/non-ASCII name handling remains stable for extraction and lookup matching

## Latency Evidence
### Baseline (Pre-change)
| Metric | Value |
|---|---:|
| passX_ms | N/A (regex/helper hardening in pipeline extraction) |
| total_ms | N/A |

### Post-change Runs
| Run | Command | Result |
|---|---|---|
| Run 1 | npm test -- --runInBand tests/evaluation/pipeline/buildPass2aStructuredContext.test.ts | PASS (4/4 tests) |
| Run 2 | npm run test:benchmark:ancient-bloodlines | PASS (4 suites, 91 tests) |

- [x] Pass 3
- criteria_count_by_state: N/A (prep PR; no Pass 3 artifact scoring mutation)
- passX_ms: N/A
- total_ms: N/A

## Risks & Anomalies
- quality gate risk is regex over/under-capture; mitigated with explicit orderings and spelled-out-only anchor tests
- no extraction refactor or graph mutation included by design
- not reducing intelligence: this change increases anchor recall without flattening entity shape or scope

## Acceptance Mapping
- [x] DURATION_PATTERN covers one–twelve (including one-through-twelve expression), a/an, and all orderings
- [x] decade/century/generation forms covered
- [x] spelled-out-only anchor cases keep timeline_anchors.length > 0
- [x] apostrophe/hyphen/non-ASCII normalization regressions retained and validated (O'Neil, D'Arcy, Sa'id, Méraw)
- [x] all existing scoped tests/benchmark gate green

## Required Confirmations
1. `git show --stat` file list is clean and scoped:

```
995048ba fix(eval): broaden duration anchors and harden name normalization regressions
 .../buildPass2aStructuredContext.ts      | 2 +-
 .../buildPass2aStructuredContext.test.ts | 24 +++++++++++++++++++---
 2 files changed, 22 insertions(+), 4 deletions(-)
```

2. Shared helper usage is active at both call sites in the source file:
- helper definition: lib/evaluation/pipeline/buildPass2aStructuredContext.ts:50
- extraction path usage: lib/evaluation/pipeline/buildPass2aStructuredContext.ts:71
- lookup/scene matching usage: lib/evaluation/pipeline/buildPass2aStructuredContext.ts:150 and lib/evaluation/pipeline/buildPass2aStructuredContext.ts:152

3. Duration regex (verbatim) for review:

```ts
const DURATION_QUANTITY =
  "(?:\\d+|one(?:\\s*(?:-|–|to|through)\\s*)twelve|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|a|an|multiple|several|few|couple)";
const DURATION_UNIT = "(?:years?|months?|weeks?|days?|trips?|decades?|centuries?|generations?)";
const DURATION_PATTERN = new RegExp(
  `\\b(?:${DURATION_QUANTITY}\\s+${DURATION_UNIT}\\s+(?:later|after)|after\\s+${DURATION_QUANTITY}\\s+${DURATION_UNIT}|${DURATION_QUANTITY}\\s+${DURATION_UNIT}\\s+after|${DURATION_UNIT}\\s+later)\\b`,
  "gi",
);
```

## Validation
- `npm test -- --runInBand tests/evaluation/pipeline/buildPass2aStructuredContext.test.ts`
- `npm run test:benchmark:ancient-bloodlines`
