### PR TITLE
fix(jobs): restore claim_job_atomic TTL clamp and correct test fixture phase_status

### DIFF
--- a/docs/evidence/ttl-clamp-restore-proof-20260513T055056.txt
+++ b/docs/evidence/ttl-clamp-restore-proof-20260513T055056.txt
@@ -1,0 +1,13 @@
+PASS tests/ttl-clamping.test.ts (13.191 s)
+  TTL Clamping Tests
+    ✓ clamps negative TTL to minimum 30 seconds (2716 ms)
+    ✓ clamps zero TTL to minimum 30 seconds (2356 ms)
+    ✓ clamps huge TTL to maximum 900 seconds (2461 ms)
+    ✓ accepts valid TTL within bounds (300 seconds) (2302 ms)
+    ✓ guarantees lease advances on reclaim (monotonic) (3157 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       5 passed, 5 total
+Snapshots:   0 total
+Time:        13.244 s, estimated 16 s
+Ran all test suites within paths "tests/ttl-clamping.test.ts".

--- a/supabase/migrations/20260513000000_restore_claim_job_atomic_ttl_clamp.sql
+++ b/supabase/migrations/20260513000000_restore_claim_job_atomic_ttl_clamp.sql
@@ -1,0 +1,81 @@
+-- Restore canonical TTL clamping contract in claim_job_atomic.
+-- Required bounds: 30s <= lease ttl <= 900s.
+
+DO $migration$
+BEGIN
+  EXECUTE 'DROP FUNCTION IF EXISTS public.claim_job_atomic(text, timestamptz, integer)';
+
+  EXECUTE $function$
+    CREATE FUNCTION public.claim_job_atomic(
+      p_worker_id text,
+      p_now timestamptz DEFAULT now(),
+      p_lease_seconds integer DEFAULT 300
+    )
+    RETURNS TABLE (
+      id uuid,
+      manuscript_id bigint,
+      job_type text,
+      policy_family text,
+      voice_preservation_level text,
+      english_variant text,
+      work_type text,
+      phase text,
+      status text,
+      claimed_by text,
+      worker_id text,
+      lease_token uuid,
+      lease_until timestamptz,
+      heartbeat_at timestamptz,
+      started_at timestamptz
+    )
+    LANGUAGE plpgsql
+    AS $claim_function$
+    DECLARE
+      v_lease_token uuid := gen_random_uuid();
+      v_clamped_ttl integer := GREATEST(30, LEAST(COALESCE(p_lease_seconds, 300), 900));
+      v_lease_until timestamptz := p_now + make_interval(secs => v_clamped_ttl);
+    BEGIN
+      RETURN QUERY
+      WITH candidate AS (
+        SELECT ej.id
+        FROM public.evaluation_jobs ej
+        WHERE ej.status = 'queued'
+          AND (ej.next_attempt_at IS NULL OR ej.next_attempt_at <= p_now)
+        ORDER BY ej.created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE public.evaluation_jobs ej
+      SET
+        status = 'running',
+        phase_status = 'running',
+        claimed_by = p_worker_id,
+        worker_id = p_worker_id,
+        lease_token = v_lease_token,
+        lease_until = v_lease_until,
+        heartbeat_at = p_now,
+        started_at = COALESCE(ej.started_at, p_now),
+        updated_at = p_now
+      FROM candidate
+      WHERE ej.id = candidate.id
+      RETURNING
+        ej.id,
+        ej.manuscript_id,
+        ej.job_type,
+        ej.policy_family,
+        ej.voice_preservation_level,
+        ej.english_variant,
+        ej.work_type,
+        ej.phase,
+        ej.status,
+        ej.claimed_by,
+        ej.worker_id,
+        ej.lease_token,
+        ej.lease_until,
+        ej.heartbeat_at,
+        ej.started_at;
+    END;
+    $claim_function$
+  $function$;
+END;
+$migration$;

--- a/tests/ttl-clamping.test.ts
+++ b/tests/ttl-clamping.test.ts
@@ -173,7 +173,7 @@ describe('TTL Clamping Tests', () => {
     // Reset job to queued (simulating lease expiration)
     runSql(`
       UPDATE public.evaluation_jobs 
-      SET status = 'queued', lease_until = NULL, worker_id = NULL 
+      SET status = 'queued', phase_status = 'queued', lease_until = NULL, worker_id = NULL 
       WHERE id = '${jobId}';
     `);
     


### PR DESCRIPTION
## Summary
- Bucket A: restore canonical `claim_job_atomic` TTL clamp via migration `20260513000000_restore_claim_job_atomic_ttl_clamp.sql`.
- Bucket C: fix `tests/ttl-clamping.test.ts` fixture reset to enforce consistent `status`/`phase_status` (`queued`/`queued`).

## Scope
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3
- Focused scope: DB lease TTL clamping + TTL test fixture contract correctness.
- No Track A live-parity evaluator assertions were modified.

## Contract Integrity
- Canonical function behavior restored: clamp lease seconds to `max(30, min(input, 900))`.
- Fixture update now preserves lifecycle invariant (`status=queued` requires `phase_status=queued`).
- Governance/state invariants remain fail-closed.

## Behavioral Quality
- Quality gate disclosure: no new `QG_` anomalies introduced by this PR.
- Quality Gate statement: behavior is tightened defensively (out-of-range TTL inputs no longer leak through).
- This change is about reliability hardening and **not reducing intelligence**.

## Latency Evidence
### Baseline (Pre-change)
| Metric | Value |
|---|---:|
| passX_ms | N/A (DB migration + fixture correction; no evaluator scoring path changes) |
| total_ms | N/A |

### Post-change Runs
| Run | Command | Result |
|---|---|---|
| Run 1 | `npx jest --runInBand --runTestsByPath tests/ttl-clamping.test.ts` | PASS (5/5), total_ms≈13244 |
| Run 2 | `npx jest --runInBand --runTestsByPath tests/ttl-clamping.test.ts` | PASS (5/5), total_ms≈12738 |

## Risks & Anomalies
- Main risk: deployment env drift across Preview scopes can still fail Vercel validation independent of this code path.
- Mitigation: keep Preview timeout vars aligned with invariant (`EVAL_OPENAI_TIMEOUT_MS >= EVAL_PASS_TIMEOUT_MS`, `EVAL_WORKER_MAX_EXECUTION_MS >= 780000` under current pass timeout policy).
- Test anomaly status: none observed in targeted TTL suite after migration.

## Notes
- Proof artifact (Run 1): `docs/evidence/ttl-clamp-restore-proof-20260513T055056.txt`.
- This PR is intentionally isolated from Track A live-parity work (#461).
