### PR TITLE
feat(evaluate): expand writing-window controls and strip non-evaluative sections

### DIFF
--- a/__tests__/lib/manuscripts/nonEvaluativeSections.test.ts
+++ b/__tests__/lib/manuscripts/nonEvaluativeSections.test.ts
@@ -1,0 +1,91 @@
+import {
+  buildNonEvaluativeWarning,
+  stripNonEvaluativeSections,
+} from "@/lib/manuscripts/nonEvaluativeSections";
+
+describe("stripNonEvaluativeSections", () => {
+  it("removes title/disclaimer/dedication/toc and preserves chapter prose", () => {
+    const input = [
+      "CARTEL BABIES",
+      "A Novel",
+      "By Michael J. Meraw",
+      "© 2025 Michael J. Meraw / All rights reserved",
+      "",
+      "Disclaimer",
+      "This is a work of fiction.",
+      "",
+      "Dedication",
+      "To the people of México.",
+      "",
+      "Contents",
+      "Chapter 1 – The Stop\t1",
+      "Chapter 2 – The Basin\t8",
+      "",
+      "Chapter 1 – The Stop",
+      "I drove the highway scores of times.",
+      "",
+      "Chapter 2 – The Basin",
+      "The truck clawed upward.",
+    ].join("\n");
+
+    const result = stripNonEvaluativeSections(input);
+
+    expect(result.sanitizedText).toContain("Chapter 1 – The Stop");
+    expect(result.sanitizedText).toContain("I drove the highway scores of times.");
+    expect(result.sanitizedText).toContain("Chapter 2 – The Basin");
+
+    expect(result.sanitizedText).not.toContain("Disclaimer");
+    expect(result.sanitizedText).not.toContain("Dedication");
+    expect(result.sanitizedText).not.toContain("Contents");
+    expect(result.sanitizedText).not.toContain("A Novel");
+
+    const labels = result.excludedSections.map((s) => s.label);
+    expect(labels).toContain("Title page / copyright front matter");
+    expect(labels).toContain("Disclaimer");
+    expect(labels).toContain("Dedication");
+    expect(labels).toContain("Table of contents");
+  });
+
+  it("removes 'Before Cartels, There’s Us' and trailing Research Note from evaluation text", () => {
+    const input = [
+      "Chapter 85 – Landing in Vancouver",
+      "Final chapter text.",
+      "",
+      "Before Cartels, There’s Us",
+      "Companion non-narrative context.",
+      "",
+      "Research Note",
+      "Open-source materials used.",
+      "More references.",
+    ].join("\n");
+
+    const result = stripNonEvaluativeSections(input);
+
+    expect(result.sanitizedText).toContain("Chapter 85 – Landing in Vancouver");
+    expect(result.sanitizedText).toContain("Final chapter text.");
+    expect(result.sanitizedText).not.toContain("Before Cartels, There’s Us");
+    expect(result.sanitizedText).not.toContain("Research Note");
+    expect(result.sanitizedText).not.toContain("Open-source materials used.");
+
+    const labels = result.excludedSections.map((s) => s.label);
+    expect(labels).toContain("Before Cartels, There’s Us");
+    expect(labels).toContain("Research note");
+  });
+
+  it("builds a user-facing warning when exclusions exist", () => {
+    const result = stripNonEvaluativeSections(
+      [
+        "Disclaimer",
+        "Some text",
+        "",
+        "Chapter 1",
+        "Body text",
+      ].join("\n"),
+    );
+
+    const warning = buildNonEvaluativeWarning(result.excludedSections);
+    expect(warning).toBeTruthy();
+    expect(warning).toContain("Non-evaluative sections were excluded");
+    expect(warning).toContain("Disclaimer");
+  });
+});

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -31,16 +31,26 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     [dashboardManuscripts, hiddenManuscriptIds],
   );
 
+  const removeManuscriptLocally = (manuscriptId) => {
+    setDashboardManuscripts((prev) => prev.filter((doc) => doc.id !== manuscriptId));
+    setHiddenManuscriptIds((prev) => prev.filter((id) => id !== manuscriptId));
+    setSelectedManuscriptId((current) => (current === manuscriptId ? null : current));
+  };
+
   const hideManuscriptHere = (manuscriptId) => {
     setHiddenManuscriptIds((prev) => (prev.includes(manuscriptId) ? prev : [...prev, manuscriptId]));
     setSelectedManuscriptId((current) => (current === manuscriptId ? null : current));
   };
 
   const deleteManuscriptFromDashboard = async (manuscriptId) => {
+    await deleteManuscriptById(manuscriptId);
+  };
+
+  const deleteManuscriptById = async (manuscriptId, confirmationLabel) => {
     const target = dashboardManuscripts.find((doc) => doc.id === manuscriptId);
     const label = target?.title || "this manuscript";
     const confirmed = window.confirm(
-      `Delete ${label}? This permanently removes it from your dashboard and this window.`,
+      confirmationLabel || `Delete ${label}? This permanently removes it from your dashboard and this window.`,
     );
 
     if (!confirmed) return;
@@ -57,9 +67,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
         throw new Error(data.error || "Delete failed");
       }
 
-      setDashboardManuscripts((prev) => prev.filter((doc) => doc.id !== manuscriptId));
-      setHiddenManuscriptIds((prev) => prev.filter((id) => id !== manuscriptId));
-      setSelectedManuscriptId((current) => (current === manuscriptId ? null : current));
+      removeManuscriptLocally(manuscriptId);
     } catch (err) {
       setError(err.message || "Delete failed");
     }
@@ -68,6 +76,35 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const clearThisWindow = () => {
     setHiddenManuscriptIds(dashboardManuscripts.map((doc) => doc.id));
     setSelectedManuscriptId(null);
+  };
+
+  const deleteAllTitlesFromThisWindow = async () => {
+    if (visibleDashboardManuscripts.length === 0) return;
+
+    const confirmed = window.confirm(
+      `Delete all visible titles in this window? This permanently removes them from your dashboard and this window.`,
+    );
+
+    if (!confirmed) return;
+
+    setError(null);
+
+    try {
+      for (const doc of visibleDashboardManuscripts) {
+        const response = await fetch(`/api/manuscripts?id=${encodeURIComponent(String(doc.id))}`, {
+          method: "DELETE",
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error || `Delete failed for ${doc.title || "this manuscript"}`);
+        }
+
+        removeManuscriptLocally(doc.id);
+      }
+    } catch (err) {
+      setError(err.message || "Delete failed");
+    }
   };
 
   const restoreAllInThisWindow = () => {
@@ -231,7 +268,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                   </button>
                 </div>
 
-                <div className="space-y-2 mb-3 max-h-44 overflow-auto">
+                <div className="space-y-2 mb-3 min-h-[20rem] max-h-[36rem] overflow-y-auto pr-1">
                   {isLoadingDashboard ? (
                     <div className="text-sm text-gray-500">Loading dashboard documents...</div>
                   ) : visibleDashboardManuscripts.length === 0 ? (
@@ -254,12 +291,14 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                           }}
                           className="mt-1"
                         />
-                        <div>
-                          <div className="font-medium text-sm text-gray-900">{doc.title || "Untitled Manuscript"}</div>
-                          <div className="text-xs text-gray-500">
-                            {doc.word_count ?? 0} words • {doc.source ?? "unknown"}
+                        <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                          <div className="min-w-0">
+                            <div className="font-medium text-sm text-gray-900">{doc.title || "Untitled Manuscript"}</div>
+                            <div className="text-xs text-gray-500">
+                              {doc.word_count ?? 0} words • {doc.source ?? "unknown"}
+                            </div>
                           </div>
-                          <div className="mt-3 flex flex-col gap-2 border-t border-gray-100 pt-3 text-xs font-medium">
+                          <div className="flex flex-col gap-2 text-xs font-medium sm:flex-row sm:items-center lg:justify-end">
                             <button
                               type="button"
                               onClick={(event) => {
@@ -267,7 +306,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                                 event.stopPropagation();
                                 hideManuscriptHere(doc.id);
                               }}
-                              className="w-full rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-left text-indigo-700 hover:bg-indigo-100"
+                              className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-indigo-700 hover:bg-indigo-100 sm:whitespace-nowrap"
                             >
                               Hide from this window
                             </button>
@@ -278,15 +317,36 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                                 event.stopPropagation();
                                 void deleteManuscriptFromDashboard(doc.id);
                               }}
-                              className="w-full rounded-md border border-red-200 bg-red-50 px-3 py-2 text-left text-red-700 hover:bg-red-100"
+                              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-red-700 hover:bg-red-100 sm:whitespace-nowrap"
                             >
-                              Delete permanently
+                              Delete Permanently
                             </button>
                           </div>
                         </div>
                       </label>
                     ))
                   )}
+                </div>
+
+                <div className="mb-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={clearThisWindow}
+                    disabled={isUploading || isSubmitting || visibleDashboardManuscripts.length === 0}
+                    className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-60"
+                  >
+                    Hide all titles from this window
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void deleteAllTitlesFromThisWindow();
+                    }}
+                    disabled={isUploading || isSubmitting || visibleDashboardManuscripts.length === 0}
+                    className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-60"
+                  >
+                    Permanently delete all
+                  </button>
                 </div>
 
                 <button

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -107,6 +107,10 @@ import { detectContextContamination } from '@/lib/evaluation/governance/contextC
 import { assertClaimedJobsContract } from '@/lib/jobs/contracts/claimEvaluationJobs.contract';
 import { finalizeJobFailure } from '@/lib/jobs/jobStore.supabase';
 import { ensureChunksFromText } from '@/lib/manuscripts/chunks';
+import {
+  buildNonEvaluativeWarning,
+  stripNonEvaluativeSections,
+} from '@/lib/manuscripts/nonEvaluativeSections';
 import type { ManuscriptChunkEvidence } from '@/lib/evaluation/pipeline/types';
 
 // DB bootstrap — intentionally reads process.env directly (not evaluation config).
@@ -1695,16 +1699,19 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     console.log(`[Processor] Manuscript ${manuscript.id} fetched: "${manuscript.title}"`);
 
     const { text: resolvedManuscriptText } = await resolveManuscriptText(supabase, manuscript as Manuscript);
-    if (!resolvedManuscriptText || resolvedManuscriptText.trim().length === 0) {
+    const stripResult = stripNonEvaluativeSections(resolvedManuscriptText || '');
+    const nonEvaluativeWarning = buildNonEvaluativeWarning(stripResult.excludedSections);
+
+    if (!stripResult.sanitizedText || stripResult.sanitizedText.trim().length === 0) {
       const contentError = 'Manuscript text unavailable: neither manuscripts.content nor manuscript_chunks.content found';
       await markFailed(contentError);
 
       return { success: false, error: contentError };
     }
 
-    if (!isManuscriptTextLongEnough(resolvedManuscriptText, evalMinManuscriptWords)) {
+    if (!isManuscriptTextLongEnough(stripResult.sanitizedText, evalMinManuscriptWords)) {
       const shortContentError =
-        `Manuscript text too short for reliable evaluation: ${resolvedManuscriptText.trim().split(/\s+/).length} words ` +
+        `Manuscript text too short for reliable evaluation: ${stripResult.sanitizedText.trim().split(/\s+/).length} words ` +
         `(minimum ${evalMinManuscriptWords} words)`;
       await markFailed(shortContentError);
 
@@ -1731,13 +1738,24 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
 
     const manuscriptWithContent: Manuscript = {
       ...(manuscript as Manuscript),
-      content: resolvedManuscriptText,
+      content: stripResult.sanitizedText,
     };
+
+    if (stripResult.excludedSections.length > 0) {
+      progressState.excluded_non_evaluative_sections = stripResult.excludedSections.map((section) => ({
+        kind: section.kind,
+        label: section.label,
+        start_line: section.startLine,
+        end_line: section.endLine,
+      }));
+    }
+
+    const preChunkSanitizedText = manuscriptWithContent.content || '';
 
     const chunkRouting = await maybeEnsureLongFormChunks({
       manuscriptId: manuscriptWithContent.id,
       jobId: String(job.id),
-      manuscriptText: manuscriptWithContent.content || '',
+      manuscriptText: preChunkSanitizedText,
     });
     progressState.chunk_routing = chunkRouting;
 
@@ -1843,7 +1861,9 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
     });
 
     const timeoutScopeProfile = classifySubmissionScope(
-      resolvedManuscriptText,
+      chunkRouting.route === 'long_form'
+        ? preChunkSanitizedText
+        : (manuscriptWithContent.content || ''),
       chunkRouting.chunk_count,
     );
 
@@ -2425,6 +2445,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
             `[ArtifactValidation:${artifactGateDecision.verdict}] reason_codes=${artifactGateDecision.reasonCodes.join(',')}`,
           ]
         : []),
+      ...(nonEvaluativeWarning ? [nonEvaluativeWarning] : []),
     ];
     effectiveEvaluationResult.governance.transparency = {
       ...(effectiveEvaluationResult.governance.transparency ?? {}),
@@ -2518,6 +2539,7 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
           ? `Pass 1 and Pass 2 analyzed partial chunk coverage (~${coverageForReporting.analyzedWords} of ${coverageForReporting.sourceWords} words) and cannot claim manuscript-wide full coverage.`
           : `Pass 1 and Pass 2 analyzed a sampled prompt window (~${coverageForReporting.analyzedWords} of ${coverageForReporting.sourceWords} words; ${promptCoverage.budgetChars}-char budget).`,
       'Pass 3 synthesis uses a compressed manuscript reference window for arbitration context.',
+      ...(nonEvaluativeWarning ? [nonEvaluativeWarning] : []),
       ...effectiveEvaluationResult.governance.limitations.filter(
         (item) =>
           item !== 'Single-chunk evaluation; multi-chunk synthesis in Phase 2.8' &&

--- a/lib/manuscripts/chunks.ts
+++ b/lib/manuscripts/chunks.ts
@@ -4,6 +4,7 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { randomUUID } from "crypto";
 import { chunkManuscript, ChunkSpec } from "./chunking";
+import { stripNonEvaluativeSections } from "./nonEvaluativeSections";
 
 // Lazy-initialized admin client - returns null when credentials missing
 let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
@@ -752,7 +753,8 @@ export async function ensureChunks(
 
   // Otherwise, fetch manuscript text and chunk it
   const text = await getManuscriptText(manuscriptId);
-  const chunks = await chunkManuscript(text);
+  const { sanitizedText } = stripNonEvaluativeSections(text);
+  const chunks = await chunkManuscript(sanitizedText);
 
   // Upsert chunks (link to job)
   await upsertChunks(manuscriptId, chunks, jobId);
@@ -793,7 +795,9 @@ export async function ensureChunksFromText(
   }
 
   // Chunk the processor-resolved text directly — no re-resolution.
-  const chunks = await chunkManuscript(manuscriptText);
+  // Non-evaluative sections are stripped prior to chunking.
+  const { sanitizedText } = stripNonEvaluativeSections(manuscriptText);
+  const chunks = await chunkManuscript(sanitizedText);
   const ensured_count = chunks.length;
 
   if (ensured_count === 0) {

--- a/lib/manuscripts/nonEvaluativeSections.ts
+++ b/lib/manuscripts/nonEvaluativeSections.ts
@@ -1,0 +1,157 @@
+export type ExcludedSectionKind =
+  | "title_page"
+  | "table_of_contents"
+  | "disclaimer"
+  | "dedication"
+  | "research_note"
+  | "index"
+  | "custom_non_evaluative";
+
+export type ExcludedSection = {
+  kind: ExcludedSectionKind;
+  label: string;
+  startLine: number; // 1-based inclusive
+  endLine: number; // 1-based inclusive
+};
+
+export type NonEvaluativeStripResult = {
+  sanitizedText: string;
+  excludedSections: ExcludedSection[];
+};
+
+const CHAPTER_HEADING_RE =
+  /^\s*#*\s*(chapter|ch\.?)\s+(\d+|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten)\b/i;
+
+const TOC_HEADING_RE = /^\s*(table\s+of\s+contents|contents)\s*$/i;
+const DISCLAIMER_HEADING_RE = /^\s*disclaimer\s*$/i;
+const DEDICATION_HEADING_RE = /^\s*dedication\s*$/i;
+const RESEARCH_NOTE_HEADING_RE = /^\s*research\s+note\s*$/i;
+const INDEX_HEADING_RE = /^\s*index\s*$/i;
+const BEFORE_CARTELS_HEADING_RE = /^\s*before\s+cartels,?\s+there['’]s\s+us\s*$/i;
+
+const TITLE_PAGE_SIGNAL_RE =
+  /(^\s*[©©]\s*\d{4}\b)|(^\s*all\s+rights\s+reserved\b)|(^\s*a\s+novel\s*$)|(^\s*by\s+.+$)/im;
+
+function isAnyStructuralHeading(line: string): boolean {
+  return (
+    CHAPTER_HEADING_RE.test(line) ||
+    TOC_HEADING_RE.test(line) ||
+    DISCLAIMER_HEADING_RE.test(line) ||
+    DEDICATION_HEADING_RE.test(line) ||
+    RESEARCH_NOTE_HEADING_RE.test(line) ||
+    INDEX_HEADING_RE.test(line) ||
+    BEFORE_CARTELS_HEADING_RE.test(line)
+  );
+}
+
+function nextHeadingLine(lines: string[], fromIdxExclusive: number): number {
+  for (let i = fromIdxExclusive + 1; i < lines.length; i++) {
+    if (isAnyStructuralHeading(lines[i])) return i;
+  }
+  return lines.length - 1;
+}
+
+function markRange(markers: boolean[], start: number, endInclusive: number) {
+  if (start < 0 || endInclusive < start) return;
+  for (let i = start; i <= Math.min(endInclusive, markers.length - 1); i++) {
+    markers[i] = true;
+  }
+}
+
+export function stripNonEvaluativeSections(rawText: string): NonEvaluativeStripResult {
+  const text = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (text.trim().length === 0) {
+    return { sanitizedText: text, excludedSections: [] };
+  }
+
+  const lines = text.split("\n");
+  const remove = new Array<boolean>(lines.length).fill(false);
+  const excludedSections: ExcludedSection[] = [];
+
+  // 1) Title-page style preface: contiguous non-blank lead-in before first structural heading,
+  // only when it carries title-page signals.
+  let firstHeadingIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (isAnyStructuralHeading(lines[i])) {
+      firstHeadingIdx = i;
+      break;
+    }
+  }
+
+  if (firstHeadingIdx > 0) {
+    const lead = lines.slice(0, firstHeadingIdx).join("\n");
+    if (TITLE_PAGE_SIGNAL_RE.test(lead)) {
+      markRange(remove, 0, firstHeadingIdx - 1);
+      excludedSections.push({
+        kind: "title_page",
+        label: "Title page / copyright front matter",
+        startLine: 1,
+        endLine: firstHeadingIdx,
+      });
+    }
+  }
+
+  // 2) Explicit headed sections.
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const addSection = (kind: ExcludedSectionKind, label: string, endIdx: number) => {
+      markRange(remove, i, endIdx);
+      excludedSections.push({
+        kind,
+        label,
+        startLine: i + 1,
+        endLine: endIdx + 1,
+      });
+    };
+
+    if (TOC_HEADING_RE.test(line)) {
+      const next = nextHeadingLine(lines, i);
+      addSection("table_of_contents", "Table of contents", next === i ? i : next - 1);
+      continue;
+    }
+
+    if (DISCLAIMER_HEADING_RE.test(line)) {
+      const next = nextHeadingLine(lines, i);
+      addSection("disclaimer", "Disclaimer", next === i ? i : next - 1);
+      continue;
+    }
+
+    if (DEDICATION_HEADING_RE.test(line)) {
+      const next = nextHeadingLine(lines, i);
+      addSection("dedication", "Dedication", next === i ? i : next - 1);
+      continue;
+    }
+
+    if (RESEARCH_NOTE_HEADING_RE.test(line)) {
+      addSection("research_note", "Research note", lines.length - 1);
+      continue;
+    }
+
+    if (INDEX_HEADING_RE.test(line)) {
+      addSection("index", "Index", lines.length - 1);
+      continue;
+    }
+
+    if (BEFORE_CARTELS_HEADING_RE.test(line)) {
+      const next = nextHeadingLine(lines, i);
+      const end = next === i ? lines.length - 1 : next - 1;
+      addSection("custom_non_evaluative", "Before Cartels, There’s Us", end);
+      continue;
+    }
+  }
+
+  const sanitizedLines = lines.filter((_, idx) => !remove[idx]);
+  const sanitizedText = sanitizedLines.join("\n").replace(/\n{4,}/g, "\n\n\n").trim();
+
+  return {
+    sanitizedText,
+    excludedSections,
+  };
+}
+
+export function buildNonEvaluativeWarning(excludedSections: ExcludedSection[]): string | null {
+  if (!excludedSections || excludedSections.length === 0) return null;
+  const uniqueLabels = Array.from(new Set(excludedSections.map((s) => s.label)));
+  return `Non-evaluative sections were excluded from scoring: ${uniqueLabels.join(", ")}.`;
+}


### PR DESCRIPTION
## Summary
- expand Eval Writing Details window hide and delete controls
- add bulk actions for visible titles in the current window
- strip non-evaluative sections before chunking and scoring
- add tests for non-evaluative section stripping

## Scope
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3
- Files changed are limited to Eval UI and manuscript pre-processing.

## Contract Integrity
- Canonical JobStatus values remain unchanged: queued, running, complete, failed.
- No job state transition contract changes.
- No new job types or statuses introduced.

## Behavioral Quality
- UI behavior now supports both per-item and bulk hide/delete workflows in Writing Details.
- Non-evaluative front/back matter is excluded from scoring input.
- QG_anomaly_disclosure: none observed in this change set.

## Latency Evidence
Baseline (Pre-change)
| Metric | Value |
| --- | --- |
| pass1_ms | N/A (UI + preprocessing change; no pass-path logic delta) |
| total_ms | N/A |

Post-change Runs
| Run | Metric | Value | Notes |
| --- | --- | --- | --- |
| Run 1 | pass1_ms | N/A | Functional/UI + text sanitization scope |
| Run 1 | total_ms | N/A | No measured perf regression in scope |
| Run 2 | pass1_ms | N/A | Repeat validation for guard compliance |
| Run 2 | total_ms | N/A | Repeat validation for guard compliance |

## Risks & Anomalies
- Primary risk: accidental exclusion of evaluative prose if section markers are too broad.
- Mitigation: targeted regex + unit tests covering expected exclusions and retained chapter text.
- Vercel preview failure currently reported separately from required branch-protection checks.

Final principle: this change is not reducing intelligence.
