### PR TITLE
fix(eval): make writing selection deterministic with click-to-toggle

### DIFF
--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -281,9 +281,17 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                     <div className="text-sm text-gray-500">No documents found in dashboard yet.</div>
                   ) : (
                     visibleDashboardManuscripts.map((doc) => (
-                      <label
+                      <div
                         key={doc.id}
+                        role="button"
+                        tabIndex={0}
                         onClick={() => toggleManuscriptSelection(doc.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            toggleManuscriptSelection(doc.id);
+                          }
+                        }}
                         className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer ${
                           selectedManuscriptId === doc.id ? "border-indigo-500 bg-white" : "border-gray-200 bg-white/70"
                         }`}
@@ -292,8 +300,9 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                           type="radio"
                           name="dashboard-manuscript"
                           checked={selectedManuscriptId === doc.id}
-                          onChange={() => toggleManuscriptSelection(doc.id)}
-                          className="mt-1"
+                          readOnly
+                          tabIndex={-1}
+                          className="mt-1 pointer-events-none"
                         />
                         <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                           <div className="min-w-0">
@@ -327,7 +336,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                             </button>
                           </div>
                         </div>
-                      </label>
+                      </div>
                     ))
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- replace row wrapper from label to div to avoid duplicate form-control event paths
- keep a single selection toggle path on row click
- make radio display-only (`readOnly`, `tabIndex={-1}`, `pointer-events-none`)
- add keyboard parity (`Enter`/`Space`) on each selectable row

## Scope
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Contract Integrity
- no API, job-type, or JobStatus contract changes
- UI interaction fix only

## Behavioral Quality
- first click now reliably selects a manuscript
- second click on same row reliably deselects it
- avoids event double-fire regressions from label+radio interaction coupling
- QG_UI_INTERACTION: no anomalies observed

## Latency Evidence
Baseline (Pre-change)
| Metric | Value |
| --- | --- |
| pass1_ms | N/A |
| total_ms | N/A |

Post-change Runs
| Run | pass1_ms | total_ms |
| --- | --- | --- |
| Run 1 | N/A (UI-only) | N/A (UI-only) |
| Run 2 | N/A (UI-only) | N/A (UI-only) |

## Risks & Anomalies
- low risk: presentational wrapper change in row markup
- mitigation: single deterministic toggle handler + keyboard support

Final principle: this change is not reducing intelligence.