### PR TITLE
fix(eval): restore selectable rows and second-click deselect

### DIFF
--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -285,7 +285,12 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                         key={doc.id}
                         role="button"
                         tabIndex={0}
-                        onClick={() => toggleManuscriptSelection(doc.id)}
+                        onClick={(event) => {
+                          if (event.target.closest("button") || event.target.closest("input")) {
+                            return;
+                          }
+                          toggleManuscriptSelection(doc.id);
+                        }}
                         onKeyDown={(event) => {
                           if (event.key === "Enter" || event.key === " ") {
                             event.preventDefault();
@@ -300,9 +305,19 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                           type="radio"
                           name="dashboard-manuscript"
                           checked={selectedManuscriptId === doc.id}
-                          readOnly
-                          tabIndex={-1}
-                          className="mt-1 pointer-events-none"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            if (selectedManuscriptId === doc.id) {
+                              event.preventDefault();
+                              toggleManuscriptSelection(doc.id);
+                            }
+                          }}
+                          onChange={() => {
+                            if (selectedManuscriptId !== doc.id) {
+                              toggleManuscriptSelection(doc.id);
+                            }
+                          }}
+                          className="mt-1"
                         />
                         <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                           <div className="min-w-0">


### PR DESCRIPTION
## Summary
- fix row selection so manuscripts can be selected reliably again
- preserve second-click deselect behavior
- prevent duplicate toggle paths between row container and radio input

## Scope
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

## Contract Integrity
- no job/API/schema/status contract changes
- UI interaction fix only

## Behavioral Quality
- row click now toggles selection unless click originates from action buttons or input
- radio click now handles deselect-on-second-click safely (`preventDefault` only when already selected)
- radio change handles first-time selection deterministically
- QG_UI_INTERACTION: no anomalies observed

## Latency Evidence
Baseline (Pre-change)
| Metric | Value |
| --- | --- |
| pass1_ms | N/A |
| total_ms | N/A |

Post-change Runs
| Run | pass1_ms | total_ms |
| --- | --- | --- |
| Run 1 | N/A (UI-only) | N/A (UI-only) |
| Run 2 | N/A (UI-only) | N/A (UI-only) |

## Risks & Anomalies
- low risk: event-routing behavior in a single UI component
- mitigation: explicit guard clauses for `button` and `input` targets; single toggle helper

Final principle: this change is not reducing intelligence.