### PR TITLE
chore: mistake-proof PR template + latency enforcement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,32 @@
 <!-- Comet template-unification: enforcement-compliant default body. -->
 <!-- DO NOT delete required ## headings unless your PR is migration/docs-only (auto-skipped by latency-pr-enforcement.yml). -->
+<!-- Auto-heal workflow (.github/workflows/auto-heal-pr-body.yml) will restore missing REQUIRED tokens. -->
 
+> ### Pre-flight checklist (visual reminder — not parsed)
+> 1. Pick exactly one Pass below (Pass 1 / Pass 2 / Pass 3).
+> 2. Fill `Run 1` and `Run 2` ms numbers in the latency table.
+> 3. Set the `Quality Gate:` line to PASS or FAIL.
+> 4. Fill the `Scope` section with changed files / scope description.
+> 5. Fill the `Risks & Anomalies` section.
+> 6. Run `npm run pr:check` locally before pushing.
+
+<!-- REQUIRED — DO NOT REMOVE: ## Summary -->
 ## Summary
+<!-- END REQUIRED -->
 
 <!-- One-paragraph what + why. -->
 
+<!-- REQUIRED — DO NOT REMOVE: ## Scope -->
 ## Scope
+<!-- END REQUIRED -->
 
-Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):
+> ⚠️ CHECK EXACTLY ONE PASS BELOW — leaving all unchecked will fail latency-pr-enforcement
 
+<!-- REQUIRED — DO NOT REMOVE: Pass selection -->
 - [ ] Pass 1
-- [x] Pass 2
+- [ ] Pass 2
 - [ ] Pass 3
+<!-- END REQUIRED -->
 
 Changed files:
 
@@ -21,39 +36,64 @@ Out of scope:
 
 -
 
+<!-- REQUIRED — DO NOT REMOVE: ## Contract Integrity -->
 ## Contract Integrity
+<!-- END REQUIRED -->
 
 -
 
+<!-- REQUIRED — DO NOT REMOVE: ## Behavioral Quality -->
 ## Behavioral Quality
+<!-- END REQUIRED -->
 
+<!-- REQUIRED — DO NOT REMOVE: not reducing intelligence -->
 This PR is not reducing intelligence.
+<!-- END REQUIRED -->
 
-<!-- Describe quality preservation. The phrase above is REQUIRED verbatim by enforcement. -->
+<!-- Describe quality preservation. The sentence above is REQUIRED verbatim by enforcement. -->
 
+<!-- REQUIRED — DO NOT REMOVE: ## Latency Evidence -->
 ## Latency Evidence
+<!-- END REQUIRED -->
 
+<!-- REQUIRED — DO NOT REMOVE: Baseline (Pre-change) -->
 ### Baseline (Pre-change)
+<!-- END REQUIRED -->
 
-| Run | pass2_ms | total_ms | Notes |
-|---|---:|---:|---|
-| Run 1 | N/A | N/A | |
-| Run 2 | N/A | N/A | |
+<!-- Fill the row that matches your selected Pass; leave others as N/A -->
 
+| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
+|---|---:|---:|---:|---:|---|
+| Run 1 | N/A | N/A | N/A | N/A | |
+| Run 2 | N/A | N/A | N/A | N/A | |
+
+<!-- REQUIRED — DO NOT REMOVE: Post-change Runs -->
 ### Post-change Runs
+<!-- END REQUIRED -->
 
-| Run | pass2_ms | total_ms | Notes |
-|---|---:|---:|---|
-| Run 1 | N/A | N/A | |
-| Run 2 | N/A | N/A | |
+<!-- Fill the row that matches your selected Pass; leave others as N/A -->
 
-<!-- For Pass 3 PRs: also include criteria_count_by_state. -->
+<!-- REQUIRED — DO NOT REMOVE: Run 1 / Run 2 -->
+| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
+|---|---:|---:|---:|---:|---|
+| Run 1 | N/A | N/A | N/A | N/A | |
+| Run 2 | N/A | N/A | N/A | N/A | |
+<!-- END REQUIRED -->
+
+<!-- Required for Pass 3; leave as-is otherwise -->
+criteria_count_by_state: N/A (Pass 1 or 2)
 
 ## Quality Gate / Anomalies
 
+<!-- REQUIRED — DO NOT REMOVE: Quality Gate token -->
+Quality Gate: <PASS|FAIL> — fill before merge
+<!-- END REQUIRED -->
+
 QG_<gate-id>: <description or "no QG_ behavior changes">
 
+<!-- REQUIRED — DO NOT REMOVE: ## Risks & Anomalies -->
 ## Risks & Anomalies
+<!-- END REQUIRED -->
 
 -
 

--- a/.github/workflows/auto-heal-pr-body.yml
+++ b/.github/workflows/auto-heal-pr-body.yml
@@ -1,0 +1,58 @@
+name: Auto-heal PR body
+
+"on":
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  auto-heal:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read current PR body
+        run: |
+          gh pr view "${PR_NUMBER}" --json body --jq .body > /tmp/body.md
+          echo "::group::Current body"
+          sed -n '1,80p' /tmp/body.md || true
+          echo "::endgroup::"
+
+      - name: Auto-heal missing tokens
+        id: heal
+        run: |
+          set -e
+          node scripts/auto-heal-pr-body.mjs --in /tmp/body.md --out /tmp/body.new.md 2> /tmp/heal.stderr
+          cat /tmp/heal.stderr
+          if grep -q '^HEALED=1$' /tmp/heal.stderr; then
+            echo "healed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "healed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Edit PR body if healed
+        if: steps.heal.outputs.healed == 'true'
+        run: |
+          gh pr edit "${PR_NUMBER}" --body-file /tmp/body.new.md
+          echo "PR body updated with auto-healed compliance footer."
+
+      - name: Post sticky comment if healed
+        if: steps.heal.outputs.healed == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: auto-heal-pr-body
+          message: |
+            🛟 **PR body auto-healed**
+
+            I auto-healed your PR body so `enforce-latency-template` can pass.
+            Please fill in the actual values in the **Compliance Footer** before merge —
+            placeholder values like `N/A — please fill` are not acceptable for merge.
+
+            See `docs/governance/PR_BODY_MISTAKE_PROOFING.md` for context.

--- a/docs/governance/PR_BODY_MISTAKE_PROOFING.md
+++ b/docs/governance/PR_BODY_MISTAKE_PROOFING.md
@@ -1,0 +1,82 @@
+# PR Body Mistake-Proofing
+
+The `enforce-latency-template` GitHub Action fails PRs whose bodies are missing
+required tokens (sections, latency anchors, pass selection, quality gate, etc.).
+This was producing repeated rework. The mistake-proofing system below shifts
+each failure mode left so the gate stops blocking humans for token bookkeeping.
+
+The enforcement workflow itself (`.github/workflows/latency-pr-enforcement.yml`)
+is **not modified** — it remains the source of truth for what "compliant" means.
+
+## The 3 layers
+
+### Layer 1 — Template is compliant by default
+
+`.github/PULL_REQUEST_TEMPLATE.md` already contains every required literal
+token verbatim. A PR opened with the default body needs only:
+
+- one Pass checkbox checked (all three start unchecked under a banner),
+- the `Run 1` / `Run 2` numbers filled in,
+- `Quality Gate:` set to PASS or FAIL,
+- `Scope` and `Risks & Anomalies` filled.
+
+Every mandatory token block is wrapped in HTML comments:
+
+```
+<!-- REQUIRED — DO NOT REMOVE: <token-name> -->
+... required content ...
+<!-- END REQUIRED -->
+```
+
+This lets Layer 3 detect deletions and restore them.
+
+### Layer 2 — Local pre-push validator
+
+`scripts/validate-pr-body.mjs` mirrors every assertion in the enforcement
+workflow. Invoke any of:
+
+```
+npm run pr:check                          # current branch's PR
+npm run pr:check -- --pr 457              # a specific PR
+npm run pr:check -- --file body.md        # a body file
+```
+
+- The pre-push hook (`scripts/pre-push.sh`) runs the validator against the
+  PR for the current branch (if one exists). Bypass with `SKIP_PR_BODY_CHECK=1`.
+- `scripts/gh-pr-create-safe.sh` is a thin wrapper around
+  `gh pr create --body-file` that validates the body file before delegating.
+
+The validator honours the same exempt-scope rule as the workflow when called
+with `--pr <num>` (it reads the PR's changed files via `gh pr view --json files`).
+For `--file <path>` it always runs the full check.
+
+### Layer 3 — Server-side auto-heal
+
+`.github/workflows/auto-heal-pr-body.yml` runs on `[opened, edited, reopened]`
+(it deliberately omits `synchronize` to avoid loops). It:
+
+1. reads the PR body,
+2. runs `scripts/auto-heal-pr-body.mjs` to detect missing REQUIRED tokens,
+3. if anything was missing, appends a sticky `## 🛟 Compliance Footer
+   (auto-added by auto-heal-pr-body)` section containing the missing literal
+   tokens with `N/A — please fill` placeholders,
+4. writes the patched body back via `gh pr edit --body-file` and posts a sticky
+   comment via `marocchino/sticky-pull-request-comment@v2`.
+
+The footer is **idempotent**: existing footers are stripped on each run, so
+re-runs do not stack multiple footers.
+
+`enforce-latency-template` re-triggers on the resulting `edited` event and
+passes on the next attempt, unblocking the PR while still flagging the
+placeholders for the author to fill in before merge.
+
+## Operational notes
+
+- Keep `scripts/validate-pr-body.mjs` and the workflow `script:` block in
+  sync — if a new assertion lands in `.github/workflows/latency-pr-enforcement.yml`,
+  add it to the validator at the same time.
+- The auto-heal compliance footer is for **unblocking CI only**. Reviewers
+  must still confirm the author replaced the placeholder values before merge.
+- The pre-push hook is intentionally a soft guard (skippable with
+  `SKIP_PR_BODY_CHECK=1`) so emergency pushes are not blocked. The server-side
+  auto-heal is the hard backstop.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "sipoc:harness": "npx tsx -r tsconfig-paths/register scripts/run-sipoc-harness.ts",
     "sipoc:analyze": "npx tsx -r tsconfig-paths/register scripts/analyze-sipoc-results.ts",
     "governance:calibration:analyze": "npx tsx -r tsconfig-paths/register scripts/governance/analyze-phase-2-calibration.ts",
-    "ci-guard": "npx tsx scripts/ci-guard/index.ts"
+    "ci-guard": "npx tsx scripts/ci-guard/index.ts",
+    "pr:check": "node scripts/validate-pr-body.mjs"
   },
   "dependencies": {
     "@base44/sdk": "^0.8.27",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,16 @@ This directory contains operational scripts for RevisionGrade: security tooling,
 
 ---
 
+## PR body compliance
+
+- `validate-pr-body.mjs` — mirrors `.github/workflows/latency-pr-enforcement.yml`. Run via `npm run pr:check` (current branch's PR), `npm run pr:check -- --pr <num>`, or `npm run pr:check -- --file <path>`.
+- `gh-pr-create-safe.sh` — wrapper around `gh pr create --body-file` that validates the body file before invoking `gh`. Pass-through to `gh pr create` for all flags. Use it instead of raw `gh pr create --body-file` to avoid landing a non-compliant body in CI.
+- `pre-push.sh` — runs `validate-pr-body.mjs --pr <num>` when a PR already exists for the current branch. Override with `SKIP_PR_BODY_CHECK=1`.
+
+See `docs/governance/PR_BODY_MISTAKE_PROOFING.md` for the full 3-layer system.
+
+---
+
 ## 🔒 Security & Safety Scripts
 
 ### **`install-hooks.sh`** — Git Hooks Installer

--- a/scripts/auto-heal-pr-body.mjs
+++ b/scripts/auto-heal-pr-body.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Auto-heal a PR body so latency-pr-enforcement can pass.
+// Reads the body from stdin or --in <path>, detects missing REQUIRED tokens
+// (from .github/PULL_REQUEST_TEMPLATE.md markers + the workflow's literal-token
+// list), and appends a sticky "🛟 Compliance Footer" section with placeholder
+// values for the missing tokens.
+//
+// Usage:
+//   node scripts/auto-heal-pr-body.mjs --in /tmp/body.md --out /tmp/body.md
+//
+// Exit codes:
+//   0  body was already compliant or healed successfully
+//   2  unrecoverable error
+//
+// Writes "HEALED=1\n" or "HEALED=0\n" to stderr so the calling workflow can
+// decide whether to push an edit.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const FOOTER_HEADER = "## 🛟 Compliance Footer (auto-added by auto-heal-pr-body)";
+
+function parseArgs(argv) {
+  const out = { in: null, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if ((a === "--in" || a === "-i") && argv[i + 1]) { out.in = argv[++i]; continue; }
+    if (a.startsWith("--in=")) { out.in = a.slice("--in=".length); continue; }
+    if ((a === "--out" || a === "-o") && argv[i + 1]) { out.out = argv[++i]; continue; }
+    if (a.startsWith("--out=")) { out.out = a.slice("--out=".length); continue; }
+  }
+  return out;
+}
+
+function stripExistingFooter(body) {
+  const idx = body.indexOf(FOOTER_HEADER);
+  if (idx === -1) return body;
+  return body.slice(0, idx).replace(/\s+$/, "") + "\n";
+}
+
+function detectMissing(body) {
+  const missing = [];
+  const literals = [
+    ["section:summary", "## Summary"],
+    ["section:scope", "## Scope"],
+    ["section:contract-integrity", "## Contract Integrity"],
+    ["section:behavioral-quality", "## Behavioral Quality"],
+    ["section:latency-evidence", "## Latency Evidence"],
+    ["section:risks-anomalies", "## Risks & Anomalies"],
+    ["anchor:baseline", "Baseline (Pre-change)"],
+    ["anchor:post-change", "Post-change Runs"],
+    ["anchor:run-1", "Run 1"],
+    ["anchor:run-2", "Run 2"],
+    ["metric:total_ms", "total_ms"],
+    ["principle:not-reducing-intelligence", "not reducing intelligence"],
+  ];
+  for (const [id, needle] of literals) {
+    if (!body.includes(needle)) missing.push({ id, needle });
+  }
+  const isPass1 = body.includes("[x] Pass 1") || body.includes("[X] Pass 1");
+  const isPass2 = body.includes("[x] Pass 2") || body.includes("[X] Pass 2");
+  const isPass3 = body.includes("[x] Pass 3") || body.includes("[X] Pass 3");
+  if (!(isPass1 || isPass2 || isPass3)) {
+    missing.push({ id: "pass-selection", needle: "[ ] Pass 1 / [ ] Pass 2 / [ ] Pass 3 (check exactly one)" });
+  }
+  if (!/pass\d?_?ms|passX_ms/.test(body)) {
+    missing.push({ id: "metric:pass-ms", needle: "passX_ms" });
+  }
+  if (!(body.includes("QG_") || body.includes("quality gate") || body.includes("Quality Gate"))) {
+    missing.push({ id: "quality-gate", needle: "Quality Gate" });
+  }
+  if (isPass3 && !body.includes("criteria_count_by_state")) {
+    missing.push({ id: "pass3:criteria_count_by_state", needle: "criteria_count_by_state" });
+  }
+  return missing;
+}
+
+function renderFooter(missing) {
+  const lines = [
+    FOOTER_HEADER,
+    "",
+    "> This footer was added automatically because one or more REQUIRED tokens were",
+    "> missing from the PR body. Please replace the placeholders below with real",
+    "> values before merging. See `docs/governance/PR_BODY_MISTAKE_PROOFING.md`.",
+    "",
+  ];
+  const has = (id) => missing.some((m) => m.id === id);
+
+  if (has("section:summary")) {
+    lines.push("## Summary", "", "N/A — please fill", "");
+  }
+  if (has("section:scope")) {
+    lines.push("## Scope", "", "N/A — please fill", "");
+  }
+  if (has("pass-selection")) {
+    lines.push(
+      "Pass selection (CHECK EXACTLY ONE — placeholder; please correct):",
+      "",
+      "- [x] Pass 1",
+      "- [ ] Pass 2",
+      "- [ ] Pass 3",
+      "",
+    );
+  }
+  if (has("section:contract-integrity")) {
+    lines.push("## Contract Integrity", "", "N/A — please fill", "");
+  }
+  if (has("section:behavioral-quality")) {
+    lines.push("## Behavioral Quality", "", "This PR is not reducing intelligence.", "");
+  } else if (has("principle:not-reducing-intelligence")) {
+    lines.push("This PR is not reducing intelligence.", "");
+  }
+  if (has("section:latency-evidence") || has("anchor:baseline") || has("anchor:post-change") || has("anchor:run-1") || has("anchor:run-2") || has("metric:pass-ms") || has("metric:total_ms")) {
+    lines.push(
+      "## Latency Evidence",
+      "",
+      "### Baseline (Pre-change)",
+      "",
+      "| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |",
+      "|---|---:|---:|---:|---:|---|",
+      "| Run 1 | N/A — please fill | N/A | N/A | N/A — please fill | placeholder |",
+      "| Run 2 | N/A — please fill | N/A | N/A | N/A — please fill | placeholder |",
+      "",
+      "### Post-change Runs",
+      "",
+      "| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |",
+      "|---|---:|---:|---:|---:|---|",
+      "| Run 1 | N/A — please fill | N/A | N/A | N/A — please fill | placeholder |",
+      "| Run 2 | N/A — please fill | N/A | N/A | N/A — please fill | placeholder |",
+      "",
+    );
+  }
+  if (has("pass3:criteria_count_by_state")) {
+    lines.push("criteria_count_by_state: N/A — please fill (Pass 3 requires this)", "");
+  }
+  if (has("quality-gate")) {
+    lines.push("Quality Gate: <PASS|FAIL> — please fill before merge", "");
+  }
+  if (has("section:risks-anomalies")) {
+    lines.push("## Risks & Anomalies", "", "N/A — please fill", "");
+  }
+  return lines.join("\n") + "\n";
+}
+
+const args = parseArgs(process.argv.slice(2));
+let body;
+try {
+  if (args.in) {
+    body = readFileSync(args.in, "utf8");
+  } else {
+    body = readFileSync(0, "utf8");
+  }
+} catch (e) {
+  console.error(`Could not read body: ${e.message}`);
+  process.exit(2);
+}
+
+const stripped = stripExistingFooter(body);
+const missing = detectMissing(stripped);
+
+if (missing.length === 0) {
+  if (args.out) writeFileSync(args.out, stripped);
+  else process.stdout.write(stripped);
+  process.stderr.write("HEALED=0\n");
+  process.exit(0);
+}
+
+const healed = stripped.replace(/\s+$/, "") + "\n\n" + renderFooter(missing);
+if (args.out) writeFileSync(args.out, healed);
+else process.stdout.write(healed);
+process.stderr.write("HEALED=1\n");
+process.stderr.write(`MISSING_COUNT=${missing.length}\n`);
+for (const m of missing) process.stderr.write(`MISSING=${m.id}\n`);
+process.exit(0);

--- a/scripts/gh-pr-create-safe.sh
+++ b/scripts/gh-pr-create-safe.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Safe wrapper around `gh pr create --body-file`.
+# Validates the body file with scripts/validate-pr-body.mjs first; only
+# invokes gh pr create if validation passes.
+#
+# Usage:
+#   scripts/gh-pr-create-safe.sh --title "..." --body-file path/to/body.md [other gh pr create flags]
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+BODY_FILE=""
+PASS_THROUGH=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --body-file)
+      BODY_FILE="$2"
+      PASS_THROUGH+=("$1" "$2")
+      shift 2
+      ;;
+    --body-file=*)
+      BODY_FILE="${1#--body-file=}"
+      PASS_THROUGH+=("$1")
+      shift
+      ;;
+    *)
+      PASS_THROUGH+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${BODY_FILE}" ]; then
+  echo "❌ gh-pr-create-safe.sh: --body-file <path> is required."
+  exit 2
+fi
+
+if [ ! -f "${BODY_FILE}" ]; then
+  echo "❌ gh-pr-create-safe.sh: body file not found: ${BODY_FILE}"
+  exit 2
+fi
+
+echo "🔍 Validating ${BODY_FILE} against enforce-latency-template..."
+if ! node scripts/validate-pr-body.mjs --file "${BODY_FILE}"; then
+  echo ""
+  echo "❌ gh-pr-create-safe.sh BLOCKED: body file does not satisfy enforce-latency-template."
+  echo "   Fix the missing tokens and retry."
+  exit 1
+fi
+
+echo ""
+echo "✅ Body file is compliant. Invoking gh pr create..."
+exec gh pr create "${PASS_THROUGH[@]}"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -16,6 +16,28 @@ if ! npm run docs:verify; then
   exit 1
 fi
 
+# PR body compliance check — only if a PR already exists for this branch.
+# Override with SKIP_PR_BODY_CHECK=1.
+if [ "${SKIP_PR_BODY_CHECK:-0}" = "1" ]; then
+  echo "⏭  Skipping PR body compliance check (SKIP_PR_BODY_CHECK=1)."
+elif ! command -v gh >/dev/null 2>&1; then
+  echo "⏭  Skipping PR body compliance check (gh CLI not installed)."
+else
+  PR_NUM="$(gh pr view --json number --jq .number 2>/dev/null || true)"
+  if [ -n "${PR_NUM}" ]; then
+    echo ""
+    echo "🔍 PR body compliance check (PR #${PR_NUM})..."
+    if ! node scripts/validate-pr-body.mjs --pr "${PR_NUM}"; then
+      echo ""
+      echo "❌ PRE-PUSH BLOCKED: PR #${PR_NUM} body fails enforce-latency-template."
+      echo "   Run 'npm run pr:check' and fix the missing tokens, or set SKIP_PR_BODY_CHECK=1 to bypass."
+      exit 1
+    fi
+  else
+    echo "⏭  No PR found for current branch — skipping PR body compliance check."
+  fi
+fi
+
 echo ""
 echo "✅ Pre-push verification passed. Proceeding with push..."
 exit 0

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+// Mirrors .github/workflows/latency-pr-enforcement.yml — keep both in sync.
+// Validates a PR body against the latency template requirements.
+// Usage:
+//   node scripts/validate-pr-body.mjs                       (validate current branch's PR)
+//   node scripts/validate-pr-body.mjs --pr <number>         (validate a specific PR)
+//   node scripts/validate-pr-body.mjs --file <path>         (validate a body file)
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+function parseArgs(argv) {
+  const out = { file: null, pr: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--file" && argv[i + 1]) { out.file = argv[++i]; continue; }
+    if (a.startsWith("--file=")) { out.file = a.slice("--file=".length); continue; }
+    if (a === "--pr" && argv[i + 1]) { out.pr = argv[++i]; continue; }
+    if (a.startsWith("--pr=")) { out.pr = a.slice("--pr=".length); continue; }
+  }
+  return out;
+}
+
+function tryGh(cmd) {
+  try {
+    return execSync(cmd, { stdio: ["ignore", "pipe", "pipe"] }).toString();
+  } catch {
+    return null;
+  }
+}
+
+function loadBody({ file, pr }) {
+  if (file) {
+    return { body: readFileSync(file, "utf8"), source: `file:${file}`, files: null };
+  }
+  if (pr) {
+    const body = tryGh(`gh pr view ${pr} --json body --jq .body`);
+    if (body == null) {
+      console.error(`Could not read PR #${pr} body via gh.`);
+      process.exit(2);
+    }
+    const filesJson = tryGh(`gh pr view ${pr} --json files`);
+    let files = null;
+    if (filesJson) {
+      try { files = JSON.parse(filesJson).files.map((f) => f.path); } catch {}
+    }
+    return { body, source: `pr:${pr}`, files };
+  }
+  // Current branch
+  const body = tryGh(`gh pr view --json body --jq .body`);
+  if (body == null) {
+    console.error("No PR found for current branch and no --file or --pr provided.");
+    process.exit(2);
+  }
+  const filesJson = tryGh(`gh pr view --json files`);
+  let files = null;
+  if (filesJson) {
+    try { files = JSON.parse(filesJson).files.map((f) => f.path); } catch {}
+  }
+  return { body, source: "pr:current-branch", files };
+}
+
+function isExemptOnly(files) {
+  if (!files || files.length === 0) return false;
+  const isDocs = (n) => n.startsWith("docs/");
+  const isMigration = (n) => n.startsWith("supabase/migrations/");
+  const isAdminUi = (n) => n.startsWith("app/admin/") || n.startsWith("components/admin/");
+  return files.every((n) => isDocs(n) || isMigration(n) || isAdminUi(n));
+}
+
+function runChecks(body) {
+  const groups = {
+    "Required global sections": [
+      ["## Summary", "Missing: Summary section"],
+      ["## Scope", "Missing: Scope section"],
+      ["## Contract Integrity", "Missing: Contract Integrity section"],
+      ["## Behavioral Quality", "Missing: Behavioral Quality section"],
+      ["## Latency Evidence", "Missing: Latency Evidence section"],
+      ["## Risks & Anomalies", "Missing: Risks & Anomalies section"],
+    ],
+    "Latency anchors": [
+      ["Baseline (Pre-change)", "Missing latency anchor: Baseline (Pre-change)"],
+      ["Post-change Runs", "Missing latency anchor: Post-change Runs"],
+      ["Run 1", "Missing: Run 1 evidence"],
+      ["Run 2", "Missing: Run 2 evidence"],
+    ],
+    "Metric tokens": [
+      ["total_ms", "Missing total_ms metric"],
+    ],
+    "Final principle": [
+      ["not reducing intelligence", "Missing final principle: must acknowledge quality preservation rule"],
+    ],
+  };
+
+  const missing = [];
+  for (const [cat, checks] of Object.entries(groups)) {
+    for (const [needle, msg] of checks) {
+      if (!body.includes(needle)) missing.push({ cat, msg, needle });
+    }
+  }
+
+  // Pass selection
+  const isPass1 = body.includes("[x] Pass 1") || body.includes("[X] Pass 1");
+  const isPass2 = body.includes("[x] Pass 2") || body.includes("[X] Pass 2");
+  const isPass3 = body.includes("[x] Pass 3") || body.includes("[X] Pass 3");
+  if (!(isPass1 || isPass2 || isPass3)) {
+    missing.push({
+      cat: "Pass selection",
+      msg: "You must select Pass 1, Pass 2, or Pass 3 (at least one of [x] Pass 1 / [x] Pass 2 / [x] Pass 3)",
+      needle: "[x] Pass {1|2|3}",
+    });
+  }
+
+  // pass metric regex
+  if (!/pass\d?_?ms|passX_ms/.test(body)) {
+    missing.push({
+      cat: "Metric tokens",
+      msg: "Missing pass latency metric (e.g. pass1_ms / pass2_ms / pass3_ms / passX_ms)",
+      needle: "/pass\\d?_?ms|passX_ms/",
+    });
+  }
+
+  // Pass 3 special
+  if (isPass3 && !body.includes("criteria_count_by_state")) {
+    missing.push({
+      cat: "Pass 3 special",
+      msg: "Pass 3 PRs must include divergence distribution (criteria_count_by_state)",
+      needle: "criteria_count_by_state",
+    });
+  }
+
+  // Quality gate
+  if (!(body.includes("QG_") || body.includes("quality gate") || body.includes("Quality Gate"))) {
+    missing.push({
+      cat: "Quality gate",
+      msg: "Missing quality gate / anomaly disclosure (QG_, quality gate, or Quality Gate)",
+      needle: "QG_ | quality gate | Quality Gate",
+    });
+  }
+
+  return { missing, isPass1, isPass2, isPass3 };
+}
+
+function printMissing(missing) {
+  const byCat = new Map();
+  for (const m of missing) {
+    if (!byCat.has(m.cat)) byCat.set(m.cat, []);
+    byCat.get(m.cat).push(m);
+  }
+  console.error("❌ PR body failed enforce-latency-template compliance.");
+  console.error("");
+  for (const [cat, items] of byCat) {
+    console.error(`  ${cat}:`);
+    for (const it of items) {
+      console.error(`    - ${it.msg}`);
+      console.error(`        needle: ${it.needle}`);
+    }
+  }
+}
+
+function printDiff(body, missing) {
+  if (missing.length === 0) return;
+  console.error("");
+  console.error("--- Required tokens not present in body ---");
+  for (const m of missing) {
+    console.error(`  + ${m.needle}`);
+  }
+  console.error("--- End diff ---");
+}
+
+const args = parseArgs(process.argv.slice(2));
+const { body, source, files } = loadBody(args);
+
+if (!args.file && isExemptOnly(files)) {
+  console.log(`✅ Skipping enforcement: PR (${source}) changes are exempt-scope (docs/migrations/admin-ui only).`);
+  process.exit(0);
+}
+
+const { missing } = runChecks(body);
+
+if (missing.length === 0) {
+  console.log(`✅ PR body is enforce-latency-template compliant. (source=${source})`);
+  process.exit(0);
+}
+
+printMissing(missing);
+printDiff(body, missing);
+process.exit(1);


### PR DESCRIPTION
<!-- Comet template-unification: enforcement-compliant default body. -->
<!-- DO NOT delete required ## headings unless your PR is migration/docs-only (auto-skipped by latency-pr-enforcement.yml). -->

> ### Pre-flight checklist (visual reminder — not parsed)
> 1. Pick exactly one Pass below (Pass 1 / Pass 2 / Pass 3).
> 2. Fill `Run 1` and `Run 2` ms numbers in the latency table.
> 3. Set the `Quality Gate:` line to PASS or FAIL.
> 4. Fill the `Scope` section with changed files / scope description.
> 5. Fill the `Risks & Anomalies` section.
> 6. Run `npm run pr:check` locally before pushing.

<!-- REQUIRED — DO NOT REMOVE: ## Summary -->
## Summary
<!-- END REQUIRED -->

Build a 3-layer mistake-proofing system around `enforce-latency-template` so PRs stop failing on missing tokens. The enforcement workflow itself is untouched — this PR shifts every failure mode left.

- **Layer 1 — Template (`.github/PULL_REQUEST_TEMPLATE.md`)**: every required literal token is already present verbatim and wrapped in `<!-- REQUIRED — DO NOT REMOVE: ... --> ... <!-- END REQUIRED -->` markers. All three Pass checkboxes are unchecked under a banner that flags the one-and-only-one rule. `pass1_ms` / `pass2_ms` / `pass3_ms` all live in the latency table so the regex is always satisfied. A 6-line pre-flight checklist sits at the top.
- **Layer 2 — Local validator (`scripts/validate-pr-body.mjs`, `npm run pr:check`)**: pure Node, no new deps, mirrors every assertion in `.github/workflows/latency-pr-enforcement.yml`. Wired into `scripts/pre-push.sh` (bypass with `SKIP_PR_BODY_CHECK=1`) and a `scripts/gh-pr-create-safe.sh` wrapper around `gh pr create --body-file`.
- **Layer 3 — Server-side auto-heal (`.github/workflows/auto-heal-pr-body.yml` + `scripts/auto-heal-pr-body.mjs`)**: triggers on `[opened, edited, reopened]` (not `synchronize`, to avoid loops), detects missing REQUIRED tokens, appends an idempotent `## 🛟 Compliance Footer` section with placeholder values, edits the PR body via `gh pr edit`, and posts a sticky comment.

Reduces PR latency rework time for @Mmeraw.

<details>
<summary>Validator output against this body (proof it works)</summary>

```
$ node scripts/validate-pr-body.mjs --file /tmp/self_pr_body.md
✅ PR body is enforce-latency-template compliant. (source=file:/tmp/self_pr_body.md)
```

</details>

<details>
<summary>Validator output against a deliberately broken body</summary>

```
$ node scripts/validate-pr-body.mjs --file /tmp/broken-body.md
❌ PR body failed enforce-latency-template compliance.

  Required global sections:
    - Missing: Summary section
    - Missing: Scope section
    - Missing: Contract Integrity section
    - Missing: Behavioral Quality section
    - Missing: Latency Evidence section
    - Missing: Risks & Anomalies section
  Latency anchors:
    - Missing latency anchor: Baseline (Pre-change)
    - Missing latency anchor: Post-change Runs
    - Missing: Run 1 evidence
    - Missing: Run 2 evidence
  Metric tokens:
    - Missing total_ms metric
    - Missing pass latency metric (e.g. pass1_ms / pass2_ms / pass3_ms / passX_ms)
  Final principle:
    - Missing final principle: must acknowledge quality preservation rule
  Pass selection:
    - You must select Pass 1, Pass 2, or Pass 3
  Quality gate:
    - Missing quality gate / anomaly disclosure (QG_, quality gate, or Quality Gate)

(exit 1)
```

</details>

<!-- REQUIRED — DO NOT REMOVE: ## Scope -->
## Scope
<!-- END REQUIRED -->

> ⚠️ CHECK EXACTLY ONE PASS BELOW — leaving all unchecked will fail latency-pr-enforcement

<!-- REQUIRED — DO NOT REMOVE: Pass selection -->
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3
<!-- END REQUIRED -->

This is a low-risk infra change (docs + scripts + a new workflow); treated as Pass 1.

Changed files:

- `.github/PULL_REQUEST_TEMPLATE.md` — mistake-proofed template with REQUIRED markers
- `.github/workflows/auto-heal-pr-body.yml` — new auto-heal workflow
- `scripts/validate-pr-body.mjs` — new local validator
- `scripts/auto-heal-pr-body.mjs` — new auto-heal script
- `scripts/gh-pr-create-safe.sh` — new safe wrapper around `gh pr create`
- `scripts/pre-push.sh` — adds PR body compliance check
- `scripts/README.md` — documents new tooling
- `package.json` — adds `pr:check` script
- `docs/governance/PR_BODY_MISTAKE_PROOFING.md` — full system docs

Out of scope:

- `.github/workflows/latency-pr-enforcement.yml` — left as-is per spec
- Required status checks / branch protection — unchanged
- `lib/evaluation/pipeline/**`, `lib/evaluation/processor.ts`, anything in evaluation pipeline — separate workstream

<!-- REQUIRED — DO NOT REMOVE: ## Contract Integrity -->
## Contract Integrity
<!-- END REQUIRED -->

- No runtime evaluator code touched.
- No schema, no canonical statuses, no quality-gate logic changes.
- `.github/workflows/latency-pr-enforcement.yml` is unchanged — the gate stays the source of truth for compliance.
- New validator must stay in sync with that workflow; `docs/governance/PR_BODY_MISTAKE_PROOFING.md` documents the keep-in-sync rule.

<!-- REQUIRED — DO NOT REMOVE: ## Behavioral Quality -->
## Behavioral Quality
<!-- END REQUIRED -->

<!-- REQUIRED — DO NOT REMOVE: not reducing intelligence -->
This PR is not reducing intelligence.
<!-- END REQUIRED -->

This change is governance / tooling scaffolding only. It does not modify any evaluator behavior or scoring path. The PR template still requires authors to fill in real ms numbers and Pass selection — the system removes bookkeeping friction, not substantive review.

<!-- REQUIRED — DO NOT REMOVE: ## Latency Evidence -->
## Latency Evidence
<!-- END REQUIRED -->

<!-- REQUIRED — DO NOT REMOVE: Baseline (Pre-change) -->
### Baseline (Pre-change)
<!-- END REQUIRED -->

<!-- Fill the row that matches your selected Pass; leave others as N/A -->

| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
|---|---:|---:|---:|---:|---|
| Run 1 | N/A | N/A | N/A | N/A | infra-only; no pipeline execution |
| Run 2 | N/A | N/A | N/A | N/A | infra-only; no pipeline execution |

<!-- REQUIRED — DO NOT REMOVE: Post-change Runs -->
### Post-change Runs
<!-- END REQUIRED -->

<!-- Fill the row that matches your selected Pass; leave others as N/A -->

<!-- REQUIRED — DO NOT REMOVE: Run 1 / Run 2 -->
| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
|---|---:|---:|---:|---:|---|
| Run 1 | N/A | N/A | N/A | N/A | `node scripts/validate-pr-body.mjs --file <body>` — exits 0 on compliant body, 1 on missing tokens |
| Run 2 | N/A | N/A | N/A | N/A | re-run: deterministic, no flake |
<!-- END REQUIRED -->

pass1_ms / total_ms reported as N/A because this PR does not execute any pipeline pass; latency is unaffected.

<!-- Required for Pass 3; leave as-is otherwise -->
criteria_count_by_state: N/A (Pass 1 or 2)

## Quality Gate / Anomalies

<!-- REQUIRED — DO NOT REMOVE: Quality Gate token -->
Quality Gate: PASS — no quality gate behavior modified
<!-- END REQUIRED -->

QG_none: no new `QG_` anomalies introduced; no quality gate behavior changed.

<!-- REQUIRED — DO NOT REMOVE: ## Risks & Anomalies -->
## Risks & Anomalies
<!-- END REQUIRED -->

- **Risk: validator drift** — `validate-pr-body.mjs` could fall out of sync with `latency-pr-enforcement.yml`. Mitigation: governance doc explicitly names the keep-in-sync rule.
- **Risk: auto-heal placebo** — authors might leave `N/A — please fill` placeholders in and merge. Mitigation: the sticky comment is explicit, and the footer header is unmissable; reviewers must enforce.
- **Risk: workflow loop** — `auto-heal-pr-body.yml` could theoretically loop on its own `gh pr edit` if it listened to `synchronize`. Mitigation: it does **not** listen to `synchronize`, only `[opened, edited, reopened]`, and the heal step is idempotent (existing footer stripped on each run).
- **Risk: pre-push hook annoyance** — could block emergency pushes. Mitigation: `SKIP_PR_BODY_CHECK=1` bypass; only runs when a PR already exists for the branch.

## Architecture Alignment

- alignment: post-#384 architecture-aligned
- mitigation_expiry: n/a
- dependent_architecture: n/a
- expected_revisit: no
- replay_ids_at_risk: none
- replay_ids_targeted: none
