### PR TITLE
fix: chunker post-condition prevents prompt-window overflow (CHUNK_BUDGET_OVERFLOW)

### DIFF
--- a/__tests__/lib/evaluation/processor.chunk-routing.test.ts
+++ b/__tests__/lib/evaluation/processor.chunk-routing.test.ts
@@ -603,4 +603,135 @@ describe("processEvaluationJob long-form chunk routing", () => {
     expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
     expect(runPipelineMock).not.toHaveBeenCalled();
   });
+
+  test("long_form fails closed with CHUNK_BUDGET_OVERFLOW in <100ms when any chunk exceeds inputCharBudget * 0.95 (Cartel Babies regression)", async () => {
+    // 137,758-word manuscript shape — chunker emits a 50,000-char chunk that exceeds
+    // the 40,000-char prompt window. Without this gate, Pass 1 would be dispatched
+    // and absorb the full 720s LONG_FORM_TIMEOUT_FLOOR_MS before failing with PASS1_TIMEOUT.
+    const manuscriptContent =
+      "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(13_776);
+    const supabaseStub = makeSupabaseStub(manuscriptContent);
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksFromTextMock.mockResolvedValueOnce({
+      ensured_count: 1,
+      persisted_count: 1,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+      max_chunk_chars: 50_000,
+      max_chunk_index: 0,
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const startedAt = Date.now();
+    const result = await processEvaluationJob("job-long-form-routing");
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/chunk 0/);
+    expect(result.error).toMatch(/char_count=50000/);
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).not.toHaveBeenCalled();
+    // Must fail closed in well under the 720s LONG_FORM_TIMEOUT_FLOOR_MS.
+    expect(elapsedMs).toBeLessThan(100);
+
+    const failureUpdate = supabaseStub.evaluationJobUpdates.find((payload) => {
+      const progress = payload.progress as
+        | {
+            error_code?: string;
+            pipeline_failure_envelope?: {
+              error_code?: string;
+              failed_at?: string;
+              pipeline_stage?: string;
+              reason_codes?: string[];
+            };
+          }
+        | undefined;
+      return (
+        progress?.error_code === "CHUNK_BUDGET_OVERFLOW" ||
+        progress?.pipeline_failure_envelope?.error_code === "CHUNK_BUDGET_OVERFLOW"
+      );
+    });
+    expect(failureUpdate).toBeDefined();
+    const envelope = (failureUpdate?.progress as {
+      pipeline_failure_envelope?: {
+        error_code?: string;
+        failed_at?: string;
+        pipeline_stage?: string;
+        reason_codes?: string[];
+      };
+    })?.pipeline_failure_envelope;
+    expect(envelope?.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
+    expect(envelope?.failed_at).toBe("chunking");
+    expect(envelope?.pipeline_stage).toBe("chunking");
+    expect(envelope?.reason_codes).toEqual(["CHUNK_BUDGET_OVERFLOW"]);
+  });
+
+  test("long_form with max_chunk_chars ≤ 38,000 passes the chunker post-condition and dispatches the pipeline", async () => {
+    const manuscriptContent =
+      "alpha beta gamma delta epsilon zeta eta theta iota kappa ".repeat(2600);
+    const supabaseStub = makeSupabaseStub(manuscriptContent, {
+      manuscriptChunks: [
+        { chunk_index: 0, content: "Chunk 0 text" },
+        { chunk_index: 1, content: "Chunk 1 text" },
+        { chunk_index: 2, content: "Chunk 2 text" },
+        { chunk_index: 3, content: "Chunk 3 text" },
+      ],
+    });
+    createClientMock.mockReturnValue(supabaseStub);
+
+    ensureChunksFromTextMock.mockResolvedValueOnce({
+      ensured_count: 4,
+      persisted_count: 4,
+      chunk_source: "processor_resolved_text",
+      verified_at: new Date().toISOString(),
+      max_chunk_chars: 38_000,
+      max_chunk_index: 1,
+    });
+
+    runPipelineMock.mockResolvedValue({
+      ok: true,
+      synthesis: {
+        criteria: [],
+        overall: {
+          overall_score_0_100: 82,
+          verdict: "pass",
+          one_paragraph_summary: "Summary",
+          top_3_strengths: [],
+          top_3_risks: [],
+        },
+        metadata: {
+          pass1_model: "gpt-4o",
+          pass2_model: "o3",
+          pass3_model: "o3",
+          generated_at: new Date().toISOString(),
+        },
+      },
+      quality_gate: { pass: true, checks: [], warnings: [] },
+      pass4_governance: { ok: true },
+    });
+
+    synthesisToEvaluationResultV2Mock.mockReturnValue(buildEvaluationResult());
+    runQualityGateV2Mock.mockReturnValue({ pass: true, checks: [], warnings: [] });
+    mapEvaluationResultV2ToGovernanceEnvelopeMock.mockReturnValue({
+      evaluation_run_id: "run-long-form-1",
+      criteria: [],
+    });
+
+    const { processEvaluationJob } = require("../../../lib/evaluation/processor");
+    const result = await processEvaluationJob("job-long-form-routing");
+
+    expect(result.success).toBe(true);
+    expect(ensureChunksFromTextMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).toHaveBeenCalledTimes(1);
+
+    // No CHUNK_BUDGET_OVERFLOW envelope persisted.
+    const budgetFailure = supabaseStub.evaluationJobUpdates.find((payload) => {
+      const progress = payload.progress as
+        | { pipeline_failure_envelope?: { error_code?: string } }
+        | undefined;
+      return progress?.pipeline_failure_envelope?.error_code === "CHUNK_BUDGET_OVERFLOW";
+    });
+    expect(budgetFailure).toBeUndefined();
+  });
 });

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -158,6 +158,9 @@ type ChunkRoutingTelemetry = {
   persisted_chunk_count?: number;
   chunk_source?: 'processor_resolved_text';
   verified_at?: string;
+  // Largest chunk size — surfaced for the CHUNK_BUDGET_OVERFLOW post-condition.
+  max_chunk_chars?: number;
+  max_chunk_index?: number;
 }
 
 type FinalTextProvenance = {
@@ -943,6 +946,8 @@ async function maybeEnsureLongFormChunks(args: {
     persisted_chunk_count: chunkResult.persisted_count,
     chunk_source: chunkResult.chunk_source,
     verified_at: chunkResult.verified_at,
+    max_chunk_chars: chunkResult.max_chunk_chars,
+    max_chunk_index: chunkResult.max_chunk_index,
   };
 }
 
@@ -1798,6 +1803,41 @@ export async function processEvaluationJob(jobId: string): Promise<{ success: bo
         diagnostics: { chunk_routing: chunkRouting },
       });
       return { success: false, error: chunkMaterializationError };
+    }
+
+    // Post-condition: every materialized chunk MUST fit the Pass 1 prompt window.
+    // Audit PR #1 — prevent the Cartel Babies failure class (137 758-word manuscript →
+    // 720 s PASS1_TIMEOUT). Fail closed BEFORE Pass 1 dispatch with a typed
+    // CHUNK_BUDGET_OVERFLOW so the user gets actionable feedback in <100 ms
+    // instead of absorbing the full LONG_FORM_TIMEOUT_FLOOR_MS.
+    if (
+      chunkRouting.route === 'long_form' &&
+      typeof chunkRouting.max_chunk_chars === 'number' &&
+      chunkRouting.max_chunk_chars > 0
+    ) {
+      const charBudget = chunkRouting.prompt_budget_chars;
+      const budgetCeiling = Math.floor(charBudget * 0.95);
+      if (chunkRouting.max_chunk_chars > budgetCeiling) {
+        const violatingIndex = chunkRouting.max_chunk_index ?? 0;
+        const ratio = charBudget > 0 ? chunkRouting.max_chunk_chars / charBudget : 0;
+        const chunkBudgetError =
+          `Chunker post-condition violated: chunk ${violatingIndex} has ` +
+          `char_count=${chunkRouting.max_chunk_chars} which exceeds 95% of ` +
+          `inputCharBudget (${charBudget}). Pass 1 cannot complete within the prompt ` +
+          `window — failing closed before dispatch.`;
+        await markFailed(chunkBudgetError, 'CHUNK_BUDGET_OVERFLOW', {
+          pipelineStage: 'chunking',
+          reasonCodes: ['CHUNK_BUDGET_OVERFLOW'],
+          diagnostics: {
+            chunk_routing: chunkRouting,
+            violating_chunk_index: violatingIndex,
+            chunk_char_count: chunkRouting.max_chunk_chars,
+            char_budget: charBudget,
+            ratio,
+          },
+        });
+        return { success: false, error: chunkBudgetError };
+      }
     }
 
     let manuscriptChunksForPipeline: ManuscriptChunkEvidence[] | undefined;

--- a/lib/manuscripts/chunks.ts
+++ b/lib/manuscripts/chunks.ts
@@ -783,6 +783,10 @@ export type EnsureChunksFromTextResult = {
   overlap_words?: number;
   /** Derived overlap/duplication chars = chunk_storage_chars - source_manuscript_chars. */
   overlap_chars?: number;
+  /** Largest chunk content length in chars (used by the CHUNK_BUDGET_OVERFLOW post-condition). */
+  max_chunk_chars?: number;
+  /** chunk_index of the chunk whose content matched max_chunk_chars. */
+  max_chunk_index?: number;
 };
 
 function countWordsFromText(text: string): number {
@@ -825,6 +829,15 @@ export async function ensureChunksFromText(
   const chunk_storage_chars = chunks.reduce((acc, chunk) => acc + chunk.content.length, 0);
   const overlap_words = Math.max(0, chunk_storage_words - source_manuscript_words);
   const overlap_chars = Math.max(0, chunk_storage_chars - source_manuscript_chars);
+  let max_chunk_chars = 0;
+  let max_chunk_index = 0;
+  for (const chunk of chunks) {
+    const len = chunk.content.length;
+    if (len > max_chunk_chars) {
+      max_chunk_chars = len;
+      max_chunk_index = chunk.chunk_index;
+    }
+  }
 
   if (ensured_count === 0) {
     throw new Error(
@@ -864,5 +877,7 @@ export async function ensureChunksFromText(
     chunk_storage_chars,
     overlap_words,
     overlap_chars,
+    max_chunk_chars,
+    max_chunk_index,
   };
 }

--- a/tests/fixtures/sipoc/s04_chunker_budget_overflow.json
+++ b/tests/fixtures/sipoc/s04_chunker_budget_overflow.json
@@ -1,0 +1,34 @@
+{
+  "fixture_id": "s04b.routing-chunking.fail-closed-on-budget-overflow",
+  "fixture_version": "v1",
+  "stage_id": "S04_ROUTING_CHUNKING",
+  "track": "evaluation_runtime_sipoc",
+  "severity": "critical",
+  "invariant_id": "ROUTING_CHUNKING_BUDGET_OVERFLOW_FAIL_CLOSED",
+  "description": "Chunker must fail closed before Pass 1 dispatch when any materialized chunk's char_count exceeds inputCharBudget * 0.95.",
+  "input_stub": {
+    "routing_mode": "chunked",
+    "input_char_budget": 40000,
+    "max_chunk_chars": 50000,
+    "violating_chunk_index": 0,
+    "ratio_to_budget": 1.25,
+    "failed_at_step": "chunking"
+  },
+  "expected": {
+    "result_type": "fail",
+    "must_fail_closed": true,
+    "required_failure_codes": ["CHUNK_BUDGET_OVERFLOW"],
+    "forbidden_failure_codes": [
+      "PASS1_TIMEOUT",
+      "PASS1_TRUNCATED_EMPTY_RESPONSE",
+      "PASS1_ACCEPTED_WITH_INCOMPLETE_EVIDENCE"
+    ],
+    "notes": "Fail-closed at the chunking boundary (failed_at='chunking', not phase_1) in <100 ms — prevents the LONG_FORM_TIMEOUT_FLOOR_MS absorption path identified by the Cartel Babies audit (PR #1)."
+  },
+  "evidence_artifacts": ["pipeline_failure_envelope", "evaluation_result_v2"],
+  "authority_refs": {
+    "sipoc_contract": "docs/SIPOC_EVALUATION_PROCESS.md",
+    "spec": ["docs/JOB_CONTRACT_v1.md"],
+    "runtime": ["lib/evaluation/processor.ts", "lib/manuscripts/chunks.ts"]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a chunker post-condition that asserts `max chunk char_count ≤ inputCharBudget × 0.95` before Pass 1 dispatch. This eliminates the **Cartel Babies** failure class — where a 137,758-word manuscript hands Pass 1 a 50,000-char chunk that mathematically cannot complete in the 40,000-char prompt window, and the worker absorbs the full 720 s `LONG_FORM_TIMEOUT_FLOOR_MS` before emitting `PASS1_TIMEOUT`. With this gate, the same input fails closed in <100 ms with a typed `CHUNK_BUDGET_OVERFLOW` code and a `pipeline_failure_envelope` carrying `{violating_chunk_index, chunk_char_count, char_budget, ratio}` at `failed_at='chunking'`.

Closes / refs: PR #1 of the RevisionGrade pipeline audit (`audit_findings_summary.md` §3 "Recommended next 3 PRs").

**Root cause (verbatim from audit):**
> The chunker emitted a chunk larger than the 40 000-char prompt window, and no precondition gate catches that mismatch before the pass is dispatched. The entire 720 s `LONG_FORM_TIMEOUT_FLOOR_MS` exists to absorb that. s05 codifies the cleanup; it does not codify the prevention.

**Cartel Babies before/after:** Before: 720 s timeout absorption → `PASS1_TIMEOUT` (correct fail-closed, wrong latency). After: <100 ms typed `CHUNK_BUDGET_OVERFLOW` at the chunking boundary.

## Scope

Pass selection (CHECK EXACTLY ONE — Pass 2 pre-checked as default):

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

Changed files:

- `lib/evaluation/processor.ts` — post-condition gate between `maybeEnsureLongFormChunks` and Pass 1 dispatch; emits `CHUNK_BUDGET_OVERFLOW` via existing `markFailed` with `pipelineStage='chunking'` so the envelope reports `failed_at='chunking'` (not `phase_1`). Also extends `ChunkRoutingTelemetry` with `max_chunk_chars` / `max_chunk_index`.
- `lib/manuscripts/chunks.ts` — `ensureChunksFromText` now computes and returns `max_chunk_chars` / `max_chunk_index` so the post-condition can run without a second DB read.
- `__tests__/lib/evaluation/processor.chunk-routing.test.ts` — two new tests: (a) 50,000-char chunk fails closed in <100 ms with `CHUNK_BUDGET_OVERFLOW`, `pipeline_stage='chunking'`, Pass 1 not invoked; (b) 38,000-char chunks pass the gate and dispatch the pipeline normally.
- `tests/fixtures/sipoc/s04_chunker_budget_overflow.json` — new SIPOC contract fixture codifying the fail-closed invariant.

Out of scope (explicit follow-ups per audit sequence):

- PR #2: coverage-vs-truncation hard gate (replace silent `buildPromptInputWindow` downgrade with `PASS{N}_COVERAGE_TRUNCATION_INCOMPLETE`).
- PR #3: SIPOC harness runtime wiring (invoke `runPipeline` with `input_stub`) + add `sipoc-certification` to required status checks on the `main` ruleset.
- `AbortController` plumbing on `withTimeout` (separate audit-sequence PR).

## Contract Integrity

- New invariant `ROUTING_CHUNKING_BUDGET_OVERFLOW_FAIL_CLOSED` codified in SIPOC fixture `s04_chunker_budget_overflow.json` (stage `S04_ROUTING_CHUNKING`). Validator (`npm run sipoc:validate`) and harness (`npm run sipoc:harness`) both pass for all 13 fixtures.
- Does NOT modify `LONG_FORM_TIMEOUT_FLOOR_MS` (still 720_000) — the timeout floor remains the safety net for everything else; this gate makes it unreachable for the chunk-size-vs-budget failure class.
- Does NOT modify `buildPromptInputWindow` truncation behavior — that downgrade path is PR #2.
- s05 (`PASS1_TIMEOUT_TRUNCATION_FAIL_CLOSED`) is preserved; it now reflects the residual long-tail timeout cases, not the chunker-induced ones.

## Behavioral Quality

This PR is not reducing intelligence.

The post-condition fires only when a chunk strictly exceeds 95% of the prompt window — the previous behavior in that case was a guaranteed 720 s timeout followed by `PASS1_TIMEOUT`, which never produced any criterion scoring. Replacing an unreachable code path with a typed sub-second failure preserves all valid evaluations and surfaces actionable feedback for invalid ones.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | 720000 | 720000 | Cartel Babies job 26220f5b-62fe-4079-8804-e69bdc0edc5f — absorbed full LONG_FORM_TIMEOUT_FLOOR_MS, emitted PASS1_TIMEOUT |
| Run 2 | 720000 | 720000 | Same shape (137,758-word manuscript, single 50k-char chunk) — deterministic 720 s floor |

### Post-change Runs

| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | 0 | <100 | Unit test: 50,000-char chunk → CHUNK_BUDGET_OVERFLOW, Pass 1 not invoked, fail-closed in <100 ms (asserted) |
| Run 2 | (unchanged) | (unchanged) | Unit test: max_chunk_chars=38,000 → pipeline dispatches normally, no regression |

## Quality Gate / Anomalies

QG_chunk_budget: new chunker-boundary fail-closed gate. No QG_ behavior changes in pass-2/pass-3 quality gates; the new gate fires strictly upstream of Pass 1.

## Risks & Anomalies

- Threshold (`× 0.95`) is conservative — chunkManuscript() targets ~12,000-char `maxChars` so the budget should not be reachable in practice for normal manuscripts; the gate only catches pathological/regression chunker output. Default `inputCharBudget=40000` → ceiling = 38,000 chars.
- The gate runs AFTER `LONG_FORM_CHUNK_MATERIALIZATION_FAILED` (existing chunk-count gate), so chunk-count mismatches still surface their original code first.
- Telemetry-only addition (`max_chunk_chars`, `max_chunk_index`) on `ChunkRoutingTelemetry`; optional fields, no schema migration.

## Architecture Alignment

- alignment: post-#384 architecture-aligned
- mitigation_expiry: n/a
- dependent_architecture: depends on existing `markFailed` + `buildPipelineFailureEnvelope` + `ChunkRoutingTelemetry` (no new abstractions).
- expected_revisit: no — this gate becomes redundant if PR #2 (coverage gate) and PR #3 (SIPOC runtime wiring) land, but it is correct standalone and is the cheapest fix.
- replay_ids_at_risk: none — no replay artifacts modified.
- replay_ids_targeted: Cartel Babies `evaluation_jobs.id='26220f5b-62fe-4079-8804-e69bdc0edc5f'` (audit reference; would now fail in <100 ms with `CHUNK_BUDGET_OVERFLOW`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)