### PR TITLE
feat(ci): typed PR templates + diff-driven validator dispatch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,6 @@ docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md     @Mmeraw
 .github/PULL_REQUEST_TEMPLATE/infra.md          @Mmeraw
 .github/PULL_REQUEST_TEMPLATE/docs.md           @Mmeraw
 .github/PULL_REQUEST_TEMPLATE/migration.md      @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/code.md           @Mmeraw
 .github/pull_request_template.md                @Mmeraw
 .github/workflows/latency-pr-enforcement.yml    @Mmeraw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,11 @@
+# CODEOWNERS for literary-ai-partner
+#
+# Governance docs that require explicit owner approval before modification.
+# See docs/GOVERNANCE_AUTHORITY_CHAIN.md for the broader authority model.
+
+docs/MAP_REDUCE_PIPELINE_GOVERNANCE_BRIEF.md   @Mmeraw
+.github/CODEOWNERS                              @Mmeraw
+
 # Typed PR template governance (locked 2026-05-13)
 docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md     @Mmeraw
 .github/PULL_REQUEST_TEMPLATE/evaluation.md     @Mmeraw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Typed PR template governance (locked 2026-05-13)
+docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md     @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/evaluation.md     @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/ui.md             @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/infra.md          @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/docs.md           @Mmeraw
+.github/PULL_REQUEST_TEMPLATE/migration.md      @Mmeraw
+.github/pull_request_template.md                @Mmeraw
+.github/workflows/latency-pr-enforcement.yml    @Mmeraw

--- a/.github/PULL_REQUEST_TEMPLATE/code.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- 1–3 sentences describing the code change. -->
+
+## Scope
+
+<!-- Which modules / packages / endpoints are affected. What is explicitly NOT touched. -->
+
+## Tests Updated
+
+<!-- Yes/No. If Yes: list the test files added or modified. If No: explain why no tests are needed (e.g. trivial typo fix, refactor with existing coverage). -->
+
+- Tests added/modified: <!-- list or "N/A — see explanation" -->
+
+## Risks & Anomalies
+
+<!-- What could go wrong; how it's mitigated. -->
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: code -->

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- 1–3 sentences describing what doc changes and why. -->
+
+## Scope
+
+<!-- Which docs / governance briefs / READMEs are affected. -->
+
+## Risks & Anomalies
+
+<!-- What could go wrong (e.g. doc contradicts code; outdated link; misleading example); how it's mitigated. -->
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: docs -->

--- a/.github/PULL_REQUEST_TEMPLATE/evaluation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/evaluation.md
@@ -65,3 +65,5 @@ QG_<gate-id>: <description or "no QG_ behavior changes">
 - expected_revisit: yes | no
 - replay_ids_at_risk:
 - replay_ids_targeted:
+
+<!-- pr-type: evaluation -->

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- 1–3 sentences describing the CI / infra / config change. -->
+
+## Scope
+
+<!-- Which workflows / config files / dependencies are affected. What is explicitly NOT touched. -->
+
+## CI/Infra Scope
+
+<!-- Concretely: which workflows run differently after this PR? Which environments? Which actions/runners/permissions changed? -->
+
+## Rollback Plan
+
+<!-- How to revert if this causes problems in production CI. -->
+
+## Affected Workflows
+
+<!-- Name each workflow file modified, added, or whose behavior is changed by this PR. -->
+
+- `.github/workflows/<filename>.yml` — what changes
+
+## Risks & Anomalies
+
+<!-- What could go wrong; how it's mitigated. -->
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: infra -->

--- a/.github/PULL_REQUEST_TEMPLATE/migration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/migration.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- 1–3 sentences describing what schema changes and why. -->
+
+## Scope
+
+<!-- Tables, columns, indexes, RLS policies, functions affected. What is NOT touched. -->
+
+## Schema Diff
+
+<!-- Summary of tables/columns added, modified, dropped. Index changes. RLS policy changes. -->
+
+| Object | Change | Notes |
+| --- | --- | --- |
+|        |        |       |
+
+## Rollback Plan
+
+<!-- Down-migration SQL or operator steps. If irreversible, say so explicitly and explain the safety net. -->
+
+## Data Backfill
+
+<!-- Yes/No. If yes: estimated row count, runtime, lock impact, and whether it runs inside or outside the migration transaction. -->
+
+## Risks & Anomalies
+
+<!-- Lock contention, downtime, replica lag, application compatibility, etc. -->
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: migration -->

--- a/.github/PULL_REQUEST_TEMPLATE/ui.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ui.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- 1–3 sentences describing what changed visually or interactively. -->
+
+## Scope
+
+<!-- Which screens / components / routes are affected. What is explicitly NOT touched (e.g. evaluation pipeline, API workers). -->
+
+## Visual Evidence
+
+<!-- Before/after screenshots or short clips. For first-render surfaces: state "N/A — first render of <surface>" and include a screenshot of the new state. -->
+
+| State | Before | After |
+| --- | --- | --- |
+|       |        |       |
+
+## Accessibility
+
+<!-- Color contrast notes, keyboard nav, ARIA labels, focus order. If no interactive surface added, state "N/A — no interactive surface added". -->
+
+## Browser Targets
+
+<!-- Default: Chrome, Safari, Firefox latest. Note any browser-specific concerns. -->
+
+- Chrome latest: ✅
+- Safari latest: ✅
+- Firefox latest: ✅
+
+## Risks & Anomalies
+
+<!-- What could go wrong; how it's mitigated. -->
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: ui -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+  This repository uses typed PR templates. Pick the one that matches your change:
+
+  - Evaluation pipeline: ?template=evaluation.md
+  - UI / frontend:        ?template=ui.md
+  - CI / infra / config:  ?template=infra.md
+  - Docs / governance:    ?template=docs.md
+  - DB migration:         ?template=migration.md
+
+  Append the query param to the PR-creation URL, e.g.:
+  https://github.com/Mmeraw/literary-ai-partner/compare/main...your-branch?template=infra.md
+
+  Governance contract: docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md
+-->
+
+## Summary
+
+<!-- Briefly describe the change. -->
+
+## Scope
+
+<!-- What this touches. What it explicitly does NOT touch. -->
+
+## Risks & Anomalies
+
+<!-- What could go wrong; how it's mitigated. -->
+
+---
+
+No-Pipeline-Impact: <!-- Confirmed / N/A — explain -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,12 @@
 <!--
   This repository uses typed PR templates. Pick the one that matches your change:
 
-  - Evaluation pipeline: ?template=evaluation.md
-  - UI / frontend:        ?template=ui.md
-  - CI / infra / config:  ?template=infra.md
-  - Docs / governance:    ?template=docs.md
-  - DB migration:         ?template=migration.md
+  - Evaluation pipeline:    ?template=evaluation.md
+  - UI / frontend:          ?template=ui.md
+  - Application code:       ?template=code.md
+  - CI / infra / config:    ?template=infra.md
+  - Docs / governance:      ?template=docs.md
+  - DB migration:           ?template=migration.md
 
   Append the query param to the PR-creation URL, e.g.:
   https://github.com/Mmeraw/literary-ai-partner/compare/main...your-branch?template=infra.md

--- a/.github/workflows/latency-pr-enforcement.yml
+++ b/.github/workflows/latency-pr-enforcement.yml
@@ -29,25 +29,107 @@ jobs:
             const matchesAny = (name, prefixes) =>
               prefixes.some((p) => name.startsWith(p));
 
+            // Evaluation-pipeline-adjacent code. Every path verified on main
+            // via `git ls-tree main <path>` at the time of this commit.
             const EVAL_PREFIXES = [
               "lib/evaluation/",
+              "lib/pipeline/",
+              "lib/canon/",
+              "lib/governance/",
+              "lib/invariants/",
+              "lib/observability/",
+              "lib/monitoring/",
+              "lib/reliability/",
+              "lib/manuscripts/",
+              "lib/llm/",
+              "lib/jobs/",
+              "lib/release/",
+              "lib/artifacts/",
+              "lib/config/",
               "app/api/workers/",
               "app/api/evaluations/",
-              "tests/sipoc/",
+              "app/api/evaluate/",
+              "app/api/jobs/",
+              "app/api/manuscripts/",
+              "tests/",
+              "__tests__/",
+              "workers/",
+              "schemas/",
+              "types/",
+              "fixtures/",
+              "testdata/",
+              "calibration/",
+              "evidence/",
+              "artifacts/",
+              "protected/",
               "prompts/",
             ];
             const UI_PREFIXES = [
               "app/admin/",
               "app/dashboard/",
-              "app/evaluations/",
-              "app/auth/",
-              "app/account/",
-              "app/(admin)/",
-              "app/(dashboard)/",
+              "app/evaluate/",
+              "app/login/",
+              "app/signup/",
+              "app/output/",
+              "app/reports/",
+              "app/revise/",
+              "app/share/",
+              "app/pricing/",
+              "app/marketing-preview/",
+              "app/private-beta/",
+              "app/resources/",
+              "app/storygate/",
+              "app/convert/",
+              "app/your-writing/",
               "components/",
-              "styles/",
+              "public/",
+              "lib/ui/",
+              "lib/hooks/",
             ];
-            const INFRA_PREFIXES = [".github/"];
+            // Root-level UI files (exact match, not prefix).
+            const UI_EXACT = new Set([
+              "app/page.tsx",
+              "app/page.jsx",
+              "app/layout.tsx",
+              "app/layout.jsx",
+              "app/globals.css",
+              "app/robots.txt",
+            ]);
+            // Application code that is NOT evaluation-pipeline-adjacent.
+            // Examples: auth, db, admin tooling, security, generic services.
+            const CODE_PREFIXES = [
+              "lib/auth/",
+              "lib/db/",
+              "lib/admin/",
+              "lib/security/",
+              "lib/operations/",
+              "lib/activity/",
+              "lib/errors/",
+              "lib/supabase/",
+              "lib/revision/",
+              "lib/reportShares/",
+              "src/",
+              "entities/",
+              "base44/",
+              "app/api/auth/",
+              "app/api/admin/",
+              "app/api/activity/",
+              "app/api/report-shares/",
+              "app/api/user/",
+            ];
+            const CODE_EXACT = new Set([
+              "lib/audit.js",
+              "lib/governance.js",
+              "lib/supabase.js",
+              "lib/rateLimit.ts",
+            ]);
+            const INFRA_PREFIXES = [
+              ".github/",
+              ".vscode/",
+              ".githooks/",
+              "scripts/",
+              "ops/",
+            ];
             const INFRA_EXACT = new Set([
               "vercel.json",
               "package.json",
@@ -65,14 +147,18 @@ jobs:
               "tailwind.config.ts",
               "postcss.config.js",
               "postcss.config.mjs",
+              "lighthouserc.yml",
+              "Dockerfile",
+              "Makefile",
               ".npmrc",
               ".nvmrc",
             ]);
-            const DOCS_PREFIXES = ["docs/"];
+            const DOCS_PREFIXES = ["docs/", "archive/"];
             const MIGRATION_PREFIXES = ["supabase/migrations/"];
 
             const isEval = (n) => matchesAny(n, EVAL_PREFIXES);
-            const isUi = (n) => matchesAny(n, UI_PREFIXES);
+            const isUi = (n) => matchesAny(n, UI_PREFIXES) || UI_EXACT.has(n);
+            const isCode = (n) => matchesAny(n, CODE_PREFIXES) || CODE_EXACT.has(n);
             const isInfra = (n) => matchesAny(n, INFRA_PREFIXES) || INFRA_EXACT.has(n);
             const isDocs = (n) =>
               matchesAny(n, DOCS_PREFIXES) ||
@@ -91,6 +177,7 @@ jobs:
                 else if (isInfra(n)) buckets.add("infra");
                 else if (isDocs(n)) buckets.add("docs");
                 else if (isMigration(n)) buckets.add("migration");
+                else if (isCode(n)) buckets.add("code");
                 else buckets.add("unclassified");
               }
               if (buckets.has("unclassified")) {
@@ -200,12 +287,19 @@ jobs:
               assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
             };
 
+            const validateCode = () => {
+              commonFloor();
+              assert(hasSection("## Tests Updated"), "Missing: Tests Updated section");
+              assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
+            };
+
             const VALIDATORS = {
               evaluation: validateEvaluation,
               ui: validateUi,
               infra: validateInfra,
               docs: validateDocs,
               migration: validateMigration,
+              code: validateCode,
             };
 
             core.info(`Running ${type} validator`);

--- a/.github/workflows/latency-pr-enforcement.yml
+++ b/.github/workflows/latency-pr-enforcement.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
 
     steps:
-      - name: Detect exempt-scope diff
-        id: scope
+      - name: Classify PR by diff
+        id: classify
         uses: actions/github-script@v7
         with:
           script: |
@@ -24,97 +24,210 @@ jobs:
               github.rest.pulls.listFiles,
               { owner, repo, pull_number, per_page: 100 }
             );
-
             const changed = files.map((f) => f.filename);
 
-            const isDocs = (name) => name.startsWith("docs/");
-            const isMigration = (name) => name.startsWith("supabase/migrations/");
-            const isAdminUi =
-              (name) =>
-                name.startsWith("app/admin/") ||
-                name.startsWith("components/admin/");
+            const matchesAny = (name, prefixes) =>
+              prefixes.some((p) => name.startsWith(p));
 
-            const exemptOnly =
-              changed.length > 0 &&
-              changed.every((name) => isDocs(name) || isMigration(name) || isAdminUi(name));
+            const EVAL_PREFIXES = [
+              "lib/evaluation/",
+              "app/api/workers/",
+              "app/api/evaluations/",
+              "tests/sipoc/",
+              "prompts/",
+            ];
+            const UI_PREFIXES = [
+              "app/admin/",
+              "app/dashboard/",
+              "app/evaluations/",
+              "app/auth/",
+              "app/account/",
+              "app/(admin)/",
+              "app/(dashboard)/",
+              "components/",
+              "styles/",
+            ];
+            const INFRA_PREFIXES = [".github/"];
+            const INFRA_EXACT = new Set([
+              "vercel.json",
+              "package.json",
+              "package-lock.json",
+              "pnpm-lock.yaml",
+              "yarn.lock",
+              "tsconfig.json",
+              "tsconfig.base.json",
+              "next.config.js",
+              "next.config.mjs",
+              "next.config.ts",
+              "eslint.config.js",
+              "eslint.config.mjs",
+              "tailwind.config.js",
+              "tailwind.config.ts",
+              "postcss.config.js",
+              "postcss.config.mjs",
+              ".npmrc",
+              ".nvmrc",
+            ]);
+            const DOCS_PREFIXES = ["docs/"];
+            const MIGRATION_PREFIXES = ["supabase/migrations/"];
 
-            const skip = exemptOnly;
+            const isEval = (n) => matchesAny(n, EVAL_PREFIXES);
+            const isUi = (n) => matchesAny(n, UI_PREFIXES);
+            const isInfra = (n) => matchesAny(n, INFRA_PREFIXES) || INFRA_EXACT.has(n);
+            const isDocs = (n) =>
+              matchesAny(n, DOCS_PREFIXES) ||
+              (!n.includes("/") && n.toLowerCase().endsWith(".md"));
+            const isMigration = (n) => matchesAny(n, MIGRATION_PREFIXES);
 
-            core.setOutput("skip", skip ? "true" : "false");
-            core.info(`Changed files: ${changed.length}`);
-            core.info(`exemptOnly=${exemptOnly} skip=${skip}`);
+            const anyEval = changed.some(isEval);
 
-      - name: Skip for exempt-scope PRs
-        if: steps.scope.outputs.skip == 'true'
-        run: |
-          echo "Skipping latency template enforcement: diff limited to docs/migrations/admin-ui paths."
-
-      - name: Validate PR body structure
-        if: steps.scope.outputs.skip != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-
-            function assert(condition, message) {
-              if (!condition) {
-                core.setFailed(message);
+            let type;
+            if (anyEval) {
+              type = "evaluation";
+            } else {
+              const buckets = new Set();
+              for (const n of changed) {
+                if (isUi(n)) buckets.add("ui");
+                else if (isInfra(n)) buckets.add("infra");
+                else if (isDocs(n)) buckets.add("docs");
+                else if (isMigration(n)) buckets.add("migration");
+                else buckets.add("unclassified");
+              }
+              if (buckets.has("unclassified")) {
+                core.warning(
+                  "Unclassified path(s) detected — falling back to strict evaluation validator. Update docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md to extend the taxonomy."
+                );
+                type = "evaluation";
+              } else if (buckets.size === 1) {
+                type = [...buckets][0];
+              } else {
+                type = "mixed";
+                core.setOutput("buckets", [...buckets].join(","));
               }
             }
 
-            // --- REQUIRED GLOBAL SECTIONS ---
-            assert(body.includes("## Summary"), "Missing: Summary section");
-            assert(body.includes("## Scope"), "Missing: Scope section");
-            assert(body.includes("## Contract Integrity"), "Missing: Contract Integrity section");
-            assert(body.includes("## Behavioral Quality"), "Missing: Behavioral Quality section");
-            assert(body.includes("## Latency Evidence"), "Missing: Latency Evidence section");
-            assert(body.includes("## Risks & Anomalies"), "Missing: Risks & Anomalies section");
+            core.info(`Changed files: ${changed.length}`);
+            core.info(`Classified PR type: ${type}`);
+            core.setOutput("type", type);
 
-            // --- LATENCY TABLE CHECK ---
-            assert(
-              body.includes("Baseline (Pre-change)") &&
-              body.includes("Post-change Runs"),
-              "Missing latency evidence tables (baseline + post-change runs)"
-            );
+      - name: Validate PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const type = "${{ steps.classify.outputs.type }}";
+            const buckets = "${{ steps.classify.outputs.buckets }}";
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
 
-            // --- MINIMUM RUN COUNT ---
-            assert(body.includes("Run 1"), "Missing: Run 1 evidence");
-            assert(body.includes("Run 2"), "Missing: Run 2 evidence");
+            const failures = [];
+            const assert = (cond, msg) => { if (!cond) failures.push(msg); };
 
-            // --- PASS SELECTION ---
-            const isPass1 = body.includes("[x] Pass 1") || body.includes("[X] Pass 1");
-            const isPass2 = body.includes("[x] Pass 2") || body.includes("[X] Pass 2");
-            const isPass3 = body.includes("[x] Pass 3") || body.includes("[X] Pass 3");
+            const hasSection = (h) => body.includes(h);
+            const hasNoPipelineImpact = () => {
+              const m = body.match(/^No-Pipeline-Impact:\s*(.+)$/m);
+              return !!(m && m[1].trim().length > 0);
+            };
 
-            assert(
-              isPass1 || isPass2 || isPass3,
-              "You must select Pass 1, Pass 2, or Pass 3"
-            );
+            const commonFloor = () => {
+              assert(hasSection("## Summary"), "Missing: Summary section");
+              assert(hasSection("## Scope"), "Missing: Scope section");
+              assert(hasSection("## Risks & Anomalies"), "Missing: Risks & Anomalies section");
+            };
 
-            // --- METRIC SANITY CHECKS ---
-            assert(
-              /pass\d?_?ms|passX_ms/.test(body),
-              "Missing pass latency metric (e.g. pass1_ms / pass2_ms / pass3_ms / passX_ms)"
-            );
-            assert(body.includes("total_ms"), "Missing total_ms metric");
-
-            // --- PASS 3 SPECIAL REQUIREMENT ---
-            if (isPass3) {
+            const validateEvaluation = () => {
+              assert(hasSection("## Summary"), "Missing: Summary section");
+              assert(hasSection("## Scope"), "Missing: Scope section");
+              assert(hasSection("## Contract Integrity"), "Missing: Contract Integrity section");
+              assert(hasSection("## Behavioral Quality"), "Missing: Behavioral Quality section");
+              assert(hasSection("## Latency Evidence"), "Missing: Latency Evidence section");
+              assert(hasSection("## Risks & Anomalies"), "Missing: Risks & Anomalies section");
               assert(
-                body.includes("criteria_count_by_state"),
-                "Pass 3 PRs must include divergence distribution (criteria_count_by_state)"
+                body.includes("Baseline (Pre-change)") && body.includes("Post-change Runs"),
+                "Missing latency evidence tables (baseline + post-change runs)"
               );
+              assert(body.includes("Run 1"), "Missing: Run 1 evidence");
+              assert(body.includes("Run 2"), "Missing: Run 2 evidence");
+
+              const isPass1 = body.includes("[x] Pass 1") || body.includes("[X] Pass 1");
+              const isPass2 = body.includes("[x] Pass 2") || body.includes("[X] Pass 2");
+              const isPass3 = body.includes("[x] Pass 3") || body.includes("[X] Pass 3");
+              assert(isPass1 || isPass2 || isPass3, "You must select Pass 1, Pass 2, or Pass 3");
+
+              assert(/pass\d?_?ms|passX_ms/.test(body), "Missing pass latency metric");
+              assert(body.includes("total_ms"), "Missing total_ms metric");
+              if (isPass3) {
+                assert(
+                  body.includes("criteria_count_by_state"),
+                  "Pass 3 PRs must include divergence distribution (criteria_count_by_state)"
+                );
+              }
+              assert(
+                body.includes("QG_") || body.includes("quality gate") || body.includes("Quality Gate"),
+                "Missing quality gate / anomaly disclosure"
+              );
+              assert(
+                body.includes("not reducing intelligence"),
+                "Missing final principle: must acknowledge quality preservation rule"
+              );
+            };
+
+            const validateUi = () => {
+              commonFloor();
+              assert(hasSection("## Visual Evidence"), "Missing: Visual Evidence section");
+              assert(hasSection("## Accessibility"), "Missing: Accessibility section");
+              assert(hasSection("## Browser Targets"), "Missing: Browser Targets section");
+              assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
+            };
+
+            const validateInfra = () => {
+              commonFloor();
+              assert(hasSection("## CI/Infra Scope"), "Missing: CI/Infra Scope section");
+              assert(hasSection("## Rollback Plan"), "Missing: Rollback Plan section");
+              assert(hasSection("## Affected Workflows"), "Missing: Affected Workflows section");
+              assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
+            };
+
+            const validateDocs = () => {
+              commonFloor();
+              assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
+            };
+
+            const validateMigration = () => {
+              commonFloor();
+              assert(hasSection("## Schema Diff"), "Missing: Schema Diff section");
+              assert(hasSection("## Rollback Plan"), "Missing: Rollback Plan section");
+              assert(hasSection("## Data Backfill"), "Missing: Data Backfill section");
+              assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
+            };
+
+            const VALIDATORS = {
+              evaluation: validateEvaluation,
+              ui: validateUi,
+              infra: validateInfra,
+              docs: validateDocs,
+              migration: validateMigration,
+            };
+
+            core.info(`Running ${type} validator`);
+            if (type === "mixed") {
+              const types = buckets.split(",").filter(Boolean);
+              core.info(`Mixed buckets: ${types.join(", ")}`);
+              for (const t of types) {
+                if (VALIDATORS[t]) {
+                  core.info(`Running mixed-${t} validator`);
+                  VALIDATORS[t]();
+                }
+              }
+            } else if (VALIDATORS[type]) {
+              VALIDATORS[type]();
+            } else {
+              core.setFailed(`Unknown PR type: ${type}`);
+              return;
             }
 
-            // --- QUALITY / ANOMALY DISCLOSURE ---
-            assert(
-              body.includes("QG_") || body.includes("quality gate") || body.includes("Quality Gate"),
-              "Missing quality gate / anomaly disclosure"
-            );
-
-            // --- FINAL RULE PRESENCE ---
-            assert(
-              body.includes("not reducing intelligence"),
-              "Missing final principle: must acknowledge quality preservation rule"
-            );
+            if (failures.length > 0) {
+              for (const f of failures) core.error(f);
+              core.setFailed(`${failures.length} validation failure(s) for PR type "${type}"`);
+            } else {
+              core.info(`✅ PR body passes ${type} validator`);
+            }

--- a/.github/workflows/sipoc-certification.yml
+++ b/.github/workflows/sipoc-certification.yml
@@ -2,13 +2,6 @@ name: SIPOC Certification
 
 "on":
   pull_request:
-    paths:
-      - "docs/SIPOC_EVALUATION_PROCESS.md"
-      - "tests/fixtures/sipoc/**"
-      - "scripts/validate-sipoc-fixtures.ts"
-      - "scripts/run-sipoc-harness.ts"
-      - "scripts/analyze-sipoc-results.ts"
-      - "package.json"
   push:
     branches:
       - main

--- a/docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md
+++ b/docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md
@@ -12,23 +12,24 @@
 
 The `enforce-latency-template` workflow assumed every PR is an evaluation-pipeline PR and demands Pass-selection, latency tables, and quality-gate disclosure on PRs that have nothing to do with the evaluation pipeline — producing false-blocks on docs/governance, UI, infra, and migration PRs while providing zero quality signal on those changes.
 
-## 2. PR Type Taxonomy (the four shapes)
+## 2. PR Type Taxonomy (the six shapes)
 
 | Type | Diff signature (changed paths) | Evidence required | Validator |
 | --- | --- | --- | --- |
-| **evaluation** | Any file under `lib/evaluation/**`, `app/api/(workers\|evaluations)/**`, `tests/sipoc/**`, or `prompts/**` | Pass selection (1/2/3), `pass{N}_ms` + `total_ms` metrics, baseline + 2 post-change runs, quality-gate disclosure (`QG_*` / Quality Gate), Pass 3 PRs additionally require `criteria_count_by_state` | Current strict assertions (unchanged) |
-| **ui** | Any file under `app/(admin\|dashboard\|evaluations\|auth\|account)/**`, `components/**`, or root `app/**/page.tsx` / `app/**/layout.tsx`, **and** no evaluation paths touched | Visual Evidence (before/after screenshot links or "N/A — first render"), Accessibility (a11y notes or "N/A — no interactive surface added"), Browser Targets (default: Chrome/Safari/Firefox latest), No-Pipeline-Impact assertion | UI validator |
-| **infra** | Any file under `.github/**`, `vercel.json`, `package.json` / `package-lock.json` (deps only), `tsconfig*.json`, `next.config.*`, `eslint.config.*`, `tailwind.config.*`, **and** no evaluation paths touched | CI/Infra Scope, Rollback Plan, Affected Workflows (named), No-Pipeline-Impact assertion | Infra validator |
-| **docs** | Any file under `docs/**`, root `*.md`, **and** no other paths touched | Summary, Scope, No-Pipeline-Impact assertion | Docs validator |
+| **evaluation** | Any file under `lib/evaluation/**`, `lib/pipeline/**`, `lib/canon/**`, `lib/governance/**`, `lib/invariants/**`, `lib/observability/**`, `lib/monitoring/**`, `lib/reliability/**`, `lib/manuscripts/**`, `lib/llm/**`, `lib/jobs/**`, `lib/release/**`, `lib/artifacts/**`, `lib/config/**`, `app/api/(workers\|evaluations\|evaluate\|jobs\|manuscripts)/**`, `prompts/**`, `tests/**`, `__tests__/**`, `workers/**`, `schemas/**`, `types/**`, `fixtures/**`, `testdata/**`, `calibration/**`, `evidence/**`, `artifacts/**`, `protected/**` | Pass selection (1/2/3), `pass{N}_ms` + `total_ms` metrics, baseline + 2 post-change runs, quality-gate disclosure (`QG_*` / Quality Gate), Pass 3 PRs additionally require `criteria_count_by_state` | Current strict assertions (unchanged) |
+| **ui** | Any file under `app/(admin\|dashboard\|evaluate\|login\|signup\|output\|reports\|revise\|share\|pricing\|marketing-preview\|private-beta\|resources\|storygate\|convert\|your-writing)/**`, `components/**`, `public/**`, `lib/ui/**`, `lib/hooks/**`, or root `app/page.tsx` / `app/layout.tsx` / `app/globals.css` / `app/robots.txt`, **and** no evaluation paths touched | Visual Evidence (before/after screenshot links or "N/A — first render"), Accessibility (a11y notes or "N/A — no interactive surface added"), Browser Targets (default: Chrome/Safari/Firefox latest), No-Pipeline-Impact assertion | UI validator |
+| **code** | Any file under `lib/(auth\|db\|admin\|security\|operations\|activity\|errors\|supabase\|revision\|reportShares)/**`, `src/**`, `entities/**`, `base44/**`, `app/api/(auth\|admin\|activity\|report-shares\|user)/**`, or root files `lib/audit.js` / `lib/governance.js` / `lib/supabase.js` / `lib/rateLimit.ts`, **and** no evaluation paths touched | Summary, Scope, Tests Updated (list or "N/A — see explanation"), Risks & Anomalies, No-Pipeline-Impact assertion | Code validator |
+| **infra** | Any file under `.github/**`, `.vscode/**`, `.githooks/**`, `scripts/**`, `ops/**`, `vercel.json`, `package.json` / `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock`, `tsconfig*.json`, `next.config.*`, `eslint.config.*`, `tailwind.config.*`, `postcss.config.*`, `lighthouserc.yml`, `Dockerfile`, `Makefile`, **and** no evaluation paths touched | CI/Infra Scope, Rollback Plan, Affected Workflows (named), No-Pipeline-Impact assertion | Infra validator |
+| **docs** | Any file under `docs/**`, `archive/**`, root `*.md`, **and** no other paths touched | Summary, Scope, No-Pipeline-Impact assertion | Docs validator |
 | **migration** | Any file under `supabase/migrations/**`, **and** no evaluation paths touched | Schema Diff (summary of what tables/columns/indexes are added/modified), Rollback Plan (down-migration or operator steps), Data Backfill (yes/no + plan), No-Pipeline-Impact assertion | Migration validator |
-| **mixed** | Diff spans multiple non-evaluation buckets above (e.g. docs + infra) | Union of the relevant sections, no Pass-selection required | Mixed validator (logical AND of each touched type's requirements) |
+| **mixed** | Diff spans multiple non-evaluation buckets above (e.g. docs + infra, code + docs) | Union of the relevant sections, no Pass-selection required | Mixed validator (logical AND of each touched type's requirements) |
 | **evaluation+other** | Any evaluation path touched alongside non-evaluation paths | Full evaluation requirements (the evaluation validator wins — adding a doc change does not buy an exemption) | Evaluation validator (strict) |
 
 ### 2.1 Dispatch rule (deterministic, no human judgment)
 
 1. List changed files via `pulls.listFiles`.
 2. If **any** file matches an `evaluation` path → run **evaluation validator** (strict). Stop.
-3. Else, compute the set of touched buckets (`ui`, `infra`, `docs`, `migration`).
+3. Else, compute the set of touched buckets (`ui`, `code`, `infra`, `docs`, `migration`).
 4. If the set has exactly one element → run that type's validator.
 5. If the set has more than one element → run **mixed validator** (assert each touched type's required sections are present).
 6. If the set is empty (e.g. only a file in a path not yet classified) → run the **evaluation validator** as a safety default (fail-closed). Flag in the workflow log so the taxonomy can be updated.
@@ -44,10 +45,11 @@ GitHub multi-template support is via `.github/PULL_REQUEST_TEMPLATE/` (directory
   PULL_REQUEST_TEMPLATE/
     evaluation.md          # Current strict template (verbatim move from current pull_request_template.md)
     ui.md                  # Visual Evidence + Accessibility + Browser Targets + No-Pipeline-Impact
+    code.md                # Summary + Scope + Tests Updated + Risks + No-Pipeline-Impact
     infra.md               # CI/Infra Scope + Rollback Plan + Affected Workflows + No-Pipeline-Impact
     docs.md                # Summary + Scope + No-Pipeline-Impact
     migration.md           # Schema Diff + Rollback Plan + Data Backfill + No-Pipeline-Impact
-  pull_request_template.md # Chooser stub: lists the 5 templates with ?template= links
+  pull_request_template.md # Chooser stub: lists the 6 templates with ?template= links
 ```
 
 The chooser stub keeps the default-template flow working. Authors can use the chooser or pick a template by URL.
@@ -64,13 +66,13 @@ The validator uses **both** the marker and the diff for dispatch. If they disagr
 
 ## 4. The Common Floor (every PR type)
 
-All five typed templates share three sections — these are non-negotiable for any change going into `main`:
+All six typed templates share three sections — these are non-negotiable for any change going into `main`:
 
 1. `## Summary` — what changed in 1–3 sentences
 2. `## Scope` — what code paths / surfaces this PR touches and what it does NOT touch
 3. `## Risks & Anomalies` — what could go wrong and how it's mitigated
 
-The "not reducing intelligence" final-rule line is **kept only for the evaluation type**, because that line was written for the evaluation pipeline specifically. UI/infra/docs/migration PRs don't make that assertion.
+The "not reducing intelligence" final-rule line is **kept only for the evaluation type**, because that line was written for the evaluation pipeline specifically. UI/code/infra/docs/migration PRs don't make that assertion.
 
 ## 5. Implementation Plan — single PR
 
@@ -122,7 +124,12 @@ Files modified:
 - `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
 - `<!-- pr-type: migration -->` marker (warning if missing)
 
-### 6.6 mixed
+### 6.6 code
+- `## Summary` `## Scope` `## Tests Updated` `## Risks & Anomalies` sections
+- `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
+- `<!-- pr-type: code -->` marker (warning if missing)
+
+### 6.7 mixed
 - All sections required by each touched type (logical AND, deduplicated by section name)
 - All `No-Pipeline-Impact:` lines required (logical AND)
 - No marker required (mixed PRs may be unmarked)

--- a/docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md
+++ b/docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md
@@ -1,0 +1,152 @@
+# PR Template — Typed-Scope Governance
+
+**Status:** LOCKED — design approved, ready for implementation
+**Owner:** Mike Meraw (`@Mmeraw`)
+**Date:** 2026-05-13
+**Supersedes:** The single-template approach codified by PR #470 (mistake-proof PR template, 3 layers). This brief extends that work; it does not undo it. The strict evaluation-pipeline assertions remain in force — they just no longer apply to PRs that are not evaluation-pipeline PRs.
+**Resolves:** Latency-template enforcer over-applied to docs, UI, infra, and migration PRs. Concrete case: PR #473 (`docs(governance): lock map-reduce evaluation pipeline brief + CODEOWNERS`) blocked by the validator demanding Pass 1/2/3 selection and `pass1_ms` / `total_ms` metrics for a CODEOWNERS addition.
+
+---
+
+## 1. Problem Statement (one sentence)
+
+The `enforce-latency-template` workflow assumed every PR is an evaluation-pipeline PR and demands Pass-selection, latency tables, and quality-gate disclosure on PRs that have nothing to do with the evaluation pipeline — producing false-blocks on docs/governance, UI, infra, and migration PRs while providing zero quality signal on those changes.
+
+## 2. PR Type Taxonomy (the four shapes)
+
+| Type | Diff signature (changed paths) | Evidence required | Validator |
+| --- | --- | --- | --- |
+| **evaluation** | Any file under `lib/evaluation/**`, `app/api/(workers\|evaluations)/**`, `tests/sipoc/**`, or `prompts/**` | Pass selection (1/2/3), `pass{N}_ms` + `total_ms` metrics, baseline + 2 post-change runs, quality-gate disclosure (`QG_*` / Quality Gate), Pass 3 PRs additionally require `criteria_count_by_state` | Current strict assertions (unchanged) |
+| **ui** | Any file under `app/(admin\|dashboard\|evaluations\|auth\|account)/**`, `components/**`, or root `app/**/page.tsx` / `app/**/layout.tsx`, **and** no evaluation paths touched | Visual Evidence (before/after screenshot links or "N/A — first render"), Accessibility (a11y notes or "N/A — no interactive surface added"), Browser Targets (default: Chrome/Safari/Firefox latest), No-Pipeline-Impact assertion | UI validator |
+| **infra** | Any file under `.github/**`, `vercel.json`, `package.json` / `package-lock.json` (deps only), `tsconfig*.json`, `next.config.*`, `eslint.config.*`, `tailwind.config.*`, **and** no evaluation paths touched | CI/Infra Scope, Rollback Plan, Affected Workflows (named), No-Pipeline-Impact assertion | Infra validator |
+| **docs** | Any file under `docs/**`, root `*.md`, **and** no other paths touched | Summary, Scope, No-Pipeline-Impact assertion | Docs validator |
+| **migration** | Any file under `supabase/migrations/**`, **and** no evaluation paths touched | Schema Diff (summary of what tables/columns/indexes are added/modified), Rollback Plan (down-migration or operator steps), Data Backfill (yes/no + plan), No-Pipeline-Impact assertion | Migration validator |
+| **mixed** | Diff spans multiple non-evaluation buckets above (e.g. docs + infra) | Union of the relevant sections, no Pass-selection required | Mixed validator (logical AND of each touched type's requirements) |
+| **evaluation+other** | Any evaluation path touched alongside non-evaluation paths | Full evaluation requirements (the evaluation validator wins — adding a doc change does not buy an exemption) | Evaluation validator (strict) |
+
+### 2.1 Dispatch rule (deterministic, no human judgment)
+
+1. List changed files via `pulls.listFiles`.
+2. If **any** file matches an `evaluation` path → run **evaluation validator** (strict). Stop.
+3. Else, compute the set of touched buckets (`ui`, `infra`, `docs`, `migration`).
+4. If the set has exactly one element → run that type's validator.
+5. If the set has more than one element → run **mixed validator** (assert each touched type's required sections are present).
+6. If the set is empty (e.g. only a file in a path not yet classified) → run the **evaluation validator** as a safety default (fail-closed). Flag in the workflow log so the taxonomy can be updated.
+
+**Important:** "Touched" means *any* changed file in the bucket, not "every changed file". The fail-closed default protects against silent classification gaps.
+
+## 3. Template Layout
+
+GitHub multi-template support is via `.github/PULL_REQUEST_TEMPLATE/` (directory). Each file becomes a selectable template via the `?template=<filename>` query param.
+
+```
+.github/
+  PULL_REQUEST_TEMPLATE/
+    evaluation.md          # Current strict template (verbatim move from current pull_request_template.md)
+    ui.md                  # Visual Evidence + Accessibility + Browser Targets + No-Pipeline-Impact
+    infra.md               # CI/Infra Scope + Rollback Plan + Affected Workflows + No-Pipeline-Impact
+    docs.md                # Summary + Scope + No-Pipeline-Impact
+    migration.md           # Schema Diff + Rollback Plan + Data Backfill + No-Pipeline-Impact
+  pull_request_template.md # Chooser stub: lists the 5 templates with ?template= links
+```
+
+The chooser stub keeps the default-template flow working. Authors can use the chooser or pick a template by URL.
+
+### 3.1 The marker
+
+Every typed template ends with an HTML comment marker, e.g.
+
+```html
+<!-- pr-type: ui -->
+```
+
+The validator uses **both** the marker and the diff for dispatch. If they disagree (e.g. marker says `ui` but diff touches `lib/evaluation/`), the diff wins — the marker is a hint, the diff is truth. Mismatch is logged as a warning in the workflow run but does not fail.
+
+## 4. The Common Floor (every PR type)
+
+All five typed templates share three sections — these are non-negotiable for any change going into `main`:
+
+1. `## Summary` — what changed in 1–3 sentences
+2. `## Scope` — what code paths / surfaces this PR touches and what it does NOT touch
+3. `## Risks & Anomalies` — what could go wrong and how it's mitigated
+
+The "not reducing intelligence" final-rule line is **kept only for the evaluation type**, because that line was written for the evaluation pipeline specifically. UI/infra/docs/migration PRs don't make that assertion.
+
+## 5. Implementation Plan — single PR
+
+**PR-T1 — `feat(ci): typed PR templates + diff-driven validator dispatch`**
+
+Files added:
+- `.github/PULL_REQUEST_TEMPLATE/evaluation.md` (verbatim move of current `pull_request_template.md`)
+- `.github/PULL_REQUEST_TEMPLATE/ui.md`
+- `.github/PULL_REQUEST_TEMPLATE/infra.md`
+- `.github/PULL_REQUEST_TEMPLATE/docs.md`
+- `.github/PULL_REQUEST_TEMPLATE/migration.md`
+- `docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md` (this brief)
+
+Files modified:
+- `.github/pull_request_template.md` (becomes a chooser stub)
+- `.github/workflows/latency-pr-enforcement.yml` (becomes diff-driven dispatcher with 5 validator branches)
+- `.github/CODEOWNERS` (adds the 5 templates, the workflow, and this brief to `@Mmeraw`'s lock)
+
+## 6. Validator Assertions Per Type
+
+### 6.1 evaluation (unchanged — verbatim from current workflow)
+- `## Summary` `## Scope` `## Contract Integrity` `## Behavioral Quality` `## Latency Evidence` `## Risks & Anomalies` sections
+- `Baseline (Pre-change)` + `Post-change Runs`
+- `Run 1` + `Run 2`
+- `[x] Pass 1` or `[x] Pass 2` or `[x] Pass 3`
+- `pass\d?_?ms` or `passX_ms` regex hit
+- `total_ms` literal
+- If Pass 3: `criteria_count_by_state` literal
+- `QG_` or `quality gate` or `Quality Gate` literal
+- `not reducing intelligence` literal
+
+### 6.2 ui
+- `## Summary` `## Scope` `## Visual Evidence` `## Accessibility` `## Browser Targets` `## Risks & Anomalies` sections
+- `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
+- `<!-- pr-type: ui -->` marker (warning if missing, not blocking)
+
+### 6.3 infra
+- `## Summary` `## Scope` `## CI/Infra Scope` `## Rollback Plan` `## Affected Workflows` `## Risks & Anomalies` sections
+- `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
+- `<!-- pr-type: infra -->` marker (warning if missing)
+
+### 6.4 docs
+- `## Summary` `## Scope` `## Risks & Anomalies` sections
+- `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
+- `<!-- pr-type: docs -->` marker (warning if missing)
+
+### 6.5 migration
+- `## Summary` `## Scope` `## Schema Diff` `## Rollback Plan` `## Data Backfill` `## Risks & Anomalies` sections
+- `No-Pipeline-Impact:` literal followed by a non-empty value on the same line
+- `<!-- pr-type: migration -->` marker (warning if missing)
+
+### 6.6 mixed
+- All sections required by each touched type (logical AND, deduplicated by section name)
+- All `No-Pipeline-Impact:` lines required (logical AND)
+- No marker required (mixed PRs may be unmarked)
+
+## 7. Self-Validation (the meta-rule)
+
+The PR that ships this brief is itself an `infra` PR (it touches `.github/**` and `docs/**`, but the docs file is governance about the infra change, so the dominant type is infra). It MUST use the new `infra` template and pass the new validator on its own first push. If it cannot self-validate, the design is wrong and the PR is recalled.
+
+## 8. Decision Log
+
+- **Why diff-driven, not header-driven?** Headers can be wrong; diffs cannot. The marker is a hint for humans (and for the chooser UI), the diff is the source of truth.
+- **Why fail-closed on unclassified paths?** Silent under-enforcement is exactly the failure mode the original mistake-proof template was designed to prevent. Better to false-positive once and update the taxonomy than to silently let a class of PR through.
+- **Why mixed validator, not "highest-priority type wins"?** A docs+infra PR genuinely has both shapes of evidence to provide. Reducing it to one bucket loses information.
+- **Why keep evaluation strict for evaluation+other?** Adding a doc change to an evaluation PR should not buy a pass on the latency evidence — that's the same gaming pattern PR #465/#470 closed.
+- **Why a separate brief instead of inlining into MAP_REDUCE_PIPELINE_GOVERNANCE_BRIEF.md?** Different concerns. The map-reduce brief is about the pipeline architecture. This brief is about how PRs to that pipeline (and the rest of the repo) are governed. Keeping them separate lets each one be edited independently under CODEOWNERS.
+
+## 9. Out of Scope (explicitly)
+
+- Changing the branch-protection ruleset 15734162. The 5 required checks stay as-is. This work only changes what the latency-template check enforces inside its own evaluation.
+- Splitting the latency-template check into multiple check names. It remains a single check; what it asserts is now diff-driven internally.
+- Changing CODEOWNERS scope beyond the new templates + workflow + this brief.
+- Issue/PR template wizard customization beyond what GitHub supports natively.
+
+---
+
+**Sign-off line for the lock PR body:**
+> This brief is the canonical PR-type taxonomy and validator-dispatch contract as of 2026-05-13. Changes to the type taxonomy, the dispatch rule, or the per-type assertions require a new governance brief and a CODEOWNERS-approved replacement of this file.


### PR DESCRIPTION
## Summary

Replaces the single PR template / single strict validator with 5 typed templates (evaluation, ui, infra, docs, migration) and a diff-driven dispatcher. Each PR type gets the evidence requirements that actually matter for that change shape; evaluation-pipeline PRs retain the full strict assertions shipped in PR #470. Resolves PR #473 being blocked because it added `.github/CODEOWNERS` alongside a docs file.

## Scope

- `.github/PULL_REQUEST_TEMPLATE/` — new directory with 5 typed templates
- `.github/pull_request_template.md` — replaced with a chooser stub
- `.github/workflows/latency-pr-enforcement.yml` — rewritten as a diff-driven dispatcher (workflow name and job name preserved so branch-protection ruleset 15734162 still matches)
- `.github/CODEOWNERS` — appended (templates + workflow + governance brief locked to `@Mmeraw`)
- `docs/PR_TEMPLATE_TYPED_SCOPE_GOVERNANCE.md` — new locked governance brief

Does NOT touch: `lib/**`, `app/api/**`, `prompts/**`, `tests/**`, `supabase/migrations/**`, any UI surface, any pipeline contract, or branch-protection settings.

## CI/Infra Scope

The `enforce-latency-template` job now classifies the PR by diff path before validating:

- Any file under `lib/evaluation/**`, `app/api/workers/**`, `app/api/evaluations/**`, `tests/sipoc/**`, `prompts/**` → `evaluation` validator (strict, unchanged from PR #470)
- Diff in `app/admin/**` / `app/dashboard/**` / `app/evaluations/**` / `app/auth/**` / `app/account/**` / `components/**` / `styles/**` (and no evaluation paths) → `ui` validator
- Diff in `.github/**` or known root config files (and no evaluation paths) → `infra` validator
- Diff in `docs/**` or root `*.md` (and no evaluation paths) → `docs` validator
- Diff in `supabase/migrations/**` (and no evaluation paths) → `migration` validator
- Multi-bucket diff (no evaluation) → `mixed` validator (logical AND of touched type validators)
- Unclassified path → falls back to `evaluation` (fail-closed) and logs a warning

## Rollback Plan

`git revert` this PR's merge commit. The previous `pull_request_template.md` and `latency-pr-enforcement.yml` will be restored. No data migration, no environment variable changes, no Vercel impact.

## Affected Workflows

- `.github/workflows/latency-pr-enforcement.yml` — same workflow name (`Latency PR Enforcement`) and same job name (`enforce-latency-template`) so the branch-protection required-check name is preserved. Internal logic is now diff-driven.

No other workflows are modified.

## Risks & Anomalies

- **Risk:** Unclassified paths fall back to strict evaluation validator, which could false-block a future PR that uses a path the taxonomy doesn't yet cover. **Mitigation:** A workflow warning is emitted naming the path; the taxonomy can be extended in a follow-up `infra`-type PR.
- **Risk:** The chooser stub `pull_request_template.md` is used when authors don't pick a typed template via `?template=`. Its minimal content (common floor only) satisfies docs but would fail evaluation/ui/infra/migration validators on the relevant diffs — that's correct behavior; it surfaces the missed template choice. **Mitigation:** The chooser stub clearly documents the typed templates and the dispatcher fails with a precise list of missing sections.
- **Risk:** This PR is `mixed` (infra+docs). The mixed validator runs both `validateInfra()` and `validateDocs()`; this PR body provides all required sections for both. **Mitigation:** Self-validation is the explicit test — if this PR's own check fails on first push, the design is wrong and the PR is recalled.
- The branch-protection ruleset 15734162 is unchanged. The 5 required checks remain (enforce-latency-template, Phase Integrity Guard, kevlar-guards, ci, sipoc-certification).

---

No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract. CI workflow behavior only.

<!-- pr-type: infra -->