### PR TITLE
feat(evaluation): add manuscript title normalization helper with tests

### DIFF
--- a/lib/evaluation/manuscriptTitle.ts
+++ b/lib/evaluation/manuscriptTitle.ts
@@ -1,0 +1,23 @@
+export function normalizeTitle(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+export function normalizeManuscriptId(
+  manuscriptId?: number | string | null,
+): number | null {
+  if (typeof manuscriptId === "number") {
+    if (!Number.isFinite(manuscriptId) || manuscriptId <= 0) return null;
+    return Math.floor(manuscriptId);
+  }
+
+  if (typeof manuscriptId === "string") {
+    const trimmed = manuscriptId.trim();
+    if (!/^\d+$/.test(trimmed)) return null;
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed) || parsed <= 0) return null;
+    return Math.floor(parsed);
+  }
+
+  return null;
+}

--- a/tests/lib/evaluation/manuscriptTitle.test.ts
+++ b/tests/lib/evaluation/manuscriptTitle.test.ts
@@ -1,0 +1,35 @@
+import { normalizeManuscriptId, normalizeTitle } from "@/lib/evaluation/manuscriptTitle";
+
+describe("normalizeManuscriptId", () => {
+  it("accepts positive numeric ids", () => {
+    expect(normalizeManuscriptId(42)).toBe(42);
+    expect(normalizeManuscriptId(42.9)).toBe(42);
+  });
+
+  it("accepts numeric string ids", () => {
+    expect(normalizeManuscriptId("26220")).toBe(26220);
+    expect(normalizeManuscriptId("  26220  ")).toBe(26220);
+  });
+
+  it("rejects invalid ids", () => {
+    expect(normalizeManuscriptId(undefined)).toBeNull();
+    expect(normalizeManuscriptId(null)).toBeNull();
+    expect(normalizeManuscriptId(0)).toBeNull();
+    expect(normalizeManuscriptId(-7)).toBeNull();
+    expect(normalizeManuscriptId("0")).toBeNull();
+    expect(normalizeManuscriptId("12a")).toBeNull();
+    expect(normalizeManuscriptId("abc")).toBeNull();
+  });
+});
+
+describe("normalizeTitle", () => {
+  it("trims and returns non-empty title", () => {
+    expect(normalizeTitle("  Cartel Babies  ")).toBe("Cartel Babies");
+  });
+
+  it("returns null for empty-like title values", () => {
+    expect(normalizeTitle("   ")).toBeNull();
+    expect(normalizeTitle(null)).toBeNull();
+    expect(normalizeTitle(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Add evaluation input normalization helpers for manuscript id/title handling, with focused unit tests.

## What changed
- Added `normalizeManuscriptId` and `normalizeTitle` in `lib/evaluation/manuscriptTitle.ts`
- Added tests in `tests/lib/evaluation/manuscriptTitle.test.ts`

## Validation
- Ran targeted tests: `tests/lib/evaluation/manuscriptTitle.test.ts` (pass)

## Notes
- Temporary local artifacts (`.tmp/`, `artifacts/sipoc/sipoc-runtime-results.json`, `test_output.txt`) were intentionally not included in this PR.