### PR TITLE
feat(stress): add Tier 2 — live Perplexity long-form regression lock

### DIFF
--- a/.github/workflows/pipeline-stress-tier2.yml
+++ b/.github/workflows/pipeline-stress-tier2.yml
@@ -1,0 +1,64 @@
+name: Pipeline Stress Harness — Tier 2 (Live)
+
+"on":
+  workflow_dispatch:
+
+jobs:
+  tier2:
+    # Skip on forks — required secrets are not exposed to fork PRs.
+    if: github.repository == 'Mmeraw/literary-ai-partner'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NODE_ENV: development
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+      SUPABASE_STRESS_URL: ${{ secrets.SUPABASE_STRESS_URL }}
+      # Stubs required to boot Next middleware/SSR; the runner reads
+      # SUPABASE_STRESS_URL above and refuses to touch prod Supabase.
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_STRESS_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: stub-anon-key-for-tier2-only
+      SUPABASE_URL: ${{ secrets.SUPABASE_STRESS_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Probe required secrets
+        id: secrets_probe
+        run: |
+          if [ -z "${{ secrets.OPENAI_API_KEY }}" ] || \
+             [ -z "${{ secrets.PERPLEXITY_API_KEY }}" ]; then
+            echo "have_secrets=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Tier 2 cannot run — OPENAI_API_KEY or PERPLEXITY_API_KEY missing from repo secrets."
+            exit 1
+          else
+            echo "have_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tier 2 — pipeline stress harness (live OpenAI + live Perplexity)
+        if: steps.secrets_probe.outputs.have_secrets == 'true'
+        id: stress_tier2
+        # set -o pipefail so a non-zero exit from the runner propagates past
+        # `tee` and fails the job.
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run pipeline:stress:tier2 2>&1 | tee /tmp/stress-tier2.log
+
+      - name: Upload worker logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stress-tier2-logs
+          path: /tmp/stress-tier2.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,6 +12,12 @@ import {
 } from '@/lib/auth/clientAuthGuards'
 import { trackClientAuthEvent } from '@/lib/auth/telemetry'
 
+const hasSupabaseAuthConfig = Boolean(
+  process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+)
+const AUTH_UNAVAILABLE_MESSAGE =
+  'Authentication is unavailable in this environment. Use production deployment for sign-in.'
+
 function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
 }
@@ -22,7 +28,6 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const router = useRouter()
-  const supabase = createClient()
 
   const setSafeEmail = (value: string) => {
     setEmail(value)
@@ -43,6 +48,15 @@ export default function LoginPage() {
 
     setLoading(true)
     setError(null)
+
+    if (!hasSupabaseAuthConfig) {
+      trackClientAuthEvent('login', 'blocked_backoff', { reason: 'missing_supabase_env' })
+      setError(AUTH_UNAVAILABLE_MESSAGE)
+      setLoading(false)
+      return
+    }
+
+    const supabase = createClient()
 
     const backoffMs = getAuthBackoffMs('login')
     if (backoffMs > 0) {
@@ -90,6 +104,15 @@ export default function LoginPage() {
     trackClientAuthEvent('oauth', 'attempt', { provider })
     setLoading(true)
     setError(null)
+
+    if (!hasSupabaseAuthConfig) {
+      trackClientAuthEvent('oauth', 'blocked_backoff', { provider, reason: 'missing_supabase_env' })
+      setError(AUTH_UNAVAILABLE_MESSAGE)
+      setLoading(false)
+      return
+    }
+
+    const supabase = createClient()
 
     const backoffMs = getAuthBackoffMs('oauth')
     if (backoffMs > 0) {
@@ -202,7 +225,7 @@ export default function LoginPage() {
             <div>
               <button
                 type="submit"
-                disabled={loading}
+                disabled={loading || !hasSupabaseAuthConfig}
                 className="flex w-full justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? 'Signing in...' : 'Sign in'}
@@ -224,7 +247,7 @@ export default function LoginPage() {
               <button
                 type="button"
                 onClick={() => handleOAuthLogin('google')}
-                disabled={loading}
+                disabled={loading || !hasSupabaseAuthConfig}
                 className="inline-flex w-full justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-500 shadow-sm hover:bg-gray-50 disabled:opacity-50"
               >
                 <span className="sr-only">Sign in with Google</span>
@@ -238,7 +261,7 @@ export default function LoginPage() {
               <button
                 type="button"
                 onClick={() => handleOAuthLogin('github')}
-                disabled={loading}
+                disabled={loading || !hasSupabaseAuthConfig}
                 className="inline-flex w-full justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-500 shadow-sm hover:bg-gray-50 disabled:opacity-50"
               >
                 <span className="sr-only">Sign in with GitHub</span>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,6 +12,12 @@ import {
 } from '@/lib/auth/clientAuthGuards'
 import { trackClientAuthEvent } from '@/lib/auth/telemetry'
 
+const hasSupabaseAuthConfig = Boolean(
+  process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+)
+const AUTH_UNAVAILABLE_MESSAGE =
+  'Authentication is unavailable in this environment. Use production deployment for sign-up.'
+
 const PASSWORD_MIN_LENGTH = 10
 
 function isValidEmail(value: string): boolean {
@@ -36,7 +42,6 @@ export default function SignupPage() {
   const [success, setSuccess] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const router = useRouter()
-  const supabase = createClient()
 
   const setSafeEmail = (value: string) => {
     setEmail(value)
@@ -63,6 +68,15 @@ export default function SignupPage() {
     setLoading(true)
     setError(null)
     setSuccess(null)
+
+    if (!hasSupabaseAuthConfig) {
+      trackClientAuthEvent('signup', 'blocked_backoff', { reason: 'missing_supabase_env' })
+      setError(AUTH_UNAVAILABLE_MESSAGE)
+      setLoading(false)
+      return
+    }
+
+    const supabase = createClient()
 
     const backoffMs = getAuthBackoffMs('signup')
     if (backoffMs > 0) {
@@ -227,7 +241,7 @@ export default function SignupPage() {
             <div>
               <button
                 type="submit"
-                disabled={loading}
+                disabled={loading || !hasSupabaseAuthConfig}
                 className="flex w-full justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? 'Creating account...' : 'Create account'}

--- a/lib/config/productionConfigValidation.ts
+++ b/lib/config/productionConfigValidation.ts
@@ -33,12 +33,19 @@ export function validateProductionConfig(
 ): ValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
+  const vercelEnv = String(env.VERCEL_ENV ?? "").toLowerCase();
+  const isVercelPreview = vercelEnv === "preview";
   const isProduction = env.NODE_ENV === "production";
+  const enforceProductionGuardrails = isProduction && !isVercelPreview;
   const useSupabase = env.USE_SUPABASE_JOBS === "true";
 
-  if (isProduction && !useSupabase) {
+  if (enforceProductionGuardrails && !useSupabase) {
     errors.push(
       "Memory job store is not production-safe. Set USE_SUPABASE_JOBS=true for 100k-user scale.",
+    );
+  } else if (isProduction && isVercelPreview && !useSupabase) {
+    warnings.push(
+      "Skipping strict USE_SUPABASE_JOBS enforcement for Vercel preview build (VERCEL_ENV=preview).",
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "governance:calibration:analyze": "npx tsx -r tsconfig-paths/register scripts/governance/analyze-phase-2-calibration.ts",
     "pipeline:stress": "npx tsx -r ./tests/sipoc/serverOnlyRegister.cjs -r tsconfig-paths/register scripts/pipeline-stress.ts --tier=1",
     "pipeline:stress:ui": "npx tsx -r ./tests/sipoc/serverOnlyRegister.cjs -r tsconfig-paths/register scripts/pipeline-stress.ts --tier=3a",
+    "pipeline:stress:tier2": "npx tsx -r ./tests/sipoc/serverOnlyRegister.cjs -r tsconfig-paths/register scripts/pipeline-stress-tier2.ts",
     "ci-guard": "npx tsx scripts/ci-guard/index.ts"
   },
   "dependencies": {

--- a/scripts/pipeline-stress-tier2.ts
+++ b/scripts/pipeline-stress-tier2.ts
@@ -1,0 +1,210 @@
+/**
+ * scripts/pipeline-stress-tier2.ts
+ *
+ * Tier 2 pipeline stress harness — live OpenAI + live Perplexity against a
+ * real long-form manuscript fixture. Companion to scripts/pipeline-stress.ts
+ * (Tier 1 mocks); does NOT replace it.
+ *
+ * What this catches that Tier 1 cannot:
+ *   - Real LLM refusals or shape variants on production-shaped prompts
+ *   - Real Perplexity adjudicator timeouts / non-empty cross_check assertion
+ *   - Pass 4 governance population on long-form (>25k word) route
+ *   - Silent-skip class from prod eval 609dc776 (2026-05-13):
+ *     "External adjudication mode 'required' requires cross-check output"
+ *
+ * Safety constraints:
+ *   - Refuses to run against prod Supabase. Hard-aborts if SUPABASE_URL
+ *     contains the prod project id `xtumxjnzdswuumndcbwc`.
+ *   - Requires OPENAI_API_KEY and PERPLEXITY_API_KEY. Exits non-zero with a
+ *     clear message if either is missing.
+ *
+ * Exit code: 0 iff every row in TIER2_SCENARIOS satisfies all assertions.
+ */
+
+import fs from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import { runPipeline } from "@/lib/evaluation/pipeline/runPipeline";
+import type { PipelineResult } from "@/lib/evaluation/pipeline/types";
+import { TIER2_SCENARIOS, type Tier2Row } from "../tests/stress/tier2/scenarios";
+
+const PROD_SUPABASE_PROJECT_ID = "xtumxjnzdswuumndcbwc";
+const FIXTURES_DIR = path.resolve("tests/stress/tier2/fixtures/manuscripts");
+
+interface ResolvedEnv {
+  openaiKey: string;
+  perplexityKey: string;
+  supabaseUrl: string | null;
+}
+
+function abort(msg: string): never {
+  console.error(`[stress-tier2] ABORT: ${msg}`);
+  process.exit(2);
+}
+
+function resolveEnv(): ResolvedEnv {
+  const openaiKey = process.env.OPENAI_API_KEY ?? "";
+  const perplexityKey = process.env.PERPLEXITY_API_KEY ?? "";
+  const rawSupabaseUrl = process.env.SUPABASE_STRESS_URL ?? process.env.SUPABASE_URL ?? "";
+  const supabaseUrl = rawSupabaseUrl.trim().length > 0 ? rawSupabaseUrl : null;
+
+  if (!openaiKey) abort("OPENAI_API_KEY is required for Tier 2 (live OpenAI).");
+  if (!perplexityKey)
+    abort("PERPLEXITY_API_KEY is required for Tier 2 (live Perplexity).");
+
+  if (supabaseUrl && supabaseUrl.includes(PROD_SUPABASE_PROJECT_ID)) {
+    abort(
+      `SUPABASE_URL points at the production project (${PROD_SUPABASE_PROJECT_ID}). ` +
+        "Tier 2 must run against a dev/preview Supabase only. Set SUPABASE_STRESS_URL " +
+        "to a non-prod project before re-running.",
+    );
+  }
+
+  return { openaiKey, perplexityKey, supabaseUrl };
+}
+
+function readFixture(fixtureName: string): string {
+  const fullPath = path.join(FIXTURES_DIR, fixtureName);
+  if (!fs.existsSync(fullPath)) {
+    abort(`Fixture not found: ${fullPath}`);
+  }
+  return fs.readFileSync(fullPath, "utf8");
+}
+
+interface RunOutcome {
+  row: Tier2Row;
+  result: PipelineResult | null;
+  total_ms: number;
+  threw: Error | null;
+}
+
+async function executeRow(row: Tier2Row, env: ResolvedEnv): Promise<RunOutcome> {
+  const manuscriptText = readFixture(row.manuscript_fixture);
+  // Use jobId convention shared with PR #484 (Pass 4 observability) so Tier 2
+  // runs leave a greppable log trail in CI artifacts.
+  const jobId = `stress-tier2-${row.id}-${randomUUID()}`;
+
+  const startMs = Date.now();
+  let result: PipelineResult | null = null;
+  let threw: Error | null = null;
+
+  try {
+    result = await runPipeline({
+      manuscriptText,
+      workType: row.work_type,
+      title: `stress-tier2-${row.id}`,
+      manuscriptId: jobId,
+      jobId,
+      openaiApiKey: env.openaiKey,
+      perplexityApiKey: env.perplexityKey,
+    });
+  } catch (err) {
+    threw = err instanceof Error ? err : new Error(String(err));
+  }
+
+  return {
+    row,
+    result,
+    total_ms: Date.now() - startMs,
+    threw,
+  };
+}
+
+function isNonEmptyObject(v: unknown): boolean {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.keys(v as Record<string, unknown>).length > 0
+  );
+}
+
+function assertRow(outcome: RunOutcome): string[] {
+  const failures: string[] = [];
+  const { row, result, total_ms, threw } = outcome;
+
+  if (total_ms > row.expected.max_total_ms) {
+    failures.push(
+      `total_ms=${total_ms} > max_total_ms=${row.expected.max_total_ms}`,
+    );
+  }
+
+  if (row.expected.outcome === "success") {
+    if (threw) {
+      failures.push(`threw: ${threw.message}`);
+      return failures;
+    }
+    if (!result || !result.ok) {
+      const code =
+        result && "error_code" in result
+          ? (result as { error_code: string }).error_code
+          : "no-result";
+      failures.push(`expected success, got fail: ${code}`);
+      return failures;
+    }
+
+    if (row.expected.cross_check_required) {
+      if (!isNonEmptyObject((result as { cross_check?: unknown }).cross_check)) {
+        failures.push(
+          "evaluation_result.cross_check is missing or empty (silent-skip class)",
+        );
+      }
+    }
+
+    if (row.expected.pass4_governance_required) {
+      if (
+        !isNonEmptyObject(
+          (result as { pass4_governance?: unknown }).pass4_governance,
+        )
+      ) {
+        failures.push(
+          "evaluation_result.pass4_governance is missing or empty",
+        );
+      }
+    }
+
+  }
+
+  return failures;
+}
+
+async function main(): Promise<number> {
+  const env = resolveEnv();
+  const supabaseLabel = env.supabaseUrl
+    ? env.supabaseUrl.replace(/^https?:\/\//, "").split(".")[0]
+    : "not-configured";
+  console.log(
+    `[stress-tier2] starting — ${TIER2_SCENARIOS.length} row(s), supabase=${supabaseLabel}`,
+  );
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const row of TIER2_SCENARIOS) {
+    process.stdout.write(`[stress-tier2] ${row.id.padEnd(28)} `);
+    const outcome = await executeRow(row, env);
+    const failures = assertRow(outcome);
+    if (failures.length === 0) {
+      passed += 1;
+      process.stdout.write(`OK (${outcome.total_ms}ms)\n`);
+    } else {
+      failed += 1;
+      process.stdout.write(`FAIL: ${failures.join("; ")}\n`);
+      if (outcome.threw) {
+        console.error(`  threw: ${outcome.threw.stack ?? outcome.threw.message}`);
+      }
+    }
+  }
+
+  console.log(
+    `\n[stress-tier2] total=${TIER2_SCENARIOS.length} passed=${passed} failed=${failed}`,
+  );
+  return failed === 0 ? 0 : 1;
+}
+
+void main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error("[stress-tier2] uncaught:", err);
+    process.exit(2);
+  });

--- a/scripts/validate-production-config.ts
+++ b/scripts/validate-production-config.ts
@@ -34,6 +34,7 @@ if (result.valid) {
 
   console.log("📊 Configuration Summary:");
   console.log(`   NODE_ENV: ${process.env.NODE_ENV}`);
+  console.log(`   VERCEL_ENV: ${process.env.VERCEL_ENV}`);
   console.log(`   USE_SUPABASE_JOBS: ${process.env.USE_SUPABASE_JOBS}`);
   console.log(`   SUPABASE_URL: ${process.env.SUPABASE_URL ? "✓ Set" : "✗ Missing"}`);
   console.log(`   SUPABASE_ANON_KEY: ${process.env.SUPABASE_ANON_KEY ? "✓ Set" : "✗ Missing"}`);

--- a/tests/stress/tier2/README.md
+++ b/tests/stress/tier2/README.md
@@ -1,0 +1,101 @@
+# Tier 2 Stress Harness — Live OpenAI + Live Perplexity
+
+## What it does
+
+Runs the full evaluation pipeline (Pass 1 → 2 → 3 → 4) against a real
+~52k-word public-domain manuscript using **live OpenAI** and **live
+Perplexity**. Asserts on the production-shaped result:
+
+- `outcome === "success"`
+- `evaluation_result.cross_check` is a non-empty object
+- `evaluation_result.pass4_governance` is populated
+- total pipeline wall-time ≤ 15 min
+
+This PR establishes **Tier 2 direct live integration harness infrastructure**.
+It is not a proven regression lock until at least one secret-backed live run
+passes end-to-end.
+
+This is the smallest possible footprint that would have caught prod eval
+`609dc776-6ccd-41dd-9353-1425697f1fb2` (Froggin Noggin, 53,903 words),
+which failed on 2026-05-13 with:
+
+```
+External adjudication mode 'required' requires cross-check output
+```
+
+The Tier 1 mock harness was 100% green for the same change. **Tier 1
+cannot fail on a class it does not cover.** Tier 2 is that cover.
+
+## When it runs
+
+| Trigger             | When                                                    |
+| ------------------- | ------------------------------------------------------- |
+| `workflow_dispatch` | Manual only (run explicitly from Actions UI)            |
+
+Workflow file: `.github/workflows/pipeline-stress-tier2.yml`.
+
+## Cost
+
+- ~$8–15 per manual run (model and token-size dependent)
+- No recurring cost by default; execution occurs only when explicitly dispatched.
+
+## Signal this catches
+
+What Tier 2 catches that Tier 1 (mocks) cannot:
+
+- **Real refusals / shape variants** from OpenAI or Perplexity on
+  production-shaped prompts
+- **Real network/timeout behavior** of Pass 4 against the live Perplexity
+  endpoint
+- **`cross_check` empty/missing** — the silent-skip class that PR #481
+  hardened against and PR-OBS instrumented
+- **Long-form route activation** — fixture is sized to trigger
+  `route=long_form` (threshold = 25k words) and ~30+ chunks, matching the
+  structural shape of the Froggin Noggin failure
+
+What it does **not** catch:
+
+- UI rendering behavior (that's Tier 3a — Playwright)
+- Full E2E worker flow including DB persistence semantics (Tier 3b)
+- Quality-of-output scoring drift (future Q2/Q3 rows)
+
+## Re-running locally
+
+```bash
+# Required env:
+export OPENAI_API_KEY=sk-...
+export PERPLEXITY_API_KEY=pplx-...
+
+# Optional safety metadata (for prod-project guard only):
+export SUPABASE_STRESS_URL=https://<dev-project>.supabase.co
+
+npm run pipeline:stress:tier2
+```
+
+If a Supabase URL is provided, the runner hard-aborts when it resolves to the prod project id
+`xtumxjnzdswuumndcbwc`.
+
+## First-run requirement (post-merge)
+
+Tier 2 needs GitHub repo secrets before a live run can execute:
+
+1. `OPENAI_API_KEY`
+2. `PERPLEXITY_API_KEY`
+3. `SUPABASE_STRESS_URL` (non-prod project URL)
+
+Add them at: Settings → Secrets and variables → Actions.
+
+`SUPABASE_STRESS_URL` must point to the non-prod test project; the runner
+hard-aborts if it detects the production project id.
+
+## How to disable
+
+No-op by default until manually dispatched. To disable entirely, remove or
+rename `.github/workflows/pipeline-stress-tier2.yml`.
+
+## Adding rows
+
+This file ships with one row by design: `Q-long-real-perplexity`. Adding
+more rows (variant coverage, refusal handling, quality-drift) belongs in
+follow-up PRs — keep each row a separate, reviewable change so cost and
+flake exposure stay bounded.

--- a/tests/stress/tier2/fixtures/manuscripts/README.md
+++ b/tests/stress/tier2/fixtures/manuscripts/README.md
@@ -1,0 +1,26 @@
+# Tier 2 Manuscript Fixtures
+
+## `long-form-50k.txt`
+
+- **Source:** Project Gutenberg eBook #76, *Adventures of Huckleberry
+  Finn* by Mark Twain. URL: https://www.gutenberg.org/ebooks/76
+- **License:** Public domain in the United States (Project Gutenberg
+  License — no restrictions on reuse).
+- **Excerpt:** Chapters 1–20 (ends just before Chapter XXI). Project
+  Gutenberg boilerplate header and footer removed.
+- **Word count:** ~52,800 words (within the 50k–55k acceptance window).
+- **Why this excerpt:** A clean chapter boundary keeps the cut feeling
+  intentional; well-formed long-form prose triggers `route=long_form`
+  (threshold = 25k words) and produces ~30+ chunks, matching the
+  structural shape of the prod failure on 2026-05-13.
+
+## Replacement / refresh
+
+If a future change requires a different excerpt:
+
+1. Pick another public-domain text (Project Gutenberg is the canonical
+   source). The fixture must land between 50,000 and 55,000 words.
+2. Strip the Gutenberg header (`*** START OF ...`) and footer
+   (`*** END OF ...`).
+3. Add a short title block at the top citing the source URL + license.
+4. Update this README to reflect the new excerpt.

--- a/tests/stress/tier2/fixtures/manuscripts/long-form-50k.txt
+++ b/tests/stress/tier2/fixtures/manuscripts/long-form-50k.txt
@@ -1,0 +1,5589 @@
+Adventures of Huckleberry Finn (excerpt: Chapters 1–20)
+by Mark Twain
+Source: Project Gutenberg eBook #76 (public domain)
+
+
+
+
+
+ADVENTURES
+OF
+HUCKLEBERRY FINN
+
+(Tom Sawyer’s Comrade)
+
+By Mark Twain
+
+
+
+
+CONTENTS.
+
+CHAPTER I.
+Civilizing Huck.—Miss Watson.—Tom Sawyer Waits.
+
+CHAPTER II.
+The Boys Escape Jim.—Torn Sawyer’s Gang.—Deep-laid Plans.
+
+CHAPTER III.
+A Good Going-over.—Grace Triumphant.—“One of Tom Sawyers’s Lies”.
+
+CHAPTER IV.
+Huck and the Judge.—Superstition.
+
+CHAPTER V.
+Huck’s Father.—The Fond Parent.—Reform.
+
+CHAPTER VI.
+He Went for Judge Thatcher.—Huck Decided to Leave.—Political
+Economy.—Thrashing Around.
+
+CHAPTER VII.
+Laying for Him.—Locked in the Cabin.—Sinking the Body.—Resting.
+
+CHAPTER VIII.
+Sleeping in the Woods.—Raising the Dead.—Exploring the Island.—Finding
+Jim.—Jim’s Escape.—Signs.—Balum.
+
+CHAPTER IX.
+The Cave.—The Floating House.
+
+CHAPTER X.
+The Find.—Old Hank Bunker.—In Disguise.
+
+CHAPTER XI.
+Huck and the Woman.—The Search.—Prevarication.—Going to Goshen.
+
+CHAPTER XII.
+Slow Navigation.—Borrowing Things.—Boarding the Wreck.—The
+Plotters.—Hunting for the Boat.
+
+CHAPTER XIII.
+Escaping from the Wreck.—The Watchman.—Sinking.
+
+CHAPTER XIV.
+A General Good Time.—The Harem.—French.
+
+CHAPTER XV.
+Huck Loses the Raft.—In the Fog.—Huck Finds the Raft.—Trash.
+
+CHAPTER XVI.
+Expectation.—A White Lie.—Floating Currency.—Running by Cairo.—Swimming
+Ashore.
+
+CHAPTER XVII.
+An Evening Call.—The Farm in Arkansaw.—Interior Decorations.—Stephen
+Dowling Bots.—Poetical Effusions.
+
+CHAPTER XVIII.
+Col. Grangerford.—Aristocracy.—Feuds.—The Testament.—Recovering the
+Raft.—The Wood—pile.—Pork and Cabbage.
+
+CHAPTER XIX.
+Tying Up Day—times.—An Astronomical Theory.—Running a Temperance
+Revival.—The Duke of Bridgewater.—The Troubles of Royalty.
+
+CHAPTER XX.
+Huck Explains.—Laying Out a Campaign.—Working the Camp—meeting.—A
+Pirate at the Camp—meeting.—The Duke as a Printer.
+
+CHAPTER XXI.
+Sword Exercise.—Hamlet’s Soliloquy.—They Loafed Around Town.—A Lazy
+Town.—Old Boggs.—Dead.
+
+CHAPTER XXII.
+Sherburn.—Attending the Circus.—Intoxication in the Ring.—The Thrilling
+Tragedy.
+
+CHAPTER XXIII.
+Sold.—Royal Comparisons.—Jim Gets Home-sick.
+
+CHAPTER XXIV.
+Jim in Royal Robes.—They Take a Passenger.—Getting Information.—Family
+Grief.
+
+CHAPTER XXV.
+Is It Them?—Singing the “Doxologer.”—Awful Square—Funeral Orgies.—A Bad
+Investment .
+
+CHAPTER XXVI.
+A Pious King.—The King’s Clergy.—She Asked His Pardon.—Hiding in the
+Room.—Huck Takes the Money.
+
+CHAPTER XXVII.
+The Funeral.—Satisfying Curiosity.—Suspicious of Huck,—Quick Sales and
+Small.
+
+CHAPTER XXVIII.
+The Trip to England.—“The Brute!”—Mary Jane Decides to Leave.—Huck
+Parting with Mary Jane.—Mumps.—The Opposition Line.
+
+CHAPTER XXIX.
+Contested Relationship.—The King Explains the Loss.—A Question of
+Handwriting.—Digging up the Corpse.—Huck Escapes.
+
+CHAPTER XXX.
+The King Went for Him.—A Royal Row.—Powerful Mellow.
+
+CHAPTER XXXI.
+Ominous Plans.—News from Jim.—Old Recollections.—A Sheep
+Story.—Valuable Information.
+
+CHAPTER XXXII.
+Still and Sunday—like.—Mistaken Identity.—Up a Stump.—In a Dilemma.
+
+CHAPTER XXXIII.
+A Nigger Stealer.—Southern Hospitality.—A Pretty Long Blessing.—Tar and
+Feathers.
+
+CHAPTER XXXIV.
+The Hut by the Ash Hopper.—Outrageous.—Climbing the Lightning
+Rod.—Troubled with Witches.
+
+CHAPTER XXXV.
+Escaping Properly.—Dark Schemes.—Discrimination in Stealing.—A Deep
+Hole.
+
+CHAPTER XXXVI.
+The Lightning Rod.—His Level Best.—A Bequest to Posterity.—A High
+Figure.
+
+CHAPTER XXXVII.
+The Last Shirt.—Mooning Around.—Sailing Orders.—The Witch Pie.
+
+CHAPTER XXXVIII.
+The Coat of Arms.—A Skilled Superintendent.—Unpleasant Glory.—A Tearful
+Subject.
+
+CHAPTER XXXIX.
+Rats.—Lively Bed—fellows.—The Straw Dummy.
+
+CHAPTER XL.
+Fishing.—The Vigilance Committee.—A Lively Run.—Jim Advises a Doctor.
+
+CHAPTER XLI.
+The Doctor.—Uncle Silas.—Sister Hotchkiss.—Aunt Sally in Trouble.
+
+CHAPTER XLII.
+Tom Sawyer Wounded.—The Doctor’s Story.—Tom Confesses.—Aunt Polly
+Arrives.—Hand Out Them Letters.
+
+CHAPTER THE LAST.
+Out of Bondage.—Paying the Captive.—Yours Truly, Huck Finn.
+
+
+
+
+ILLUSTRATIONS.
+
+ The Widows
+ Moses and the “Bulrushers”
+ Miss Watson
+ Huck Stealing Away
+ They Tip-toed Along
+ Jim
+ Tom Sawyer’s Band of Robbers
+ Huck Creeps into his Window
+ Miss Watson’s Lecture
+ The Robbers Dispersed
+ Rubbing the Lamp
+ ! ! ! !
+ Judge Thatcher surprised
+ Jim Listening
+ “Pap”
+ Huck and his Father
+ Reforming the Drunkard
+ Falling from Grace
+ Getting out of the Way
+ Solid Comfort
+ Thinking it Over
+ Raising a Howl
+ “Git Up”
+ The Shanty
+ Shooting the Pig
+ Taking a Rest
+ In the Woods
+ Watching the Boat
+ Discovering the Camp Fire
+ Jim and the Ghost
+ Misto Bradish’s Nigger
+ Exploring the Cave
+ In the Cave
+ Jim sees a Dead Man
+ They Found Eight Dollars
+ Jim and the Snake
+ Old Hank Bunker
+ “A Fair Fit”
+ “Come In”
+ “Him and another Man”
+ She puts up a Snack
+ “Hump Yourself”
+ On the Raft
+ He sometimes Lifted a Chicken
+ “Please don’t, Bill”
+ “It ain’t Good Morals”
+ “Oh! Lordy, Lordy!”
+ In a Fix
+ “Hello, What’s Up?”
+ The Wreck
+ We turned in and Slept
+ Turning over the Truck
+ Solomon and his Million Wives
+ The story of “Sollermun”
+ “We Would Sell the Raft”
+ Among the Snags
+ Asleep on the Raft
+ “Something being Raftsman”
+ “Boy, that’s a Lie”
+ “Here I is, Huck”
+ Climbing up the Bank
+ “Who’s There?”
+ “Buck”
+ “It made Her look Spidery”
+ “They got him out and emptied Him”
+ The House
+ Col. Grangerford
+ Young Harney Shepherdson
+ Miss Charlotte
+ “And asked me if I Liked Her”
+ “Behind the Wood-pile”
+ Hiding Day-times
+ “And Dogs a-Coming”
+ “By rights I am a Duke!”
+ “I am the Late Dauphin”
+ Tail Piece
+ On the Raft
+ The King as Juliet
+ “Courting on the Sly”
+ “A Pirate for Thirty Years”
+ Another little Job
+ Practizing
+ Hamlet’s Soliloquy
+ “Gimme a Chaw”
+ A Little Monthly Drunk
+ The Death of Boggs
+ Sherburn steps out
+ A Dead Head
+ He shed Seventeen Suits
+ Tragedy
+ Their Pockets Bulged
+ Henry the Eighth in Boston Harbor
+ Harmless
+ Adolphus
+ He fairly emptied that Young Fellow
+ “Alas, our Poor Brother”
+ “You Bet it is”
+ Leaking
+ Making up the “Deffisit”
+ Going for him
+ The Doctor
+ The Bag of Money
+ The Cubby
+ Supper with the Hare-Lip
+ Honest Injun
+ The Duke looks under the Bed
+ Huck takes the Money
+ A Crack in the Dining-room Door
+ The Undertaker
+ “He had a Rat!”
+ “Was you in my Room?”
+ Jawing
+ In Trouble
+ Indignation
+ How to Find Them
+ He Wrote
+ Hannah with the Mumps
+ The Auction
+ The True Brothers
+ The Doctor leads Huck
+ The Duke Wrote
+ “Gentlemen, Gentlemen!”
+ “Jim Lit Out”
+ The King shakes Huck
+ The Duke went for Him
+ Spanish Moss
+ “Who Nailed Him?”
+ Thinking
+ He gave him Ten Cents
+ Striking for the Back Country
+ Still and Sunday-like
+ She hugged him tight
+ “Who do you reckon it is?”
+ “It was Tom Sawyer”
+ “Mr. Archibald Nichols, I presume?”
+ A pretty long Blessing
+ Traveling By Rail
+ Vittles
+ A Simple Job
+ Witches
+ Getting Wood
+ One of the Best Authorities
+ The Breakfast-Horn
+ Smouching the Knives
+ Going down the Lightning-Rod
+ Stealing spoons
+ Tom advises a Witch Pie
+ The Rubbage-Pile
+ “Missus, dey’s a Sheet Gone”
+ In a Tearing Way
+ One of his Ancestors
+ Jim’s Coat of Arms
+ A Tough Job
+ Buttons on their Tails
+ Irrigation
+ Keeping off Dull Times
+ Sawdust Diet
+ Trouble is Brewing
+ Fishing
+ Every one had a Gun
+ Tom caught on a Splinter
+ Jim advises a Doctor
+ The Doctor
+ Uncle Silas in Danger
+ Old Mrs. Hotchkiss
+ Aunt Sally talks to Huck
+ Tom Sawyer wounded
+ The Doctor speaks for Jim
+ Tom rose square up in Bed
+ “Hand out them Letters”
+ Out of Bondage
+ Tom’s Liberality
+ Yours Truly
+
+
+
+
+NOTICE.
+
+Persons attempting to find a motive in this narrative will be
+prosecuted; persons attempting to find a moral in it will be banished;
+persons attempting to find a plot in it will be shot.
+
+BY ORDER OF THE AUTHOR
+PER G. G., CHIEF OF ORDNANCE.
+
+
+
+
+EXPLANATORY
+
+In this book a number of dialects are used, to wit: the Missouri negro
+dialect; the extremest form of the backwoods Southwestern dialect; the
+ordinary “Pike County” dialect; and four modified varieties of this
+last. The shadings have not been done in a haphazard fashion, or by
+guesswork; but painstakingly, and with the trustworthy guidance and
+support of personal familiarity with these several forms of speech.
+
+I make this explanation for the reason that without it many readers
+would suppose that all these characters were trying to talk alike and
+not succeeding.
+
+THE AUTHOR.
+
+
+
+
+HUCKLEBERRY FINN
+
+Scene: The Mississippi Valley Time: Forty to fifty years ago
+
+
+
+
+CHAPTER I.
+
+
+You don’t know about me without you have read a book by the name of The
+Adventures of Tom Sawyer; but that ain’t no matter. That book was made
+by Mr. Mark Twain, and he told the truth, mainly. There was things
+which he stretched, but mainly he told the truth. That is nothing. I
+never seen anybody but lied one time or another, without it was Aunt
+Polly, or the widow, or maybe Mary. Aunt Polly—Tom’s Aunt Polly, she
+is—and Mary, and the Widow Douglas is all told about in that book,
+which is mostly a true book, with some stretchers, as I said before.
+
+Now the way that the book winds up is this: Tom and me found the money
+that the robbers hid in the cave, and it made us rich. We got six
+thousand dollars apiece—all gold. It was an awful sight of money when
+it was piled up. Well, Judge Thatcher he took it and put it out at
+interest, and it fetched us a dollar a day apiece all the year
+round—more than a body could tell what to do with. The Widow Douglas
+she took me for her son, and allowed she would sivilize me; but it was
+rough living in the house all the time, considering how dismal regular
+and decent the widow was in all her ways; and so when I couldn’t stand
+it no longer I lit out. I got into my old rags and my sugar-hogshead
+again, and was free and satisfied. But Tom Sawyer he hunted me up and
+said he was going to start a band of robbers, and I might join if I
+would go back to the widow and be respectable. So I went back.
+
+The widow she cried over me, and called me a poor lost lamb, and she
+called me a lot of other names, too, but she never meant no harm by it.
+She put me in them new clothes again, and I couldn’t do nothing but
+sweat and sweat, and feel all cramped up. Well, then, the old thing
+commenced again. The widow rung a bell for supper, and you had to come
+to time. When you got to the table you couldn’t go right to eating, but
+you had to wait for the widow to tuck down her head and grumble a
+little over the victuals, though there warn’t really anything the
+matter with them,—that is, nothing only everything was cooked by
+itself. In a barrel of odds and ends it is different; things get mixed
+up, and the juice kind of swaps around, and the things go better.
+
+After supper she got out her book and learned me about Moses and the
+Bulrushers, and I was in a sweat to find out all about him; but
+by-and-by she let it out that Moses had been dead a considerable long
+time; so then I didn’t care no more about him, because I don’t take no
+stock in dead people.
+
+Pretty soon I wanted to smoke, and asked the widow to let me. But she
+wouldn’t. She said it was a mean practice and wasn’t clean, and I must
+try to not do it any more. That is just the way with some people. They
+get down on a thing when they don’t know nothing about it. Here she was
+a-bothering about Moses, which was no kin to her, and no use to
+anybody, being gone, you see, yet finding a power of fault with me for
+doing a thing that had some good in it. And she took snuff, too; of
+course that was all right, because she done it herself.
+
+Her sister, Miss Watson, a tolerable slim old maid, with goggles on,
+had just come to live with her, and took a set at me now with a
+spelling-book. She worked me middling hard for about an hour, and then
+the widow made her ease up. I couldn’t stood it much longer. Then for
+an hour it was deadly dull, and I was fidgety. Miss Watson would say,
+“Don’t put your feet up there, Huckleberry;” and “Don’t scrunch up like
+that, Huckleberry—set up straight;” and pretty soon she would say,
+“Don’t gap and stretch like that, Huckleberry—why don’t you try to
+behave?” Then she told me all about the bad place, and I said I wished
+I was there. She got mad then, but I didn’t mean no harm. All I wanted
+was to go somewheres; all I wanted was a change, I warn’t particular.
+She said it was wicked to say what I said; said she wouldn’t say it for
+the whole world; she was going to live so as to go to the good place.
+Well, I couldn’t see no advantage in going where she was going, so I
+made up my mind I wouldn’t try for it. But I never said so, because it
+would only make trouble, and wouldn’t do no good.
+
+Now she had got a start, and she went on and told me all about the good
+place. She said all a body would have to do there was to go around all
+day long with a harp and sing, forever and ever. So I didn’t think much
+of it. But I never said so. I asked her if she reckoned Tom Sawyer
+would go there, and she said not by a considerable sight. I was glad
+about that, because I wanted him and me to be together.
+
+Miss Watson she kept pecking at me, and it got tiresome and lonesome.
+By-and-by they fetched the niggers in and had prayers, and then
+everybody was off to bed. I went up to my room with a piece of candle,
+and put it on the table. Then I set down in a chair by the window and
+tried to think of something cheerful, but it warn’t no use. I felt so
+lonesome I most wished I was dead. The stars were shining, and the
+leaves rustled in the woods ever so mournful; and I heard an owl, away
+off, who-whooing about somebody that was dead, and a whippowill and a
+dog crying about somebody that was going to die; and the wind was
+trying to whisper something to me, and I couldn’t make out what it was,
+and so it made the cold shivers run over me. Then away out in the woods
+I heard that kind of a sound that a ghost makes when it wants to tell
+about something that’s on its mind and can’t make itself understood,
+and so can’t rest easy in its grave, and has to go about that way every
+night grieving. I got so down-hearted and scared I did wish I had some
+company. Pretty soon a spider went crawling up my shoulder, and I
+flipped it off and it lit in the candle; and before I could budge it
+was all shriveled up. I didn’t need anybody to tell me that that was an
+awful bad sign and would fetch me some bad luck, so I was scared and
+most shook the clothes off of me. I got up and turned around in my
+tracks three times and crossed my breast every time; and then I tied up
+a little lock of my hair with a thread to keep witches away. But I
+hadn’t no confidence. You do that when you’ve lost a horseshoe that
+you’ve found, instead of nailing it up over the door, but I hadn’t ever
+heard anybody say it was any way to keep off bad luck when you’d killed
+a spider.
+
+I set down again, a-shaking all over, and got out my pipe for a smoke;
+for the house was all as still as death now, and so the widow wouldn’t
+know. Well, after a long time I heard the clock away off in the town go
+boom—boom—boom—twelve licks; and all still again—stiller than ever.
+Pretty soon I heard a twig snap down in the dark amongst the
+trees—something was a stirring. I set still and listened. Directly I
+could just barely hear a “_me-yow! me-yow!_” down there. That was good!
+Says I, “_me-yow! me-yow!_” as soft as I could, and then I put out the
+light and scrambled out of the window on to the shed. Then I slipped
+down to the ground and crawled in among the trees, and, sure enough,
+there was Tom Sawyer waiting for me.
+
+
+
+
+CHAPTER II.
+
+
+We went tiptoeing along a path amongst the trees back towards the end
+of the widow’s garden, stooping down so as the branches wouldn’t scrape
+our heads. When we was passing by the kitchen I fell over a root and
+made a noise. We scrouched down and laid still. Miss Watson’s big
+nigger, named Jim, was setting in the kitchen door; we could see him
+pretty clear, because there was a light behind him. He got up and
+stretched his neck out about a minute, listening. Then he says:
+
+“Who dah?”
+
+He listened some more; then he come tiptoeing down and stood right
+between us; we could a touched him, nearly. Well, likely it was minutes
+and minutes that there warn’t a sound, and we all there so close
+together. There was a place on my ankle that got to itching, but I
+dasn’t scratch it; and then my ear begun to itch; and next my back,
+right between my shoulders. Seemed like I’d die if I couldn’t scratch.
+Well, I’ve noticed that thing plenty times since. If you are with the
+quality, or at a funeral, or trying to go to sleep when you ain’t
+sleepy—if you are anywheres where it won’t do for you to scratch, why
+you will itch all over in upwards of a thousand places. Pretty soon Jim
+says:
+
+“Say, who is you? Whar is you? Dog my cats ef I didn’ hear sumf’n.
+Well, I know what I’s gwyne to do: I’s gwyne to set down here and
+listen tell I hears it agin.”
+
+So he set down on the ground betwixt me and Tom. He leaned his back up
+against a tree, and stretched his legs out till one of them most
+touched one of mine. My nose begun to itch. It itched till the tears
+come into my eyes. But I dasn’t scratch. Then it begun to itch on the
+inside. Next I got to itching underneath. I didn’t know how I was going
+to set still. This miserableness went on as much as six or seven
+minutes; but it seemed a sight longer than that. I was itching in
+eleven different places now. I reckoned I couldn’t stand it more’n a
+minute longer, but I set my teeth hard and got ready to try. Just then
+Jim begun to breathe heavy; next he begun to snore—and then I was
+pretty soon comfortable again.
+
+Tom he made a sign to me—kind of a little noise with his mouth—and we
+went creeping away on our hands and knees. When we was ten foot off Tom
+whispered to me, and wanted to tie Jim to the tree for fun. But I said
+no; he might wake and make a disturbance, and then they’d find out I
+warn’t in. Then Tom said he hadn’t got candles enough, and he would
+slip in the kitchen and get some more. I didn’t want him to try. I said
+Jim might wake up and come. But Tom wanted to resk it; so we slid in
+there and got three candles, and Tom laid five cents on the table for
+pay. Then we got out, and I was in a sweat to get away; but nothing
+would do Tom but he must crawl to where Jim was, on his hands and
+knees, and play something on him. I waited, and it seemed a good while,
+everything was so still and lonesome.
+
+As soon as Tom was back we cut along the path, around the garden fence,
+and by-and-by fetched up on the steep top of the hill the other side of
+the house. Tom said he slipped Jim’s hat off of his head and hung it on
+a limb right over him, and Jim stirred a little, but he didn’t wake.
+Afterwards Jim said the witches bewitched him and put him in a trance,
+and rode him all over the State, and then set him under the trees
+again, and hung his hat on a limb to show who done it. And next time
+Jim told it he said they rode him down to New Orleans; and, after that,
+every time he told it he spread it more and more, till by-and-by he
+said they rode him all over the world, and tired him most to death, and
+his back was all over saddle-boils. Jim was monstrous proud about it,
+and he got so he wouldn’t hardly notice the other niggers. Niggers
+would come miles to hear Jim tell about it, and he was more looked up
+to than any nigger in that country. Strange niggers would stand with
+their mouths open and look him all over, same as if he was a wonder.
+Niggers is always talking about witches in the dark by the kitchen
+fire; but whenever one was talking and letting on to know all about
+such things, Jim would happen in and say, “Hm! What you know ’bout
+witches?” and that nigger was corked up and had to take a back seat.
+Jim always kept that five-center piece round his neck with a string,
+and said it was a charm the devil give to him with his own hands, and
+told him he could cure anybody with it and fetch witches whenever he
+wanted to just by saying something to it; but he never told what it was
+he said to it. Niggers would come from all around there and give Jim
+anything they had, just for a sight of that five-center piece; but they
+wouldn’t touch it, because the devil had had his hands on it. Jim was
+most ruined for a servant, because he got stuck up on account of having
+seen the devil and been rode by witches.
+
+Well, when Tom and me got to the edge of the hilltop we looked away
+down into the village and could see three or four lights twinkling,
+where there was sick folks, maybe; and the stars over us was sparkling
+ever so fine; and down by the village was the river, a whole mile
+broad, and awful still and grand. We went down the hill and found Jo
+Harper and Ben Rogers, and two or three more of the boys, hid in the
+old tanyard. So we unhitched a skiff and pulled down the river two mile
+and a half, to the big scar on the hillside, and went ashore.
+
+We went to a clump of bushes, and Tom made everybody swear to keep the
+secret, and then showed them a hole in the hill, right in the thickest
+part of the bushes. Then we lit the candles, and crawled in on our
+hands and knees. We went about two hundred yards, and then the cave
+opened up. Tom poked about amongst the passages, and pretty soon ducked
+under a wall where you wouldn’t a noticed that there was a hole. We
+went along a narrow place and got into a kind of room, all damp and
+sweaty and cold, and there we stopped. Tom says:
+
+“Now, we’ll start this band of robbers and call it Tom Sawyer’s Gang.
+Everybody that wants to join has got to take an oath, and write his
+name in blood.”
+
+Everybody was willing. So Tom got out a sheet of paper that he had
+wrote the oath on, and read it. It swore every boy to stick to the
+band, and never tell any of the secrets; and if anybody done anything
+to any boy in the band, whichever boy was ordered to kill that person
+and his family must do it, and he mustn’t eat and he mustn’t sleep till
+he had killed them and hacked a cross in their breasts, which was the
+sign of the band. And nobody that didn’t belong to the band could use
+that mark, and if he did he must be sued; and if he done it again he
+must be killed. And if anybody that belonged to the band told the
+secrets, he must have his throat cut, and then have his carcass burnt
+up and the ashes scattered all around, and his name blotted off of the
+list with blood and never mentioned again by the gang, but have a curse
+put on it and be forgot forever.
+
+Everybody said it was a real beautiful oath, and asked Tom if he got it
+out of his own head. He said, some of it, but the rest was out of
+pirate-books and robber-books, and every gang that was high-toned had
+it.
+
+Some thought it would be good to kill the _families_ of boys that told
+the secrets. Tom said it was a good idea, so he took a pencil and wrote
+it in. Then Ben Rogers says:
+
+“Here’s Huck Finn, he hain’t got no family; what you going to do ’bout
+him?”
+
+“Well, hain’t he got a father?” says Tom Sawyer.
+
+“Yes, he’s got a father, but you can’t never find him these days. He
+used to lay drunk with the hogs in the tanyard, but he hain’t been seen
+in these parts for a year or more.”
+
+They talked it over, and they was going to rule me out, because they
+said every boy must have a family or somebody to kill, or else it
+wouldn’t be fair and square for the others. Well, nobody could think of
+anything to do—everybody was stumped, and set still. I was most ready
+to cry; but all at once I thought of a way, and so I offered them Miss
+Watson—they could kill her. Everybody said:
+
+“Oh, she’ll do. That’s all right. Huck can come in.”
+
+Then they all stuck a pin in their fingers to get blood to sign with,
+and I made my mark on the paper.
+
+“Now,” says Ben Rogers, “what’s the line of business of this Gang?”
+
+“Nothing only robbery and murder,” Tom said.
+
+“But who are we going to rob?—houses, or cattle, or—”
+
+“Stuff! stealing cattle and such things ain’t robbery; it’s burglary,”
+says Tom Sawyer. “We ain’t burglars. That ain’t no sort of style. We
+are highwaymen. We stop stages and carriages on the road, with masks
+on, and kill the people and take their watches and money.”
+
+“Must we always kill the people?”
+
+“Oh, certainly. It’s best. Some authorities think different, but mostly
+it’s considered best to kill them—except some that you bring to the
+cave here, and keep them till they’re ransomed.”
+
+“Ransomed? What’s that?”
+
+“I don’t know. But that’s what they do. I’ve seen it in books; and so
+of course that’s what we’ve got to do.”
+
+“But how can we do it if we don’t know what it is?”
+
+“Why, blame it all, we’ve _got_ to do it. Don’t I tell you it’s in the
+books? Do you want to go to doing different from what’s in the books,
+and get things all muddled up?”
+
+“Oh, that’s all very fine to _say_, Tom Sawyer, but how in the nation
+are these fellows going to be ransomed if we don’t know how to do it to
+them?—that’s the thing _I_ want to get at. Now, what do you _reckon_ it
+is?”
+
+“Well, I don’t know. But per’aps if we keep them till they’re ransomed,
+it means that we keep them till they’re dead.”
+
+“Now, that’s something _like_. That’ll answer. Why couldn’t you said
+that before? We’ll keep them till they’re ransomed to death; and a
+bothersome lot they’ll be, too—eating up everything, and always trying
+to get loose.”
+
+“How you talk, Ben Rogers. How can they get loose when there’s a guard
+over them, ready to shoot them down if they move a peg?”
+
+“A guard! Well, that _is_ good. So somebody’s got to set up all night
+and never get any sleep, just so as to watch them. I think that’s
+foolishness. Why can’t a body take a club and ransom them as soon as
+they get here?”
+
+“Because it ain’t in the books so—that’s why. Now, Ben Rogers, do you
+want to do things regular, or don’t you?—that’s the idea. Don’t you
+reckon that the people that made the books knows what’s the correct
+thing to do? Do you reckon _you_ can learn ’em anything? Not by a good
+deal. No, sir, we’ll just go on and ransom them in the regular way.”
+
+“All right. I don’t mind; but I say it’s a fool way, anyhow. Say, do we
+kill the women, too?”
+
+“Well, Ben Rogers, if I was as ignorant as you I wouldn’t let on. Kill
+the women? No; nobody ever saw anything in the books like that. You
+fetch them to the cave, and you’re always as polite as pie to them; and
+by-and-by they fall in love with you, and never want to go home any
+more.”
+
+“Well, if that’s the way I’m agreed, but I don’t take no stock in it.
+Mighty soon we’ll have the cave so cluttered up with women, and fellows
+waiting to be ransomed, that there won’t be no place for the robbers.
+But go ahead, I ain’t got nothing to say.”
+
+Little Tommy Barnes was asleep now, and when they waked him up he was
+scared, and cried, and said he wanted to go home to his ma, and didn’t
+want to be a robber any more.
+
+So they all made fun of him, and called him cry-baby, and that made him
+mad, and he said he would go straight and tell all the secrets. But Tom
+give him five cents to keep quiet, and said we would all go home and
+meet next week, and rob somebody and kill some people.
+
+Ben Rogers said he couldn’t get out much, only Sundays, and so he
+wanted to begin next Sunday; but all the boys said it would be wicked
+to do it on Sunday, and that settled the thing. They agreed to get
+together and fix a day as soon as they could, and then we elected Tom
+Sawyer first captain and Jo Harper second captain of the Gang, and so
+started home.
+
+I clumb up the shed and crept into my window just before day was
+breaking. My new clothes was all greased up and clayey, and I was
+dog-tired.
+
+
+
+
+CHAPTER III.
+
+
+Well, I got a good going-over in the morning from old Miss Watson on
+account of my clothes; but the widow she didn’t scold, but only cleaned
+off the grease and clay, and looked so sorry that I thought I would
+behave a while if I could. Then Miss Watson she took me in the closet
+and prayed, but nothing come of it. She told me to pray every day, and
+whatever I asked for I would get it. But it warn’t so. I tried it. Once
+I got a fish-line, but no hooks. It warn’t any good to me without
+hooks. I tried for the hooks three or four times, but somehow I
+couldn’t make it work. By-and-by, one day, I asked Miss Watson to try
+for me, but she said I was a fool. She never told me why, and I
+couldn’t make it out no way.
+
+I set down one time back in the woods, and had a long think about it. I
+says to myself, if a body can get anything they pray for, why don’t
+Deacon Winn get back the money he lost on pork? Why can’t the widow get
+back her silver snuffbox that was stole? Why can’t Miss Watson fat up?
+No, says I to myself, there ain’t nothing in it. I went and told the
+widow about it, and she said the thing a body could get by praying for
+it was “spiritual gifts.” This was too many for me, but she told me
+what she meant—I must help other people, and do everything I could for
+other people, and look out for them all the time, and never think about
+myself. This was including Miss Watson, as I took it. I went out in the
+woods and turned it over in my mind a long time, but I couldn’t see no
+advantage about it—except for the other people; so at last I reckoned I
+wouldn’t worry about it any more, but just let it go. Sometimes the
+widow would take me one side and talk about Providence in a way to make
+a body’s mouth water; but maybe next day Miss Watson would take hold
+and knock it all down again. I judged I could see that there was two
+Providences, and a poor chap would stand considerable show with the
+widow’s Providence, but if Miss Watson’s got him there warn’t no help
+for him any more. I thought it all out, and reckoned I would belong to
+the widow’s if he wanted me, though I couldn’t make out how he was
+a-going to be any better off then than what he was before, seeing I was
+so ignorant, and so kind of low-down and ornery.
+
+Pap he hadn’t been seen for more than a year, and that was comfortable
+for me; I didn’t want to see him no more. He used to always whale me
+when he was sober and could get his hands on me; though I used to take
+to the woods most of the time when he was around. Well, about this time
+he was found in the river drownded, about twelve mile above town, so
+people said. They judged it was him, anyway; said this drownded man was
+just his size, and was ragged, and had uncommon long hair, which was
+all like pap; but they couldn’t make nothing out of the face, because
+it had been in the water so long it warn’t much like a face at all.
+They said he was floating on his back in the water. They took him and
+buried him on the bank. But I warn’t comfortable long, because I
+happened to think of something. I knowed mighty well that a drownded
+man don’t float on his back, but on his face. So I knowed, then, that
+this warn’t pap, but a woman dressed up in a man’s clothes. So I was
+uncomfortable again. I judged the old man would turn up again
+by-and-by, though I wished he wouldn’t.
+
+We played robber now and then about a month, and then I resigned. All
+the boys did. We hadn’t robbed nobody, hadn’t killed any people, but
+only just pretended. We used to hop out of the woods and go charging
+down on hog-drivers and women in carts taking garden stuff to market,
+but we never hived any of them. Tom Sawyer called the hogs “ingots,”
+and he called the turnips and stuff “julery,” and we would go to the
+cave and powwow over what we had done, and how many people we had
+killed and marked. But I couldn’t see no profit in it. One time Tom
+sent a boy to run about town with a blazing stick, which he called a
+slogan (which was the sign for the Gang to get together), and then he
+said he had got secret news by his spies that next day a whole parcel
+of Spanish merchants and rich A-rabs was going to camp in Cave Hollow
+with two hundred elephants, and six hundred camels, and over a thousand
+“sumter” mules, all loaded down with di’monds, and they didn’t have
+only a guard of four hundred soldiers, and so we would lay in
+ambuscade, as he called it, and kill the lot and scoop the things. He
+said we must slick up our swords and guns, and get ready. He never
+could go after even a turnip-cart but he must have the swords and guns
+all scoured up for it, though they was only lath and broomsticks, and
+you might scour at them till you rotted, and then they warn’t worth a
+mouthful of ashes more than what they was before. I didn’t believe we
+could lick such a crowd of Spaniards and A-rabs, but I wanted to see
+the camels and elephants, so I was on hand next day, Saturday, in the
+ambuscade; and when we got the word we rushed out of the woods and down
+the hill. But there warn’t no Spaniards and A-rabs, and there warn’t no
+camels nor no elephants. It warn’t anything but a Sunday-school picnic,
+and only a primer-class at that. We busted it up, and chased the
+children up the hollow; but we never got anything but some doughnuts
+and jam, though Ben Rogers got a rag doll, and Jo Harper got a
+hymn-book and a tract; and then the teacher charged in, and made us
+drop everything and cut.
+
+I didn’t see no di’monds, and I told Tom Sawyer so. He said there was
+loads of them there, anyway; and he said there was A-rabs there, too,
+and elephants and things. I said, why couldn’t we see them, then? He
+said if I warn’t so ignorant, but had read a book called Don Quixote, I
+would know without asking. He said it was all done by enchantment. He
+said there was hundreds of soldiers there, and elephants and treasure,
+and so on, but we had enemies which he called magicians; and they had
+turned the whole thing into an infant Sunday-school, just out of spite.
+I said, all right; then the thing for us to do was to go for the
+magicians. Tom Sawyer said I was a numskull.
+
+“Why,” said he, “a magician could call up a lot of genies, and they
+would hash you up like nothing before you could say Jack Robinson. They
+are as tall as a tree and as big around as a church.”
+
+“Well,” I says, “s’pose we got some genies to help _us_—can’t we lick
+the other crowd then?”
+
+“How you going to get them?”
+
+“I don’t know. How do _they_ get them?”
+
+“Why, they rub an old tin lamp or an iron ring, and then the genies
+come tearing in, with the thunder and lightning a-ripping around and
+the smoke a-rolling, and everything they’re told to do they up and do
+it. They don’t think nothing of pulling a shot-tower up by the roots,
+and belting a Sunday-school superintendent over the head with it—or any
+other man.”
+
+“Who makes them tear around so?”
+
+“Why, whoever rubs the lamp or the ring. They belong to whoever rubs
+the lamp or the ring, and they’ve got to do whatever he says. If he
+tells them to build a palace forty miles long out of di’monds, and fill
+it full of chewing-gum, or whatever you want, and fetch an emperor’s
+daughter from China for you to marry, they’ve got to do it—and they’ve
+got to do it before sun-up next morning, too. And more: they’ve got to
+waltz that palace around over the country wherever you want it, you
+understand.”
+
+“Well,” says I, “I think they are a pack of flat-heads for not keeping
+the palace themselves ’stead of fooling them away like that. And what’s
+more—if I was one of them I would see a man in Jericho before I would
+drop my business and come to him for the rubbing of an old tin lamp.”
+
+“How you talk, Huck Finn. Why, you’d _have_ to come when he rubbed it,
+whether you wanted to or not.”
+
+“What! and I as high as a tree and as big as a church? All right, then;
+I _would_ come; but I lay I’d make that man climb the highest tree
+there was in the country.”
+
+“Shucks, it ain’t no use to talk to you, Huck Finn. You don’t seem to
+know anything, somehow—perfect saphead.”
+
+I thought all this over for two or three days, and then I reckoned I
+would see if there was anything in it. I got an old tin lamp and an
+iron ring, and went out in the woods and rubbed and rubbed till I sweat
+like an Injun, calculating to build a palace and sell it; but it warn’t
+no use, none of the genies come. So then I judged that all that stuff
+was only just one of Tom Sawyer’s lies. I reckoned he believed in the
+A-rabs and the elephants, but as for me I think different. It had all
+the marks of a Sunday-school.
+
+
+
+
+CHAPTER IV.
+
+
+Well, three or four months run along, and it was well into the winter
+now. I had been to school most all the time and could spell and read
+and write just a little, and could say the multiplication table up to
+six times seven is thirty-five, and I don’t reckon I could ever get any
+further than that if I was to live forever. I don’t take no stock in
+mathematics, anyway.
+
+At first I hated the school, but by-and-by I got so I could stand it.
+Whenever I got uncommon tired I played hookey, and the hiding I got
+next day done me good and cheered me up. So the longer I went to school
+the easier it got to be. I was getting sort of used to the widow’s
+ways, too, and they warn’t so raspy on me. Living in a house and
+sleeping in a bed pulled on me pretty tight mostly, but before the cold
+weather I used to slide out and sleep in the woods sometimes, and so
+that was a rest to me. I liked the old ways best, but I was getting so
+I liked the new ones, too, a little bit. The widow said I was coming
+along slow but sure, and doing very satisfactory. She said she warn’t
+ashamed of me.
+
+One morning I happened to turn over the salt-cellar at breakfast. I
+reached for some of it as quick as I could to throw over my left
+shoulder and keep off the bad luck, but Miss Watson was in ahead of me,
+and crossed me off. She says, “Take your hands away, Huckleberry; what
+a mess you are always making!” The widow put in a good word for me, but
+that warn’t going to keep off the bad luck, I knowed that well enough.
+I started out, after breakfast, feeling worried and shaky, and
+wondering where it was going to fall on me, and what it was going to
+be. There is ways to keep off some kinds of bad luck, but this wasn’t
+one of them kind; so I never tried to do anything, but just poked along
+low-spirited and on the watch-out.
+
+I went down to the front garden and clumb over the stile where you go
+through the high board fence. There was an inch of new snow on the
+ground, and I seen somebody’s tracks. They had come up from the quarry
+and stood around the stile a while, and then went on around the garden
+fence. It was funny they hadn’t come in, after standing around so. I
+couldn’t make it out. It was very curious, somehow. I was going to
+follow around, but I stooped down to look at the tracks first. I didn’t
+notice anything at first, but next I did. There was a cross in the left
+boot-heel made with big nails, to keep off the devil.
+
+I was up in a second and shinning down the hill. I looked over my
+shoulder every now and then, but I didn’t see nobody. I was at Judge
+Thatcher’s as quick as I could get there. He said:
+
+“Why, my boy, you are all out of breath. Did you come for your
+interest?”
+
+“No, sir,” I says; “is there some for me?”
+
+“Oh, yes, a half-yearly is in, last night—over a hundred and fifty
+dollars. Quite a fortune for you. You had better let me invest it along
+with your six thousand, because if you take it you’ll spend it.”
+
+“No, sir,” I says, “I don’t want to spend it. I don’t want it at
+all—nor the six thousand, nuther. I want you to take it; I want to give
+it to you—the six thousand and all.”
+
+He looked surprised. He couldn’t seem to make it out. He says:
+
+“Why, what can you mean, my boy?”
+
+I says, “Don’t you ask me no questions about it, please. You’ll take
+it—won’t you?”
+
+He says:
+
+“Well, I’m puzzled. Is something the matter?”
+
+“Please take it,” says I, “and don’t ask me nothing—then I won’t have
+to tell no lies.”
+
+He studied a while, and then he says:
+
+“Oho-o! I think I see. You want to _sell_ all your property to me—not
+give it. That’s the correct idea.”
+
+Then he wrote something on a paper and read it over, and says:
+
+“There; you see it says ‘for a consideration.’ That means I have bought
+it of you and paid you for it. Here’s a dollar for you. Now you sign
+it.”
+
+So I signed it, and left.
+
+Miss Watson’s nigger, Jim, had a hair-ball as big as your fist, which
+had been took out of the fourth stomach of an ox, and he used to do
+magic with it. He said there was a spirit inside of it, and it knowed
+everything. So I went to him that night and told him pap was here
+again, for I found his tracks in the snow. What I wanted to know was,
+what he was going to do, and was he going to stay? Jim got out his
+hair-ball and said something over it, and then he held it up and
+dropped it on the floor. It fell pretty solid, and only rolled about an
+inch. Jim tried it again, and then another time, and it acted just the
+same. Jim got down on his knees, and put his ear against it and
+listened. But it warn’t no use; he said it wouldn’t talk. He said
+sometimes it wouldn’t talk without money. I told him I had an old slick
+counterfeit quarter that warn’t no good because the brass showed
+through the silver a little, and it wouldn’t pass nohow, even if the
+brass didn’t show, because it was so slick it felt greasy, and so that
+would tell on it every time. (I reckoned I wouldn’t say nothing about
+the dollar I got from the judge.) I said it was pretty bad money, but
+maybe the hair-ball would take it, because maybe it wouldn’t know the
+difference. Jim smelt it and bit it and rubbed it, and said he would
+manage so the hair-ball would think it was good. He said he would split
+open a raw Irish potato and stick the quarter in between and keep it
+there all night, and next morning you couldn’t see no brass, and it
+wouldn’t feel greasy no more, and so anybody in town would take it in a
+minute, let alone a hair-ball. Well, I knowed a potato would do that
+before, but I had forgot it.
+
+Jim put the quarter under the hair-ball, and got down and listened
+again. This time he said the hair-ball was all right. He said it would
+tell my whole fortune if I wanted it to. I says, go on. So the
+hair-ball talked to Jim, and Jim told it to me. He says:
+
+“Yo’ ole father doan’ know yit what he’s a-gwyne to do. Sometimes he
+spec he’ll go ’way, en den agin he spec he’ll stay. De bes’ way is to
+res’ easy en let de ole man take his own way. Dey’s two angels hoverin’
+roun’ ’bout him. One uv ’em is white en shiny, en t’other one is black.
+De white one gits him to go right a little while, den de black one sail
+in en bust it all up. A body can’t tell yit which one gwyne to fetch
+him at de las’. But you is all right. You gwyne to have considable
+trouble in yo’ life, en considable joy. Sometimes you gwyne to git
+hurt, en sometimes you gwyne to git sick; but every time you’s gwyne to
+git well agin. Dey’s two gals flyin’ ’bout you in yo’ life. One uv
+’em’s light en t’other one is dark. One is rich en t’other is po’.
+You’s gwyne to marry de po’ one fust en de rich one by en by. You wants
+to keep ’way fum de water as much as you kin, en don’t run no resk,
+’kase it’s down in de bills dat you’s gwyne to git hung.”
+
+When I lit my candle and went up to my room that night there sat pap
+his own self!
+
+
+
+
+CHAPTER V.
+
+
+I had shut the door to. Then I turned around and there he was. I used
+to be scared of him all the time, he tanned me so much. I reckoned I
+was scared now, too; but in a minute I see I was mistaken—that is,
+after the first jolt, as you may say, when my breath sort of hitched,
+he being so unexpected; but right away after I see I warn’t scared of
+him worth bothring about.
+
+He was most fifty, and he looked it. His hair was long and tangled and
+greasy, and hung down, and you could see his eyes shining through like
+he was behind vines. It was all black, no gray; so was his long,
+mixed-up whiskers. There warn’t no color in his face, where his face
+showed; it was white; not like another man’s white, but a white to make
+a body sick, a white to make a body’s flesh crawl—a tree-toad white, a
+fish-belly white. As for his clothes—just rags, that was all. He had
+one ankle resting on t’other knee; the boot on that foot was busted,
+and two of his toes stuck through, and he worked them now and then. His
+hat was laying on the floor—an old black slouch with the top caved in,
+like a lid.
+
+I stood a-looking at him; he set there a-looking at me, with his chair
+tilted back a little. I set the candle down. I noticed the window was
+up; so he had clumb in by the shed. He kept a-looking me all over.
+By-and-by he says:
+
+“Starchy clothes—very. You think you’re a good deal of a big-bug,
+_don’t_ you?”
+
+“Maybe I am, maybe I ain’t,” I says.
+
+“Don’t you give me none o’ your lip,” says he. “You’ve put on
+considerable many frills since I been away. I’ll take you down a peg
+before I get done with you. You’re educated, too, they say—can read and
+write. You think you’re better’n your father, now, don’t you, because
+he can’t? _I’ll_ take it out of you. Who told you you might meddle with
+such hifalut’n foolishness, hey?—who told you you could?”
+
+“The widow. She told me.”
+
+“The widow, hey?—and who told the widow she could put in her shovel
+about a thing that ain’t none of her business?”
+
+“Nobody never told her.”
+
+“Well, I’ll learn her how to meddle. And looky here—you drop that
+school, you hear? I’ll learn people to bring up a boy to put on airs
+over his own father and let on to be better’n what _he_ is. You lemme
+catch you fooling around that school again, you hear? Your mother
+couldn’t read, and she couldn’t write, nuther, before she died. None of
+the family couldn’t before _they_ died. _I_ can’t; and here you’re
+a-swelling yourself up like this. I ain’t the man to stand it—you hear?
+Say, lemme hear you read.”
+
+I took up a book and begun something about General Washington and the
+wars. When I’d read about a half a minute, he fetched the book a whack
+with his hand and knocked it across the house. He says:
+
+“It’s so. You can do it. I had my doubts when you told me. Now looky
+here; you stop that putting on frills. I won’t have it. I’ll lay for
+you, my smarty; and if I catch you about that school I’ll tan you good.
+First you know you’ll get religion, too. I never see such a son.”
+
+He took up a little blue and yaller picture of some cows and a boy, and
+says:
+
+“What’s this?”
+
+“It’s something they give me for learning my lessons good.”
+
+He tore it up, and says:
+
+“I’ll give you something better—I’ll give you a cowhide.”
+
+He set there a-mumbling and a-growling a minute, and then he says:
+
+“_Ain’t_ you a sweet-scented dandy, though? A bed; and bedclothes; and
+a look’n’-glass; and a piece of carpet on the floor—and your own father
+got to sleep with the hogs in the tanyard. I never see such a son. I
+bet I’ll take some o’ these frills out o’ you before I’m done with you.
+Why, there ain’t no end to your airs—they say you’re rich. Hey?—how’s
+that?”
+
+“They lie—that’s how.”
+
+“Looky here—mind how you talk to me; I’m a-standing about all I can
+stand now—so don’t gimme no sass. I’ve been in town two days, and I
+hain’t heard nothing but about you bein’ rich. I heard about it away
+down the river, too. That’s why I come. You git me that money
+to-morrow—I want it.”
+
+“I hain’t got no money.”
+
+“It’s a lie. Judge Thatcher’s got it. You git it. I want it.”
+
+“I hain’t got no money, I tell you. You ask Judge Thatcher; he’ll tell
+you the same.”
+
+“All right. I’ll ask him; and I’ll make him pungle, too, or I’ll know
+the reason why. Say, how much you got in your pocket? I want it.”
+
+“I hain’t got only a dollar, and I want that to—”
+
+“It don’t make no difference what you want it for—you just shell it
+out.”
+
+He took it and bit it to see if it was good, and then he said he was
+going down town to get some whisky; said he hadn’t had a drink all day.
+When he had got out on the shed he put his head in again, and cussed me
+for putting on frills and trying to be better than him; and when I
+reckoned he was gone he come back and put his head in again, and told
+me to mind about that school, because he was going to lay for me and
+lick me if I didn’t drop that.
+
+Next day he was drunk, and he went to Judge Thatcher’s and bullyragged
+him, and tried to make him give up the money; but he couldn’t, and then
+he swore he’d make the law force him.
+
+The judge and the widow went to law to get the court to take me away
+from him and let one of them be my guardian; but it was a new judge
+that had just come, and he didn’t know the old man; so he said courts
+mustn’t interfere and separate families if they could help it; said
+he’d druther not take a child away from its father. So Judge Thatcher
+and the widow had to quit on the business.
+
+That pleased the old man till he couldn’t rest. He said he’d cowhide me
+till I was black and blue if I didn’t raise some money for him. I
+borrowed three dollars from Judge Thatcher, and pap took it and got
+drunk, and went a-blowing around and cussing and whooping and carrying
+on; and he kept it up all over town, with a tin pan, till most
+midnight; then they jailed him, and next day they had him before court,
+and jailed him again for a week. But he said _he_ was satisfied; said
+he was boss of his son, and he’d make it warm for _him_.
+
+When he got out the new judge said he was a-going to make a man of him.
+So he took him to his own house, and dressed him up clean and nice, and
+had him to breakfast and dinner and supper with the family, and was
+just old pie to him, so to speak. And after supper he talked to him
+about temperance and such things till the old man cried, and said he’d
+been a fool, and fooled away his life; but now he was a-going to turn
+over a new leaf and be a man nobody wouldn’t be ashamed of, and he
+hoped the judge would help him and not look down on him. The judge said
+he could hug him for them words; so _he_ cried, and his wife she cried
+again; pap said he’d been a man that had always been misunderstood
+before, and the judge said he believed it. The old man said that what a
+man wanted that was down was sympathy, and the judge said it was so; so
+they cried again. And when it was bedtime the old man rose up and held
+out his hand, and says:
+
+“Look at it, gentlemen and ladies all; take a-hold of it; shake it.
+There’s a hand that was the hand of a hog; but it ain’t so no more;
+it’s the hand of a man that’s started in on a new life, and’ll die
+before he’ll go back. You mark them words—don’t forget I said them.
+It’s a clean hand now; shake it—don’t be afeard.”
+
+So they shook it, one after the other, all around, and cried. The
+judge’s wife she kissed it. Then the old man he signed a pledge—made
+his mark. The judge said it was the holiest time on record, or
+something like that. Then they tucked the old man into a beautiful
+room, which was the spare room, and in the night some time he got
+powerful thirsty and clumb out on to the porch-roof and slid down a
+stanchion and traded his new coat for a jug of forty-rod, and clumb
+back again and had a good old time; and towards daylight he crawled out
+again, drunk as a fiddler, and rolled off the porch and broke his left
+arm in two places, and was most froze to death when somebody found him
+after sun-up. And when they come to look at that spare room they had to
+take soundings before they could navigate it.
+
+The judge he felt kind of sore. He said he reckoned a body could reform
+the old man with a shotgun, maybe, but he didn’t know no other way.
+
+
+
+
+CHAPTER VI.
+
+
+Well, pretty soon the old man was up and around again, and then he went
+for Judge Thatcher in the courts to make him give up that money, and he
+went for me, too, for not stopping school. He catched me a couple of
+times and thrashed me, but I went to school just the same, and dodged
+him or outrun him most of the time. I didn’t want to go to school much
+before, but I reckoned I’d go now to spite pap. That law trial was a
+slow business—appeared like they warn’t ever going to get started on
+it; so every now and then I’d borrow two or three dollars off of the
+judge for him, to keep from getting a cowhiding. Every time he got
+money he got drunk; and every time he got drunk he raised Cain around
+town; and every time he raised Cain he got jailed. He was just
+suited—this kind of thing was right in his line.
+
+He got to hanging around the widow’s too much and so she told him at
+last that if he didn’t quit using around there she would make trouble
+for him. Well, _wasn’t_ he mad? He said he would show who was Huck
+Finn’s boss. So he watched out for me one day in the spring, and
+catched me, and took me up the river about three mile in a skiff, and
+crossed over to the Illinois shore where it was woody and there warn’t
+no houses but an old log hut in a place where the timber was so thick
+you couldn’t find it if you didn’t know where it was.
+
+He kept me with him all the time, and I never got a chance to run off.
+We lived in that old cabin, and he always locked the door and put the
+key under his head nights. He had a gun which he had stole, I reckon,
+and we fished and hunted, and that was what we lived on. Every little
+while he locked me in and went down to the store, three miles, to the
+ferry, and traded fish and game for whisky, and fetched it home and got
+drunk and had a good time, and licked me. The widow she found out where
+I was by-and-by, and she sent a man over to try to get hold of me; but
+pap drove him off with the gun, and it warn’t long after that till I
+was used to being where I was, and liked it—all but the cowhide part.
+
+It was kind of lazy and jolly, laying off comfortable all day, smoking
+and fishing, and no books nor study. Two months or more run along, and
+my clothes got to be all rags and dirt, and I didn’t see how I’d ever
+got to like it so well at the widow’s, where you had to wash, and eat
+on a plate, and comb up, and go to bed and get up regular, and be
+forever bothering over a book, and have old Miss Watson pecking at you
+all the time. I didn’t want to go back no more. I had stopped cussing,
+because the widow didn’t like it; but now I took to it again because
+pap hadn’t no objections. It was pretty good times up in the woods
+there, take it all around.
+
+But by-and-by pap got too handy with his hick’ry, and I couldn’t stand
+it. I was all over welts. He got to going away so much, too, and
+locking me in. Once he locked me in and was gone three days. It was
+dreadful lonesome. I judged he had got drownded, and I wasn’t ever
+going to get out any more. I was scared. I made up my mind I would fix
+up some way to leave there. I had tried to get out of that cabin many a
+time, but I couldn’t find no way. There warn’t a window to it big
+enough for a dog to get through. I couldn’t get up the chimbly; it was
+too narrow. The door was thick, solid oak slabs. Pap was pretty careful
+not to leave a knife or anything in the cabin when he was away; I
+reckon I had hunted the place over as much as a hundred times; well, I
+was most all the time at it, because it was about the only way to put
+in the time. But this time I found something at last; I found an old
+rusty wood-saw without any handle; it was laid in between a rafter and
+the clapboards of the roof. I greased it up and went to work. There was
+an old horse-blanket nailed against the logs at the far end of the
+cabin behind the table, to keep the wind from blowing through the
+chinks and putting the candle out. I got under the table and raised the
+blanket, and went to work to saw a section of the big bottom log
+out—big enough to let me through. Well, it was a good long job, but I
+was getting towards the end of it when I heard pap’s gun in the woods.
+I got rid of the signs of my work, and dropped the blanket and hid my
+saw, and pretty soon pap come in.
+
+Pap warn’t in a good humor—so he was his natural self. He said he was
+down town, and everything was going wrong. His lawyer said he reckoned
+he would win his lawsuit and get the money if they ever got started on
+the trial; but then there was ways to put it off a long time, and Judge
+Thatcher knowed how to do it. And he said people allowed there’d be
+another trial to get me away from him and give me to the widow for my
+guardian, and they guessed it would win this time. This shook me up
+considerable, because I didn’t want to go back to the widow’s any more
+and be so cramped up and sivilized, as they called it. Then the old man
+got to cussing, and cussed everything and everybody he could think of,
+and then cussed them all over again to make sure he hadn’t skipped any,
+and after that he polished off with a kind of a general cuss all round,
+including a considerable parcel of people which he didn’t know the
+names of, and so called them what’s-his-name when he got to them, and
+went right along with his cussing.
+
+He said he would like to see the widow get me. He said he would watch
+out, and if they tried to come any such game on him he knowed of a
+place six or seven mile off to stow me in, where they might hunt till
+they dropped and they couldn’t find me. That made me pretty uneasy
+again, but only for a minute; I reckoned I wouldn’t stay on hand till
+he got that chance.
+
+The old man made me go to the skiff and fetch the things he had got.
+There was a fifty-pound sack of corn meal, and a side of bacon,
+ammunition, and a four-gallon jug of whisky, and an old book and two
+newspapers for wadding, besides some tow. I toted up a load, and went
+back and set down on the bow of the skiff to rest. I thought it all
+over, and I reckoned I would walk off with the gun and some lines, and
+take to the woods when I run away. I guessed I wouldn’t stay in one
+place, but just tramp right across the country, mostly night times, and
+hunt and fish to keep alive, and so get so far away that the old man
+nor the widow couldn’t ever find me any more. I judged I would saw out
+and leave that night if pap got drunk enough, and I reckoned he would.
+I got so full of it I didn’t notice how long I was staying till the old
+man hollered and asked me whether I was asleep or drownded.
+
+I got the things all up to the cabin, and then it was about dark. While
+I was cooking supper the old man took a swig or two and got sort of
+warmed up, and went to ripping again. He had been drunk over in town,
+and laid in the gutter all night, and he was a sight to look at. A body
+would a thought he was Adam—he was just all mud. Whenever his liquor
+begun to work he most always went for the govment, this time he says:
+
+“Call this a govment! why, just look at it and see what it’s like.
+Here’s the law a-standing ready to take a man’s son away from him—a
+man’s own son, which he has had all the trouble and all the anxiety and
+all the expense of raising. Yes, just as that man has got that son
+raised at last, and ready to go to work and begin to do suthin’ for
+_him_ and give him a rest, the law up and goes for him. And they call
+_that_ govment! That ain’t all, nuther. The law backs that old Judge
+Thatcher up and helps him to keep me out o’ my property. Here’s what
+the law does: The law takes a man worth six thousand dollars and
+up’ards, and jams him into an old trap of a cabin like this, and lets
+him go round in clothes that ain’t fitten for a hog. They call that
+govment! A man can’t get his rights in a govment like this. Sometimes
+I’ve a mighty notion to just leave the country for good and all. Yes,
+and I _told_ ’em so; I told old Thatcher so to his face. Lots of ’em
+heard me, and can tell what I said. Says I, for two cents I’d leave the
+blamed country and never come a-near it agin. Them’s the very words. I
+says look at my hat—if you call it a hat—but the lid raises up and the
+rest of it goes down till it’s below my chin, and then it ain’t rightly
+a hat at all, but more like my head was shoved up through a jint o’
+stove-pipe. Look at it, says I—such a hat for me to wear—one of the
+wealthiest men in this town if I could git my rights.
+
+“Oh, yes, this is a wonderful govment, wonderful. Why, looky here.
+There was a free nigger there from Ohio—a mulatter, most as white as a
+white man. He had the whitest shirt on you ever see, too, and the
+shiniest hat; and there ain’t a man in that town that’s got as fine
+clothes as what he had; and he had a gold watch and chain, and a
+silver-headed cane—the awfulest old gray-headed nabob in the State. And
+what do you think? They said he was a p’fessor in a college, and could
+talk all kinds of languages, and knowed everything. And that ain’t the
+wust. They said he could _vote_ when he was at home. Well, that let me
+out. Thinks I, what is the country a-coming to? It was ’lection day,
+and I was just about to go and vote myself if I warn’t too drunk to get
+there; but when they told me there was a State in this country where
+they’d let that nigger vote, I drawed out. I says I’ll never vote agin.
+Them’s the very words I said; they all heard me; and the country may
+rot for all me—I’ll never vote agin as long as I live. And to see the
+cool way of that nigger—why, he wouldn’t a give me the road if I hadn’t
+shoved him out o’ the way. I says to the people, why ain’t this nigger
+put up at auction and sold?—that’s what I want to know. And what do you
+reckon they said? Why, they said he couldn’t be sold till he’d been in
+the State six months, and he hadn’t been there that long yet. There,
+now—that’s a specimen. They call that a govment that can’t sell a free
+nigger till he’s been in the State six months. Here’s a govment that
+calls itself a govment, and lets on to be a govment, and thinks it is a
+govment, and yet’s got to set stock-still for six whole months before
+it can take a hold of a prowling, thieving, infernal, white-shirted
+free nigger, and—”
+
+Pap was agoing on so he never noticed where his old limber legs was
+taking him to, so he went head over heels over the tub of salt pork and
+barked both shins, and the rest of his speech was all the hottest kind
+of language—mostly hove at the nigger and the govment, though he give
+the tub some, too, all along, here and there. He hopped around the
+cabin considerable, first on one leg and then on the other, holding
+first one shin and then the other one, and at last he let out with his
+left foot all of a sudden and fetched the tub a rattling kick. But it
+warn’t good judgment, because that was the boot that had a couple of
+his toes leaking out of the front end of it; so now he raised a howl
+that fairly made a body’s hair raise, and down he went in the dirt, and
+rolled there, and held his toes; and the cussing he done then laid over
+anything he had ever done previous. He said so his own self afterwards.
+He had heard old Sowberry Hagan in his best days, and he said it laid
+over him, too; but I reckon that was sort of piling it on, maybe.
+
+After supper pap took the jug, and said he had enough whisky there for
+two drunks and one delirium tremens. That was always his word. I judged
+he would be blind drunk in about an hour, and then I would steal the
+key, or saw myself out, one or t’other. He drank and drank, and tumbled
+down on his blankets by-and-by; but luck didn’t run my way. He didn’t
+go sound asleep, but was uneasy. He groaned and moaned and thrashed
+around this way and that for a long time. At last I got so sleepy I
+couldn’t keep my eyes open all I could do, and so before I knowed what
+I was about I was sound asleep, and the candle burning.
+
+I don’t know how long I was asleep, but all of a sudden there was an
+awful scream and I was up. There was pap looking wild, and skipping
+around every which way and yelling about snakes. He said they was
+crawling up his legs; and then he would give a jump and scream, and say
+one had bit him on the cheek—but I couldn’t see no snakes. He started
+and run round and round the cabin, hollering “Take him off! take him
+off! he’s biting me on the neck!” I never see a man look so wild in the
+eyes. Pretty soon he was all fagged out, and fell down panting; then he
+rolled over and over wonderful fast, kicking things every which way,
+and striking and grabbing at the air with his hands, and screaming and
+saying there was devils a-hold of him. He wore out by-and-by, and laid
+still a while, moaning. Then he laid stiller, and didn’t make a sound.
+I could hear the owls and the wolves away off in the woods, and it
+seemed terrible still. He was laying over by the corner. By-and-by he
+raised up part way and listened, with his head to one side. He says,
+very low:
+
+“Tramp—tramp—tramp; that’s the dead; tramp—tramp—tramp; they’re coming
+after me; but I won’t go. Oh, they’re here! don’t touch me—don’t! hands
+off—they’re cold; let go. Oh, let a poor devil alone!”
+
+Then he went down on all fours and crawled off, begging them to let him
+alone, and he rolled himself up in his blanket and wallowed in under
+the old pine table, still a-begging; and then he went to crying. I
+could hear him through the blanket.
+
+By-and-by he rolled out and jumped up on his feet looking wild, and he
+see me and went for me. He chased me round and round the place with a
+clasp-knife, calling me the Angel of Death, and saying he would kill
+me, and then I couldn’t come for him no more. I begged, and told him I
+was only Huck; but he laughed _such_ a screechy laugh, and roared and
+cussed, and kept on chasing me up. Once when I turned short and dodged
+under his arm he made a grab and got me by the jacket between my
+shoulders, and I thought I was gone; but I slid out of the jacket quick
+as lightning, and saved myself. Pretty soon he was all tired out, and
+dropped down with his back against the door, and said he would rest a
+minute and then kill me. He put his knife under him, and said he would
+sleep and get strong, and then he would see who was who.
+
+So he dozed off pretty soon. By-and-by I got the old split-bottom chair
+and clumb up as easy as I could, not to make any noise, and got down
+the gun. I slipped the ramrod down it to make sure it was loaded, then
+I laid it across the turnip barrel, pointing towards pap, and set down
+behind it to wait for him to stir. And how slow and still the time did
+drag along.
+
+
+
+
+CHAPTER VII.
+
+
+“Git up! What you ’bout?”
+
+I opened my eyes and looked around, trying to make out where I was. It
+was after sun-up, and I had been sound asleep. Pap was standing over me
+looking sour and sick, too. He says:
+
+“What you doin’ with this gun?”
+
+I judged he didn’t know nothing about what he had been doing, so I
+says:
+
+“Somebody tried to get in, so I was laying for him.”
+
+“Why didn’t you roust me out?”
+
+“Well, I tried to, but I couldn’t; I couldn’t budge you.”
+
+“Well, all right. Don’t stand there palavering all day, but out with
+you and see if there’s a fish on the lines for breakfast. I’ll be along
+in a minute.”
+
+He unlocked the door, and I cleared out up the river-bank. I noticed
+some pieces of limbs and such things floating down, and a sprinkling of
+bark; so I knowed the river had begun to rise. I reckoned I would have
+great times now if I was over at the town. The June rise used to be
+always luck for me; because as soon as that rise begins here comes
+cordwood floating down, and pieces of log rafts—sometimes a dozen logs
+together; so all you have to do is to catch them and sell them to the
+wood-yards and the sawmill.
+
+I went along up the bank with one eye out for pap and t’other one out
+for what the rise might fetch along. Well, all at once here comes a
+canoe; just a beauty, too, about thirteen or fourteen foot long, riding
+high like a duck. I shot head-first off of the bank like a frog,
+clothes and all on, and struck out for the canoe. I just expected
+there’d be somebody laying down in it, because people often done that
+to fool folks, and when a chap had pulled a skiff out most to it they’d
+raise up and laugh at him. But it warn’t so this time. It was a
+drift-canoe sure enough, and I clumb in and paddled her ashore. Thinks
+I, the old man will be glad when he sees this—she’s worth ten dollars.
+But when I got to shore pap wasn’t in sight yet, and as I was running
+her into a little creek like a gully, all hung over with vines and
+willows, I struck another idea: I judged I’d hide her good, and then,
+’stead of taking to the woods when I run off, I’d go down the river
+about fifty mile and camp in one place for good, and not have such a
+rough time tramping on foot.
+
+It was pretty close to the shanty, and I thought I heard the old man
+coming all the time; but I got her hid; and then I out and looked
+around a bunch of willows, and there was the old man down the path a
+piece just drawing a bead on a bird with his gun. So he hadn’t seen
+anything.
+
+When he got along I was hard at it taking up a “trot” line. He abused
+me a little for being so slow; but I told him I fell in the river, and
+that was what made me so long. I knowed he would see I was wet, and
+then he would be asking questions. We got five catfish off the lines
+and went home.
+
+While we laid off after breakfast to sleep up, both of us being about
+wore out, I got to thinking that if I could fix up some way to keep pap
+and the widow from trying to follow me, it would be a certainer thing
+than trusting to luck to get far enough off before they missed me; you
+see, all kinds of things might happen. Well, I didn’t see no way for a
+while, but by-and-by pap raised up a minute to drink another barrel of
+water, and he says:
+
+“Another time a man comes a-prowling round here you roust me out, you
+hear? That man warn’t here for no good. I’d a shot him. Next time you
+roust me out, you hear?”
+
+Then he dropped down and went to sleep again; but what he had been
+saying give me the very idea I wanted. I says to myself, I can fix it
+now so nobody won’t think of following me.
+
+About twelve o’clock we turned out and went along up the bank. The
+river was coming up pretty fast, and lots of driftwood going by on the
+rise. By-and-by along comes part of a log raft—nine logs fast together.
+We went out with the skiff and towed it ashore. Then we had dinner.
+Anybody but pap would a waited and seen the day through, so as to catch
+more stuff; but that warn’t pap’s style. Nine logs was enough for one
+time; he must shove right over to town and sell. So he locked me in and
+took the skiff, and started off towing the raft about half-past three.
+I judged he wouldn’t come back that night. I waited till I reckoned he
+had got a good start; then I out with my saw, and went to work on that
+log again. Before he was t’other side of the river I was out of the
+hole; him and his raft was just a speck on the water away off yonder.
+
+I took the sack of corn meal and took it to where the canoe was hid,
+and shoved the vines and branches apart and put it in; then I done the
+same with the side of bacon; then the whisky-jug. I took all the coffee
+and sugar there was, and all the ammunition; I took the wadding; I took
+the bucket and gourd; I took a dipper and a tin cup, and my old saw and
+two blankets, and the skillet and the coffee-pot. I took fish-lines and
+matches and other things—everything that was worth a cent. I cleaned
+out the place. I wanted an axe, but there wasn’t any, only the one out
+at the woodpile, and I knowed why I was going to leave that. I fetched
+out the gun, and now I was done.
+
+I had wore the ground a good deal crawling out of the hole and dragging
+out so many things. So I fixed that as good as I could from the outside
+by scattering dust on the place, which covered up the smoothness and
+the sawdust. Then I fixed the piece of log back into its place, and put
+two rocks under it and one against it to hold it there, for it was bent
+up at that place and didn’t quite touch ground. If you stood four or
+five foot away and didn’t know it was sawed, you wouldn’t never notice
+it; and besides, this was the back of the cabin, and it warn’t likely
+anybody would go fooling around there.
+
+It was all grass clear to the canoe, so I hadn’t left a track. I
+followed around to see. I stood on the bank and looked out over the
+river. All safe. So I took the gun and went up a piece into the woods,
+and was hunting around for some birds when I see a wild pig; hogs soon
+went wild in them bottoms after they had got away from the prairie
+farms. I shot this fellow and took him into camp.
+
+I took the axe and smashed in the door. I beat it and hacked it
+considerable a-doing it. I fetched the pig in, and took him back nearly
+to the table and hacked into his throat with the axe, and laid him down
+on the ground to bleed; I say ground because it _was_ ground—hard
+packed, and no boards. Well, next I took an old sack and put a lot of
+big rocks in it—all I could drag—and I started it from the pig, and
+dragged it to the door and through the woods down to the river and
+dumped it in, and down it sunk, out of sight. You could easy see that
+something had been dragged over the ground. I did wish Tom Sawyer was
+there; I knowed he would take an interest in this kind of business, and
+throw in the fancy touches. Nobody could spread himself like Tom Sawyer
+in such a thing as that.
+
+Well, last I pulled out some of my hair, and blooded the axe good, and
+stuck it on the back side, and slung the axe in the corner. Then I took
+up the pig and held him to my breast with my jacket (so he couldn’t
+drip) till I got a good piece below the house and then dumped him into
+the river. Now I thought of something else. So I went and got the bag
+of meal and my old saw out of the canoe, and fetched them to the house.
+I took the bag to where it used to stand, and ripped a hole in the
+bottom of it with the saw, for there warn’t no knives and forks on the
+place—pap done everything with his clasp-knife about the cooking. Then
+I carried the sack about a hundred yards across the grass and through
+the willows east of the house, to a shallow lake that was five mile
+wide and full of rushes—and ducks too, you might say, in the season.
+There was a slough or a creek leading out of it on the other side that
+went miles away, I don’t know where, but it didn’t go to the river. The
+meal sifted out and made a little track all the way to the lake. I
+dropped pap’s whetstone there too, so as to look like it had been done
+by accident. Then I tied up the rip in the meal sack with a string, so
+it wouldn’t leak no more, and took it and my saw to the canoe again.
+
+It was about dark now; so I dropped the canoe down the river under some
+willows that hung over the bank, and waited for the moon to rise. I
+made fast to a willow; then I took a bite to eat, and by-and-by laid
+down in the canoe to smoke a pipe and lay out a plan. I says to myself,
+they’ll follow the track of that sackful of rocks to the shore and then
+drag the river for me. And they’ll follow that meal track to the lake
+and go browsing down the creek that leads out of it to find the robbers
+that killed me and took the things. They won’t ever hunt the river for
+anything but my dead carcass. They’ll soon get tired of that, and won’t
+bother no more about me. All right; I can stop anywhere I want to.
+Jackson’s Island is good enough for me; I know that island pretty well,
+and nobody ever comes there. And then I can paddle over to town nights,
+and slink around and pick up things I want. Jackson’s Island’s the
+place.
+
+I was pretty tired, and the first thing I knowed I was asleep. When I
+woke up I didn’t know where I was for a minute. I set up and looked
+around, a little scared. Then I remembered. The river looked miles and
+miles across. The moon was so bright I could a counted the drift logs
+that went a-slipping along, black and still, hundreds of yards out from
+shore. Everything was dead quiet, and it looked late, and _smelt_ late.
+You know what I mean—I don’t know the words to put it in.
+
+I took a good gap and a stretch, and was just going to unhitch and
+start when I heard a sound away over the water. I listened. Pretty soon
+I made it out. It was that dull kind of a regular sound that comes from
+oars working in rowlocks when it’s a still night. I peeped out through
+the willow branches, and there it was—a skiff, away across the water. I
+couldn’t tell how many was in it. It kept a-coming, and when it was
+abreast of me I see there warn’t but one man in it. Think’s I, maybe
+it’s pap, though I warn’t expecting him. He dropped below me with the
+current, and by-and-by he came a-swinging up shore in the easy water,
+and he went by so close I could a reached out the gun and touched him.
+Well, it _was_ pap, sure enough—and sober, too, by the way he laid his
+oars.
+
+I didn’t lose no time. The next minute I was a-spinning down stream
+soft but quick in the shade of the bank. I made two mile and a half,
+and then struck out a quarter of a mile or more towards the middle of
+the river, because pretty soon I would be passing the ferry landing,
+and people might see me and hail me. I got out amongst the driftwood,
+and then laid down in the bottom of the canoe and let her float.
+
+I laid there, and had a good rest and a smoke out of my pipe, looking
+away into the sky; not a cloud in it. The sky looks ever so deep when
+you lay down on your back in the moonshine; I never knowed it before.
+And how far a body can hear on the water such nights! I heard people
+talking at the ferry landing. I heard what they said, too—every word of
+it. One man said it was getting towards the long days and the short
+nights now. T’other one said _this_ warn’t one of the short ones, he
+reckoned—and then they laughed, and he said it over again, and they
+laughed again; then they waked up another fellow and told him, and
+laughed, but he didn’t laugh; he ripped out something brisk, and said
+let him alone. The first fellow said he ’lowed to tell it to his old
+woman—she would think it was pretty good; but he said that warn’t
+nothing to some things he had said in his time. I heard one man say it
+was nearly three o’clock, and he hoped daylight wouldn’t wait more than
+about a week longer. After that the talk got further and further away,
+and I couldn’t make out the words any more; but I could hear the
+mumble, and now and then a laugh, too, but it seemed a long ways off.
+
+I was away below the ferry now. I rose up, and there was Jackson’s
+Island, about two mile and a half down stream, heavy timbered and
+standing up out of the middle of the river, big and dark and solid,
+like a steamboat without any lights. There warn’t any signs of the bar
+at the head—it was all under water now.
+
+It didn’t take me long to get there. I shot past the head at a ripping
+rate, the current was so swift, and then I got into the dead water and
+landed on the side towards the Illinois shore. I run the canoe into a
+deep dent in the bank that I knowed about; I had to part the willow
+branches to get in; and when I made fast nobody could a seen the canoe
+from the outside.
+
+I went up and set down on a log at the head of the island, and looked
+out on the big river and the black driftwood and away over to the town,
+three mile away, where there was three or four lights twinkling. A
+monstrous big lumber-raft was about a mile up stream, coming along
+down, with a lantern in the middle of it. I watched it come creeping
+down, and when it was most abreast of where I stood I heard a man say,
+“Stern oars, there! heave her head to stabboard!” I heard that just as
+plain as if the man was by my side.
+
+There was a little gray in the sky now; so I stepped into the woods,
+and laid down for a nap before breakfast.
+
+
+
+
+CHAPTER VIII.
+
+
+The sun was up so high when I waked that I judged it was after eight
+o’clock. I laid there in the grass and the cool shade thinking about
+things, and feeling rested and ruther comfortable and satisfied. I
+could see the sun out at one or two holes, but mostly it was big trees
+all about, and gloomy in there amongst them. There was freckled places
+on the ground where the light sifted down through the leaves, and the
+freckled places swapped about a little, showing there was a little
+breeze up there. A couple of squirrels set on a limb and jabbered at me
+very friendly.
+
+I was powerful lazy and comfortable—didn’t want to get up and cook
+breakfast. Well, I was dozing off again when I thinks I hears a deep
+sound of “boom!” away up the river. I rouses up, and rests on my elbow
+and listens; pretty soon I hears it again. I hopped up, and went and
+looked out at a hole in the leaves, and I see a bunch of smoke laying
+on the water a long ways up—about abreast the ferry. And there was the
+ferry-boat full of people floating along down. I knowed what was the
+matter now. “Boom!” I see the white smoke squirt out of the ferry-boat’s
+side. You see, they was firing cannon over the water, trying to make my
+carcass come to the top.
+
+I was pretty hungry, but it warn’t going to do for me to start a fire,
+because they might see the smoke. So I set there and watched the
+cannon-smoke and listened to the boom. The river was a mile wide there,
+and it always looks pretty on a summer morning—so I was having a good
+enough time seeing them hunt for my remainders if I only had a bite to
+eat. Well, then I happened to think how they always put quicksilver in
+loaves of bread and float them off, because they always go right to the
+drownded carcass and stop there. So, says I, I’ll keep a lookout, and
+if any of them’s floating around after me I’ll give them a show. I
+changed to the Illinois edge of the island to see what luck I could
+have, and I warn’t disappointed. A big double loaf come along, and I
+most got it with a long stick, but my foot slipped and she floated out
+further. Of course I was where the current set in the closest to the
+shore—I knowed enough for that. But by-and-by along comes another one,
+and this time I won. I took out the plug and shook out the little dab
+of quicksilver, and set my teeth in. It was “baker’s bread”—what the
+quality eat; none of your low-down corn-pone.
+
+I got a good place amongst the leaves, and set there on a log, munching
+the bread and watching the ferry-boat, and very well satisfied. And
+then something struck me. I says, now I reckon the widow or the parson
+or somebody prayed that this bread would find me, and here it has gone
+and done it. So there ain’t no doubt but there is something in that
+thing—that is, there’s something in it when a body like the widow or
+the parson prays, but it don’t work for me, and I reckon it don’t work
+for only just the right kind.
+
+I lit a pipe and had a good long smoke, and went on watching. The
+ferry-boat was floating with the current, and I allowed I’d have a
+chance to see who was aboard when she come along, because she would
+come in close, where the bread did. When she’d got pretty well along
+down towards me, I put out my pipe and went to where I fished out the
+bread, and laid down behind a log on the bank in a little open place.
+Where the log forked I could peep through.
+
+By-and-by she come along, and she drifted in so close that they could a
+run out a plank and walked ashore. Most everybody was on the boat. Pap,
+and Judge Thatcher, and Bessie Thatcher, and Jo Harper, and Tom Sawyer,
+and his old Aunt Polly, and Sid and Mary, and plenty more. Everybody
+was talking about the murder, but the captain broke in and says:
+
+“Look sharp, now; the current sets in the closest here, and maybe he’s
+washed ashore and got tangled amongst the brush at the water’s edge. I
+hope so, anyway.”
+
+I didn’t hope so. They all crowded up and leaned over the rails, nearly
+in my face, and kept still, watching with all their might. I could see
+them first-rate, but they couldn’t see me. Then the captain sung out:
+
+“Stand away!” and the cannon let off such a blast right before me that
+it made me deef with the noise and pretty near blind with the smoke,
+and I judged I was gone. If they’d a had some bullets in, I reckon
+they’d a got the corpse they was after. Well, I see I warn’t hurt,
+thanks to goodness. The boat floated on and went out of sight around
+the shoulder of the island. I could hear the booming now and then,
+further and further off, and by-and-by, after an hour, I didn’t hear it
+no more. The island was three mile long. I judged they had got to the
+foot, and was giving it up. But they didn’t yet a while. They turned
+around the foot of the island and started up the channel on the
+Missouri side, under steam, and booming once in a while as they went. I
+crossed over to that side and watched them. When they got abreast the
+head of the island they quit shooting and dropped over to the Missouri
+shore and went home to the town.
+
+I knowed I was all right now. Nobody else would come a-hunting after
+me. I got my traps out of the canoe and made me a nice camp in the
+thick woods. I made a kind of a tent out of my blankets to put my
+things under so the rain couldn’t get at them. I catched a catfish and
+haggled him open with my saw, and towards sundown I started my camp
+fire and had supper. Then I set out a line to catch some fish for
+breakfast.
+
+When it was dark I set by my camp fire smoking, and feeling pretty well
+satisfied; but by-and-by it got sort of lonesome, and so I went and set
+on the bank and listened to the current swashing along, and counted the
+stars and drift logs and rafts that come down, and then went to bed;
+there ain’t no better way to put in time when you are lonesome; you
+can’t stay so, you soon get over it.
+
+And so for three days and nights. No difference—just the same thing.
+But the next day I went exploring around down through the island. I was
+boss of it; it all belonged to me, so to say, and I wanted to know all
+about it; but mainly I wanted to put in the time. I found plenty
+strawberries, ripe and prime; and green summer grapes, and green
+razberries; and the green blackberries was just beginning to show. They
+would all come handy by-and-by, I judged.
+
+Well, I went fooling along in the deep woods till I judged I warn’t far
+from the foot of the island. I had my gun along, but I hadn’t shot
+nothing; it was for protection; thought I would kill some game nigh
+home. About this time I mighty near stepped on a good-sized snake, and
+it went sliding off through the grass and flowers, and I after it,
+trying to get a shot at it. I clipped along, and all of a sudden I
+bounded right on to the ashes of a camp fire that was still smoking.
+
+My heart jumped up amongst my lungs. I never waited for to look
+further, but uncocked my gun and went sneaking back on my tiptoes as
+fast as ever I could. Every now and then I stopped a second amongst the
+thick leaves and listened, but my breath come so hard I couldn’t hear
+nothing else. I slunk along another piece further, then listened again;
+and so on, and so on. If I see a stump, I took it for a man; if I trod
+on a stick and broke it, it made me feel like a person had cut one of
+my breaths in two and I only got half, and the short half, too.
+
+When I got to camp I warn’t feeling very brash, there warn’t much sand
+in my craw; but I says, this ain’t no time to be fooling around. So I
+got all my traps into my canoe again so as to have them out of sight,
+and I put out the fire and scattered the ashes around to look like an
+old last year’s camp, and then clumb a tree.
+
+I reckon I was up in the tree two hours; but I didn’t see nothing, I
+didn’t hear nothing—I only _thought_ I heard and seen as much as a
+thousand things. Well, I couldn’t stay up there forever; so at last I
+got down, but I kept in the thick woods and on the lookout all the
+time. All I could get to eat was berries and what was left over from
+breakfast.
+
+By the time it was night I was pretty hungry. So when it was good and
+dark I slid out from shore before moonrise and paddled over to the
+Illinois bank—about a quarter of a mile. I went out in the woods and
+cooked a supper, and I had about made up my mind I would stay there all
+night when I hear a _plunkety-plunk, plunkety-plunk_, and says to
+myself, horses coming; and next I hear people’s voices. I got
+everything into the canoe as quick as I could, and then went creeping
+through the woods to see what I could find out. I hadn’t got far when I
+hear a man say:
+
+“We better camp here if we can find a good place; the horses is about
+beat out. Let’s look around.”
+
+I didn’t wait, but shoved out and paddled away easy. I tied up in the
+old place, and reckoned I would sleep in the canoe.
+
+I didn’t sleep much. I couldn’t, somehow, for thinking. And every time
+I waked up I thought somebody had me by the neck. So the sleep didn’t
+do me no good. By-and-by I says to myself, I can’t live this way; I’m
+a-going to find out who it is that’s here on the island with me; I’ll
+find it out or bust. Well, I felt better right off.
+
+So I took my paddle and slid out from shore just a step or two, and
+then let the canoe drop along down amongst the shadows. The moon was
+shining, and outside of the shadows it made it most as light as day. I
+poked along well on to an hour, everything still as rocks and sound
+asleep. Well, by this time I was most down to the foot of the island. A
+little ripply, cool breeze begun to blow, and that was as good as
+saying the night was about done. I give her a turn with the paddle and
+brung her nose to shore; then I got my gun and slipped out and into the
+edge of the woods. I sat down there on a log, and looked out through
+the leaves. I see the moon go off watch, and the darkness begin to
+blanket the river. But in a little while I see a pale streak over the
+treetops, and knowed the day was coming. So I took my gun and slipped
+off towards where I had run across that camp fire, stopping every
+minute or two to listen. But I hadn’t no luck somehow; I couldn’t seem
+to find the place. But by-and-by, sure enough, I catched a glimpse of
+fire away through the trees. I went for it, cautious and slow.
+By-and-by I was close enough to have a look, and there laid a man on
+the ground. It most give me the fan-tods. He had a blanket around his
+head, and his head was nearly in the fire. I set there behind a clump
+of bushes, in about six foot of him, and kept my eyes on him steady. It
+was getting gray daylight now. Pretty soon he gapped and stretched
+himself and hove off the blanket, and it was Miss Watson’s Jim! I bet I
+was glad to see him. I says:
+
+“Hello, Jim!” and skipped out.
+
+He bounced up and stared at me wild. Then he drops down on his knees,
+and puts his hands together and says:
+
+“Doan’ hurt me—don’t! I hain’t ever done no harm to a ghos’. I alwuz
+liked dead people, en done all I could for ’em. You go en git in de
+river agin, whah you b’longs, en doan’ do nuffn to Ole Jim, ’at ’uz
+awluz yo’ fren’.”
+
+Well, I warn’t long making him understand I warn’t dead. I was ever so
+glad to see Jim. I warn’t lonesome now. I told him I warn’t afraid of
+_him_ telling the people where I was. I talked along, but he only set
+there and looked at me; never said nothing. Then I says:
+
+“It’s good daylight. Le’s get breakfast. Make up your camp fire good.”
+
+“What’s de use er makin’ up de camp fire to cook strawbries en sich
+truck? But you got a gun, hain’t you? Den we kin git sumfn better den
+strawbries.”
+
+“Strawberries and such truck,” I says. “Is that what you live on?”
+
+“I couldn’ git nuffn else,” he says.
+
+“Why, how long you been on the island, Jim?”
+
+“I come heah de night arter you’s killed.”
+
+“What, all that time?”
+
+“Yes—indeedy.”
+
+“And ain’t you had nothing but that kind of rubbage to eat?”
+
+“No, sah—nuffn else.”
+
+“Well, you must be most starved, ain’t you?”
+
+“I reck’n I could eat a hoss. I think I could. How long you ben on de
+islan’?”
+
+“Since the night I got killed.”
+
+“No! W’y, what has you lived on? But you got a gun. Oh, yes, you got a
+gun. Dat’s good. Now you kill sumfn en I’ll make up de fire.”
+
+So we went over to where the canoe was, and while he built a fire in a
+grassy open place amongst the trees, I fetched meal and bacon and
+coffee, and coffee-pot and frying-pan, and sugar and tin cups, and the
+nigger was set back considerable, because he reckoned it was all done
+with witchcraft. I catched a good big catfish, too, and Jim cleaned him
+with his knife, and fried him.
+
+When breakfast was ready we lolled on the grass and eat it smoking hot.
+Jim laid it in with all his might, for he was most about starved. Then
+when we had got pretty well stuffed, we laid off and lazied. By-and-by
+Jim says:
+
+“But looky here, Huck, who wuz it dat ’uz killed in dat shanty ef it
+warn’t you?”
+
+Then I told him the whole thing, and he said it was smart. He said Tom
+Sawyer couldn’t get up no better plan than what I had. Then I says:
+
+“How do you come to be here, Jim, and how’d you get here?”
+
+He looked pretty uneasy, and didn’t say nothing for a minute. Then he
+says:
+
+“Maybe I better not tell.”
+
+“Why, Jim?”
+
+“Well, dey’s reasons. But you wouldn’ tell on me ef I uz to tell you,
+would you, Huck?”
+
+“Blamed if I would, Jim.”
+
+“Well, I b’lieve you, Huck. I—I _run off_.”
+
+“Jim!”
+
+“But mind, you said you wouldn’ tell—you know you said you wouldn’
+tell, Huck.”
+
+“Well, I did. I said I wouldn’t, and I’ll stick to it. Honest _injun_,
+I will. People would call me a low-down Abolitionist and despise me for
+keeping mum—but that don’t make no difference. I ain’t a-going to tell,
+and I ain’t a-going back there, anyways. So, now, le’s know all about
+it.”
+
+“Well, you see, it ’uz dis way. Ole missus—dat’s Miss Watson—she pecks
+on me all de time, en treats me pooty rough, but she awluz said she
+wouldn’ sell me down to Orleans. But I noticed dey wuz a nigger trader
+roun’ de place considable lately, en I begin to git oneasy. Well, one
+night I creeps to de do’ pooty late, en de do’ warn’t quite shet, en I
+hear old missus tell de widder she gwyne to sell me down to Orleans,
+but she didn’ want to, but she could git eight hund’d dollars for me,
+en it ’uz sich a big stack o’ money she couldn’ resis’. De widder she
+try to git her to say she wouldn’ do it, but I never waited to hear de
+res’. I lit out mighty quick, I tell you.
+
+“I tuck out en shin down de hill, en ’spec to steal a skift ’long de
+sho’ som’ers ’bove de town, but dey wuz people a-stirring yit, so I hid
+in de ole tumble-down cooper-shop on de bank to wait for everybody to
+go ’way. Well, I wuz dah all night. Dey wuz somebody roun’ all de time.
+’Long ’bout six in de mawnin’ skifts begin to go by, en ’bout eight er
+nine every skift dat went ’long wuz talkin’ ’bout how yo’ pap come over
+to de town en say you’s killed. Dese las’ skifts wuz full o’ ladies en
+genlmen a-goin’ over for to see de place. Sometimes dey’d pull up at de
+sho’ en take a res’ b’fo’ dey started acrost, so by de talk I got to
+know all ’bout de killin’. I ’uz powerful sorry you’s killed, Huck, but
+I ain’t no mo’ now.
+
+“I laid dah under de shavin’s all day. I ’uz hungry, but I warn’t
+afeard; bekase I knowed ole missus en de widder wuz goin’ to start to
+de camp-meet’n’ right arter breakfas’ en be gone all day, en dey knows
+I goes off wid de cattle ’bout daylight, so dey wouldn’ ’spec to see me
+roun’ de place, en so dey wouldn’ miss me tell arter dark in de
+evenin’. De yuther servants wouldn’ miss me, kase dey’d shin out en
+take holiday soon as de ole folks ’uz out’n de way.
+
+“Well, when it come dark I tuck out up de river road, en went ’bout two
+mile er more to whah dey warn’t no houses. I’d made up my mine ’bout
+what I’s agwyne to do. You see, ef I kep’ on tryin’ to git away afoot,
+de dogs ’ud track me; ef I stole a skift to cross over, dey’d miss dat
+skift, you see, en dey’d know ’bout whah I’d lan’ on de yuther side, en
+whah to pick up my track. So I says, a raff is what I’s arter; it doan’
+_make_ no track.
+
+“I see a light a-comin’ roun’ de p’int bymeby, so I wade’ in en shove’
+a log ahead o’ me en swum more’n half way acrost de river, en got in
+’mongst de drift-wood, en kep’ my head down low, en kinder swum agin de
+current tell de raff come along. Den I swum to de stern uv it en tuck
+a-holt. It clouded up en ’uz pooty dark for a little while. So I clumb
+up en laid down on de planks. De men ’uz all ’way yonder in de middle,
+whah de lantern wuz. De river wuz a-risin’, en dey wuz a good current;
+so I reck’n’d ’at by fo’ in de mawnin’ I’d be twenty-five mile down de
+river, en den I’d slip in jis b’fo’ daylight en swim asho’, en take to
+de woods on de Illinois side.
+
+“But I didn’ have no luck. When we ’uz mos’ down to de head er de
+islan’ a man begin to come aft wid de lantern, I see it warn’t no use
+fer to wait, so I slid overboard en struck out fer de islan’. Well, I
+had a notion I could lan’ mos’ anywhers, but I couldn’t—bank too bluff.
+I ’uz mos’ to de foot er de islan’ b’fo’ I found’ a good place. I went
+into de woods en jedged I wouldn’ fool wid raffs no mo’, long as dey
+move de lantern roun’ so. I had my pipe en a plug er dog-leg, en some
+matches in my cap, en dey warn’t wet, so I ’uz all right.”
+
+“And so you ain’t had no meat nor bread to eat all this time? Why
+didn’t you get mud-turkles?”
+
+“How you gwyne to git ’m? You can’t slip up on um en grab um; en how’s
+a body gwyne to hit um wid a rock? How could a body do it in de night?
+En I warn’t gwyne to show mysef on de bank in de daytime.”
+
+“Well, that’s so. You’ve had to keep in the woods all the time, of
+course. Did you hear ’em shooting the cannon?”
+
+“Oh, yes. I knowed dey was arter you. I see um go by heah—watched um
+thoo de bushes.”
+
+Some young birds come along, flying a yard or two at a time and
+lighting. Jim said it was a sign it was going to rain. He said it was a
+sign when young chickens flew that way, and so he reckoned it was the
+same way when young birds done it. I was going to catch some of them,
+but Jim wouldn’t let me. He said it was death. He said his father laid
+mighty sick once, and some of them catched a bird, and his old granny
+said his father would die, and he did.
+
+And Jim said you mustn’t count the things you are going to cook for
+dinner, because that would bring bad luck. The same if you shook the
+table-cloth after sundown. And he said if a man owned a beehive and
+that man died, the bees must be told about it before sun-up next
+morning, or else the bees would all weaken down and quit work and die.
+Jim said bees wouldn’t sting idiots; but I didn’t believe that, because
+I had tried them lots of times myself, and they wouldn’t sting me.
+
+I had heard about some of these things before, but not all of them. Jim
+knowed all kinds of signs. He said he knowed most everything. I said it
+looked to me like all the signs was about bad luck, and so I asked him
+if there warn’t any good-luck signs. He says:
+
+“Mighty few—an’ _dey_ ain’t no use to a body. What you want to know
+when good luck’s a-comin’ for? Want to keep it off?” And he said: “Ef
+you’s got hairy arms en a hairy breas’, it’s a sign dat you’s agwyne to
+be rich. Well, dey’s some use in a sign like dat, ’kase it’s so fur
+ahead. You see, maybe you’s got to be po’ a long time fust, en so you
+might git discourage’ en kill yo’sef ’f you didn’ know by de sign dat
+you gwyne to be rich bymeby.”
+
+“Have you got hairy arms and a hairy breast, Jim?”
+
+“What’s de use to ax dat question? Don’t you see I has?”
+
+“Well, are you rich?”
+
+“No, but I ben rich wunst, and gwyne to be rich agin. Wunst I had
+foteen dollars, but I tuck to specalat’n’, en got busted out.”
+
+“What did you speculate in, Jim?”
+
+“Well, fust I tackled stock.”
+
+“What kind of stock?”
+
+“Why, live stock—cattle, you know. I put ten dollars in a cow. But I
+ain’ gwyne to resk no mo’ money in stock. De cow up ’n’ died on my
+han’s.”
+
+“So you lost the ten dollars.”
+
+“No, I didn’t lose it all. I on’y los’ ’bout nine of it. I sole de hide
+en taller for a dollar en ten cents.”
+
+“You had five dollars and ten cents left. Did you speculate any more?”
+
+“Yes. You know that one-laigged nigger dat b’longs to old Misto
+Bradish? Well, he sot up a bank, en say anybody dat put in a dollar
+would git fo’ dollars mo’ at de en’ er de year. Well, all de niggers
+went in, but dey didn’t have much. I wuz de on’y one dat had much. So I
+stuck out for mo’ dan fo’ dollars, en I said ’f I didn’ git it I’d
+start a bank mysef. Well, o’ course dat nigger want’ to keep me out er
+de business, bekase he says dey warn’t business ’nough for two banks,
+so he say I could put in my five dollars en he pay me thirty-five at de
+en’ er de year.
+
+“So I done it. Den I reck’n’d I’d inves’ de thirty-five dollars right
+off en keep things a-movin’. Dey wuz a nigger name’ Bob, dat had
+ketched a wood-flat, en his marster didn’ know it; en I bought it off’n
+him en told him to take de thirty-five dollars when de en’ er de year
+come; but somebody stole de wood-flat dat night, en nex day de
+one-laigged nigger say de bank’s busted. So dey didn’ none uv us git no
+money.”
+
+“What did you do with the ten cents, Jim?”
+
+“Well, I ’uz gwyne to spen’ it, but I had a dream, en de dream tole me
+to give it to a nigger name’ Balum—Balum’s Ass dey call him for short;
+he’s one er dem chuckleheads, you know. But he’s lucky, dey say, en I
+see I warn’t lucky. De dream say let Balum inves’ de ten cents en he’d
+make a raise for me. Well, Balum he tuck de money, en when he wuz in
+church he hear de preacher say dat whoever give to de po’ len’ to de
+Lord, en boun’ to git his money back a hund’d times. So Balum he tuck
+en give de ten cents to de po’, en laid low to see what wuz gwyne to
+come of it.”
+
+“Well, what did come of it, Jim?”
+
+“Nuffn never come of it. I couldn’ manage to k’leck dat money no way;
+en Balum he couldn’. I ain’ gwyne to len’ no mo’ money ’dout I see de
+security. Boun’ to git yo’ money back a hund’d times, de preacher says!
+Ef I could git de ten _cents_ back, I’d call it squah, en be glad er de
+chanst.”
+
+“Well, it’s all right anyway, Jim, long as you’re going to be rich
+again some time or other.”
+
+“Yes; en I’s rich now, come to look at it. I owns mysef, en I’s wuth
+eight hund’d dollars. I wisht I had de money, I wouldn’ want no mo’.”
+
+
+
+
+CHAPTER IX.
+
+
+I wanted to go and look at a place right about the middle of the island
+that I’d found when I was exploring; so we started and soon got to it,
+because the island was only three miles long and a quarter of a mile
+wide.
+
+This place was a tolerable long, steep hill or ridge about forty foot
+high. We had a rough time getting to the top, the sides was so steep
+and the bushes so thick. We tramped and clumb around all over it, and
+by-and-by found a good big cavern in the rock, most up to the top on
+the side towards Illinois. The cavern was as big as two or three rooms
+bunched together, and Jim could stand up straight in it. It was cool in
+there. Jim was for putting our traps in there right away, but I said we
+didn’t want to be climbing up and down there all the time.
+
+Jim said if we had the canoe hid in a good place, and had all the traps
+in the cavern, we could rush there if anybody was to come to the
+island, and they would never find us without dogs. And, besides, he
+said them little birds had said it was going to rain, and did I want
+the things to get wet?
+
+So we went back and got the canoe, and paddled up abreast the cavern,
+and lugged all the traps up there. Then we hunted up a place close by
+to hide the canoe in, amongst the thick willows. We took some fish off
+of the lines and set them again, and begun to get ready for dinner.
+
+The door of the cavern was big enough to roll a hogshead in, and on one
+side of the door the floor stuck out a little bit, and was flat and a
+good place to build a fire on. So we built it there and cooked dinner.
+
+We spread the blankets inside for a carpet, and eat our dinner in
+there. We put all the other things handy at the back of the cavern.
+Pretty soon it darkened up, and begun to thunder and lighten; so the
+birds was right about it. Directly it begun to rain, and it rained like
+all fury, too, and I never see the wind blow so. It was one of these
+regular summer storms. It would get so dark that it looked all
+blue-black outside, and lovely; and the rain would thrash along by so
+thick that the trees off a little ways looked dim and spider-webby; and
+here would come a blast of wind that would bend the trees down and turn
+up the pale underside of the leaves; and then a perfect ripper of a
+gust would follow along and set the branches to tossing their arms as
+if they was just wild; and next, when it was just about the bluest and
+blackest—_fst!_ it was as bright as glory, and you’d have a little
+glimpse of tree-tops a-plunging about away off yonder in the storm,
+hundreds of yards further than you could see before; dark as sin again
+in a second, and now you’d hear the thunder let go with an awful crash,
+and then go rumbling, grumbling, tumbling, down the sky towards the
+under side of the world, like rolling empty barrels down stairs—where
+it’s long stairs and they bounce a good deal, you know.
+
+“Jim, this is nice,” I says. “I wouldn’t want to be nowhere else but
+here. Pass me along another hunk of fish and some hot corn-bread.”
+
+“Well, you wouldn’t a ben here ’f it hadn’t a ben for Jim. You’d a ben
+down dah in de woods widout any dinner, en gittn’ mos’ drownded, too;
+dat you would, honey. Chickens knows when it’s gwyne to rain, en so do
+de birds, chile.”
+
+The river went on raising and raising for ten or twelve days, till at
+last it was over the banks. The water was three or four foot deep on
+the island in the low places and on the Illinois bottom. On that side
+it was a good many miles wide, but on the Missouri side it was the same
+old distance across—a half a mile—because the Missouri shore was just a
+wall of high bluffs.
+
+Daytimes we paddled all over the island in the canoe, It was mighty
+cool and shady in the deep woods, even if the sun was blazing outside.
+We went winding in and out amongst the trees, and sometimes the vines
+hung so thick we had to back away and go some other way. Well, on every
+old broken-down tree you could see rabbits and snakes and such things;
+and when the island had been overflowed a day or two they got so tame,
+on account of being hungry, that you could paddle right up and put your
+hand on them if you wanted to; but not the snakes and turtles—they
+would slide off in the water. The ridge our cavern was in was full of
+them. We could a had pets enough if we’d wanted them.
+
+One night we catched a little section of a lumber raft—nice pine
+planks. It was twelve foot wide and about fifteen or sixteen foot long,
+and the top stood above water six or seven inches—a solid, level floor.
+We could see saw-logs go by in the daylight sometimes, but we let them
+go; we didn’t show ourselves in daylight.
+
+Another night when we was up at the head of the island, just before
+daylight, here comes a frame-house down, on the west side. She was a
+two-story, and tilted over considerable. We paddled out and got
+aboard—clumb in at an upstairs window. But it was too dark to see yet,
+so we made the canoe fast and set in her to wait for daylight.
+
+The light begun to come before we got to the foot of the island. Then
+we looked in at the window. We could make out a bed, and a table, and
+two old chairs, and lots of things around about on the floor, and there
+was clothes hanging against the wall. There was something laying on the
+floor in the far corner that looked like a man. So Jim says:
+
+“Hello, you!”
+
+But it didn’t budge. So I hollered again, and then Jim says:
+
+“De man ain’t asleep—he’s dead. You hold still—I’ll go en see.”
+
+He went, and bent down and looked, and says:
+
+“It’s a dead man. Yes, indeedy; naked, too. He’s ben shot in de back. I
+reck’n he’s ben dead two er three days. Come in, Huck, but doan’ look
+at his face—it’s too gashly.”
+
+I didn’t look at him at all. Jim throwed some old rags over him, but he
+needn’t done it; I didn’t want to see him. There was heaps of old
+greasy cards scattered around over the floor, and old whisky bottles,
+and a couple of masks made out of black cloth; and all over the walls
+was the ignorantest kind of words and pictures made with charcoal.
+There was two old dirty calico dresses, and a sun-bonnet, and some
+women’s underclothes hanging against the wall, and some men’s clothing,
+too. We put the lot into the canoe—it might come good. There was a
+boy’s old speckled straw hat on the floor; I took that, too. And there
+was a bottle that had had milk in it, and it had a rag stopper for a
+baby to suck. We would a took the bottle, but it was broke. There was a
+seedy old chest, and an old hair trunk with the hinges broke. They
+stood open, but there warn’t nothing left in them that was any account.
+The way things was scattered about we reckoned the people left in a
+hurry, and warn’t fixed so as to carry off most of their stuff.
+
+We got an old tin lantern, and a butcher-knife without any handle, and
+a bran-new Barlow knife worth two bits in any store, and a lot of
+tallow candles, and a tin candlestick, and a gourd, and a tin cup, and
+a ratty old bedquilt off the bed, and a reticule with needles and pins
+and beeswax and buttons and thread and all such truck in it, and a
+hatchet and some nails, and a fishline as thick as my little finger
+with some monstrous hooks on it, and a roll of buckskin, and a leather
+dog-collar, and a horseshoe, and some vials of medicine that didn’t
+have no label on them; and just as we was leaving I found a tolerable
+good curry-comb, and Jim he found a ratty old fiddle-bow, and a wooden
+leg. The straps was broke off of it, but, barring that, it was a good
+enough leg, though it was too long for me and not long enough for Jim,
+and we couldn’t find the other one, though we hunted all around.
+
+And so, take it all around, we made a good haul. When we was ready to
+shove off we was a quarter of a mile below the island, and it was
+pretty broad day; so I made Jim lay down in the canoe and cover up with
+the quilt, because if he set up people could tell he was a nigger a
+good ways off. I paddled over to the Illinois shore, and drifted down
+most a half a mile doing it. I crept up the dead water under the bank,
+and hadn’t no accidents and didn’t see nobody. We got home all safe.
+
+
+
+
+CHAPTER X.
+
+
+After breakfast I wanted to talk about the dead man and guess out how
+he come to be killed, but Jim didn’t want to. He said it would fetch
+bad luck; and besides, he said, he might come and ha’nt us; he said a
+man that warn’t buried was more likely to go a-ha’nting around than one
+that was planted and comfortable. That sounded pretty reasonable, so I
+didn’t say no more; but I couldn’t keep from studying over it and
+wishing I knowed who shot the man, and what they done it for.
+
+We rummaged the clothes we’d got, and found eight dollars in silver
+sewed up in the lining of an old blanket overcoat. Jim said he reckoned
+the people in that house stole the coat, because if they’d a knowed the
+money was there they wouldn’t a left it. I said I reckoned they killed
+him, too; but Jim didn’t want to talk about that. I says:
+
+“Now you think it’s bad luck; but what did you say when I fetched in
+the snake-skin that I found on the top of the ridge day before
+yesterday? You said it was the worst bad luck in the world to touch a
+snake-skin with my hands. Well, here’s your bad luck! We’ve raked in
+all this truck and eight dollars besides. I wish we could have some bad
+luck like this every day, Jim.”
+
+“Never you mind, honey, never you mind. Don’t you git too peart. It’s
+a-comin’. Mind I tell you, it’s a-comin’.”
+
+It did come, too. It was a Tuesday that we had that talk. Well, after
+dinner Friday we was laying around in the grass at the upper end of the
+ridge, and got out of tobacco. I went to the cavern to get some, and
+found a rattlesnake in there. I killed him, and curled him up on the
+foot of Jim’s blanket, ever so natural, thinking there’d be some fun
+when Jim found him there. Well, by night I forgot all about the snake,
+and when Jim flung himself down on the blanket while I struck a light
+the snake’s mate was there, and bit him.
+
+He jumped up yelling, and the first thing the light showed was the
+varmint curled up and ready for another spring. I laid him out in a
+second with a stick, and Jim grabbed pap’s whisky-jug and begun to pour
+it down.
+
+He was barefooted, and the snake bit him right on the heel. That all
+comes of my being such a fool as to not remember that wherever you
+leave a dead snake its mate always comes there and curls around it. Jim
+told me to chop off the snake’s head and throw it away, and then skin
+the body and roast a piece of it. I done it, and he eat it and said it
+would help cure him. He made me take off the rattles and tie them
+around his wrist, too. He said that that would help. Then I slid out
+quiet and throwed the snakes clear away amongst the bushes; for I
+warn’t going to let Jim find out it was all my fault, not if I could
+help it.
+
+Jim sucked and sucked at the jug, and now and then he got out of his
+head and pitched around and yelled; but every time he come to himself
+he went to sucking at the jug again. His foot swelled up pretty big,
+and so did his leg; but by-and-by the drunk begun to come, and so I
+judged he was all right; but I’d druther been bit with a snake than
+pap’s whisky.
+
+Jim was laid up for four days and nights. Then the swelling was all
+gone and he was around again. I made up my mind I wouldn’t ever take
+a-holt of a snake-skin again with my hands, now that I see what had
+come of it. Jim said he reckoned I would believe him next time. And he
+said that handling a snake-skin was such awful bad luck that maybe we
+hadn’t got to the end of it yet. He said he druther see the new moon
+over his left shoulder as much as a thousand times than take up a
+snake-skin in his hand. Well, I was getting to feel that way myself,
+though I’ve always reckoned that looking at the new moon over your left
+shoulder is one of the carelessest and foolishest things a body can do.
+Old Hank Bunker done it once, and bragged about it; and in less than
+two years he got drunk and fell off of the shot-tower, and spread
+himself out so that he was just a kind of a layer, as you may say; and
+they slid him edgeways between two barn doors for a coffin, and buried
+him so, so they say, but I didn’t see it. Pap told me. But anyway it
+all come of looking at the moon that way, like a fool.
+
+Well, the days went along, and the river went down between its banks
+again; and about the first thing we done was to bait one of the big
+hooks with a skinned rabbit and set it and catch a catfish that was as
+big as a man, being six foot two inches long, and weighed over two
+hundred pounds. We couldn’t handle him, of course; he would a flung us
+into Illinois. We just set there and watched him rip and tear around
+till he drownded. We found a brass button in his stomach and a round
+ball, and lots of rubbage. We split the ball open with the hatchet, and
+there was a spool in it. Jim said he’d had it there a long time, to
+coat it over so and make a ball of it. It was as big a fish as was ever
+catched in the Mississippi, I reckon. Jim said he hadn’t ever seen a
+bigger one. He would a been worth a good deal over at the village. They
+peddle out such a fish as that by the pound in the market-house there;
+everybody buys some of him; his meat’s as white as snow and makes a
+good fry.
+
+Next morning I said it was getting slow and dull, and I wanted to get a
+stirring up some way. I said I reckoned I would slip over the river and
+find out what was going on. Jim liked that notion; but he said I must
+go in the dark and look sharp. Then he studied it over and said,
+couldn’t I put on some of them old things and dress up like a girl?
+That was a good notion, too. So we shortened up one of the calico
+gowns, and I turned up my trouser-legs to my knees and got into it. Jim
+hitched it behind with the hooks, and it was a fair fit. I put on the
+sun-bonnet and tied it under my chin, and then for a body to look in
+and see my face was like looking down a joint of stove-pipe. Jim said
+nobody would know me, even in the daytime, hardly. I practiced around
+all day to get the hang of the things, and by-and-by I could do pretty
+well in them, only Jim said I didn’t walk like a girl; and he said I
+must quit pulling up my gown to get at my britches-pocket. I took
+notice, and done better.
+
+I started up the Illinois shore in the canoe just after dark.
+
+I started across to the town from a little below the ferry-landing, and
+the drift of the current fetched me in at the bottom of the town. I
+tied up and started along the bank. There was a light burning in a
+little shanty that hadn’t been lived in for a long time, and I wondered
+who had took up quarters there. I slipped up and peeped in at the
+window. There was a woman about forty year old in there knitting by a
+candle that was on a pine table. I didn’t know her face; she was a
+stranger, for you couldn’t start a face in that town that I didn’t
+know. Now this was lucky, because I was weakening; I was getting afraid
+I had come; people might know my voice and find me out. But if this
+woman had been in such a little town two days she could tell me all I
+wanted to know; so I knocked at the door, and made up my mind I
+wouldn’t forget I was a girl.
+
+
+
+
+CHAPTER XI.
+
+
+“Come in,” says the woman, and I did. She says: “Take a cheer.”
+
+I done it. She looked me all over with her little shiny eyes, and says:
+
+“What might your name be?”
+
+“Sarah Williams.”
+
+“Where ’bouts do you live? In this neighborhood?”
+
+“No’m. In Hookerville, seven mile below. I’ve walked all the way and
+I’m all tired out.”
+
+“Hungry, too, I reckon. I’ll find you something.”
+
+“No’m, I ain’t hungry. I was so hungry I had to stop two miles below
+here at a farm; so I ain’t hungry no more. It’s what makes me so late.
+My mother’s down sick, and out of money and everything, and I come to
+tell my uncle Abner Moore. He lives at the upper end of the town, she
+says. I hain’t ever been here before. Do you know him?”
+
+“No; but I don’t know everybody yet. I haven’t lived here quite two
+weeks. It’s a considerable ways to the upper end of the town. You
+better stay here all night. Take off your bonnet.”
+
+“No,” I says; “I’ll rest a while, I reckon, and go on. I ain’t afeared
+of the dark.”
+
+She said she wouldn’t let me go by myself, but her husband would be in
+by-and-by, maybe in a hour and a half, and she’d send him along with
+me. Then she got to talking about her husband, and about her relations
+up the river, and her relations down the river, and about how much
+better off they used to was, and how they didn’t know but they’d made a
+mistake coming to our town, instead of letting well alone—and so on and
+so on, till I was afeard _I_ had made a mistake coming to her to find
+out what was going on in the town; but by-and-by she dropped on to pap
+and the murder, and then I was pretty willing to let her clatter right
+along. She told about me and Tom Sawyer finding the six thousand
+dollars (only she got it ten) and all about pap and what a hard lot he
+was, and what a hard lot I was, and at last she got down to where I was
+murdered. I says:
+
+“Who done it? We’ve heard considerable about these goings on down in
+Hookerville, but we don’t know who ’twas that killed Huck Finn.”
+
+“Well, I reckon there’s a right smart chance of people _here_ that’d
+like to know who killed him. Some think old Finn done it himself.”
+
+“No—is that so?”
+
+“Most everybody thought it at first. He’ll never know how nigh he come
+to getting lynched. But before night they changed around and judged it
+was done by a runaway nigger named Jim.”
+
+“Why _he_—”
+
+I stopped. I reckoned I better keep still. She run on, and never
+noticed I had put in at all:
+
+“The nigger run off the very night Huck Finn was killed. So there’s a
+reward out for him—three hundred dollars. And there’s a reward out for
+old Finn, too—two hundred dollars. You see, he come to town the morning
+after the murder, and told about it, and was out with ’em on the
+ferry-boat hunt, and right away after he up and left. Before night they
+wanted to lynch him, but he was gone, you see. Well, next day they
+found out the nigger was gone; they found out he hadn’t ben seen sence
+ten o’clock the night the murder was done. So then they put it on him,
+you see; and while they was full of it, next day, back comes old Finn,
+and went boo-hooing to Judge Thatcher to get money to hunt for the
+nigger all over Illinois with. The judge gave him some, and that
+evening he got drunk, and was around till after midnight with a couple
+of mighty hard-looking strangers, and then went off with them. Well, he
+hain’t come back sence, and they ain’t looking for him back till this
+thing blows over a little, for people thinks now that he killed his boy
+and fixed things so folks would think robbers done it, and then he’d
+get Huck’s money without having to bother a long time with a lawsuit.
+People do say he warn’t any too good to do it. Oh, he’s sly, I reckon.
+If he don’t come back for a year he’ll be all right. You can’t prove
+anything on him, you know; everything will be quieted down then, and
+he’ll walk in Huck’s money as easy as nothing.”
+
+“Yes, I reckon so, ’m. I don’t see nothing in the way of it. Has
+everybody quit thinking the nigger done it?”
+
+“Oh, no, not everybody. A good many thinks he done it. But they’ll get
+the nigger pretty soon now, and maybe they can scare it out of him.”
+
+“Why, are they after him yet?”
+
+“Well, you’re innocent, ain’t you! Does three hundred dollars lay
+around every day for people to pick up? Some folks think the nigger
+ain’t far from here. I’m one of them—but I hain’t talked it around. A
+few days ago I was talking with an old couple that lives next door in
+the log shanty, and they happened to say hardly anybody ever goes to
+that island over yonder that they call Jackson’s Island. Don’t anybody
+live there? says I. No, nobody, says they. I didn’t say any more, but I
+done some thinking. I was pretty near certain I’d seen smoke over
+there, about the head of the island, a day or two before that, so I
+says to myself, like as not that nigger’s hiding over there; anyway,
+says I, it’s worth the trouble to give the place a hunt. I hain’t seen
+any smoke sence, so I reckon maybe he’s gone, if it was him; but
+husband’s going over to see—him and another man. He was gone up the
+river; but he got back to-day, and I told him as soon as he got here
+two hours ago.”
+
+I had got so uneasy I couldn’t set still. I had to do something with my
+hands; so I took up a needle off of the table and went to threading it.
+My hands shook, and I was making a bad job of it. When the woman
+stopped talking I looked up, and she was looking at me pretty curious
+and smiling a little. I put down the needle and thread, and let on to
+be interested—and I was, too—and says:
+
+“Three hundred dollars is a power of money. I wish my mother could get
+it. Is your husband going over there to-night?”
+
+“Oh, yes. He went up-town with the man I was telling you of, to get a
+boat and see if they could borrow another gun. They’ll go over after
+midnight.”
+
+“Couldn’t they see better if they was to wait till daytime?”
+
+“Yes. And couldn’t the nigger see better, too? After midnight he’ll
+likely be asleep, and they can slip around through the woods and hunt
+up his camp fire all the better for the dark, if he’s got one.”
+
+“I didn’t think of that.”
+
+The woman kept looking at me pretty curious, and I didn’t feel a bit
+comfortable. Pretty soon she says,
+
+“What did you say your name was, honey?”
+
+“M—Mary Williams.”
+
+Somehow it didn’t seem to me that I said it was Mary before, so I
+didn’t look up—seemed to me I said it was Sarah; so I felt sort of
+cornered, and was afeared maybe I was looking it, too. I wished the
+woman would say something more; the longer she set still the uneasier I
+was. But now she says:
+
+“Honey, I thought you said it was Sarah when you first come in?”
+
+“Oh, yes’m, I did. Sarah Mary Williams. Sarah’s my first name. Some
+calls me Sarah, some calls me Mary.”
+
+“Oh, that’s the way of it?”
+
+“Yes’m.”
+
+I was feeling better then, but I wished I was out of there, anyway. I
+couldn’t look up yet.
+
+Well, the woman fell to talking about how hard times was, and how poor
+they had to live, and how the rats was as free as if they owned the
+place, and so forth and so on, and then I got easy again. She was right
+about the rats. You’d see one stick his nose out of a hole in the
+corner every little while. She said she had to have things handy to
+throw at them when she was alone, or they wouldn’t give her no peace.
+She showed me a bar of lead twisted up into a knot, and said she was a
+good shot with it generly, but she’d wrenched her arm a day or two ago,
+and didn’t know whether she could throw true now. But she watched for a
+chance, and directly banged away at a rat; but she missed him wide, and
+said “Ouch!” it hurt her arm so. Then she told me to try for the next
+one. I wanted to be getting away before the old man got back, but of
+course I didn’t let on. I got the thing, and the first rat that showed
+his nose I let drive, and if he’d a stayed where he was he’d a been a
+tolerable sick rat. She said that was first-rate, and she reckoned I
+would hive the next one. She went and got the lump of lead and fetched
+it back, and brought along a hank of yarn which she wanted me to help
+her with. I held up my two hands and she put the hank over them, and
+went on talking about her and her husband’s matters. But she broke off
+to say:
+
+“Keep your eye on the rats. You better have the lead in your lap,
+handy.”
+
+So she dropped the lump into my lap just at that moment, and I clapped
+my legs together on it and she went on talking. But only about a
+minute. Then she took off the hank and looked me straight in the face,
+and very pleasant, and says:
+
+“Come, now, what’s your real name?”
+
+“Wh—what, mum?”
+
+“What’s your real name? Is it Bill, or Tom, or Bob?—or what is it?”
+
+I reckon I shook like a leaf, and I didn’t know hardly what to do. But
+I says:
+
+“Please to don’t poke fun at a poor girl like me, mum. If I’m in the
+way here, I’ll—”
+
+“No, you won’t. Set down and stay where you are. I ain’t going to hurt
+you, and I ain’t going to tell on you, nuther. You just tell me your
+secret, and trust me. I’ll keep it; and, what’s more, I’ll help you.
+So’ll my old man if you want him to. You see, you’re a runaway
+’prentice, that’s all. It ain’t anything. There ain’t no harm in it.
+You’ve been treated bad, and you made up your mind to cut. Bless you,
+child, I wouldn’t tell on you. Tell me all about it now, that’s a good
+boy.”
+
+So I said it wouldn’t be no use to try to play it any longer, and I
+would just make a clean breast and tell her everything, but she musn’t
+go back on her promise. Then I told her my father and mother was dead,
+and the law had bound me out to a mean old farmer in the country thirty
+mile back from the river, and he treated me so bad I couldn’t stand it
+no longer; he went away to be gone a couple of days, and so I took my
+chance and stole some of his daughter’s old clothes and cleared out,
+and I had been three nights coming the thirty miles. I traveled nights,
+and hid daytimes and slept, and the bag of bread and meat I carried
+from home lasted me all the way, and I had a-plenty. I said I believed
+my uncle Abner Moore would take care of me, and so that was why I
+struck out for this town of Goshen.
+
+“Goshen, child? This ain’t Goshen. This is St. Petersburg. Goshen’s ten
+mile further up the river. Who told you this was Goshen?”
+
+“Why, a man I met at daybreak this morning, just as I was going to turn
+into the woods for my regular sleep. He told me when the roads forked I
+must take the right hand, and five mile would fetch me to Goshen.”
+
+“He was drunk, I reckon. He told you just exactly wrong.”
+
+“Well, he did act like he was drunk, but it ain’t no matter now. I got
+to be moving along. I’ll fetch Goshen before daylight.”
+
+“Hold on a minute. I’ll put you up a snack to eat. You might want it.”
+
+So she put me up a snack, and says:
+
+“Say, when a cow’s laying down, which end of her gets up first? Answer
+up prompt now—don’t stop to study over it. Which end gets up first?”
+
+“The hind end, mum.”
+
+“Well, then, a horse?”
+
+“The for’rard end, mum.”
+
+“Which side of a tree does the moss grow on?”
+
+“North side.”
+
+“If fifteen cows is browsing on a hillside, how many of them eats with
+their heads pointed the same direction?”
+
+“The whole fifteen, mum.”
+
+“Well, I reckon you _have_ lived in the country. I thought maybe you
+was trying to hocus me again. What’s your real name, now?”
+
+“George Peters, mum.”
+
+“Well, try to remember it, George. Don’t forget and tell me it’s
+Elexander before you go, and then get out by saying it’s George
+Elexander when I catch you. And don’t go about women in that old
+calico. You do a girl tolerable poor, but you might fool men, maybe.
+Bless you, child, when you set out to thread a needle don’t hold the
+thread still and fetch the needle up to it; hold the needle still and
+poke the thread at it; that’s the way a woman most always does, but a
+man always does t’other way. And when you throw at a rat or anything,
+hitch yourself up a tiptoe and fetch your hand up over your head as
+awkward as you can, and miss your rat about six or seven foot. Throw
+stiff-armed from the shoulder, like there was a pivot there for it to
+turn on, like a girl; not from the wrist and elbow, with your arm out
+to one side, like a boy. And, mind you, when a girl tries to catch
+anything in her lap she throws her knees apart; she don’t clap them
+together, the way you did when you catched the lump of lead. Why, I
+spotted you for a boy when you was threading the needle; and I
+contrived the other things just to make certain. Now trot along to your
+uncle, Sarah Mary Williams George Elexander Peters, and if you get into
+trouble you send word to Mrs. Judith Loftus, which is me, and I’ll do
+what I can to get you out of it. Keep the river road all the way, and
+next time you tramp take shoes and socks with you. The river road’s a
+rocky one, and your feet’ll be in a condition when you get to Goshen, I
+reckon.”
+
+I went up the bank about fifty yards, and then I doubled on my tracks
+and slipped back to where my canoe was, a good piece below the house. I
+jumped in, and was off in a hurry. I went up-stream far enough to make
+the head of the island, and then started across. I took off the
+sun-bonnet, for I didn’t want no blinders on then. When I was about the
+middle I heard the clock begin to strike, so I stops and listens; the
+sound come faint over the water but clear—eleven. When I struck the
+head of the island I never waited to blow, though I was most winded,
+but I shoved right into the timber where my old camp used to be, and
+started a good fire there on a high and dry spot.
+
+Then I jumped in the canoe and dug out for our place, a mile and a half
+below, as hard as I could go. I landed, and slopped through the timber
+and up the ridge and into the cavern. There Jim laid, sound asleep on
+the ground. I roused him out and says:
+
+“Git up and hump yourself, Jim! There ain’t a minute to lose. They’re
+after us!”
+
+Jim never asked no questions, he never said a word; but the way he
+worked for the next half an hour showed about how he was scared. By
+that time everything we had in the world was on our raft, and she was
+ready to be shoved out from the willow cove where she was hid. We put
+out the camp fire at the cavern the first thing, and didn’t show a
+candle outside after that.
+
+I took the canoe out from the shore a little piece, and took a look;
+but if there was a boat around I couldn’t see it, for stars and shadows
+ain’t good to see by. Then we got out the raft and slipped along down
+in the shade, past the foot of the island dead still—never saying a
+word.
+
+
+
+
+CHAPTER XII.
+
+
+It must a been close on to one o’clock when we got below the island at
+last, and the raft did seem to go mighty slow. If a boat was to come
+along we was going to take to the canoe and break for the Illinois
+shore; and it was well a boat didn’t come, for we hadn’t ever thought
+to put the gun in the canoe, or a fishing-line, or anything to eat. We
+was in ruther too much of a sweat to think of so many things. It warn’t
+good judgment to put _everything_ on the raft.
+
+If the men went to the island I just expect they found the camp fire I
+built, and watched it all night for Jim to come. Anyways, they stayed
+away from us, and if my building the fire never fooled them it warn’t
+no fault of mine. I played it as low down on them as I could.
+
+When the first streak of day began to show we tied up to a tow-head in a
+big bend on the Illinois side, and hacked off cottonwood branches with
+the hatchet, and covered up the raft with them so she looked like there
+had been a cave-in in the bank there. A tow-head is a sandbar that has
+cottonwoods on it as thick as harrow-teeth.
+
+We had mountains on the Missouri shore and heavy timber on the Illinois
+side, and the channel was down the Missouri shore at that place, so we
+warn’t afraid of anybody running across us. We laid there all day, and
+watched the rafts and steamboats spin down the Missouri shore, and
+up-bound steamboats fight the big river in the middle. I told Jim all
+about the time I had jabbering with that woman; and Jim said she was a
+smart one, and if she was to start after us herself _she_ wouldn’t set
+down and watch a camp fire—no, sir, she’d fetch a dog. Well, then, I
+said, why couldn’t she tell her husband to fetch a dog? Jim said he bet
+she did think of it by the time the men was ready to start, and he
+believed they must a gone up-town to get a dog and so they lost all
+that time, or else we wouldn’t be here on a tow-head sixteen or
+seventeen mile below the village—no, indeedy, we would be in that same
+old town again. So I said I didn’t care what was the reason they didn’t
+get us as long as they didn’t.
+
+When it was beginning to come on dark we poked our heads out of the
+cottonwood thicket, and looked up and down and across; nothing in
+sight; so Jim took up some of the top planks of the raft and built a
+snug wigwam to get under in blazing weather and rainy, and to keep the
+things dry. Jim made a floor for the wigwam, and raised it a foot or
+more above the level of the raft, so now the blankets and all the traps
+was out of reach of steamboat waves. Right in the middle of the wigwam
+we made a layer of dirt about five or six inches deep with a frame
+around it for to hold it to its place; this was to build a fire on in
+sloppy weather or chilly; the wigwam would keep it from being seen. We
+made an extra steering-oar, too, because one of the others might get
+broke on a snag or something. We fixed up a short forked stick to hang
+the old lantern on, because we must always light the lantern whenever
+we see a steamboat coming down-stream, to keep from getting run over;
+but we wouldn’t have to light it for up-stream boats unless we see we
+was in what they call a “crossing”; for the river was pretty high yet,
+very low banks being still a little under water; so up-bound boats
+didn’t always run the channel, but hunted easy water.
+
+This second night we run between seven and eight hours, with a current
+that was making over four mile an hour. We catched fish and talked, and
+we took a swim now and then to keep off sleepiness. It was kind of
+solemn, drifting down the big, still river, laying on our backs looking
+up at the stars, and we didn’t ever feel like talking loud, and it
+warn’t often that we laughed—only a little kind of a low chuckle. We
+had mighty good weather as a general thing, and nothing ever happened
+to us at all—that night, nor the next, nor the next.
+
+Every night we passed towns, some of them away up on black hillsides,
+nothing but just a shiny bed of lights; not a house could you see. The
+fifth night we passed St. Louis, and it was like the whole world lit
+up. In St. Petersburg they used to say there was twenty or thirty
+thousand people in St. Louis, but I never believed it till I see that
+wonderful spread of lights at two o’clock that still night. There
+warn’t a sound there; everybody was asleep.
+
+Every night now I used to slip ashore towards ten o’clock at some
+little village, and buy ten or fifteen cents’ worth of meal or bacon or
+other stuff to eat; and sometimes I lifted a chicken that warn’t
+roosting comfortable, and took him along. Pap always said, take a
+chicken when you get a chance, because if you don’t want him yourself
+you can easy find somebody that does, and a good deed ain’t ever
+forgot. I never see pap when he didn’t want the chicken himself, but
+that is what he used to say, anyway.
+
+Mornings before daylight I slipped into cornfields and borrowed a
+watermelon, or a mushmelon, or a punkin, or some new corn, or things of
+that kind. Pap always said it warn’t no harm to borrow things if you
+was meaning to pay them back some time; but the widow said it warn’t
+anything but a soft name for stealing, and no decent body would do it.
+Jim said he reckoned the widow was partly right and pap was partly
+right; so the best way would be for us to pick out two or three things
+from the list and say we wouldn’t borrow them any more—then he reckoned
+it wouldn’t be no harm to borrow the others. So we talked it over all
+one night, drifting along down the river, trying to make up our minds
+whether to drop the watermelons, or the cantelopes, or the mushmelons,
+or what. But towards daylight we got it all settled satisfactory, and
+concluded to drop crabapples and p’simmons. We warn’t feeling just
+right before that, but it was all comfortable now. I was glad the way
+it come out, too, because crabapples ain’t ever good, and the p’simmons
+wouldn’t be ripe for two or three months yet.
+
+We shot a water-fowl, now and, then that got up too early in the morning
+or didn’t go to bed early enough in the evening. Take it all round, we
+lived pretty high.
+
+The fifth night below St. Louis we had a big storm after midnight, with
+a power of thunder and lightning, and the rain poured down in a solid
+sheet. We stayed in the wigwam and let the raft take care of itself.
+When the lightning glared out we could see a big straight river ahead,
+and high, rocky bluffs on both sides. By-and-by says I, “Hel-_lo_, Jim,
+looky yonder!” It was a steamboat that had killed herself on a rock. We
+was drifting straight down for her. The lightning showed her very
+distinct. She was leaning over, with part of her upper deck above
+water, and you could see every little chimbly-guy clean and clear, and
+a chair by the big bell, with an old slouch hat hanging on the back of
+it, when the flashes come.
+
+Well, it being away in the night and stormy, and all so
+mysterious-like, I felt just the way any other boy would a felt when I
+see that wreck laying there so mournful and lonesome in the middle of
+the river. I wanted to get aboard of her and slink around a little, and
+see what there was there. So I says:
+
+“Le’s land on her, Jim.”
+
+But Jim was dead against it at first. He says:
+
+“I doan’ want to go fool’n ’long er no wrack. We’s doin’ blame’ well,
+en we better let blame’ well alone, as de good book says. Like as not
+dey’s a watchman on dat wrack.”
+
+“Watchman your grandmother,” I says; “there ain’t nothing to watch but
+the texas and the pilot-house; and do you reckon anybody’s going to
+resk his life for a texas and a pilot-house such a night as this, when
+it’s likely to break up and wash off down the river any minute?” Jim
+couldn’t say nothing to that, so he didn’t try. “And besides,” I says,
+“we might borrow something worth having out of the captain’s stateroom.
+Seegars, _I_ bet you—and cost five cents apiece, solid cash. Steamboat
+captains is always rich, and get sixty dollars a month, and _they_
+don’t care a cent what a thing costs, you know, long as they want it.
+Stick a candle in your pocket; I can’t rest, Jim, till we give her a
+rummaging. Do you reckon Tom Sawyer would ever go by this thing? Not
+for pie, he wouldn’t. He’d call it an adventure—that’s what he’d call
+it; and he’d land on that wreck if it was his last act. And wouldn’t he
+throw style into it?—wouldn’t he spread himself, nor nothing? Why,
+you’d think it was Christopher C’lumbus discovering Kingdom-Come. I
+wish Tom Sawyer _was_ here.”
+
+Jim he grumbled a little, but give in. He said we mustn’t talk any more
+than we could help, and then talk mighty low. The lightning showed us
+the wreck again just in time, and we fetched the stabboard derrick, and
+made fast there.
+
+The deck was high out here. We went sneaking down the slope of it to
+labboard, in the dark, towards the texas, feeling our way slow with our
+feet, and spreading our hands out to fend off the guys, for it was so
+dark we couldn’t see no sign of them. Pretty soon we struck the forward
+end of the skylight, and clumb on to it; and the next step fetched us
+in front of the captain’s door, which was open, and by Jimminy, away
+down through the texas-hall we see a light! and all in the same second
+we seem to hear low voices in yonder!
+
+Jim whispered and said he was feeling powerful sick, and told me to
+come along. I says, all right, and was going to start for the raft; but
+just then I heard a voice wail out and say:
+
+“Oh, please don’t, boys; I swear I won’t ever tell!”
+
+Another voice said, pretty loud:
+
+“It’s a lie, Jim Turner. You’ve acted this way before. You always want
+more’n your share of the truck, and you’ve always got it, too, because
+you’ve swore ’t if you didn’t you’d tell. But this time you’ve said it
+jest one time too many. You’re the meanest, treacherousest hound in
+this country.”
+
+By this time Jim was gone for the raft. I was just a-biling with
+curiosity; and I says to myself, Tom Sawyer wouldn’t back out now, and
+so I won’t either; I’m a-going to see what’s going on here. So I
+dropped on my hands and knees in the little passage, and crept aft in
+the dark till there warn’t but one stateroom betwixt me and the
+cross-hall of the texas. Then in there I see a man stretched on the
+floor and tied hand and foot, and two men standing over him, and one of
+them had a dim lantern in his hand, and the other one had a pistol.
+This one kept pointing the pistol at the man’s head on the floor, and
+saying:
+
+“I’d _like_ to! And I orter, too—a mean skunk!”
+
+The man on the floor would shrivel up and say, “Oh, please don’t, Bill;
+I hain’t ever goin’ to tell.”
+
+And every time he said that the man with the lantern would laugh and
+say:
+
+“’Deed you _ain’t!_ You never said no truer thing ’n that, you bet
+you.” And once he said: “Hear him beg! and yit if we hadn’t got the
+best of him and tied him he’d a killed us both. And what _for?_ Jist
+for noth’n. Jist because we stood on our _rights_—that’s what for. But
+I lay you ain’t a-goin’ to threaten nobody any more, Jim Turner. Put
+_up_ that pistol, Bill.”
+
+Bill says:
+
+“I don’t want to, Jake Packard. I’m for killin’ him—and didn’t he kill
+old Hatfield jist the same way—and don’t he deserve it?”
+
+“But I don’t _want_ him killed, and I’ve got my reasons for it.”
+
+“Bless yo’ heart for them words, Jake Packard! I’ll never forgit you
+long’s I live!” says the man on the floor, sort of blubbering.
+
+Packard didn’t take no notice of that, but hung up his lantern on a
+nail and started towards where I was there in the dark, and motioned
+Bill to come. I crawfished as fast as I could about two yards, but the
+boat slanted so that I couldn’t make very good time; so to keep from
+getting run over and catched I crawled into a stateroom on the upper
+side. The man came a-pawing along in the dark, and when Packard got to
+my stateroom, he says:
+
+“Here—come in here.”
+
+And in he come, and Bill after him. But before they got in I was up in
+the upper berth, cornered, and sorry I come. Then they stood there,
+with their hands on the ledge of the berth, and talked. I couldn’t see
+them, but I could tell where they was by the whisky they’d been having.
+I was glad I didn’t drink whisky; but it wouldn’t made much difference
+anyway, because most of the time they couldn’t a treed me because I
+didn’t breathe. I was too scared. And, besides, a body _couldn’t_
+breathe and hear such talk. They talked low and earnest. Bill wanted to
+kill Turner. He says:
+
+“He’s said he’ll tell, and he will. If we was to give both our shares
+to him _now_ it wouldn’t make no difference after the row and the way
+we’ve served him. Shore’s you’re born, he’ll turn State’s evidence; now
+you hear _me_. I’m for putting him out of his troubles.”
+
+“So’m I,” says Packard, very quiet.
+
+“Blame it, I’d sorter begun to think you wasn’t. Well, then, that’s all
+right. Le’s go and do it.”
+
+“Hold on a minute; I hain’t had my say yit. You listen to me.
+Shooting’s good, but there’s quieter ways if the thing’s _got_ to be
+done. But what _I_ say is this: it ain’t good sense to go court’n
+around after a halter if you can git at what you’re up to in some way
+that’s jist as good and at the same time don’t bring you into no resks.
+Ain’t that so?”
+
+“You bet it is. But how you goin’ to manage it this time?”
+
+“Well, my idea is this: we’ll rustle around and gather up whatever
+pickins we’ve overlooked in the staterooms, and shove for shore and
+hide the truck. Then we’ll wait. Now I say it ain’t a-goin’ to be
+more’n two hours befo’ this wrack breaks up and washes off down the
+river. See? He’ll be drownded, and won’t have nobody to blame for it
+but his own self. I reckon that’s a considerble sight better ’n killin’
+of him. I’m unfavorable to killin’ a man as long as you can git aroun’
+it; it ain’t good sense, it ain’t good morals. Ain’t I right?”
+
+“Yes, I reck’n you are. But s’pose she _don’t_ break up and wash off?”
+
+“Well, we can wait the two hours anyway and see, can’t we?”
+
+“All right, then; come along.”
+
+So they started, and I lit out, all in a cold sweat, and scrambled
+forward. It was dark as pitch there; but I said, in a kind of a coarse
+whisper, “Jim!” and he answered up, right at my elbow, with a sort of a
+moan, and I says:
+
+“Quick, Jim, it ain’t no time for fooling around and moaning; there’s a
+gang of murderers in yonder, and if we don’t hunt up their boat and set
+her drifting down the river so these fellows can’t get away from the
+wreck there’s one of ’em going to be in a bad fix. But if we find their
+boat we can put _all_ of ’em in a bad fix—for the Sheriff ’ll get ’em.
+Quick—hurry! I’ll hunt the labboard side, you hunt the stabboard. You
+start at the raft, and—”
+
+“Oh, my lordy, lordy! _Raf’?_ Dey ain’ no raf’ no mo’; she done broke
+loose en gone I—en here we is!”
+
+
+
+
+CHAPTER XIII.
+
+
+Well, I catched my breath and most fainted. Shut up on a wreck with
+such a gang as that! But it warn’t no time to be sentimentering. We’d
+_got_ to find that boat now—had to have it for ourselves. So we went
+a-quaking and shaking down the stabboard side, and slow work it was,
+too—seemed a week before we got to the stern. No sign of a boat. Jim
+said he didn’t believe he could go any further—so scared he hadn’t
+hardly any strength left, he said. But I said, come on, if we get left
+on this wreck we are in a fix, sure. So on we prowled again. We struck
+for the stern of the texas, and found it, and then scrabbled along
+forwards on the skylight, hanging on from shutter to shutter, for the
+edge of the skylight was in the water. When we got pretty close to the
+cross-hall door, there was the skiff, sure enough! I could just barely
+see her. I felt ever so thankful. In another second I would a been
+aboard of her, but just then the door opened. One of the men stuck his
+head out only about a couple of foot from me, and I thought I was gone;
+but he jerked it in again, and says:
+
+“Heave that blame lantern out o’ sight, Bill!”
+
+He flung a bag of something into the boat, and then got in himself and
+set down. It was Packard. Then Bill _he_ come out and got in. Packard
+says, in a low voice:
+
+“All ready—shove off!”
+
+I couldn’t hardly hang on to the shutters, I was so weak. But Bill
+says:
+
+“Hold on—’d you go through him?”
+
+“No. Didn’t you?”
+
+“No. So he’s got his share o’ the cash yet.”
+
+“Well, then, come along; no use to take truck and leave money.”
+
+“Say, won’t he suspicion what we’re up to?”
+
+“Maybe he won’t. But we got to have it anyway. Come along.”
+
+So they got out and went in.
+
+The door slammed to because it was on the careened side; and in a half
+second I was in the boat, and Jim come tumbling after me. I out with my
+knife and cut the rope, and away we went!
+
+We didn’t touch an oar, and we didn’t speak nor whisper, nor hardly
+even breathe. We went gliding swift along, dead silent, past the tip of
+the paddle-box, and past the stern; then in a second or two more we was
+a hundred yards below the wreck, and the darkness soaked her up, every
+last sign of her, and we was safe, and knowed it.
+
+When we was three or four hundred yards down-stream we see the lantern
+show like a little spark at the texas door for a second, and we knowed
+by that that the rascals had missed their boat, and was beginning to
+understand that they was in just as much trouble now as Jim Turner was.
+
+Then Jim manned the oars, and we took out after our raft. Now was the
+first time that I begun to worry about the men—I reckon I hadn’t had
+time to before. I begun to think how dreadful it was, even for
+murderers, to be in such a fix. I says to myself, there ain’t no
+telling but I might come to be a murderer myself yet, and then how
+would _I_ like it? So says I to Jim:
+
+“The first light we see we’ll land a hundred yards below it or above
+it, in a place where it’s a good hiding-place for you and the skiff,
+and then I’ll go and fix up some kind of a yarn, and get somebody to go
+for that gang and get them out of their scrape, so they can be hung
+when their time comes.”
+
+But that idea was a failure; for pretty soon it begun to storm again,
+and this time worse than ever. The rain poured down, and never a light
+showed; everybody in bed, I reckon. We boomed along down the river,
+watching for lights and watching for our raft. After a long time the
+rain let up, but the clouds stayed, and the lightning kept whimpering,
+and by-and-by a flash showed us a black thing ahead, floating, and we
+made for it.
+
+It was the raft, and mighty glad was we to get aboard of it again. We
+seen a light now away down to the right, on shore. So I said I would go
+for it. The skiff was half full of plunder which that gang had stole
+there on the wreck. We hustled it on to the raft in a pile, and I told
+Jim to float along down, and show a light when he judged he had gone
+about two mile, and keep it burning till I come; then I manned my oars
+and shoved for the light. As I got down towards it, three or four more
+showed—up on a hillside. It was a village. I closed in above the shore
+light, and laid on my oars and floated. As I went by, I see it was a
+lantern hanging on the jackstaff of a double-hull ferry-boat. I skimmed
+around for the watchman, a-wondering whereabouts he slept; and
+by-and-by I found him roosting on the bitts, forward, with his head
+down between his knees. I gave his shoulder two or three little shoves,
+and begun to cry.
+
+He stirred up, in a kind of a startlish way; but when he see it was only
+me, he took a good gap and stretch, and then he says:
+
+“Hello, what’s up? Don’t cry, bub. What’s the trouble?”
+
+I says:
+
+“Pap, and mam, and sis, and—”
+
+Then I broke down. He says:
+
+“Oh, dang it now, _don’t_ take on so; we all has to have our troubles,
+and this’n ’ll come out all right. What’s the matter with ’em?”
+
+“They’re—they’re—are you the watchman of the boat?”
+
+“Yes,” he says, kind of pretty-well-satisfied like. “I’m the captain
+and the owner and the mate and the pilot and watchman and head
+deck-hand; and sometimes I’m the freight and passengers. I ain’t as
+rich as old Jim Hornback, and I can’t be so blame’ generous and good to
+Tom, Dick and Harry as what he is, and slam around money the way he
+does; but I’ve told him a many a time ’t I wouldn’t trade places with
+him; for, says I, a sailor’s life’s the life for me, and I’m derned if
+_I’d_ live two mile out o’ town, where there ain’t nothing ever goin’
+on, not for all his spondulicks and as much more on top of it. Says I—”
+
+I broke in and says:
+
+“They’re in an awful peck of trouble, and—”
+
+“_Who_ is?”
+
+“Why, pap and mam and sis and Miss Hooker; and if you’d take your
+ferry-boat and go up there—”
+
+“Up where? Where are they?”
+
+“On the wreck.”
+
+“What wreck?”
+
+“Why, there ain’t but one.”
+
+“What, you don’t mean the _Walter Scott?_”
+
+“Yes.”
+
+“Good land! what are they doin’ _there_, for gracious sakes?”
+
+“Well, they didn’t go there a-purpose.”
+
+“I bet they didn’t! Why, great goodness, there ain’t no chance for ’em
+if they don’t git off mighty quick! Why, how in the nation did they
+ever git into such a scrape?”
+
+“Easy enough. Miss Hooker was a-visiting up there to the town—”
+
+“Yes, Booth’s Landing—go on.”
+
+“She was a-visiting there at Booth’s Landing, and just in the edge of
+the evening she started over with her nigger woman in the horse-ferry
+to stay all night at her friend’s house, Miss What-you-may-call-her I
+disremember her name—and they lost their steering-oar, and swung around
+and went a-floating down, stern first, about two mile, and
+saddle-baggsed on the wreck, and the ferryman and the nigger woman and
+the horses was all lost, but Miss Hooker she made a grab and got aboard
+the wreck. Well, about an hour after dark we come along down in our
+trading-scow, and it was so dark we didn’t notice the wreck till we was
+right on it; and so _we_ saddle-baggsed; but all of us was saved but
+Bill Whipple—and oh, he _was_ the best cretur!—I most wish’t it had
+been me, I do.”
+
+“My George! It’s the beatenest thing I ever struck. And _then_ what did
+you all do?”
+
+“Well, we hollered and took on, but it’s so wide there we couldn’t make
+nobody hear. So pap said somebody got to get ashore and get help
+somehow. I was the only one that could swim, so I made a dash for it,
+and Miss Hooker she said if I didn’t strike help sooner, come here and
+hunt up her uncle, and he’d fix the thing. I made the land about a mile
+below, and been fooling along ever since, trying to get people to do
+something, but they said, ‘What, in such a night and such a current?
+There ain’t no sense in it; go for the steam ferry.’ Now if you’ll go
+and—”
+
+“By Jackson, I’d _like_ to, and, blame it, I don’t know but I will; but
+who in the dingnation’s a-going’ to _pay_ for it? Do you reckon your
+pap—”
+
+“Why _that’s_ all right. Miss Hooker she tole me, _particular_, that
+her uncle Hornback—”
+
+“Great guns! is _he_ her uncle? Looky here, you break for that light
+over yonder-way, and turn out west when you git there, and about a
+quarter of a mile out you’ll come to the tavern; tell ’em to dart you
+out to Jim Hornback’s, and he’ll foot the bill. And don’t you fool
+around any, because he’ll want to know the news. Tell him I’ll have his
+niece all safe before he can get to town. Hump yourself, now; I’m
+a-going up around the corner here to roust out my engineer.”
+
+I struck for the light, but as soon as he turned the corner I went back
+and got into my skiff and bailed her out, and then pulled up shore in
+the easy water about six hundred yards, and tucked myself in among some
+woodboats; for I couldn’t rest easy till I could see the ferry-boat
+start. But take it all around, I was feeling ruther comfortable on
+accounts of taking all this trouble for that gang, for not many would a
+done it. I wished the widow knowed about it. I judged she would be
+proud of me for helping these rapscallions, because rapscallions and
+dead beats is the kind the widow and good people takes the most
+interest in.
+
+Well, before long, here comes the wreck, dim and dusky, sliding along
+down! A kind of cold shiver went through me, and then I struck out for
+her. She was very deep, and I see in a minute there warn’t much chance
+for anybody being alive in her. I pulled all around her and hollered a
+little, but there wasn’t any answer; all dead still. I felt a little
+bit heavy-hearted about the gang, but not much, for I reckoned if they
+could stand it, I could.
+
+Then here comes the ferry-boat; so I shoved for the middle of the river
+on a long down-stream slant; and when I judged I was out of eye-reach, I
+laid on my oars, and looked back and see her go and smell around the
+wreck for Miss Hooker’s remainders, because the captain would know her
+uncle Hornback would want them; and then pretty soon the ferry-boat give
+it up and went for the shore, and I laid into my work and went
+a-booming down the river.
+
+It did seem a powerful long time before Jim’s light showed up; and when
+it did show, it looked like it was a thousand mile off. By the time I
+got there the sky was beginning to get a little gray in the east; so we
+struck for an island, and hid the raft, and sunk the skiff, and turned
+in and slept like dead people.
+
+
+
+
+CHAPTER XIV.
+
+
+By-and-by, when we got up, we turned over the truck the gang had stole
+off of the wreck, and found boots, and blankets, and clothes, and all
+sorts of other things, and a lot of books, and a spyglass, and three
+boxes of seegars. We hadn’t ever been this rich before in neither of
+our lives. The seegars was prime. We laid off all the afternoon in the
+woods talking, and me reading the books, and having a general good
+time. I told Jim all about what happened inside the wreck and at the
+ferry-boat, and I said these kinds of things was adventures; but he said
+he didn’t want no more adventures. He said that when I went in the
+texas and he crawled back to get on the raft and found her gone, he
+nearly died; because he judged it was all up with _him_, anyway it could
+be fixed; for if he didn’t get saved he would get drownded; and if he
+did get saved, whoever saved him would send him back home so as to get
+the reward, and then Miss Watson would sell him South, sure. Well, he
+was right; he was most always right; he had an uncommon level head, for
+a nigger.
+
+I read considerable to Jim about kings and dukes and earls and such,
+and how gaudy they dressed, and how much style they put on, and called
+each other your majesty, and your grace, and your lordship, and so on,
+’stead of mister; and Jim’s eyes bugged out, and he was interested. He
+says:
+
+“I didn’ know dey was so many un um. I hain’t hearn ’bout none un um,
+skasely, but ole King Sollermun, onless you counts dem kings dat’s in a
+pack er k’yards. How much do a king git?”
+
+“Get?” I says; “why, they get a thousand dollars a month if they want
+it; they can have just as much as they want; everything belongs to
+them.”
+
+“_Ain’_ dat gay? En what dey got to do, Huck?”
+
+“_They_ don’t do nothing! Why, how you talk! They just set around.”
+
+“No; is dat so?”
+
+“Of course it is. They just set around—except, maybe, when there’s a
+war; then they go to the war. But other times they just lazy around; or
+go hawking—just hawking and sp— Sh!—d’ you hear a noise?”
+
+We skipped out and looked; but it warn’t nothing but the flutter of a
+steamboat’s wheel away down, coming around the point; so we come back.
+
+“Yes,” says I, “and other times, when things is dull, they fuss with
+the parlyment; and if everybody don’t go just so he whacks their heads
+off. But mostly they hang round the harem.”
+
+“Roun’ de which?”
+
+“Harem.”
+
+“What’s de harem?”
+
+“The place where he keeps his wives. Don’t you know about the harem?
+Solomon had one; he had about a million wives.”
+
+“Why, yes, dat’s so; I—I’d done forgot it. A harem’s a bo’d’n-house, I
+reck’n. Mos’ likely dey has rackety times in de nussery. En I reck’n de
+wives quarrels considable; en dat ’crease de racket. Yit dey say
+Sollermun de wises’ man dat ever live’. I doan’ take no stock in dat.
+Bekase why: would a wise man want to live in de mids’ er sich a
+blim-blammin’ all de time? No—’deed he wouldn’t. A wise man ’ud take en
+buil’ a biler-factry; en den he could shet _down_ de biler-factry when
+he want to res’.”
+
+“Well, but he _was_ the wisest man, anyway; because the widow she told
+me so, her own self.”
+
+“I doan k’yer what de widder say, he _warn’t_ no wise man nuther. He
+had some er de dad-fetchedes’ ways I ever see. Does you know ’bout dat
+chile dat he ’uz gwyne to chop in two?”
+
+“Yes, the widow told me all about it.”
+
+“_Well_, den! Warn’ dat de beatenes’ notion in de worl’? You jes’ take
+en look at it a minute. Dah’s de stump, dah—dat’s one er de women;
+heah’s you—dat’s de yuther one; I’s Sollermun; en dish yer dollar
+bill’s de chile. Bofe un you claims it. What does I do? Does I shin
+aroun’ mongs’ de neighbors en fine out which un you de bill _do_ b’long
+to, en han’ it over to de right one, all safe en soun’, de way dat
+anybody dat had any gumption would? No; I take en whack de bill in
+_two_, en give half un it to you, en de yuther half to de yuther woman.
+Dat’s de way Sollermun was gwyne to do wid de chile. Now I want to ast
+you: what’s de use er dat half a bill?—can’t buy noth’n wid it. En what
+use is a half a chile? I wouldn’ give a dern for a million un um.”
+
+“But hang it, Jim, you’ve clean missed the point—blame it, you’ve
+missed it a thousand mile.”
+
+“Who? Me? Go ’long. Doan’ talk to _me_ ’bout yo’ pints. I reck’n I
+knows sense when I sees it; en dey ain’ no sense in sich doin’s as dat.
+De ’spute warn’t ’bout a half a chile, de ’spute was ’bout a whole
+chile; en de man dat think he kin settle a ’spute ’bout a whole chile
+wid a half a chile doan’ know enough to come in out’n de rain. Doan’
+talk to me ’bout Sollermun, Huck, I knows him by de back.”
+
+“But I tell you you don’t get the point.”
+
+“Blame de point! I reck’n I knows what I knows. En mine you, de _real_
+pint is down furder—it’s down deeper. It lays in de way Sollermun was
+raised. You take a man dat’s got on’y one or two chillen; is dat man
+gwyne to be waseful o’ chillen? No, he ain’t; he can’t ’ford it. _He_
+know how to value ’em. But you take a man dat’s got ’bout five million
+chillen runnin’ roun’ de house, en it’s diffunt. _He_ as soon chop a
+chile in two as a cat. Dey’s plenty mo’. A chile er two, mo’ er less,
+warn’t no consekens to Sollermun, dad fatch him!”
+
+I never see such a nigger. If he got a notion in his head once, there
+warn’t no getting it out again. He was the most down on Solomon of any
+nigger I ever see. So I went to talking about other kings, and let
+Solomon slide. I told about Louis Sixteenth that got his head cut off
+in France long time ago; and about his little boy the dolphin, that
+would a been a king, but they took and shut him up in jail, and some
+say he died there.
+
+“Po’ little chap.”
+
+“But some says he got out and got away, and come to America.”
+
+“Dat’s good! But he’ll be pooty lonesome—dey ain’ no kings here, is
+dey, Huck?”
+
+“No.”
+
+“Den he cain’t git no situation. What he gwyne to do?”
+
+“Well, I don’t know. Some of them gets on the police, and some of them
+learns people how to talk French.”
+
+“Why, Huck, doan’ de French people talk de same way we does?”
+
+“_No_, Jim; you couldn’t understand a word they said—not a single
+word.”
+
+“Well, now, I be ding-busted! How do dat come?”
+
+“_I_ don’t know; but it’s so. I got some of their jabber out of a book.
+S’pose a man was to come to you and say _Polly-voo-franzy_—what would
+you think?”
+
+“I wouldn’ think nuff’n; I’d take en bust him over de head—dat is, if
+he warn’t white. I wouldn’t ’low no nigger to call me dat.”
+
+“Shucks, it ain’t calling you anything. It’s only saying, do you know
+how to talk French?”
+
+“Well, den, why couldn’t he _say_ it?”
+
+“Why, he _is_ a-saying it. That’s a Frenchman’s _way_ of saying it.”
+
+“Well, it’s a blame ridicklous way, en I doan’ want to hear no mo’
+’bout it. Dey ain’ no sense in it.”
+
+“Looky here, Jim; does a cat talk like we do?”
+
+“No, a cat don’t.”
+
+“Well, does a cow?”
+
+“No, a cow don’t, nuther.”
+
+“Does a cat talk like a cow, or a cow talk like a cat?”
+
+“No, dey don’t.”
+
+“It’s natural and right for ’em to talk different from each other,
+ain’t it?”
+
+“’Course.”
+
+“And ain’t it natural and right for a cat and a cow to talk different
+from _us?_”
+
+“Why, mos’ sholy it is.”
+
+“Well, then, why ain’t it natural and right for a _Frenchman_ to talk
+different from us? You answer me that.”
+
+“Is a cat a man, Huck?”
+
+“No.”
+
+“Well, den, dey ain’t no sense in a cat talkin’ like a man. Is a cow a
+man?—er is a cow a cat?”
+
+“No, she ain’t either of them.”
+
+“Well, den, she ain’t got no business to talk like either one er the
+yuther of ’em. Is a Frenchman a man?”
+
+“Yes.”
+
+“_Well_, den! Dad blame it, why doan’ he _talk_ like a man? You answer
+me _dat!_”
+
+I see it warn’t no use wasting words—you can’t learn a nigger to argue.
+So I quit.
+
+
+
+
+CHAPTER XV.
+
+
+We judged that three nights more would fetch us to Cairo, at the bottom
+of Illinois, where the Ohio River comes in, and that was what we was
+after. We would sell the raft and get on a steamboat and go way up the
+Ohio amongst the free States, and then be out of trouble.
+
+Well, the second night a fog begun to come on, and we made for a
+tow-head to tie to, for it wouldn’t do to try to run in a fog; but when
+I paddled ahead in the canoe, with the line to make fast, there warn’t
+anything but little saplings to tie to. I passed the line around one of
+them right on the edge of the cut bank, but there was a stiff current,
+and the raft come booming down so lively she tore it out by the roots
+and away she went. I see the fog closing down, and it made me so sick
+and scared I couldn’t budge for most a half a minute it seemed to
+me—and then there warn’t no raft in sight; you couldn’t see twenty
+yards. I jumped into the canoe and run back to the stern, and grabbed
+the paddle and set her back a stroke. But she didn’t come. I was in
+such a hurry I hadn’t untied her. I got up and tried to untie her, but
+I was so excited my hands shook so I couldn’t hardly do anything with
+them.
+
+As soon as I got started I took out after the raft, hot and heavy,
+right down the tow-head. That was all right as far as it went, but the
+tow-head warn’t sixty yards long, and the minute I flew by the foot of
+it I shot out into the solid white fog, and hadn’t no more idea which
+way I was going than a dead man.
+
+Thinks I, it won’t do to paddle; first I know I’ll run into the bank or
+a tow-head or something; I got to set still and float, and yet it’s
+mighty fidgety business to have to hold your hands still at such a
+time. I whooped and listened. Away down there somewheres I hears a
+small whoop, and up comes my spirits. I went tearing after it,
+listening sharp to hear it again. The next time it come, I see I warn’t
+heading for it, but heading away to the right of it. And the next time
+I was heading away to the left of it—and not gaining on it much either,
+for I was flying around, this way and that and t’other, but it was
+going straight ahead all the time.
+
+I did wish the fool would think to beat a tin pan, and beat it all the
+time, but he never did, and it was the still places between the whoops
+that was making the trouble for me. Well, I fought along, and directly
+I hears the whoop _behind_ me. I was tangled good now. That was
+somebody else’s whoop, or else I was turned around.
+
+I throwed the paddle down. I heard the whoop again; it was behind me
+yet, but in a different place; it kept coming, and kept changing its
+place, and I kept answering, till by-and-by it was in front of me
+again, and I knowed the current had swung the canoe’s head down-stream,
+and I was all right if that was Jim and not some other raftsman
+hollering. I couldn’t tell nothing about voices in a fog, for nothing
+don’t look natural nor sound natural in a fog.
+
+The whooping went on, and in about a minute I come a-booming down on a
+cut bank with smoky ghosts of big trees on it, and the current throwed
+me off to the left and shot by, amongst a lot of snags that fairly
+roared, the current was tearing by them so swift.
+
+In another second or two it was solid white and still again. I set
+perfectly still then, listening to my heart thump, and I reckon I
+didn’t draw a breath while it thumped a hundred.
+
+I just give up then. I knowed what the matter was. That cut bank was an
+island, and Jim had gone down t’other side of it. It warn’t no tow-head
+that you could float by in ten minutes. It had the big timber of a
+regular island; it might be five or six miles long and more than half a
+mile wide.
+
+I kept quiet, with my ears cocked, about fifteen minutes, I reckon. I
+was floating along, of course, four or five miles an hour; but you
+don’t ever think of that. No, you _feel_ like you are laying dead still
+on the water; and if a little glimpse of a snag slips by you don’t
+think to yourself how fast _you’re_ going, but you catch your breath
+and think, my! how that snag’s tearing along. If you think it ain’t
+dismal and lonesome out in a fog that way by yourself in the night, you
+try it once—you’ll see.
+
+Next, for about a half an hour, I whoops now and then; at last I hears
+the answer a long ways off, and tries to follow it, but I couldn’t do
+it, and directly I judged I’d got into a nest of tow-heads, for I had
+little dim glimpses of them on both sides of me—sometimes just a narrow
+channel between, and some that I couldn’t see I knowed was there
+because I’d hear the wash of the current against the old dead brush and
+trash that hung over the banks. Well, I warn’t long loosing the whoops
+down amongst the tow-heads; and I only tried to chase them a little
+while, anyway, because it was worse than chasing a Jack-o’-lantern. You
+never knowed a sound dodge around so, and swap places so quick and so
+much.
+
+I had to claw away from the bank pretty lively four or five times, to
+keep from knocking the islands out of the river; and so I judged the
+raft must be butting into the bank every now and then, or else it would
+get further ahead and clear out of hearing—it was floating a little
+faster than what I was.
+
+Well, I seemed to be in the open river again by-and-by, but I couldn’t
+hear no sign of a whoop nowheres. I reckoned Jim had fetched up on a
+snag, maybe, and it was all up with him. I was good and tired, so I
+laid down in the canoe and said I wouldn’t bother no more. I didn’t
+want to go to sleep, of course; but I was so sleepy I couldn’t help it;
+so I thought I would take jest one little cat-nap.
+
+But I reckon it was more than a cat-nap, for when I waked up the stars
+was shining bright, the fog was all gone, and I was spinning down a big
+bend stern first. First I didn’t know where I was; I thought I was
+dreaming; and when things began to come back to me they seemed to come
+up dim out of last week.
+
+It was a monstrous big river here, with the tallest and the thickest
+kind of timber on both banks; just a solid wall, as well as I could see
+by the stars. I looked away down-stream, and seen a black speck on the
+water. I took after it; but when I got to it it warn’t nothing but a
+couple of sawlogs made fast together. Then I see another speck, and
+chased that; then another, and this time I was right. It was the raft.
+
+When I got to it Jim was setting there with his head down between his
+knees, asleep, with his right arm hanging over the steering-oar. The
+other oar was smashed off, and the raft was littered up with leaves and
+branches and dirt. So she’d had a rough time.
+
+I made fast and laid down under Jim’s nose on the raft, and began to
+gap, and stretch my fists out against Jim, and says:
+
+“Hello, Jim, have I been asleep? Why didn’t you stir me up?”
+
+“Goodness gracious, is dat you, Huck? En you ain’ dead—you ain’
+drownded—you’s back agin? It’s too good for true, honey, it’s too good
+for true. Lemme look at you chile, lemme feel o’ you. No, you ain’
+dead! you’s back agin, ’live en soun’, jis de same ole Huck—de same ole
+Huck, thanks to goodness!”
+
+“What’s the matter with you, Jim? You been a-drinking?”
+
+“Drinkin’? Has I ben a-drinkin’? Has I had a chance to be a-drinkin’?”
+
+“Well, then, what makes you talk so wild?”
+
+“How does I talk wild?”
+
+“_How?_ Why, hain’t you been talking about my coming back, and all that
+stuff, as if I’d been gone away?”
+
+“Huck—Huck Finn, you look me in de eye; look me in de eye. _Hain’t_ you
+ben gone away?”
+
+“Gone away? Why, what in the nation do you mean? _I_ hain’t been gone
+anywheres. Where would I go to?”
+
+“Well, looky here, boss, dey’s sumf’n wrong, dey is. Is I _me_, or who
+_is_ I? Is I heah, or whah _is_ I? Now dat’s what I wants to know.”
+
+“Well, I think you’re here, plain enough, but I think you’re a
+tangle-headed old fool, Jim.”
+
+“I is, is I? Well, you answer me dis: Didn’t you tote out de line in de
+canoe fer to make fas’ to de tow-head?”
+
+“No, I didn’t. What tow-head? I hain’t see no tow-head.”
+
+“You hain’t seen no tow-head? Looky here, didn’t de line pull loose en
+de raf’ go a-hummin’ down de river, en leave you en de canoe behine in
+de fog?”
+
+“What fog?”
+
+“Why, _de_ fog!—de fog dat’s been aroun’ all night. En didn’t you
+whoop, en didn’t I whoop, tell we got mix’ up in de islands en one un
+us got los’ en t’other one was jis’ as good as los’, ’kase he didn’
+know whah he wuz? En didn’t I bust up agin a lot er dem islands en have
+a turrible time en mos’ git drownded? Now ain’ dat so, boss—ain’t it
+so? You answer me dat.”
+
+“Well, this is too many for me, Jim. I hain’t seen no fog, nor no
+islands, nor no troubles, nor nothing. I been setting here talking with
+you all night till you went to sleep about ten minutes ago, and I
+reckon I done the same. You couldn’t a got drunk in that time, so of
+course you’ve been dreaming.”
+
+“Dad fetch it, how is I gwyne to dream all dat in ten minutes?”
+
+“Well, hang it all, you did dream it, because there didn’t any of it
+happen.”
+
+“But, Huck, it’s all jis’ as plain to me as—”
+
+“It don’t make no difference how plain it is; there ain’t nothing in
+it. I know, because I’ve been here all the time.”
+
+Jim didn’t say nothing for about five minutes, but set there studying
+over it. Then he says:
+
+“Well, den, I reck’n I did dream it, Huck; but dog my cats ef it ain’t
+de powerfullest dream I ever see. En I hain’t ever had no dream b’fo’
+dat’s tired me like dis one.”
+
+“Oh, well, that’s all right, because a dream does tire a body like
+everything sometimes. But this one was a staving dream; tell me all
+about it, Jim.”
+
+So Jim went to work and told me the whole thing right through, just as
+it happened, only he painted it up considerable. Then he said he must
+start in and “’terpret” it, because it was sent for a warning. He said
+the first tow-head stood for a man that would try to do us some good,
+but the current was another man that would get us away from him. The
+whoops was warnings that would come to us every now and then, and if we
+didn’t try hard to make out to understand them they’d just take us into
+bad luck, ’stead of keeping us out of it. The lot of tow-heads was
+troubles we was going to get into with quarrelsome people and all kinds
+of mean folks, but if we minded our business and didn’t talk back and
+aggravate them, we would pull through and get out of the fog and into
+the big clear river, which was the free States, and wouldn’t have no
+more trouble.
+
+It had clouded up pretty dark just after I got on to the raft, but it
+was clearing up again now.
+
+“Oh, well, that’s all interpreted well enough as far as it goes, Jim,”
+I says; “but what does _these_ things stand for?”
+
+It was the leaves and rubbish on the raft and the smashed oar. You
+could see them first-rate now.
+
+Jim looked at the trash, and then looked at me, and back at the trash
+again. He had got the dream fixed so strong in his head that he
+couldn’t seem to shake it loose and get the facts back into its place
+again right away. But when he did get the thing straightened around he
+looked at me steady without ever smiling, and says:
+
+“What do dey stan’ for? I’se gwyne to tell you. When I got all wore out
+wid work, en wid de callin’ for you, en went to sleep, my heart wuz
+mos’ broke bekase you wuz los’, en I didn’ k’yer no’ mo’ what become er
+me en de raf’. En when I wake up en fine you back agin, all safe en
+soun’, de tears come, en I could a got down on my knees en kiss yo’
+foot, I’s so thankful. En all you wuz thinkin’ ’bout wuz how you could
+make a fool uv ole Jim wid a lie. Dat truck dah is _trash;_ en trash is
+what people is dat puts dirt on de head er dey fren’s en makes ’em
+ashamed.”
+
+Then he got up slow and walked to the wigwam, and went in there without
+saying anything but that. But that was enough. It made me feel so mean
+I could almost kissed _his_ foot to get him to take it back.
+
+It was fifteen minutes before I could work myself up to go and humble
+myself to a nigger; but I done it, and I warn’t ever sorry for it
+afterwards, neither. I didn’t do him no more mean tricks, and I
+wouldn’t done that one if I’d a knowed it would make him feel that way.
+
+
+
+
+CHAPTER XVI.
+
+
+We slept most all day, and started out at night, a little ways behind a
+monstrous long raft that was as long going by as a procession. She had
+four long sweeps at each end, so we judged she carried as many as
+thirty men, likely. She had five big wigwams aboard, wide apart, and an
+open camp fire in the middle, and a tall flag-pole at each end. There
+was a power of style about her. It _amounted_ to something being a
+raftsman on such a craft as that.
+
+We went drifting down into a big bend, and the night clouded up and got
+hot. The river was very wide, and was walled with solid timber on both
+sides; you couldn’t see a break in it hardly ever, or a light. We
+talked about Cairo, and wondered whether we would know it when we got
+to it. I said likely we wouldn’t, because I had heard say there warn’t
+but about a dozen houses there, and if they didn’t happen to have them
+lit up, how was we going to know we was passing a town? Jim said if the
+two big rivers joined together there, that would show. But I said maybe
+we might think we was passing the foot of an island and coming into the
+same old river again. That disturbed Jim—and me too. So the question
+was, what to do? I said, paddle ashore the first time a light showed,
+and tell them pap was behind, coming along with a trading-scow, and was
+a green hand at the business, and wanted to know how far it was to
+Cairo. Jim thought it was a good idea, so we took a smoke on it and
+waited.
+
+There warn’t nothing to do now but to look out sharp for the town, and
+not pass it without seeing it. He said he’d be mighty sure to see it,
+because he’d be a free man the minute he seen it, but if he missed it
+he’d be in a slave country again and no more show for freedom. Every
+little while he jumps up and says:
+
+“Dah she is?”
+
+But it warn’t. It was Jack-o’-lanterns, or lightning bugs; so he set
+down again, and went to watching, same as before. Jim said it made him
+all over trembly and feverish to be so close to freedom. Well, I can
+tell you it made me all over trembly and feverish, too, to hear him,
+because I begun to get it through my head that he _was_ most free—and
+who was to blame for it? Why, _me_. I couldn’t get that out of my
+conscience, no how nor no way. It got to troubling me so I couldn’t
+rest; I couldn’t stay still in one place. It hadn’t ever come home to
+me before, what this thing was that I was doing. But now it did; and it
+stayed with me, and scorched me more and more. I tried to make out to
+myself that _I_ warn’t to blame, because _I_ didn’t run Jim off from
+his rightful owner; but it warn’t no use, conscience up and says, every
+time, “But you knowed he was running for his freedom, and you could a
+paddled ashore and told somebody.” That was so—I couldn’t get around
+that noway. That was where it pinched. Conscience says to me, “What had
+poor Miss Watson done to you that you could see her nigger go off right
+under your eyes and never say one single word? What did that poor old
+woman do to you that you could treat her so mean? Why, she tried to
+learn you your book, she tried to learn you your manners, she tried to
+be good to you every way she knowed how. _That’s_ what she done.”
+
+I got to feeling so mean and so miserable I most wished I was dead. I
+fidgeted up and down the raft, abusing myself to myself, and Jim was
+fidgeting up and down past me. We neither of us could keep still. Every
+time he danced around and says, “Dah’s Cairo!” it went through me like
+a shot, and I thought if it _was_ Cairo I reckoned I would die of
+miserableness.
+
+Jim talked out loud all the time while I was talking to myself. He was
+saying how the first thing he would do when he got to a free State he
+would go to saving up money and never spend a single cent, and when he
+got enough he would buy his wife, which was owned on a farm close to
+where Miss Watson lived; and then they would both work to buy the two
+children, and if their master wouldn’t sell them, they’d get an
+Ab’litionist to go and steal them.
+
+It most froze me to hear such talk. He wouldn’t ever dared to talk such
+talk in his life before. Just see what a difference it made in him the
+minute he judged he was about free. It was according to the old saying,
+“Give a nigger an inch and he’ll take an ell.” Thinks I, this is what
+comes of my not thinking. Here was this nigger, which I had as good as
+helped to run away, coming right out flat-footed and saying he would
+steal his children—children that belonged to a man I didn’t even know;
+a man that hadn’t ever done me no harm.
+
+I was sorry to hear Jim say that, it was such a lowering of him. My
+conscience got to stirring me up hotter than ever, until at last I says
+to it, “Let up on me—it ain’t too late yet—I’ll paddle ashore at the
+first light and tell.” I felt easy and happy and light as a feather
+right off. All my troubles was gone. I went to looking out sharp for a
+light, and sort of singing to myself. By-and-by one showed. Jim sings
+out:
+
+“We’s safe, Huck, we’s safe! Jump up and crack yo’ heels! Dat’s de good
+ole Cairo at las’, I jis knows it!”
+
+I says:
+
+“I’ll take the canoe and go and see, Jim. It mightn’t be, you know.”
+
+He jumped and got the canoe ready, and put his old coat in the bottom
+for me to set on, and give me the paddle; and as I shoved off, he says:
+
+“Pooty soon I’ll be a-shout’n’ for joy, en I’ll say, it’s all on
+accounts o’ Huck; I’s a free man, en I couldn’t ever ben free ef it
+hadn’ ben for Huck; Huck done it. Jim won’t ever forgit you, Huck;
+you’s de bes’ fren’ Jim’s ever had; en you’s de _only_ fren’ ole Jim’s
+got now.”
+
+I was paddling off, all in a sweat to tell on him; but when he says
+this, it seemed to kind of take the tuck all out of me. I went along
+slow then, and I warn’t right down certain whether I was glad I started
+or whether I warn’t. When I was fifty yards off, Jim says:
+
+“Dah you goes, de ole true Huck; de on’y white genlman dat ever kep’
+his promise to ole Jim.”
+
+Well, I just felt sick. But I says, I _got_ to do it—I can’t get _out_
+of it. Right then along comes a skiff with two men in it with guns, and
+they stopped and I stopped. One of them says:
+
+“What’s that yonder?”
+
+“A piece of a raft,” I says.
+
+“Do you belong on it?”
+
+“Yes, sir.”
+
+“Any men on it?”
+
+“Only one, sir.”
+
+“Well, there’s five niggers run off to-night up yonder, above the head
+of the bend. Is your man white or black?”
+
+I didn’t answer up prompt. I tried to, but the words wouldn’t come. I
+tried for a second or two to brace up and out with it, but I warn’t man
+enough—hadn’t the spunk of a rabbit. I see I was weakening; so I just
+give up trying, and up and says:
+
+“He’s white.”
+
+“I reckon we’ll go and see for ourselves.”
+
+“I wish you would,” says I, “because it’s pap that’s there, and maybe
+you’d help me tow the raft ashore where the light is. He’s sick—and so
+is mam and Mary Ann.”
+
+“Oh, the devil! we’re in a hurry, boy. But I s’pose we’ve got to. Come,
+buckle to your paddle, and let’s get along.”
+
+I buckled to my paddle and they laid to their oars. When we had made a
+stroke or two, I says:
+
+“Pap’ll be mighty much obleeged to you, I can tell you. Everybody goes
+away when I want them to help me tow the raft ashore, and I can’t do it
+by myself.”
+
+“Well, that’s infernal mean. Odd, too. Say, boy, what’s the matter with
+your father?”
+
+“It’s the—a—the—well, it ain’t anything much.”
+
+They stopped pulling. It warn’t but a mighty little ways to the raft
+now. One says:
+
+“Boy, that’s a lie. What _is_ the matter with your pap? Answer up
+square now, and it’ll be the better for you.”
+
+“I will, sir, I will, honest—but don’t leave us, please. It’s
+the—the—gentlemen, if you’ll only pull ahead, and let me heave you the
+headline, you won’t have to come a-near the raft—please do.”
+
+“Set her back, John, set her back!” says one. They backed water. “Keep
+away, boy—keep to looard. Confound it, I just expect the wind has
+blowed it to us. Your pap’s got the small-pox, and you know it precious
+well. Why didn’t you come out and say so? Do you want to spread it all
+over?”
+
+“Well,” says I, a-blubbering, “I’ve told everybody before, and they
+just went away and left us.”
+
+“Poor devil, there’s something in that. We are right down sorry for
+you, but we—well, hang it, we don’t want the small-pox, you see. Look
+here, I’ll tell you what to do. Don’t you try to land by yourself, or
+you’ll smash everything to pieces. You float along down about twenty
+miles, and you’ll come to a town on the left-hand side of the river. It
+will be long after sun-up then, and when you ask for help you tell them
+your folks are all down with chills and fever. Don’t be a fool again,
+and let people guess what is the matter. Now we’re trying to do you a
+kindness; so you just put twenty miles between us, that’s a good boy.
+It wouldn’t do any good to land yonder where the light is—it’s only a
+wood-yard. Say, I reckon your father’s poor, and I’m bound to say he’s
+in pretty hard luck. Here, I’ll put a twenty-dollar gold piece on this
+board, and you get it when it floats by. I feel mighty mean to leave
+you; but my kingdom! it won’t do to fool with small-pox, don’t you
+see?”
+
+“Hold on, Parker,” says the other man, “here’s a twenty to put on the
+board for me. Good-bye, boy; you do as Mr. Parker told you, and you’ll
+be all right.”
+
+“That’s so, my boy—good-bye, good-bye. If you see any runaway niggers
+you get help and nab them, and you can make some money by it.”
+
+“Good-bye, sir,” says I; “I won’t let no runaway niggers get by me if I
+can help it.”
+
+They went off and I got aboard the raft, feeling bad and low, because I
+knowed very well I had done wrong, and I see it warn’t no use for me to
+try to learn to do right; a body that don’t get _started_ right when
+he’s little ain’t got no show—when the pinch comes there ain’t nothing
+to back him up and keep him to his work, and so he gets beat. Then I
+thought a minute, and says to myself, hold on; s’pose you’d a done
+right and give Jim up, would you felt better than what you do now? No,
+says I, I’d feel bad—I’d feel just the same way I do now. Well, then,
+says I, what’s the use you learning to do right when it’s troublesome
+to do right and ain’t no trouble to do wrong, and the wages is just the
+same? I was stuck. I couldn’t answer that. So I reckoned I wouldn’t
+bother no more about it, but after this always do whichever come
+handiest at the time.
+
+I went into the wigwam; Jim warn’t there. I looked all around; he
+warn’t anywhere. I says:
+
+“Jim!”
+
+“Here I is, Huck. Is dey out o’ sight yit? Don’t talk loud.”
+
+He was in the river under the stern oar, with just his nose out. I told
+him they were out of sight, so he come aboard. He says:
+
+“I was a-listenin’ to all de talk, en I slips into de river en was
+gwyne to shove for sho’ if dey come aboard. Den I was gwyne to swim to
+de raf’ agin when dey was gone. But lawsy, how you did fool ’em, Huck!
+Dat _wuz_ de smartes’ dodge! I tell you, chile, I ’speck it save’ ole
+Jim—ole Jim ain’t going to forgit you for dat, honey.”
+
+Then we talked about the money. It was a pretty good raise—twenty
+dollars apiece. Jim said we could take deck passage on a steamboat now,
+and the money would last us as far as we wanted to go in the free
+States. He said twenty mile more warn’t far for the raft to go, but he
+wished we was already there.
+
+Towards daybreak we tied up, and Jim was mighty particular about hiding
+the raft good. Then he worked all day fixing things in bundles, and
+getting all ready to quit rafting.
+
+That night about ten we hove in sight of the lights of a town away down
+in a left-hand bend.
+
+I went off in the canoe to ask about it. Pretty soon I found a man out
+in the river with a skiff, setting a trot-line. I ranged up and says:
+
+“Mister, is that town Cairo?”
+
+“Cairo? no. You must be a blame’ fool.”
+
+“What town is it, mister?”
+
+“If you want to know, go and find out. If you stay here botherin’
+around me for about a half a minute longer you’ll get something you
+won’t want.”
+
+I paddled to the raft. Jim was awful disappointed, but I said never
+mind, Cairo would be the next place, I reckoned.
+
+We passed another town before daylight, and I was going out again; but
+it was high ground, so I didn’t go. No high ground about Cairo, Jim
+said. I had forgot it. We laid up for the day on a tow-head tolerable
+close to the left-hand bank. I begun to suspicion something. So did
+Jim. I says:
+
+“Maybe we went by Cairo in the fog that night.”
+
+He says:
+
+“Doan’ le’s talk about it, Huck. Po’ niggers can’t have no luck. I
+awluz ’spected dat rattlesnake-skin warn’t done wid its work.”
+
+“I wish I’d never seen that snake-skin, Jim—I do wish I’d never laid
+eyes on it.”
+
+“It ain’t yo’ fault, Huck; you didn’ know. Don’t you blame yo’self
+’bout it.”
+
+When it was daylight, here was the clear Ohio water inshore, sure
+enough, and outside was the old regular Muddy! So it was all up with
+Cairo.
+
+We talked it all over. It wouldn’t do to take to the shore; we couldn’t
+take the raft up the stream, of course. There warn’t no way but to wait
+for dark, and start back in the canoe and take the chances. So we slept
+all day amongst the cottonwood thicket, so as to be fresh for the work,
+and when we went back to the raft about dark the canoe was gone!
+
+We didn’t say a word for a good while. There warn’t anything to say. We
+both knowed well enough it was some more work of the rattlesnake-skin;
+so what was the use to talk about it? It would only look like we was
+finding fault, and that would be bound to fetch more bad luck—and keep
+on fetching it, too, till we knowed enough to keep still.
+
+By-and-by we talked about what we better do, and found there warn’t no
+way but just to go along down with the raft till we got a chance to buy
+a canoe to go back in. We warn’t going to borrow it when there warn’t
+anybody around, the way pap would do, for that might set people after
+us.
+
+So we shoved out after dark on the raft.
+
+Anybody that don’t believe yet that it’s foolishness to handle a
+snake-skin, after all that that snake-skin done for us, will believe it
+now if they read on and see what more it done for us.
+
+The place to buy canoes is off of rafts laying up at shore. But we
+didn’t see no rafts laying up; so we went along during three hours and
+more. Well, the night got gray and ruther thick, which is the next
+meanest thing to fog. You can’t tell the shape of the river, and you
+can’t see no distance. It got to be very late and still, and then along
+comes a steamboat up the river. We lit the lantern, and judged she
+would see it. Up-stream boats didn’t generly come close to us; they go
+out and follow the bars and hunt for easy water under the reefs; but
+nights like this they bull right up the channel against the whole
+river.
+
+We could hear her pounding along, but we didn’t see her good till she
+was close. She aimed right for us. Often they do that and try to see
+how close they can come without touching; sometimes the wheel bites off
+a sweep, and then the pilot sticks his head out and laughs, and thinks
+he’s mighty smart. Well, here she comes, and we said she was going to
+try and shave us; but she didn’t seem to be sheering off a bit. She was
+a big one, and she was coming in a hurry, too, looking like a black
+cloud with rows of glow-worms around it; but all of a sudden she bulged
+out, big and scary, with a long row of wide-open furnace doors shining
+like red-hot teeth, and her monstrous bows and guards hanging right
+over us. There was a yell at us, and a jingling of bells to stop the
+engines, a powwow of cussing, and whistling of steam—and as Jim went
+overboard on one side and I on the other, she come smashing straight
+through the raft.
+
+I dived—and I aimed to find the bottom, too, for a thirty-foot wheel
+had got to go over me, and I wanted it to have plenty of room. I could
+always stay under water a minute; this time I reckon I stayed under a
+minute and a half. Then I bounced for the top in a hurry, for I was
+nearly busting. I popped out to my armpits and blowed the water out of
+my nose, and puffed a bit. Of course there was a booming current; and
+of course that boat started her engines again ten seconds after she
+stopped them, for they never cared much for raftsmen; so now she was
+churning along up the river, out of sight in the thick weather, though
+I could hear her.
+
+I sung out for Jim about a dozen times, but I didn’t get any answer; so
+I grabbed a plank that touched me while I was “treading water,” and
+struck out for shore, shoving it ahead of me. But I made out to see
+that the drift of the current was towards the left-hand shore, which
+meant that I was in a crossing; so I changed off and went that way.
+
+It was one of these long, slanting, two-mile crossings; so I was a good
+long time in getting over. I made a safe landing, and clumb up the
+bank. I couldn’t see but a little ways, but I went poking along over
+rough ground for a quarter of a mile or more, and then I run across a
+big old-fashioned double log-house before I noticed it. I was going to
+rush by and get away, but a lot of dogs jumped out and went to howling
+and barking at me, and I knowed better than to move another peg.
+
+
+
+
+CHAPTER XVII.
+
+
+In about a minute somebody spoke out of a window without putting his
+head out, and says:
+
+“Be done, boys! Who’s there?”
+
+I says:
+
+“It’s me.”
+
+“Who’s me?”
+
+“George Jackson, sir.”
+
+“What do you want?”
+
+“I don’t want nothing, sir. I only want to go along by, but the dogs
+won’t let me.”
+
+“What are you prowling around here this time of night for—hey?”
+
+“I warn’t prowling around, sir, I fell overboard off of the steamboat.”
+
+“Oh, you did, did you? Strike a light there, somebody. What did you say
+your name was?”
+
+“George Jackson, sir. I’m only a boy.”
+
+“Look here, if you’re telling the truth you needn’t be afraid—nobody’ll
+hurt you. But don’t try to budge; stand right where you are. Rouse out
+Bob and Tom, some of you, and fetch the guns. George Jackson, is there
+anybody with you?”
+
+“No, sir, nobody.”
+
+I heard the people stirring around in the house now, and see a light.
+The man sung out:
+
+“Snatch that light away, Betsy, you old fool—ain’t you got any sense?
+Put it on the floor behind the front door. Bob, if you and Tom are
+ready, take your places.”
+
+“All ready.”
+
+“Now, George Jackson, do you know the Shepherdsons?”
+
+“No, sir; I never heard of them.”
+
+“Well, that may be so, and it mayn’t. Now, all ready. Step forward,
+George Jackson. And mind, don’t you hurry—come mighty slow. If there’s
+anybody with you, let him keep back—if he shows himself he’ll be shot.
+Come along now. Come slow; push the door open yourself—just enough to
+squeeze in, d’ you hear?”
+
+I didn’t hurry; I couldn’t if I’d a wanted to. I took one slow step at
+a time and there warn’t a sound, only I thought I could hear my heart.
+The dogs were as still as the humans, but they followed a little behind
+me. When I got to the three log doorsteps I heard them unlocking and
+unbarring and unbolting. I put my hand on the door and pushed it a
+little and a little more till somebody said, “There, that’s enough—put
+your head in.” I done it, but I judged they would take it off.
+
+The candle was on the floor, and there they all was, looking at me, and
+me at them, for about a quarter of a minute: Three big men with guns
+pointed at me, which made me wince, I tell you; the oldest, gray and
+about sixty, the other two thirty or more—all of them fine and
+handsome—and the sweetest old gray-headed lady, and back of her two
+young women which I couldn’t see right well. The old gentleman says:
+
+“There; I reckon it’s all right. Come in.”
+
+As soon as I was in the old gentleman he locked the door and barred it
+and bolted it, and told the young men to come in with their guns, and
+they all went in a big parlor that had a new rag carpet on the floor,
+and got together in a corner that was out of the range of the front
+windows—there warn’t none on the side. They held the candle, and took a
+good look at me, and all said, “Why, _he_ ain’t a Shepherdson—no, there
+ain’t any Shepherdson about him.” Then the old man said he hoped I
+wouldn’t mind being searched for arms, because he didn’t mean no harm
+by it—it was only to make sure. So he didn’t pry into my pockets, but
+only felt outside with his hands, and said it was all right. He told me
+to make myself easy and at home, and tell all about myself; but the old
+lady says:
+
+“Why, bless you, Saul, the poor thing’s as wet as he can be; and don’t
+you reckon it may be he’s hungry?”
+
+“True for you, Rachel—I forgot.”
+
+So the old lady says:
+
+“Betsy” (this was a nigger woman), “you fly around and get him
+something to eat as quick as you can, poor thing; and one of you girls
+go and wake up Buck and tell him—oh, here he is himself. Buck, take
+this little stranger and get the wet clothes off from him and dress him
+up in some of yours that’s dry.”
+
+Buck looked about as old as me—thirteen or fourteen or along there,
+though he was a little bigger than me. He hadn’t on anything but a
+shirt, and he was very frowzy-headed. He came in gaping and digging one
+fist into his eyes, and he was dragging a gun along with the other one.
+He says:
+
+“Ain’t they no Shepherdsons around?”
+
+They said, no, ’twas a false alarm.
+
+“Well,” he says, “if they’d a ben some, I reckon I’d a got one.”
+
+They all laughed, and Bob says:
+
+“Why, Buck, they might have scalped us all, you’ve been so slow in
+coming.”
+
+“Well, nobody come after me, and it ain’t right I’m always kept down; I
+don’t get no show.”
+
+“Never mind, Buck, my boy,” says the old man, “you’ll have show enough,
+all in good time, don’t you fret about that. Go ’long with you now, and
+do as your mother told you.”
+
+When we got up-stairs to his room he got me a coarse shirt and a
+roundabout and pants of his, and I put them on. While I was at it he
+asked me what my name was, but before I could tell him he started to
+tell me about a bluejay and a young rabbit he had catched in the woods
+day before yesterday, and he asked me where Moses was when the candle
+went out. I said I didn’t know; I hadn’t heard about it before, no way.
+
+“Well, guess,” he says.
+
+“How’m I going to guess,” says I, “when I never heard tell of it
+before?”
+
+“But you can guess, can’t you? It’s just as easy.”
+
+“_Which_ candle?” I says.
+
+“Why, any candle,” he says.
+
+“I don’t know where he was,” says I; “where was he?”
+
+“Why, he was in the _dark!_ That’s where he was!”
+
+“Well, if you knowed where he was, what did you ask me for?”
+
+“Why, blame it, it’s a riddle, don’t you see? Say, how long are you
+going to stay here? You got to stay always. We can just have booming
+times—they don’t have no school now. Do you own a dog? I’ve got a
+dog—and he’ll go in the river and bring out chips that you throw in. Do
+you like to comb up Sundays, and all that kind of foolishness? You bet
+I don’t, but ma she makes me. Confound these ole britches! I reckon I’d
+better put ’em on, but I’d ruther not, it’s so warm. Are you all ready?
+All right. Come along, old hoss.”
+
+Cold corn-pone, cold corn-beef, butter and buttermilk—that is what they
+had for me down there, and there ain’t nothing better that ever I’ve
+come across yet. Buck and his ma and all of them smoked cob pipes,
+except the nigger woman, which was gone, and the two young women. They
+all smoked and talked, and I eat and talked. The young women had quilts
+around them, and their hair down their backs. They all asked me
+questions, and I told them how pap and me and all the family was living
+on a little farm down at the bottom of Arkansaw, and my sister Mary Ann
+run off and got married and never was heard of no more, and Bill went
+to hunt them and he warn’t heard of no more, and Tom and Mort died, and
+then there warn’t nobody but just me and pap left, and he was just
+trimmed down to nothing, on account of his troubles; so when he died I
+took what there was left, because the farm didn’t belong to us, and
+started up the river, deck passage, and fell overboard; and that was
+how I come to be here. So they said I could have a home there as long
+as I wanted it. Then it was most daylight and everybody went to bed,
+and I went to bed with Buck, and when I waked up in the morning, drat
+it all, I had forgot what my name was. So I laid there about an hour
+trying to think, and when Buck waked up I says:
+
+“Can you spell, Buck?”
+
+“Yes,” he says.
+
+“I bet you can’t spell my name,” says I.
+
+“I bet you what you dare I can,” says he.
+
+“All right,” says I, “go ahead.”
+
+“G-e-o-r-g-e J-a-x-o-n—there now,” he says.
+
+“Well,” says I, “you done it, but I didn’t think you could. It ain’t no
+slouch of a name to spell—right off without studying.”
+
+I set it down, private, because somebody might want _me_ to spell it
+next, and so I wanted to be handy with it and rattle it off like I was
+used to it.
+
+It was a mighty nice family, and a mighty nice house, too. I hadn’t
+seen no house out in the country before that was so nice and had so
+much style. It didn’t have an iron latch on the front door, nor a
+wooden one with a buckskin string, but a brass knob to turn, the same
+as houses in town. There warn’t no bed in the parlor, nor a sign of a
+bed; but heaps of parlors in towns has beds in them. There was a big
+fireplace that was bricked on the bottom, and the bricks was kept clean
+and red by pouring water on them and scrubbing them with another brick;
+sometimes they wash them over with red water-paint that they call
+Spanish-brown, same as they do in town. They had big brass dog-irons
+that could hold up a saw-log. There was a clock on the middle of the
+mantelpiece, with a picture of a town painted on the bottom half of the
+glass front, and a round place in the middle of it for the sun, and you
+could see the pendulum swinging behind it. It was beautiful to hear
+that clock tick; and sometimes when one of these peddlers had been
+along and scoured her up and got her in good shape, she would start in
+and strike a hundred and fifty before she got tuckered out. They
+wouldn’t took any money for her.
+
+Well, there was a big outlandish parrot on each side of the clock, made
+out of something like chalk, and painted up gaudy. By one of the
+parrots was a cat made of crockery, and a crockery dog by the other;
+and when you pressed down on them they squeaked, but didn’t open their
+mouths nor look different nor interested. They squeaked through
+underneath. There was a couple of big wild-turkey-wing fans spread out
+behind those things. On the table in the middle of the room was a kind
+of a lovely crockery basket that had apples and oranges and peaches and
+grapes piled up in it, which was much redder and yellower and prettier
+than real ones is, but they warn’t real because you could see where
+pieces had got chipped off and showed the white chalk, or whatever it
+was, underneath.
+
+This table had a cover made out of beautiful oilcloth, with a red and
+blue spread-eagle painted on it, and a painted border all around. It
+come all the way from Philadelphia, they said. There was some books,
+too, piled up perfectly exact, on each corner of the table. One was a
+big family Bible full of pictures. One was Pilgrim’s Progress, about a
+man that left his family, it didn’t say why. I read considerable in it
+now and then. The statements was interesting, but tough. Another was
+Friendship’s Offering, full of beautiful stuff and poetry; but I didn’t
+read the poetry. Another was Henry Clay’s Speeches, and another was Dr.
+Gunn’s Family Medicine, which told you all about what to do if a body
+was sick or dead. There was a hymn book, and a lot of other books. And
+there was nice split-bottom chairs, and perfectly sound, too—not bagged
+down in the middle and busted, like an old basket.
+
+They had pictures hung on the walls—mainly Washingtons and Lafayettes,
+and battles, and Highland Marys, and one called “Signing the
+Declaration.” There was some that they called crayons, which one of the
+daughters which was dead made her own self when she was only fifteen
+years old. They was different from any pictures I ever see
+before—blacker, mostly, than is common. One was a woman in a slim black
+dress, belted small under the armpits, with bulges like a cabbage in
+the middle of the sleeves, and a large black scoop-shovel bonnet with a
+black veil, and white slim ankles crossed about with black tape, and
+very wee black slippers, like a chisel, and she was leaning pensive on
+a tombstone on her right elbow, under a weeping willow, and her other
+hand hanging down her side holding a white handkerchief and a reticule,
+and underneath the picture it said “Shall I Never See Thee More Alas.”
+Another one was a young lady with her hair all combed up straight to
+the top of her head, and knotted there in front of a comb like a
+chair-back, and she was crying into a handkerchief and had a dead bird
+laying on its back in her other hand with its heels up, and underneath
+the picture it said “I Shall Never Hear Thy Sweet Chirrup More Alas.”
+There was one where a young lady was at a window looking up at the
+moon, and tears running down her cheeks; and she had an open letter in
+one hand with black sealing wax showing on one edge of it, and she was
+mashing a locket with a chain to it against her mouth, and underneath
+the picture it said “And Art Thou Gone Yes Thou Art Gone Alas.” These
+was all nice pictures, I reckon, but I didn’t somehow seem to take to
+them, because if ever I was down a little they always give me the
+fan-tods. Everybody was sorry she died, because she had laid out a lot
+more of these pictures to do, and a body could see by what she had done
+what they had lost. But I reckoned that with her disposition she was
+having a better time in the graveyard. She was at work on what they
+said was her greatest picture when she took sick, and every day and
+every night it was her prayer to be allowed to live till she got it
+done, but she never got the chance. It was a picture of a young woman
+in a long white gown, standing on the rail of a bridge all ready to
+jump off, with her hair all down her back, and looking up to the moon,
+with the tears running down her face, and she had two arms folded
+across her breast, and two arms stretched out in front, and two more
+reaching up towards the moon—and the idea was to see which pair would
+look best, and then scratch out all the other arms; but, as I was
+saying, she died before she got her mind made up, and now they kept
+this picture over the head of the bed in her room, and every time her
+birthday come they hung flowers on it. Other times it was hid with a
+little curtain. The young woman in the picture had a kind of a nice
+sweet face, but there was so many arms it made her look too spidery,
+seemed to me.
+
+This young girl kept a scrap-book when she was alive, and used to paste
+obituaries and accidents and cases of patient suffering in it out of
+the _Presbyterian Observer_, and write poetry after them out of her own
+head. It was very good poetry. This is what she wrote about a boy by
+the name of Stephen Dowling Bots that fell down a well and was
+drownded:
+
+ODE TO STEPHEN DOWLING BOTS, DEC’D
+
+And did young Stephen sicken,
+    And did young Stephen die?
+And did the sad hearts thicken,
+    And did the mourners cry?
+
+No; such was not the fate of
+    Young Stephen Dowling Bots;
+Though sad hearts round him thickened,
+    ’Twas not from sickness’ shots.
+
+No whooping-cough did rack his frame,
+    Nor measles drear with spots;
+Not these impaired the sacred name
+    Of Stephen Dowling Bots.
+
+Despised love struck not with woe
+    That head of curly knots,
+Nor stomach troubles laid him low,
+    Young Stephen Dowling Bots.
+
+O no. Then list with tearful eye,
+    Whilst I his fate do tell.
+His soul did from this cold world fly
+    By falling down a well.
+
+They got him out and emptied him;
+    Alas it was too late;
+His spirit was gone for to sport aloft
+    In the realms of the good and great.
+
+If Emmeline Grangerford could make poetry like that before she was
+fourteen, there ain’t no telling what she could a done by-and-by. Buck
+said she could rattle off poetry like nothing. She didn’t ever have to
+stop to think. He said she would slap down a line, and if she couldn’t
+find anything to rhyme with it would just scratch it out and slap down
+another one, and go ahead. She warn’t particular; she could write about
+anything you choose to give her to write about just so it was sadful.
+Every time a man died, or a woman died, or a child died, she would be
+on hand with her “tribute” before he was cold. She called them
+tributes. The neighbors said it was the doctor first, then Emmeline,
+then the undertaker—the undertaker never got in ahead of Emmeline but
+once, and then she hung fire on a rhyme for the dead person’s name,
+which was Whistler. She warn’t ever the same after that; she never
+complained, but she kinder pined away and did not live long. Poor
+thing, many’s the time I made myself go up to the little room that used
+to be hers and get out her poor old scrap-book and read in it when her
+pictures had been aggravating me and I had soured on her a little. I
+liked all that family, dead ones and all, and warn’t going to let
+anything come between us. Poor Emmeline made poetry about all the dead
+people when she was alive, and it didn’t seem right that there warn’t
+nobody to make some about her now she was gone; so I tried to sweat out
+a verse or two myself, but I couldn’t seem to make it go somehow. They
+kept Emmeline’s room trim and nice, and all the things fixed in it just
+the way she liked to have them when she was alive, and nobody ever
+slept there. The old lady took care of the room herself, though there
+was plenty of niggers, and she sewed there a good deal and read her
+Bible there mostly.
+
+Well, as I was saying about the parlor, there was beautiful curtains on
+the windows: white, with pictures painted on them of castles with vines
+all down the walls, and cattle coming down to drink. There was a little
+old piano, too, that had tin pans in it, I reckon, and nothing was ever
+so lovely as to hear the young ladies sing “The Last Link is Broken”
+and play “The Battle of Prague” on it. The walls of all the rooms was
+plastered, and most had carpets on the floors, and the whole house was
+whitewashed on the outside.
+
+It was a double house, and the big open place betwixt them was roofed
+and floored, and sometimes the table was set there in the middle of the
+day, and it was a cool, comfortable place. Nothing couldn’t be better.
+And warn’t the cooking good, and just bushels of it too!
+
+
+
+
+CHAPTER XVIII.
+
+
+Col. Grangerford was a gentleman, you see. He was a gentleman all over;
+and so was his family. He was well born, as the saying is, and that’s
+worth as much in a man as it is in a horse, so the Widow Douglas said,
+and nobody ever denied that she was of the first aristocracy in our
+town; and pap he always said it, too, though he warn’t no more quality
+than a mudcat himself. Col. Grangerford was very tall and very slim,
+and had a darkish-paly complexion, not a sign of red in it anywheres;
+he was clean shaved every morning all over his thin face, and he had
+the thinnest kind of lips, and the thinnest kind of nostrils, and a
+high nose, and heavy eyebrows, and the blackest kind of eyes, sunk so
+deep back that they seemed like they was looking out of caverns at you,
+as you may say. His forehead was high, and his hair was black and
+straight and hung to his shoulders. His hands was long and thin, and
+every day of his life he put on a clean shirt and a full suit from head
+to foot made out of linen so white it hurt your eyes to look at it; and
+on Sundays he wore a blue tail-coat with brass buttons on it. He
+carried a mahogany cane with a silver head to it. There warn’t no
+frivolishness about him, not a bit, and he warn’t ever loud. He was as
+kind as he could be—you could feel that, you know, and so you had
+confidence. Sometimes he smiled, and it was good to see; but when he
+straightened himself up like a liberty-pole, and the lightning begun to
+flicker out from under his eyebrows, you wanted to climb a tree first,
+and find out what the matter was afterwards. He didn’t ever have to
+tell anybody to mind their manners—everybody was always good-mannered
+where he was. Everybody loved to have him around, too; he was sunshine
+most always—I mean he made it seem like good weather. When he turned
+into a cloudbank it was awful dark for half a minute, and that was
+enough; there wouldn’t nothing go wrong again for a week.
+
+When him and the old lady come down in the morning all the family got
+up out of their chairs and give them good-day, and didn’t set down
+again till they had set down. Then Tom and Bob went to the sideboard
+where the decanter was, and mixed a glass of bitters and handed it to
+him, and he held it in his hand and waited till Tom’s and Bob’s was
+mixed, and then they bowed and said, “Our duty to you, sir, and madam;”
+and _they_ bowed the least bit in the world and said thank you, and so
+they drank, all three, and Bob and Tom poured a spoonful of water on
+the sugar and the mite of whisky or apple brandy in the bottom of their
+tumblers, and give it to me and Buck, and we drank to the old people
+too.
+
+Bob was the oldest and Tom next—tall, beautiful men with very broad
+shoulders and brown faces, and long black hair and black eyes. They
+dressed in white linen from head to foot, like the old gentleman, and
+wore broad Panama hats.
+
+Then there was Miss Charlotte; she was twenty-five, and tall and proud
+and grand, but as good as she could be when she warn’t stirred up; but
+when she was, she had a look that would make you wilt in your tracks,
+like her father. She was beautiful.
+
+So was her sister, Miss Sophia, but it was a different kind. She was
+gentle and sweet like a dove, and she was only twenty.
+
+Each person had their own nigger to wait on them—Buck too. My nigger
+had a monstrous easy time, because I warn’t used to having anybody do
+anything for me, but Buck’s was on the jump most of the time.
+
+This was all there was of the family now, but there used to be
+more—three sons; they got killed; and Emmeline that died.
+
+The old gentleman owned a lot of farms and over a hundred niggers.
+Sometimes a stack of people would come there, horseback, from ten or
+fifteen mile around, and stay five or six days, and have such
+junketings round about and on the river, and dances and picnics in the
+woods daytimes, and balls at the house nights. These people was mostly
+kinfolks of the family. The men brought their guns with them. It was a
+handsome lot of quality, I tell you.
+
+There was another clan of aristocracy around there—five or six
+families—mostly of the name of Shepherdson. They was as high-toned and
+well born and rich and grand as the tribe of Grangerfords. The
+Shepherdsons and Grangerfords used the same steamboat landing, which
+was about two mile above our house; so sometimes when I went up there
+with a lot of our folks I used to see a lot of the Shepherdsons there
+on their fine horses.
+
+One day Buck and me was away out in the woods hunting, and heard a
+horse coming. We was crossing the road. Buck says:
+
+“Quick! Jump for the woods!”
+
+We done it, and then peeped down the woods through the leaves. Pretty
+soon a splendid young man come galloping down the road, setting his
+horse easy and looking like a soldier. He had his gun across his
+pommel. I had seen him before. It was young Harney Shepherdson. I heard
+Buck’s gun go off at my ear, and Harney’s hat tumbled off from his
+head. He grabbed his gun and rode straight to the place where we was
+hid. But we didn’t wait. We started through the woods on a run. The
+woods warn’t thick, so I looked over my shoulder to dodge the bullet,
+and twice I seen Harney cover Buck with his gun; and then he rode away
+the way he come—to get his hat, I reckon, but I couldn’t see. We never
+stopped running till we got home. The old gentleman’s eyes blazed a
+minute—’twas pleasure, mainly, I judged—then his face sort of smoothed
+down, and he says, kind of gentle:
+
+“I don’t like that shooting from behind a bush. Why didn’t you step
+into the road, my boy?”
+
+“The Shepherdsons don’t, father. They always take advantage.”
+
+Miss Charlotte she held her head up like a queen while Buck was telling
+his tale, and her nostrils spread and her eyes snapped. The two young
+men looked dark, but never said nothing. Miss Sophia she turned pale,
+but the color come back when she found the man warn’t hurt.
+
+Soon as I could get Buck down by the corn-cribs under the trees by
+ourselves, I says:
+
+“Did you want to kill him, Buck?”
+
+“Well, I bet I did.”
+
+“What did he do to you?”
+
+“Him? He never done nothing to me.”
+
+“Well, then, what did you want to kill him for?”
+
+“Why, nothing—only it’s on account of the feud.”
+
+“What’s a feud?”
+
+“Why, where was you raised? Don’t you know what a feud is?”
+
+“Never heard of it before—tell me about it.”
+
+“Well,” says Buck, “a feud is this way. A man has a quarrel with
+another man, and kills him; then that other man’s brother kills _him;_
+then the other brothers, on both sides, goes for one another; then the
+_cousins_ chip in—and by-and-by everybody’s killed off, and there ain’t
+no more feud. But it’s kind of slow, and takes a long time.”
+
+“Has this one been going on long, Buck?”
+
+“Well, I should _reckon!_ It started thirty year ago, or som’ers along
+there. There was trouble ’bout something, and then a lawsuit to settle
+it; and the suit went agin one of the men, and so he up and shot the
+man that won the suit—which he would naturally do, of course. Anybody
+would.”
+
+“What was the trouble about, Buck?—land?”
+
+“I reckon maybe—I don’t know.”
+
+“Well, who done the shooting? Was it a Grangerford or a Shepherdson?”
+
+“Laws, how do _I_ know? It was so long ago.”
+
+“Don’t anybody know?”
+
+“Oh, yes, pa knows, I reckon, and some of the other old people; but
+they don’t know now what the row was about in the first place.”
+
+“Has there been many killed, Buck?”
+
+“Yes; right smart chance of funerals. But they don’t always kill. Pa’s
+got a few buckshot in him; but he don’t mind it ’cuz he don’t weigh
+much, anyway. Bob’s been carved up some with a bowie, and Tom’s been
+hurt once or twice.”
+
+“Has anybody been killed this year, Buck?”
+
+“Yes; we got one and they got one. ’Bout three months ago my cousin
+Bud, fourteen year old, was riding through the woods on t’other side of
+the river, and didn’t have no weapon with him, which was blame’
+foolishness, and in a lonesome place he hears a horse a-coming behind
+him, and sees old Baldy Shepherdson a-linkin’ after him with his gun in
+his hand and his white hair a-flying in the wind; and ’stead of jumping
+off and taking to the brush, Bud ’lowed he could out-run him; so they
+had it, nip and tuck, for five mile or more, the old man a-gaining all
+the time; so at last Bud seen it warn’t any use, so he stopped and
+faced around so as to have the bullet holes in front, you know, and the
+old man he rode up and shot him down. But he didn’t git much chance to
+enjoy his luck, for inside of a week our folks laid _him_ out.”
+
+“I reckon that old man was a coward, Buck.”
+
+“I reckon he _warn’t_ a coward. Not by a blame’ sight. There ain’t a
+coward amongst them Shepherdsons—not a one. And there ain’t no cowards
+amongst the Grangerfords either. Why, that old man kep’ up his end in a
+fight one day for half an hour against three Grangerfords, and come out
+winner. They was all a-horseback; he lit off of his horse and got
+behind a little woodpile, and kep’ his horse before him to stop the
+bullets; but the Grangerfords stayed on their horses and capered around
+the old man, and peppered away at him, and he peppered away at them.
+Him and his horse both went home pretty leaky and crippled, but the
+Grangerfords had to be _fetched_ home—and one of ’em was dead, and
+another died the next day. No, sir; if a body’s out hunting for cowards
+he don’t want to fool away any time amongst them Shepherdsons, becuz
+they don’t breed any of that _kind_.”
+
+Next Sunday we all went to church, about three mile, everybody
+a-horseback. The men took their guns along, so did Buck, and kept them
+between their knees or stood them handy against the wall. The
+Shepherdsons done the same. It was pretty ornery preaching—all about
+brotherly love, and such-like tiresomeness; but everybody said it was a
+good sermon, and they all talked it over going home, and had such a
+powerful lot to say about faith and good works and free grace and
+preforeordestination, and I don’t know what all, that it did seem to me
+to be one of the roughest Sundays I had run across yet.
+
+About an hour after dinner everybody was dozing around, some in their
+chairs and some in their rooms, and it got to be pretty dull. Buck and
+a dog was stretched out on the grass in the sun sound asleep. I went up
+to our room, and judged I would take a nap myself. I found that sweet
+Miss Sophia standing in her door, which was next to ours, and she took
+me in her room and shut the door very soft, and asked me if I liked
+her, and I said I did; and she asked me if I would do something for her
+and not tell anybody, and I said I would. Then she said she’d forgot
+her Testament, and left it in the seat at church between two other
+books, and would I slip out quiet and go there and fetch it to her, and
+not say nothing to nobody. I said I would. So I slid out and slipped
+off up the road, and there warn’t anybody at the church, except maybe a
+hog or two, for there warn’t any lock on the door, and hogs likes a
+puncheon floor in summer-time because it’s cool. If you notice, most
+folks don’t go to church only when they’ve got to; but a hog is
+different.
+
+Says I to myself, something’s up; it ain’t natural for a girl to be in
+such a sweat about a Testament. So I give it a shake, and out drops a
+little piece of paper with “_Half-past two_” wrote on it with a pencil.
+I ransacked it, but couldn’t find anything else. I couldn’t make
+anything out of that, so I put the paper in the book again, and when I
+got home and upstairs there was Miss Sophia in her door waiting for me.
+She pulled me in and shut the door; then she looked in the Testament
+till she found the paper, and as soon as she read it she looked glad;
+and before a body could think she grabbed me and give me a squeeze, and
+said I was the best boy in the world, and not to tell anybody. She was
+mighty red in the face for a minute, and her eyes lighted up, and it
+made her powerful pretty. I was a good deal astonished, but when I got
+my breath I asked her what the paper was about, and she asked me if I
+had read it, and I said no, and she asked me if I could read writing,
+and I told her “no, only coarse-hand,” and then she said the paper
+warn’t anything but a book-mark to keep her place, and I might go and
+play now.
+
+I went off down to the river, studying over this thing, and pretty soon
+I noticed that my nigger was following along behind. When we was out of
+sight of the house he looked back and around a second, and then comes
+a-running, and says:
+
+“Mars Jawge, if you’ll come down into de swamp I’ll show you a whole
+stack o’ water-moccasins.”
+
+Thinks I, that’s mighty curious; he said that yesterday. He oughter
+know a body don’t love water-moccasins enough to go around hunting for
+them. What is he up to, anyway? So I says:
+
+“All right; trot ahead.”
+
+I followed a half a mile; then he struck out over the swamp, and waded
+ankle deep as much as another half-mile. We come to a little flat piece
+of land which was dry and very thick with trees and bushes and vines,
+and he says:
+
+“You shove right in dah jist a few steps, Mars Jawge; dah’s whah dey
+is. I’s seed ’m befo’; I don’t k’yer to see ’em no mo’.”
+
+Then he slopped right along and went away, and pretty soon the trees
+hid him. I poked into the place a-ways and come to a little open patch
+as big as a bedroom all hung around with vines, and found a man laying
+there asleep—and, by jings, it was my old Jim!
+
+I waked him up, and I reckoned it was going to be a grand surprise to
+him to see me again, but it warn’t. He nearly cried he was so glad, but
+he warn’t surprised. Said he swum along behind me that night, and heard
+me yell every time, but dasn’t answer, because he didn’t want nobody to
+pick _him_ up and take him into slavery again. Says he:
+
+“I got hurt a little, en couldn’t swim fas’, so I wuz a considable ways
+behine you towards de las’; when you landed I reck’ned I could ketch up
+wid you on de lan’ ’dout havin’ to shout at you, but when I see dat
+house I begin to go slow. I ’uz off too fur to hear what dey say to
+you—I wuz ’fraid o’ de dogs; but when it ’uz all quiet agin, I knowed
+you’s in de house, so I struck out for de woods to wait for day. Early
+in de mawnin’ some er de niggers come along, gwyne to de fields, en dey
+tuk me en showed me dis place, whah de dogs can’t track me on accounts
+o’ de water, en dey brings me truck to eat every night, en tells me how
+you’s a-gitt’n along.”
+
+“Why didn’t you tell my Jack to fetch me here sooner, Jim?”
+
+“Well, ’twarn’t no use to ’sturb you, Huck, tell we could do sumfn—but
+we’s all right now. I ben a-buyin’ pots en pans en vittles, as I got a
+chanst, en a-patchin’ up de raf’ nights when—”
+
+“_What_ raft, Jim?”
+
+“Our ole raf’.”
+
+“You mean to say our old raft warn’t smashed all to flinders?”
+
+“No, she warn’t. She was tore up a good deal—one en’ of her was; but
+dey warn’t no great harm done, on’y our traps was mos’ all los’. Ef we
+hadn’ dive’ so deep en swum so fur under water, en de night hadn’ ben
+so dark, en we warn’t so sk’yerd, en ben sich punkin-heads, as de
+sayin’ is, we’d a seed de raf’. But it’s jis’ as well we didn’t, ’kase
+now she’s all fixed up agin mos’ as good as new, en we’s got a new lot
+o’ stuff, in de place o’ what ’uz los’.”
+
+“Why, how did you get hold of the raft again, Jim—did you catch her?”
+
+“How I gwyne to ketch her en I out in de woods? No; some er de niggers
+foun’ her ketched on a snag along heah in de ben’, en dey hid her in a
+crick ’mongst de willows, en dey wuz so much jawin’ ’bout which un ’um
+she b’long to de mos’ dat I come to heah ’bout it pooty soon, so I ups
+en settles de trouble by tellin’ ’um she don’t b’long to none uv um,
+but to you en me; en I ast ’m if dey gwyne to grab a young white
+genlman’s propaty, en git a hid’n for it? Den I gin ’m ten cents
+apiece, en dey ’uz mighty well satisfied, en wisht some mo’ raf’s ’ud
+come along en make ’m rich agin. Dey’s mighty good to me, dese niggers
+is, en whatever I wants ’m to do fur me, I doan’ have to ast ’m twice,
+honey. Dat Jack’s a good nigger, en pooty smart.”
+
+“Yes, he is. He ain’t ever told me you was here; told me to come, and
+he’d show me a lot of water-moccasins. If anything happens _he_ ain’t
+mixed up in it. He can say he never seen us together, and it’ll be the
+truth.”
+
+I don’t want to talk much about the next day. I reckon I’ll cut it
+pretty short. I waked up about dawn, and was a-going to turn over and
+go to sleep again, when I noticed how still it was—didn’t seem to be
+anybody stirring. That warn’t usual. Next I noticed that Buck was up
+and gone. Well, I gets up, a-wondering, and goes down stairs—nobody
+around; everything as still as a mouse. Just the same outside. Thinks
+I, what does it mean? Down by the wood-pile I comes across my Jack, and
+says:
+
+“What’s it all about?”
+
+Says he:
+
+“Don’t you know, Mars Jawge?”
+
+“No,” says I, “I don’t.”
+
+“Well, den, Miss Sophia’s run off! ’deed she has. She run off in de
+night some time—nobody don’t know jis’ when; run off to get married to
+dat young Harney Shepherdson, you know—leastways, so dey ’spec. De
+fambly foun’ it out ’bout half an hour ago—maybe a little mo’—en’ I
+_tell_ you dey warn’t no time los’. Sich another hurryin’ up guns en
+hosses _you_ never see! De women folks has gone for to stir up de
+relations, en ole Mars Saul en de boys tuck dey guns en rode up de
+river road for to try to ketch dat young man en kill him ’fo’ he kin
+git acrost de river wid Miss Sophia. I reck’n dey’s gwyne to be mighty
+rough times.”
+
+“Buck went off ’thout waking me up.”
+
+“Well, I reck’n he _did!_ Dey warn’t gwyne to mix you up in it. Mars
+Buck he loaded up his gun en ’lowed he’s gwyne to fetch home a
+Shepherdson or bust. Well, dey’ll be plenty un ’m dah, I reck’n, en you
+bet you he’ll fetch one ef he gits a chanst.”
+
+I took up the river road as hard as I could put. By-and-by I begin to
+hear guns a good ways off. When I come in sight of the log store and
+the woodpile where the steamboats lands, I worked along under the trees
+and brush till I got to a good place, and then I clumb up into the
+forks of a cottonwood that was out of reach, and watched. There was a
+wood-rank four foot high a little ways in front of the tree, and first
+I was going to hide behind that; but maybe it was luckier I didn’t.
+
+There was four or five men cavorting around on their horses in the open
+place before the log store, cussing and yelling, and trying to get at a
+couple of young chaps that was behind the wood-rank alongside of the
+steamboat landing; but they couldn’t come it. Every time one of them
+showed himself on the river side of the woodpile he got shot at. The
+two boys was squatting back to back behind the pile, so they could
+watch both ways.
+
+By-and-by the men stopped cavorting around and yelling. They started
+riding towards the store; then up gets one of the boys, draws a steady
+bead over the wood-rank, and drops one of them out of his saddle. All
+the men jumped off of their horses and grabbed the hurt one and started
+to carry him to the store; and that minute the two boys started on the
+run. They got half way to the tree I was in before the men noticed.
+Then the men see them, and jumped on their horses and took out after
+them. They gained on the boys, but it didn’t do no good, the boys had
+too good a start; they got to the woodpile that was in front of my
+tree, and slipped in behind it, and so they had the bulge on the men
+again. One of the boys was Buck, and the other was a slim young chap
+about nineteen years old.
+
+The men ripped around awhile, and then rode away. As soon as they was
+out of sight I sung out to Buck and told him. He didn’t know what to
+make of my voice coming out of the tree at first. He was awful
+surprised. He told me to watch out sharp and let him know when the men
+come in sight again; said they was up to some devilment or
+other—wouldn’t be gone long. I wished I was out of that tree, but I
+dasn’t come down. Buck begun to cry and rip, and ’lowed that him and
+his cousin Joe (that was the other young chap) would make up for this
+day yet. He said his father and his two brothers was killed, and two or
+three of the enemy. Said the Shepherdsons laid for them in ambush. Buck
+said his father and brothers ought to waited for their relations—the
+Shepherdsons was too strong for them. I asked him what was become of
+young Harney and Miss Sophia. He said they’d got across the river and
+was safe. I was glad of that; but the way Buck did take on because he
+didn’t manage to kill Harney that day he shot at him—I hain’t ever
+heard anything like it.
+
+All of a sudden, bang! bang! bang! goes three or four guns—the men had
+slipped around through the woods and come in from behind without their
+horses! The boys jumped for the river—both of them hurt—and as they
+swum down the current the men run along the bank shooting at them and
+singing out, “Kill them, kill them!” It made me so sick I most fell out
+of the tree. I ain’t a-going to tell _all_ that happened—it would make
+me sick again if I was to do that. I wished I hadn’t ever come ashore
+that night to see such things. I ain’t ever going to get shut of
+them—lots of times I dream about them.
+
+I stayed in the tree till it begun to get dark, afraid to come down.
+Sometimes I heard guns away off in the woods; and twice I seen little
+gangs of men gallop past the log store with guns; so I reckoned the
+trouble was still a-going on. I was mighty downhearted; so I made up my
+mind I wouldn’t ever go anear that house again, because I reckoned I
+was to blame, somehow. I judged that that piece of paper meant that
+Miss Sophia was to meet Harney somewheres at half-past two and run off;
+and I judged I ought to told her father about that paper and the
+curious way she acted, and then maybe he would a locked her up, and
+this awful mess wouldn’t ever happened.
+
+When I got down out of the tree, I crept along down the river bank a
+piece, and found the two bodies laying in the edge of the water, and
+tugged at them till I got them ashore; then I covered up their faces,
+and got away as quick as I could. I cried a little when I was covering
+up Buck’s face, for he was mighty good to me.
+
+It was just dark now. I never went near the house, but struck through
+the woods and made for the swamp. Jim warn’t on his island, so I
+tramped off in a hurry for the crick, and crowded through the willows,
+red-hot to jump aboard and get out of that awful country. The raft was
+gone! My souls, but I was scared! I couldn’t get my breath for most a
+minute. Then I raised a yell. A voice not twenty-five foot from me
+says:
+
+“Good lan’! is dat you, honey? Doan’ make no noise.”
+
+It was Jim’s voice—nothing ever sounded so good before. I run along the
+bank a piece and got aboard, and Jim he grabbed me and hugged me, he
+was so glad to see me. He says:
+
+“Laws bless you, chile, I ’uz right down sho’ you’s dead agin. Jack’s
+been heah; he say he reck’n you’s ben shot, kase you didn’ come home no
+mo’; so I’s jes’ dis minute a startin’ de raf’ down towards de mouf er
+de crick, so’s to be all ready for to shove out en leave soon as Jack
+comes agin en tells me for certain you _is_ dead. Lawsy, I’s mighty
+glad to git you back agin, honey.”
+
+I says:
+
+“All right—that’s mighty good; they won’t find me, and they’ll think
+I’ve been killed, and floated down the river—there’s something up there
+that’ll help them think so—so don’t you lose no time, Jim, but just
+shove off for the big water as fast as ever you can.”
+
+I never felt easy till the raft was two mile below there and out in the
+middle of the Mississippi. Then we hung up our signal lantern, and
+judged that we was free and safe once more. I hadn’t had a bite to eat
+since yesterday, so Jim he got out some corn-dodgers and buttermilk,
+and pork and cabbage and greens—there ain’t nothing in the world so
+good when it’s cooked right—and whilst I eat my supper we talked, and
+had a good time. I was powerful glad to get away from the feuds, and so
+was Jim to get away from the swamp. We said there warn’t no home like a
+raft, after all. Other places do seem so cramped up and smothery, but a
+raft don’t. You feel mighty free and easy and comfortable on a raft.
+
+
+
+
+CHAPTER XIX.
+
+
+Two or three days and nights went by; I reckon I might say they swum
+by, they slid along so quiet and smooth and lovely. Here is the way we
+put in the time. It was a monstrous big river down there—sometimes a
+mile and a half wide; we run nights, and laid up and hid daytimes; soon
+as night was most gone we stopped navigating and tied up—nearly always
+in the dead water under a tow-head; and then cut young cottonwoods and
+willows, and hid the raft with them. Then we set out the lines. Next we
+slid into the river and had a swim, so as to freshen up and cool off;
+then we set down on the sandy bottom where the water was about knee
+deep, and watched the daylight come. Not a sound anywheres—perfectly
+still—just like the whole world was asleep, only sometimes the
+bullfrogs a-cluttering, maybe. The first thing to see, looking away
+over the water, was a kind of dull line—that was the woods on t’other
+side; you couldn’t make nothing else out; then a pale place in the sky;
+then more paleness spreading around; then the river softened up away
+off, and warn’t black any more, but gray; you could see little dark
+spots drifting along ever so far away—trading scows, and such things;
+and long black streaks—rafts; sometimes you could hear a sweep
+screaking; or jumbled up voices, it was so still, and sounds come so
+far; and by-and-by you could see a streak on the water which you know
+by the look of the streak that there’s a snag there in a swift current
+which breaks on it and makes that streak look that way; and you see the
+mist curl up off of the water, and the east reddens up, and the river,
+and you make out a log-cabin in the edge of the woods, away on the bank
+on t’other side of the river, being a woodyard, likely, and piled by
+them cheats so you can throw a dog through it anywheres; then the nice
+breeze springs up, and comes fanning you from over there, so cool and
+fresh and sweet to smell on account of the woods and the flowers; but
+sometimes not that way, because they’ve left dead fish laying around,
+gars and such, and they do get pretty rank; and next you’ve got the
+full day, and everything smiling in the sun, and the song-birds just
+going it!
+
+A little smoke couldn’t be noticed now, so we would take some fish off
+of the lines and cook up a hot breakfast. And afterwards we would watch
+the lonesomeness of the river, and kind of lazy along, and by-and-by
+lazy off to sleep. Wake up by-and-by, and look to see what done it, and
+maybe see a steamboat coughing along up-stream, so far off towards the
+other side you couldn’t tell nothing about her only whether she was a
+stern-wheel or side-wheel; then for about an hour there wouldn’t be
+nothing to hear nor nothing to see—just solid lonesomeness. Next you’d
+see a raft sliding by, away off yonder, and maybe a galoot on it
+chopping, because they’re most always doing it on a raft; you’d see the
+axe flash and come down—you don’t hear nothing; you see that axe go up
+again, and by the time it’s above the man’s head then you hear the
+_k’chunk!_—it had took all that time to come over the water. So we
+would put in the day, lazying around, listening to the stillness. Once
+there was a thick fog, and the rafts and things that went by was
+beating tin pans so the steamboats wouldn’t run over them. A scow or a
+raft went by so close we could hear them talking and cussing and
+laughing—heard them plain; but we couldn’t see no sign of them; it made
+you feel crawly; it was like spirits carrying on that way in the air.
+Jim said he believed it was spirits; but I says:
+
+“No; spirits wouldn’t say, ‘Dern the dern fog.’”
+
+Soon as it was night out we shoved; when we got her out to about the
+middle we let her alone, and let her float wherever the current wanted
+her to; then we lit the pipes, and dangled our legs in the water, and
+talked about all kinds of things—we was always naked, day and night,
+whenever the mosquitoes would let us—the new clothes Buck’s folks made
+for me was too good to be comfortable, and besides I didn’t go much on
+clothes, nohow.
+
+Sometimes we’d have that whole river all to ourselves for the longest
+time. Yonder was the banks and the islands, across the water; and maybe
+a spark—which was a candle in a cabin window; and sometimes on the
+water you could see a spark or two—on a raft or a scow, you know; and
+maybe you could hear a fiddle or a song coming over from one of them
+crafts. It’s lovely to live on a raft. We had the sky up there, all
+speckled with stars, and we used to lay on our backs and look up at
+them, and discuss about whether they was made or only just happened.
+Jim he allowed they was made, but I allowed they happened; I judged it
+would have took too long to _make_ so many. Jim said the moon could a
+_laid_ them; well, that looked kind of reasonable, so I didn’t say
+nothing against it, because I’ve seen a frog lay most as many, so of
+course it could be done. We used to watch the stars that fell, too, and
+see them streak down. Jim allowed they’d got spoiled and was hove out
+of the nest.
+
+Once or twice of a night we would see a steamboat slipping along in the
+dark, and now and then she would belch a whole world of sparks up out
+of her chimbleys, and they would rain down in the river and look awful
+pretty; then she would turn a corner and her lights would wink out and
+her powwow shut off and leave the river still again; and by-and-by her
+waves would get to us, a long time after she was gone, and joggle the
+raft a bit, and after that you wouldn’t hear nothing for you couldn’t
+tell how long, except maybe frogs or something.
+
+After midnight the people on shore went to bed, and then for two or
+three hours the shores was black—no more sparks in the cabin windows.
+These sparks was our clock—the first one that showed again meant
+morning was coming, so we hunted a place to hide and tie up right away.
+
+One morning about daybreak I found a canoe and crossed over a chute to
+the main shore—it was only two hundred yards—and paddled about a mile
+up a crick amongst the cypress woods, to see if I couldn’t get some
+berries. Just as I was passing a place where a kind of a cowpath
+crossed the crick, here comes a couple of men tearing up the path as
+tight as they could foot it. I thought I was a goner, for whenever
+anybody was after anybody I judged it was _me_—or maybe Jim. I was
+about to dig out from there in a hurry, but they was pretty close to me
+then, and sung out and begged me to save their lives—said they hadn’t
+been doing nothing, and was being chased for it—said there was men and
+dogs a-coming. They wanted to jump right in, but I says:
+
+“Don’t you do it. I don’t hear the dogs and horses yet; you’ve got time
+to crowd through the brush and get up the crick a little ways; then you
+take to the water and wade down to me and get in—that’ll throw the dogs
+off the scent.”
+
+They done it, and soon as they was aboard I lit out for our tow-head,
+and in about five or ten minutes we heard the dogs and the men away
+off, shouting. We heard them come along towards the crick, but couldn’t
+see them; they seemed to stop and fool around a while; then, as we got
+further and further away all the time, we couldn’t hardly hear them at
+all; by the time we had left a mile of woods behind us and struck the
+river, everything was quiet, and we paddled over to the tow-head and hid
+in the cottonwoods and was safe.
+
+One of these fellows was about seventy or upwards, and had a bald head
+and very gray whiskers. He had an old battered-up slouch hat on, and a
+greasy blue woollen shirt, and ragged old blue jeans britches stuffed
+into his boot-tops, and home-knit galluses—no, he only had one. He had
+an old long-tailed blue jeans coat with slick brass buttons flung over
+his arm, and both of them had big, fat, ratty-looking carpet-bags.
+
+The other fellow was about thirty, and dressed about as ornery. After
+breakfast we all laid off and talked, and the first thing that come out
+was that these chaps didn’t know one another.
+
+“What got you into trouble?” says the baldhead to t’other chap.
+
+“Well, I’d been selling an article to take the tartar off the teeth—and
+it does take it off, too, and generly the enamel along with it—but I
+stayed about one night longer than I ought to, and was just in the act
+of sliding out when I ran across you on the trail this side of town,
+and you told me they were coming, and begged me to help you to get off.
+So I told you I was expecting trouble myself, and would scatter out
+_with_ you. That’s the whole yarn—what’s yourn?
+
+“Well, I’d ben a-runnin’ a little temperance revival thar, ’bout a
+week, and was the pet of the women folks, big and little, for I was
+makin’ it mighty warm for the rummies, I _tell_ you, and takin’ as much
+as five or six dollars a night—ten cents a head, children and niggers
+free—and business a-growin’ all the time, when somehow or another a
+little report got around last night that I had a way of puttin’ in my
+time with a private jug on the sly. A nigger rousted me out this
+mornin’, and told me the people was getherin’ on the quiet with their
+dogs and horses, and they’d be along pretty soon and give me ’bout half
+an hour’s start, and then run me down if they could; and if they got me
+they’d tar and feather me and ride me on a rail, sure. I didn’t wait
+for no breakfast—I warn’t hungry.”
+
+“Old man,” said the young one, “I reckon we might double-team it
+together; what do you think?”
+
+“I ain’t undisposed. What’s your line—mainly?”
+
+“Jour printer by trade; do a little in patent medicines;
+theater-actor—tragedy, you know; take a turn to mesmerism and
+phrenology when there’s a chance; teach singing-geography school for a
+change; sling a lecture sometimes—oh, I do lots of things—most anything
+that comes handy, so it ain’t work. What’s your lay?”
+
+“I’ve done considerble in the doctoring way in my time. Layin’ on o’
+hands is my best holt—for cancer and paralysis, and sich things; and I
+k’n tell a fortune pretty good when I’ve got somebody along to find out
+the facts for me. Preachin’s my line, too, and workin’ camp-meetin’s,
+and missionaryin’ around.”
+
+Nobody never said anything for a while; then the young man hove a sigh
+and says:
+
+“Alas!”
+
+“What ’re you alassin’ about?” says the baldhead.
+
+“To think I should have lived to be leading such a life, and be
+degraded down into such company.” And he begun to wipe the corner of
+his eye with a rag.
+
+“Dern your skin, ain’t the company good enough for you?” says the
+baldhead, pretty pert and uppish.
+
+“Yes, it _is_ good enough for me; it’s as good as I deserve; for who
+fetched me so low when I was so high? _I_ did myself. I don’t blame
+_you_, gentlemen—far from it; I don’t blame anybody. I deserve it all.
+Let the cold world do its worst; one thing I know—there’s a grave
+somewhere for me. The world may go on just as it’s always done, and
+take everything from me—loved ones, property, everything; but it can’t
+take that. Some day I’ll lie down in it and forget it all, and my poor
+broken heart will be at rest.” He went on a-wiping.
+
+“Drot your pore broken heart,” says the baldhead; “what are you heaving
+your pore broken heart at _us_ f’r? _We_ hain’t done nothing.”
+
+“No, I know you haven’t. I ain’t blaming you, gentlemen. I brought
+myself down—yes, I did it myself. It’s right I should suffer—perfectly
+right—I don’t make any moan.”
+
+“Brought you down from whar? Whar was you brought down from?”
+
+“Ah, you would not believe me; the world never believes—let it
+pass—’tis no matter. The secret of my birth—”
+
+“The secret of your birth! Do you mean to say—”
+
+“Gentlemen,” says the young man, very solemn, “I will reveal it to you,
+for I feel I may have confidence in you. By rights I am a duke!”
+
+Jim’s eyes bugged out when he heard that; and I reckon mine did, too.
+Then the baldhead says: “No! you can’t mean it?”
+
+“Yes. My great-grandfather, eldest son of the Duke of Bridgewater, fled
+to this country about the end of the last century, to breathe the pure
+air of freedom; married here, and died, leaving a son, his own father
+dying about the same time. The second son of the late duke seized the
+titles and estates—the infant real duke was ignored. I am the lineal
+descendant of that infant—I am the rightful Duke of Bridgewater; and
+here am I, forlorn, torn from my high estate, hunted of men, despised
+by the cold world, ragged, worn, heart-broken, and degraded to the
+companionship of felons on a raft!”
+
+Jim pitied him ever so much, and so did I. We tried to comfort him, but
+he said it warn’t much use, he couldn’t be much comforted; said if we
+was a mind to acknowledge him, that would do him more good than most
+anything else; so we said we would, if he would tell us how. He said we
+ought to bow when we spoke to him, and say “Your Grace,” or “My Lord,”
+or “Your Lordship”—and he wouldn’t mind it if we called him plain
+“Bridgewater,” which, he said, was a title anyway, and not a name; and
+one of us ought to wait on him at dinner, and do any little thing for
+him he wanted done.
+
+Well, that was all easy, so we done it. All through dinner Jim stood
+around and waited on him, and says, “Will yo’ Grace have some o’ dis or
+some o’ dat?” and so on, and a body could see it was mighty pleasing to
+him.
+
+But the old man got pretty silent by-and-by—didn’t have much to say,
+and didn’t look pretty comfortable over all that petting that was going
+on around that duke. He seemed to have something on his mind. So, along
+in the afternoon, he says:
+
+“Looky here, Bilgewater,” he says, “I’m nation sorry for you, but you
+ain’t the only person that’s had troubles like that.”
+
+“No?”
+
+“No you ain’t. You ain’t the only person that’s ben snaked down
+wrongfully out’n a high place.”
+
+“Alas!”
+
+“No, you ain’t the only person that’s had a secret of his birth.” And,
+by jings, _he_ begins to cry.
+
+“Hold! What do you mean?”
+
+“Bilgewater, kin I trust you?” says the old man, still sort of sobbing.
+
+“To the bitter death!” He took the old man by the hand and squeezed it,
+and says, “That secret of your being: speak!”
+
+“Bilgewater, I am the late Dauphin!”
+
+You bet you, Jim and me stared this time. Then the duke says:
+
+“You are what?”
+
+“Yes, my friend, it is too true—your eyes is lookin’ at this very
+moment on the pore disappeared Dauphin, Looy the Seventeen, son of Looy
+the Sixteen and Marry Antonette.”
+
+“You! At your age! No! You mean you’re the late Charlemagne; you must
+be six or seven hundred years old, at the very least.”
+
+“Trouble has done it, Bilgewater, trouble has done it; trouble has
+brung these gray hairs and this premature balditude. Yes, gentlemen,
+you see before you, in blue jeans and misery, the wanderin’, exiled,
+trampled-on, and sufferin’ rightful King of France.”
+
+Well, he cried and took on so that me and Jim didn’t know hardly what
+to do, we was so sorry—and so glad and proud we’d got him with us, too.
+So we set in, like we done before with the duke, and tried to comfort
+_him_. But he said it warn’t no use, nothing but to be dead and done
+with it all could do him any good; though he said it often made him
+feel easier and better for a while if people treated him according to
+his rights, and got down on one knee to speak to him, and always called
+him “Your Majesty,” and waited on him first at meals, and didn’t set
+down in his presence till he asked them. So Jim and me set to
+majestying him, and doing this and that and t’other for him, and
+standing up till he told us we might set down. This done him heaps of
+good, and so he got cheerful and comfortable. But the duke kind of
+soured on him, and didn’t look a bit satisfied with the way things was
+going; still, the king acted real friendly towards him, and said the
+duke’s great-grandfather and all the other Dukes of Bilgewater was a
+good deal thought of by _his_ father, and was allowed to come to the
+palace considerable; but the duke stayed huffy a good while, till
+by-and-by the king says:
+
+“Like as not we got to be together a blamed long time on this h-yer
+raft, Bilgewater, and so what’s the use o’ your bein’ sour? It’ll only
+make things oncomfortable. It ain’t my fault I warn’t born a duke, it
+ain’t your fault you warn’t born a king—so what’s the use to worry?
+Make the best o’ things the way you find ’em, says I—that’s my motto.
+This ain’t no bad thing that we’ve struck here—plenty grub and an easy
+life—come, give us your hand, Duke, and le’s all be friends.”
+
+The duke done it, and Jim and me was pretty glad to see it. It took
+away all the uncomfortableness and we felt mighty good over it, because
+it would a been a miserable business to have any unfriendliness on the
+raft; for what you want, above all things, on a raft, is for everybody
+to be satisfied, and feel right and kind towards the others.
+
+It didn’t take me long to make up my mind that these liars warn’t no
+kings nor dukes at all, but just low-down humbugs and frauds. But I
+never said nothing, never let on; kept it to myself; it’s the best way;
+then you don’t have no quarrels, and don’t get into no trouble. If they
+wanted us to call them kings and dukes, I hadn’t no objections, ’long
+as it would keep peace in the family; and it warn’t no use to tell Jim,
+so I didn’t tell him. If I never learnt nothing else out of pap, I
+learnt that the best way to get along with his kind of people is to let
+them have their own way.
+
+
+
+
+CHAPTER XX.
+
+
+They asked us considerable many questions; wanted to know what we
+covered up the raft that way for, and laid by in the daytime instead of
+running—was Jim a runaway nigger? Says I:
+
+“Goodness sakes, would a runaway nigger run _south?_”
+
+No, they allowed he wouldn’t. I had to account for things some way, so
+I says:
+
+“My folks was living in Pike County, in Missouri, where I was born, and
+they all died off but me and pa and my brother Ike. Pa, he ’lowed he’d
+break up and go down and live with Uncle Ben, who’s got a little
+one-horse place on the river, forty-four mile below Orleans. Pa was
+pretty poor, and had some debts; so when he’d squared up there warn’t
+nothing left but sixteen dollars and our nigger, Jim. That warn’t
+enough to take us fourteen hundred mile, deck passage nor no other way.
+Well, when the river rose pa had a streak of luck one day; he ketched
+this piece of a raft; so we reckoned we’d go down to Orleans on it.
+Pa’s luck didn’t hold out; a steamboat run over the forrard corner of
+the raft one night, and we all went overboard and dove under the wheel;
+Jim and me come up all right, but pa was drunk, and Ike was only four
+years old, so they never come up no more. Well, for the next day or two
+we had considerable trouble, because people was always coming out in
+skiffs and trying to take Jim away from me, saying they believed he was
+a runaway nigger. We don’t run daytimes no more now; nights they don’t
+bother us.”
+
+The duke says:
+
+“Leave me alone to cipher out a way so we can run in the daytime if we
+want to. I’ll think the thing over—I’ll invent a plan that’ll fix it.
+We’ll let it alone for to-day, because of course we don’t want to go by
+that town yonder in daylight—it mightn’t be healthy.”
+
+Towards night it begun to darken up and look like rain; the heat
+lightning was squirting around low down in the sky, and the leaves was
+beginning to shiver—it was going to be pretty ugly, it was easy to see
+that. So the duke and the king went to overhauling our wigwam, to see
+what the beds was like. My bed was a straw tick better than Jim’s,
+which was a corn-shuck tick; there’s always cobs around about in a
+shuck tick, and they poke into you and hurt; and when you roll over the
+dry shucks sound like you was rolling over in a pile of dead leaves; it
+makes such a rustling that you wake up. Well, the duke allowed he would
+take my bed; but the king allowed he wouldn’t. He says:
+
+“I should a reckoned the difference in rank would a sejested to you
+that a corn-shuck bed warn’t just fitten for me to sleep on. Your
+Grace’ll take the shuck bed yourself.”
+
+Jim and me was in a sweat again for a minute, being afraid there was
+going to be some more trouble amongst them; so we was pretty glad when
+the duke says:
+
+“’Tis my fate to be always ground into the mire under the iron heel of
+oppression. Misfortune has broken my once haughty spirit; I yield, I
+submit; ’tis my fate. I am alone in the world—let me suffer; I can bear
+it.”
+
+We got away as soon as it was good and dark. The king told us to stand
+well out towards the middle of the river, and not show a light till we
+got a long ways below the town. We come in sight of the little bunch of
+lights by-and-by—that was the town, you know—and slid by, about a half
+a mile out, all right. When we was three-quarters of a mile below we
+hoisted up our signal lantern; and about ten o’clock it come on to rain
+and blow and thunder and lighten like everything; so the king told us
+to both stay on watch till the weather got better; then him and the
+duke crawled into the wigwam and turned in for the night. It was my
+watch below till twelve, but I wouldn’t a turned in anyway if I’d had a
+bed, because a body don’t see such a storm as that every day in the
+week, not by a long sight. My souls, how the wind did scream along! And
+every second or two there’d come a glare that lit up the white-caps for
+a half a mile around, and you’d see the islands looking dusty through
+the rain, and the trees thrashing around in the wind; then comes a
+_h-whack!_—bum! bum! bumble-umble-um-bum-bum-bum-bum—and the thunder
+would go rumbling and grumbling away, and quit—and then _rip_ comes
+another flash and another sockdolager. The waves most washed me off the
+raft sometimes, but I hadn’t any clothes on, and didn’t mind. We didn’t
+have no trouble about snags; the lightning was glaring and flittering
+around so constant that we could see them plenty soon enough to throw
+her head this way or that and miss them.
+
+I had the middle watch, you know, but I was pretty sleepy by that time,
+so Jim he said he would stand the first half of it for me; he was
+always mighty good that way, Jim was. I crawled into the wigwam, but
+the king and the duke had their legs sprawled around so there warn’t no
+show for me; so I laid outside—I didn’t mind the rain, because it was
+warm, and the waves warn’t running so high now. About two they come up
+again, though, and Jim was going to call me; but he changed his mind,
+because he reckoned they warn’t high enough yet to do any harm; but he
+was mistaken about that, for pretty soon all of a sudden along comes a
+regular ripper and washed me overboard. It most killed Jim a-laughing.
+He was the easiest nigger to laugh that ever was, anyway.
+
+I took the watch, and Jim he laid down and snored away; and by-and-by
+the storm let up for good and all; and the first cabin-light that
+showed, I rousted him out and we slid the raft into hiding quarters
+for the day.
+
+The king got out an old ratty deck of cards after breakfast, and him
+and the duke played seven-up a while, five cents a game. Then they got
+tired of it, and allowed they would “lay out a campaign,” as they
+called it. The duke went down into his carpet-bag, and fetched up a lot
+of little printed bills and read them out loud. One bill said, “The
+celebrated Dr. Armand de Montalban, of Paris,” would “lecture on the
+Science of Phrenology” at such and such a place, on the blank day of
+blank, at ten cents admission, and “furnish charts of character at
+twenty-five cents apiece.” The duke said that was _him_. In another
+bill he was the “world-renowned Shakespearian tragedian, Garrick the
+Younger, of Drury Lane, London.” In other bills he had a lot of other
+names and done other wonderful things, like finding water and gold with
+a “divining-rod,” “dissipating witch spells,” and so on. By-and-by he
+says:
+
+“But the histrionic muse is the darling. Have you ever trod the boards,
+Royalty?”
+
+“No,” says the king.
+
+“You shall, then, before you’re three days older, Fallen Grandeur,”
+says the duke. “The first good town we come to we’ll hire a hall and do
+the sword fight in Richard III. and the balcony scene in Romeo and
+Juliet. How does that strike you?”
+
+“I’m in, up to the hub, for anything that will pay, Bilgewater; but,
+you see, I don’t know nothing about play-actin’, and hain’t ever seen
+much of it. I was too small when pap used to have ’em at the palace. Do
+you reckon you can learn me?”
+
+“Easy!”
+
+“All right. I’m jist a-freezn’ for something fresh, anyway. Le’s
+commence right away.”
+
+So the duke he told him all about who Romeo was and who Juliet was, and
+said he was used to being Romeo, so the king could be Juliet.
+
+“But if Juliet’s such a young gal, duke, my peeled head and my white
+whiskers is goin’ to look oncommon odd on her, maybe.”
+
+“No, don’t you worry; these country jakes won’t ever think of that.
+Besides, you know, you’ll be in costume, and that makes all the
+difference in the world; Juliet’s in a balcony, enjoying the moonlight
+before she goes to bed, and she’s got on her night-gown and her ruffled
+nightcap. Here are the costumes for the parts.”
+
+He got out two or three curtain-calico suits, which he said was
+meedyevil armor for Richard III. and t’other chap, and a long white
+cotton nightshirt and a ruffled nightcap to match. The king was
+satisfied; so the duke got out his book and read the parts over in the
+most splendid spread-eagle way, prancing around and acting at the same
+time, to show how it had got to be done; then he give the book to the
+king and told him to get his part by heart.
+
+There was a little one-horse town about three mile down the bend, and
+after dinner the duke said he had ciphered out his idea about how to
+run in daylight without it being dangersome for Jim; so he allowed he
+would go down to the town and fix that thing. The king allowed he would
+go, too, and see if he couldn’t strike something. We was out of coffee,
+so Jim said I better go along with them in the canoe and get some.
+
+When we got there there warn’t nobody stirring; streets empty, and
+perfectly dead and still, like Sunday. We found a sick nigger sunning
+himself in a back yard, and he said everybody that warn’t too young or
+too sick or too old was gone to camp-meeting, about two mile back in
+the woods. The king got the directions, and allowed he’d go and work
+that camp-meeting for all it was worth, and I might go, too.
+
+The duke said what he was after was a printing-office. We found it; a
+little bit of a concern, up over a carpenter shop—carpenters and
+printers all gone to the meeting, and no doors locked. It was a dirty,
+littered-up place, and had ink marks, and handbills with pictures of
+horses and runaway niggers on them, all over the walls. The duke shed
+his coat and said he was all right now. So me and the king lit out for
+the camp-meeting.
+
+We got there in about a half an hour fairly dripping, for it was a most
+awful hot day. There was as much as a thousand people there from twenty
+mile around. The woods was full of teams and wagons, hitched
+everywheres, feeding out of the wagon-troughs and stomping to keep off
+the flies. There was sheds made out of poles and roofed over with
+branches, where they had lemonade and gingerbread to sell, and piles of
+watermelons and green corn and such-like truck.
+
+The preaching was going on under the same kinds of sheds, only they was
+bigger and held crowds of people. The benches was made out of outside
+slabs of logs, with holes bored in the round side to drive sticks into
+for legs. They didn’t have no backs. The preachers had high platforms
+to stand on at one end of the sheds. The women had on sun-bonnets; and
+some had linsey-woolsey frocks, some gingham ones, and a few of the
+young ones had on calico. Some of the young men was barefooted, and
+some of the children didn’t have on any clothes but just a tow-linen
+shirt. Some of the old women was knitting, and some of the young folks
+was courting on the sly.
+
+The first shed we come to the preacher was lining out a hymn. He lined
+out two lines, everybody sung it, and it was kind of grand to hear it,
+there was so many of them and they done it in such a rousing way; then
+he lined out two more for them to sing—and so on. The people woke up
+more and more, and sung louder and louder; and towards the end some
+begun to groan, and some begun to shout. Then the preacher begun to
+preach, and begun in earnest, too; and went weaving first to one side
+of the platform and then the other, and then a-leaning down over the
+front of it, with his arms and his body going all the time, and
+shouting his words out with all his might; and every now and then he
+would hold up his Bible and spread it open, and kind of pass it around
+this way and that, shouting, “It’s the brazen serpent in the
+wilderness! Look upon it and live!” And people would shout out,
+“Glory!—A-a-_men!_” And so he went on, and the people groaning and
+crying and saying amen:
+
+“Oh, come to the mourners’ bench! come, black with sin! (_amen!_) come,
+sick and sore! (_amen!_) come, lame and halt and blind! (_amen!_) come,
+pore and needy, sunk in shame! (_a-a-men!_) come, all that’s worn and
+soiled and suffering!—come with a broken spirit! come with a contrite
+heart! come in your rags and sin and dirt! the waters that cleanse is
+free, the door of heaven stands open—oh, enter in and be at rest!”
+(_a-a-men!_ _glory, glory hallelujah!_)
+
+And so on. You couldn’t make out what the preacher said any more, on
+account of the shouting and crying. Folks got up everywheres in the
+crowd, and worked their way just by main strength to the mourners’
+bench, with the tears running down their faces; and when all the
+mourners had got up there to the front benches in a crowd, they sung
+and shouted and flung themselves down on the straw, just crazy and
+wild.
+
+Well, the first I knowed the king got a-going, and you could hear him
+over everybody; and next he went a-charging up on to the platform, and
+the preacher he begged him to speak to the people, and he done it. He
+told them he was a pirate—been a pirate for thirty years out in the
+Indian Ocean—and his crew was thinned out considerable last spring in a
+fight, and he was home now to take out some fresh men, and thanks to
+goodness he’d been robbed last night and put ashore off of a steamboat
+without a cent, and he was glad of it; it was the blessedest thing that
+ever happened to him, because he was a changed man now, and happy for
+the first time in his life; and, poor as he was, he was going to start
+right off and work his way back to the Indian Ocean, and put in the
+rest of his life trying to turn the pirates into the true path; for he
+could do it better than anybody else, being acquainted with all pirate
+crews in that ocean; and though it would take him a long time to get
+there without money, he would get there anyway, and every time he
+convinced a pirate he would say to him, “Don’t you thank me, don’t you
+give me no credit; it all belongs to them dear people in Pokeville
+camp-meeting, natural brothers and benefactors of the race, and that
+dear preacher there, the truest friend a pirate ever had!”
+
+And then he busted into tears, and so did everybody. Then somebody
+sings out, “Take up a collection for him, take up a collection!” Well,
+a half a dozen made a jump to do it, but somebody sings out, “Let _him_
+pass the hat around!” Then everybody said it, the preacher too.
+
+So the king went all through the crowd with his hat swabbing his eyes,
+and blessing the people and praising them and thanking them for being
+so good to the poor pirates away off there; and every little while the
+prettiest kind of girls, with the tears running down their cheeks,
+would up and ask him would he let them kiss him for to remember him by;
+and he always done it; and some of them he hugged and kissed as many as
+five or six times—and he was invited to stay a week; and everybody
+wanted him to live in their houses, and said they’d think it was an
+honor; but he said as this was the last day of the camp-meeting he
+couldn’t do no good, and besides he was in a sweat to get to the Indian
+Ocean right off and go to work on the pirates.
+
+When we got back to the raft and he come to count up he found he had
+collected eighty-seven dollars and seventy-five cents. And then he had
+fetched away a three-gallon jug of whisky, too, that he found under a
+wagon when he was starting home through the woods. The king said, take
+it all around, it laid over any day he’d ever put in in the
+missionarying line. He said it warn’t no use talking, heathens don’t
+amount to shucks alongside of pirates to work a camp-meeting with.
+
+The duke was thinking _he’d_ been doing pretty well till the king come
+to show up, but after that he didn’t think so so much. He had set up
+and printed off two little jobs for farmers in that
+printing-office—horse bills—and took the money, four dollars. And he
+had got in ten dollars’ worth of advertisements for the paper, which he
+said he would put in for four dollars if they would pay in advance—so
+they done it. The price of the paper was two dollars a year, but he
+took in three subscriptions for half a dollar apiece on condition of
+them paying him in advance; they were going to pay in cordwood and
+onions as usual, but he said he had just bought the concern and knocked
+down the price as low as he could afford it, and was going to run it
+for cash. He set up a little piece of poetry, which he made, himself,
+out of his own head—three verses—kind of sweet and saddish—the name of
+it was, “Yes, crush, cold world, this breaking heart”—and he left that
+all set up and ready to print in the paper, and didn’t charge nothing
+for it. Well, he took in nine dollars and a half, and said he’d done a
+pretty square day’s work for it.
+
+Then he showed us another little job he’d printed and hadn’t charged
+for, because it was for us. It had a picture of a runaway nigger with a
+bundle on a stick over his shoulder, and “$200 reward” under it. The
+reading was all about Jim, and just described him to a dot. It said he
+run away from St. Jacques’ plantation, forty mile below New Orleans,
+last winter, and likely went north, and whoever would catch him and
+send him back he could have the reward and expenses.
+
+“Now,” says the duke, “after to-night we can run in the daytime if we
+want to. Whenever we see anybody coming we can tie Jim hand and foot
+with a rope, and lay him in the wigwam and show this handbill and say
+we captured him up the river, and were too poor to travel on a
+steamboat, so we got this little raft on credit from our friends and
+are going down to get the reward. Handcuffs and chains would look still
+better on Jim, but it wouldn’t go well with the story of us being so
+poor. Too much like jewelry. Ropes are the correct thing—we must
+preserve the unities, as we say on the boards.”
+
+We all said the duke was pretty smart, and there couldn’t be no trouble
+about running daytimes. We judged we could make miles enough that night
+to get out of the reach of the powwow we reckoned the duke’s work in
+the printing office was going to make in that little town; then we
+could boom right along if we wanted to.
+
+We laid low and kept still, and never shoved out till nearly ten
+o’clock; then we slid by, pretty wide away from the town, and didn’t
+hoist our lantern till we was clear out of sight of it.
+
+When Jim called me to take the watch at four in the morning, he says:
+
+“Huck, does you reck’n we gwyne to run acrost any mo’ kings on dis
+trip?”
+
+“No,” I says, “I reckon not.”
+
+“Well,” says he, “dat’s all right, den. I doan’ mine one er two kings,
+but dat’s enough. Dis one’s powerful drunk, en de duke ain’ much
+better.”
+
+I found Jim had been trying to get him to talk French, so he could hear
+what it was like; but he said he had been in this country so long, and
+had so much trouble, he’d forgot it.

--- a/tests/stress/tier2/scenarios.ts
+++ b/tests/stress/tier2/scenarios.ts
@@ -1,0 +1,54 @@
+/**
+ * tests/stress/tier2/scenarios.ts
+ *
+ * Tier 2 stress matrix — live OpenAI + live Perplexity against a real
+ * long-form manuscript. One row to start, by design.
+ *
+ * Why one row: Tier 2 is expensive (live model spend, ~15 min wall-time per
+ * run). The intent is to catch the class of failure that bit prod eval
+ * 609dc776-6ccd-41dd-9353-1425697f1fb2 on 2026-05-13 — silent skip /
+ * missing cross-check / Pass 4 governance not populated on real
+ * 50k-word manuscripts at production concurrency. One representative row
+ * locks the regression; additional rows (quality drift, refusal handling,
+ * variant coverage) belong in follow-up PRs.
+ */
+
+export type Tier2Outcome = "success" | "fail";
+
+export interface Tier2Expectation {
+  outcome: Tier2Outcome;
+  /** evaluation_result.cross_check must be a non-empty object. */
+  cross_check_required: boolean;
+  /** evaluation_result.pass4_governance must be populated. */
+  pass4_governance_required: boolean;
+  /** Wall-time ceiling for the full pipeline (ms). */
+  max_total_ms: number;
+}
+
+export interface Tier2Row {
+  id: string;
+  manuscript_fixture: string;
+  work_type: string;
+  english_variant: "american" | "british";
+  expected: Tier2Expectation;
+  notes: string;
+}
+
+export const TIER2_SCENARIOS: Tier2Row[] = [
+  {
+    id: "Q-long-real-perplexity",
+    manuscript_fixture: "long-form-50k.txt",
+    work_type: "novel",
+    english_variant: "american",
+    expected: {
+      outcome: "success",
+      cross_check_required: true,
+      pass4_governance_required: true,
+      max_total_ms: 15 * 60 * 1000, // 15 min hard cap
+    },
+    notes:
+      "Long-form route (>25k words) + real OpenAI + real Perplexity. Catches " +
+      "the silent-skip class that bit prod eval 609dc776 on 2026-05-13: " +
+      "`External adjudication mode 'required' requires cross-check output`.",
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
     "suspend_industry_user.test.ts",
     "create_agent_verification_request.test.ts",
     "approve_agent_verification.test.ts",
+    "tests/stress/ui/**",
     "all-branches-export",
     "**/all-branches-export/**",
     "literary-ai-partner-all-branches-bundle.zip",


### PR DESCRIPTION
## Summary

Tier 2 pipeline stress harness — runs the real `runPipeline` against a 50k-word long-form manuscript fixture using live OpenAI + live Perplexity, asserting `cross_check` non-empty, `pass4_governance` populated, and `total_ms < 15min`. Catches the silent-skip class of bug that bit prod eval `609dc776-6ccd-41dd-9353-1425697f1fb2` on 2026-05-13 (per `audit_findings_summary`).

Workflow trigger: **`workflow_dispatch` only** — no cron, no automatic PR runs. Costs ~$8–15 per manual invocation; runs only when someone clicks "Run workflow" in Actions.

No-Pipeline-Impact: true

## Scope

- New: `.github/workflows/pipeline-stress-tier2.yml` — manual-dispatch workflow
- New: `scripts/pipeline-stress-tier2.ts` — runner with safety abort if pointed at prod Supabase project `xtumxjnzdswuumndcbwc`
- New: `tests/stress/tier2/scenarios.ts` — one row (`Q-long-real-perplexity`) by design; additional rows belong in follow-up PRs
- New: `tests/stress/tier2/fixtures/manuscripts/long-form-50k.txt` — 50k-word public-domain fixture
- New: `tests/stress/tier2/README.md` + fixtures README
- Modified: `package.json` — adds `pipeline:stress:tier2` script

Repo secrets used (already configured): `OPENAI_API_KEY`, `PERPLEXITY_API_KEY`, `SUPABASE_STRESS_URL` (points at non-prod test project `ngfszuqjoyixmtlbthyv`).

7 files changed (+6066 / −0). No production code path changed; this is purely a CI harness PR.

## Risks & Anomalies

- Risk: Workflow could theoretically be dispatched against a malicious branch and exfiltrate OPENAI/PERPLEXITY keys to a controlled endpoint. Mitigation: `workflow_dispatch` requires write access to the repo; the only person with that access is the owner. PR triggers were intentionally removed to eliminate the fork-PR attack surface.
- Risk: A run that exceeds the 15-min hard ceiling will fail the assertion. Mitigation: that's the contract — if a real long-form eval takes >15 min, the harness has caught a real regression.
- Risk: Runner asserts on in-memory `PipelineResult` rather than DB rows. If a future change makes `cross_check` populated only at persistence time (not in the return value), this harness will give a false-pass. Mitigation: PR #481's `EVAL_EXTERNAL_ADJUDICATION_MODE=required` contract requires `cross_check` to be populated in the result object, not at persistence.
- Anomaly: workflow originally specced for nightly cron + on-PR triggers; rewritten in commit `bb5614a` to manual-dispatch only per cost-control decision.

## Tests Updated

- New: `tests/stress/tier2/scenarios.ts` — declarative scenario table with one row, expectation contract (`cross_check_required`, `pass4_governance_required`, `max_total_ms`)
- New: `scripts/pipeline-stress-tier2.ts` — runner + assertion harness; non-zero exit if any row fails
- No unit tests added for the harness itself; the harness IS the test. Future PRs may add a mock-mode unit test for the assertion logic.

<!-- pr-type:code (label override active) -->