### PR TITLE
fix(phase2c): resolve PipelineResult typing failures in pipeline guard tests

### DIFF
--- a/lib/evaluation/pipeline/__tests__/runPipeline.chunk-guard.test.ts
+++ b/lib/evaluation/pipeline/__tests__/runPipeline.chunk-guard.test.ts
@@ -42,6 +42,16 @@ function chunk(index: number, content: string): ManuscriptChunkEvidence {
   return { chunk_index: index, content };
 }
 
+type PipelineFailure = Extract<Awaited<ReturnType<typeof runPipeline>>, { ok: false }>;
+
+function expectFailure(result: Awaited<ReturnType<typeof runPipeline>>): PipelineFailure {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("Expected pipeline failure but got success");
+  }
+  return result as PipelineFailure;
+}
+
 describe("runPipeline chunk-shape guards", () => {
   describe("CHUNK_BUDGET_OVERFLOW (upper bound)", () => {
     test("100k-char single chunk fails closed", async () => {
@@ -49,12 +59,10 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(100_000))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.failed_at).toBe("pass1");
-        expect(result.error).toMatch(/chunk 0/);
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.failed_at).toBe("pass1");
+      expect(failure.error).toMatch(/chunk 0/);
     });
 
     test("chunk exactly at budget ceiling passes the guard", async () => {
@@ -66,11 +74,9 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(ceiling))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
     });
 
     test("chunk at ceiling - 1 passes the guard", async () => {
@@ -80,11 +86,9 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(ceiling - 1))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
     });
 
     test("chunk at ceiling + 1 trips the guard", async () => {
@@ -94,10 +98,8 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(ceiling + 1))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
     });
 
     test("offending chunk index is surfaced when not first", async () => {
@@ -108,11 +110,9 @@ describe("runPipeline chunk-shape guards", () => {
           chunk(1, "x".repeat(100_000)),
         ],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error).toMatch(/chunk 1/);
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error).toMatch(/chunk 1/);
     });
   });
 
@@ -122,11 +122,9 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x")],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("PIPELINE_INPUT_INVALID");
-        expect(result.failed_at).toBe("pass1");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("PIPELINE_INPUT_INVALID");
+      expect(failure.failed_at).toBe("pass1");
     });
 
     test("chunk at MIN_VIABLE_CHUNK_CHARS - 1 trips the guard", async () => {
@@ -134,10 +132,8 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(31))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("PIPELINE_INPUT_INVALID");
     });
 
     test("chunk at MIN_VIABLE_CHUNK_CHARS passes the guard", async () => {
@@ -145,11 +141,9 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "x".repeat(32))],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
     });
 
     test("whitespace-only chunk is treated as undersized (trim length=0)", async () => {
@@ -157,10 +151,8 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         manuscriptChunks: [chunk(0, "   \n\n   ")],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("PIPELINE_INPUT_INVALID");
     });
   });
 
@@ -173,11 +165,9 @@ describe("runPipeline chunk-shape guards", () => {
       // Empty array means: no chunk-based input. Pipeline falls through to
       // single-pass window path using manuscriptText. Stub runners throw,
       // proving the guard did not fail closed pre-dispatch.
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
     });
 
     test("multiple in-budget chunks all pass", async () => {
@@ -189,11 +179,9 @@ describe("runPipeline chunk-shape guards", () => {
           chunk(2, "c".repeat(3_000)),
         ],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
     });
 
     test("undefined manuscriptChunks (omitted) does not invoke the guard", async () => {
@@ -201,11 +189,9 @@ describe("runPipeline chunk-shape guards", () => {
         ...BASE_OPTS,
         // manuscriptChunks omitted entirely
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
-        expect(result.error_code).not.toBe("PIPELINE_INPUT_INVALID");
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).not.toBe("CHUNK_BUDGET_OVERFLOW");
+      expect(failure.error_code).not.toBe("PIPELINE_INPUT_INVALID");
     });
   });
 
@@ -220,11 +206,9 @@ describe("runPipeline chunk-shape guards", () => {
           chunk(1, "y".repeat(100_000)),
         ],
       });
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error_code).toBe("PIPELINE_INPUT_INVALID");
-        expect(result.error).toMatch(/chunk 0/);
-      }
+      const failure = expectFailure(result);
+      expect(failure.error_code).toBe("PIPELINE_INPUT_INVALID");
+      expect(failure.error).toMatch(/chunk 0/);
     });
   });
 });

--- a/lib/evaluation/pipeline/__tests__/silent-direct-window-killed.test.ts
+++ b/lib/evaluation/pipeline/__tests__/silent-direct-window-killed.test.ts
@@ -25,6 +25,16 @@ const stubRunners = {
   runQualityGate: NEVER_RUN_QG,
 };
 
+type PipelineFailure = Extract<Awaited<ReturnType<typeof runPipeline>>, { ok: false }>;
+
+function expectFailure(result: Awaited<ReturnType<typeof runPipeline>>): PipelineFailure {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("Expected pipeline failure but got success");
+  }
+  return result as PipelineFailure;
+}
+
 function generateText(targetWords: number): string {
   const vocab = "the quick brown fox jumps over the lazy dog and considers what to do next".split(" ");
   const parts: string[] = [];
@@ -48,11 +58,9 @@ describe("silent direct_window fallback is killed", () => {
       _runners: stubRunners as unknown as Parameters<typeof runPipeline>[0]["_runners"],
       _maxManuscriptChars: 10_000_000,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error_code).toBe("CHUNK_ROUTING_NOT_ENGAGED");
-      expect(result.error).toMatch(/Chunk-routed evaluation did not engage/);
-    }
+    const failure = expectFailure(result);
+    expect(failure.error_code).toBe("CHUNK_ROUTING_NOT_ENGAGED");
+    expect(failure.error).toMatch(/Chunk-routed evaluation did not engage/);
   });
 
   test("10k-word text with exactly 1 chunk → still CHUNK_ROUTING_NOT_ENGAGED", async () => {
@@ -67,10 +75,8 @@ describe("silent direct_window fallback is killed", () => {
       _runners: stubRunners as unknown as Parameters<typeof runPipeline>[0]["_runners"],
       _maxManuscriptChars: 10_000_000,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error_code).toBe("CHUNK_ROUTING_NOT_ENGAGED");
-    }
+    const failure = expectFailure(result);
+    expect(failure.error_code).toBe("CHUNK_ROUTING_NOT_ENGAGED");
   });
 
   test("sub-threshold text (2,500 words) with no chunks is OK at the pipeline guard", async () => {
@@ -89,10 +95,8 @@ describe("silent direct_window fallback is killed", () => {
       _runners: stubRunners as unknown as Parameters<typeof runPipeline>[0]["_runners"],
       _maxManuscriptChars: 10_000_000,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error_code).not.toBe("CHUNK_ROUTING_NOT_ENGAGED");
-    }
+    const failure = expectFailure(result);
+    expect(failure.error_code).not.toBe("CHUNK_ROUTING_NOT_ENGAGED");
   });
 
   test("manuscript above HARD_MANUSCRIPT_CEILING_WORDS → MANUSCRIPT_EXCEEDS_HARD_CEILING", async () => {
@@ -107,9 +111,7 @@ describe("silent direct_window fallback is killed", () => {
       _runners: stubRunners as unknown as Parameters<typeof runPipeline>[0]["_runners"],
       _maxManuscriptChars: 100_000_000,
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error_code).toBe("MANUSCRIPT_EXCEEDS_HARD_CEILING");
-    }
+    const failure = expectFailure(result);
+    expect(failure.error_code).toBe("MANUSCRIPT_EXCEEDS_HARD_CEILING");
   });
 });


### PR DESCRIPTION
## Summary

Fixes Phase 2C Evidence Gate TypeScript failures in:
- `lib/evaluation/pipeline/__tests__/runPipeline.chunk-guard.test.ts`
- `lib/evaluation/pipeline/__tests__/silent-direct-window-killed.test.ts`

Root cause: under the current repository TypeScript settings, control-flow narrowing on `if (!result.ok)` was not sufficient for the `PipelineResult` discriminated union in these files.

## Scope

- Test-only TypeScript hardening.
- Affects only Phase 2C / pipeline guard test files.
- No runtime pipeline behavior changes.
- No prompt, scoring, model, gate, persistence, migration, Supabase, Vercel, or UI changes.

## Changes

- Added an explicit `expectFailure(...)` helper in each test file.
- Replaced repeated `if (!result.ok)` branches with helper-based assertions returning the failure shape.
- Keeps runtime test intent unchanged; only stabilizes compile-time typing.

## Tests Updated

- `lib/evaluation/pipeline/__tests__/runPipeline.chunk-guard.test.ts`
- `lib/evaluation/pipeline/__tests__/silent-direct-window-killed.test.ts`

## Validation

- Reproduced the failing `TS2339` errors locally before fix.
- Confirmed those test-file errors are resolved after fix.
- CI is expected to verify the full repository check set.

## Risks & Anomalies

- Low risk: this is a test-only type-narrowing fix.
- The helper includes a runtime assertion and throws if a test unexpectedly receives a successful pipeline result, preserving the original failure expectation.
- Does not address unrelated `@playwright/test` type availability in `tests/stress/ui`; that remains outside this PR's scope.

No-Pipeline-Impact: true