### PR TITLE
fix(stress): materialize chunks in Tier 2 harness (CHUNK_ROUTING_NOT_ENGAGED)

### DIFF
--- a/scripts/pipeline-stress-tier2.ts
+++ b/scripts/pipeline-stress-tier2.ts
@@ -26,6 +26,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { runPipeline } from "@/lib/evaluation/pipeline/runPipeline";
 import type { PipelineResult } from "@/lib/evaluation/pipeline/types";
+import { chunkManuscript } from "@/lib/manuscripts/chunking";
 import { TIER2_SCENARIOS, type Tier2Row } from "../tests/stress/tier2/scenarios";
 
 const PROD_SUPABASE_PROJECT_ID = "xtumxjnzdswuumndcbwc";
@@ -89,8 +90,19 @@ async function executeRow(row: Tier2Row, env: ResolvedEnv): Promise<RunOutcome> 
   let threw: Error | null = null;
 
   try {
+    // Materialize chunks before invoking runPipeline. Required by the
+    // fail-closed chunk-routing assertion added in PR #490: runPipeline
+    // rejects with CHUNK_ROUTING_NOT_ENGAGED when manuscriptChunks is
+    // absent/empty on long-form input. Mirrors the Tier 1 harness pattern.
+    const chunked = await chunkManuscript(manuscriptText);
+    const manuscriptChunks = chunked.map((c) => ({
+      chunk_index: c.chunk_index,
+      content: c.content,
+    }));
+
     result = await runPipeline({
       manuscriptText,
+      manuscriptChunks,
       workType: row.work_type,
       title: `stress-tier2-${row.id}`,
       manuscriptId: jobId,


### PR DESCRIPTION
## Summary

Fix harness wiring bug: Tier 2 stress harness was invoking `runPipeline()` on the 50k-word long-form fixture without first materializing chunks via `chunkManuscript()`. After the fail-closed chunk-routing assertion landed in #490, this caused Tier 2 to fail with `CHUNK_ROUTING_NOT_ENGAGED` at second 1 (before any OpenAI/Perplexity calls). Mirrors the Tier 1 harness pattern.

Failed run: https://github.com/Mmeraw/literary-ai-partner/actions/runs/25884069983

No-Pipeline-Impact: true

## Scope

- `scripts/pipeline-stress-tier2.ts` only
- Adds `chunkManuscript()` call before `runPipeline()`
- No changes to pipeline logic, chunker logic, Pass 4 logic, or latency tuning

## Risks & Anomalies

- Risk: low — harness-only change, mirrors established Tier 1 pattern
- Anomaly: none
- Tier 2 still runs only on `workflow_dispatch` (manual). No cron, no PR triggers.

## Tests Updated

- None (this IS the test/harness)
- Will be validated by re-running `pipeline-stress-tier2.yml` on main after merge
