### PR TITLE
docs(admin): formalize pipeline-health support cockpit spec

### DIFF
--- a/docs/admin/PIPELINE_HEALTH_PR_PLAN.md
+++ b/docs/admin/PIPELINE_HEALTH_PR_PLAN.md
@@ -1,0 +1,143 @@
+# Pipeline Health PR Plan
+
+Status: Sequencing plan for `/admin/pipeline-health`
+
+This plan exists to keep implementation narrow, reviewable, and canon-safe.
+
+## PR A — Spec only
+
+Title:
+
+`docs(admin): formalize pipeline-health support cockpit spec`
+
+Files:
+
+- `docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md`
+- `docs/admin/PIPELINE_HEALTH_PR_PLAN.md`
+
+Runtime changes:
+
+- none
+
+Purpose:
+
+- lock page identity
+- lock canon rule
+- lock truth rule
+- prevent future agent drift
+
+## PR B — Truthful failure rendering
+
+Goal:
+
+UI must never invent failure explanations.
+
+Scope:
+
+- fix missing Pass 4 / cross-check fallback behavior
+- render missing evidence truthfully
+- add regression coverage for Froggin-style contradiction
+
+## PR C — Backend read model foundation
+
+Scope:
+
+- add `lib/admin/pipelineHealthTypes.ts`
+- extend `GET /api/admin/pipeline-health`
+- add `GET /api/admin/pipeline-health/jobs`
+- add `GET /api/admin/pipeline-health/jobs/[id]/steps`
+- add `GET /api/admin/pipeline-health/taxonomy`
+- add unavailable response shape
+
+Unavailable response contract:
+
+- `available: false`
+- `reason`
+- `missingDependency`
+
+Rule:
+
+- no fake zeroes
+
+## PR D — SQL / view layer
+
+Scope:
+
+- add `pipeline_health_kpi_24h`
+- add `pipeline_step_observations`
+- add `admin_audit_log`
+
+Rules:
+
+- KPI tiles from materialized 24h rollup
+- job lists support keyset pagination
+- audit surface exists before admin actions expand
+- if a view/table is not provisioned yet, the API must return `available:false`; it must not synthesize fake data
+
+## PR E — Support workflow UI
+
+Scope:
+
+- dark cockpit layout
+- top search bar
+- filter chips
+- failed 24h default
+- user column
+- plan badge
+- job table
+- coverage pill
+- expandable step-contract row
+
+Goal:
+
+Implement the core support workflow before decorative dashboard work.
+
+## PR F — Step-contract + chunk telemetry
+
+Scope:
+
+- 11-step panel
+- pass timing bars
+- chunk drilldown for Pass 1 / Pass 2
+- coverage / truncation / prompt-window metrics
+
+Rule:
+
+Each step renders:
+
+- `input.spec`
+- `metric persisted`
+- `output.spec`
+
+## PR G — Right rail + actions
+
+Scope:
+
+- failure taxonomy
+- SIPOC fixtures tile
+- self-recovery tile
+- retry modal
+- copy support reply
+- open user history
+- audit writes for actions
+
+Rule:
+
+Recovery actions land only after audit logging exists.
+
+## Build order
+
+1. Truth layer first
+2. Support workflow second
+3. Visual cockpit third
+4. Recovery actions last
+
+## Non-goals
+
+Do not:
+
+- ship a static mockup as if it were the product
+- silently rewrite SIPOC canon
+- fake unavailable data as zero
+- invent failure explanations
+- add recovery actions before audit logging

--- a/docs/admin/PIPELINE_HEALTH_PR_PLAN.md
+++ b/docs/admin/PIPELINE_HEALTH_PR_PLAN.md
@@ -26,6 +26,12 @@ Purpose:
 - lock truth rule
 - prevent future agent drift
 
+Post-500 alignment (required):
+
+- Tier 2 diagnostics must remain clause-mapped (contract-clause-prefixed failures), matching the PR-C enforcement lane
+- runtime/concurrency references must reflect current setting (Pass 1/Pass 2 concurrency reduced from 5 to 3)
+- failure rendering and taxonomy must preserve canonical overlay/error codes exactly as persisted (no UI reinterpretation)
+
 ## PR B — Truthful failure rendering
 
 Goal:

--- a/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
+++ b/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
@@ -47,17 +47,19 @@ Missing Pass 4 / cross-check evidence must render as missing evidence, not as a 
 
 ### Required endpoints
 
-- `GET /api/admin/pipeline-health`
-- `GET /api/admin/pipeline-health/jobs`
-- `GET /api/admin/pipeline-health/jobs/[id]/steps`
-- `GET /api/admin/pipeline-health/jobs/[id]/steps/[k]/chunks`
-- `GET /api/admin/pipeline-health/taxonomy`
+- extend `GET /api/admin/pipeline-health`
+- add `GET /api/admin/pipeline-health/jobs`
+- add `GET /api/admin/pipeline-health/jobs/[id]/steps`
+- add `GET /api/admin/pipeline-health/jobs/[id]/steps/[k]/chunks`
+- add `GET /api/admin/pipeline-health/taxonomy`
 
 ### Required DB / read models
 
 - `pipeline_health_kpi_24h`
 - `pipeline_step_observations`
 - `admin_audit_log`
+
+If a view or table is not provisioned yet, the API must return `available:false`; it must not synthesize fake data.
 
 ### Required UI sections
 

--- a/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
+++ b/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
@@ -31,6 +31,12 @@ If the UI groups or splits stages for readability, that is a dashboard projectio
 
 No mocked truth. No fake zeroes. No invented failure explanations.
 
+Post-500 contract alignment is mandatory:
+
+- Tier 2/long-form failures must render clause-mapped diagnostics as stored (contract clause prefix + message), not paraphrased summaries.
+- Concurrency-related copy and troubleshooting hints must reflect current runtime truth (Pass 1/Pass 2 concurrency is 3, not 5).
+- Overlay/error codes are canonical persisted identifiers and must be displayed/copied faithfully (no renaming, normalization, or inferred replacements).
+
 If data is not currently backed by persisted storage, the API must return:
 
 - `available: false`
@@ -150,6 +156,7 @@ Expected visible diagnosis:
 - long-form coverage insufficiency is visible
 - front-loaded / partial analysis is visible
 - manuscript-wide certification cannot appear healthy when coverage is insufficient
+- clause-mapped Tier 2 diagnostics and overlay/error codes are visible exactly as persisted
 
 ## Acceptance bar
 

--- a/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
+++ b/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
@@ -4,13 +4,11 @@ Status: Canonical implementation authority for `/admin/pipeline-health`; does no
 
 ## Purpose
 
-`/admin/pipeline-health` is an admin-only support-ops cockpit.
-
-It is not a generic metrics dashboard.
+This page is an admin-only support-ops cockpit. It is not a generic metrics dashboard.
 
 Primary workflow:
 
-User reports failure -> admin searches by email / `user_id` / `job_id` / `manuscript_id` / support ticket -> admin finds the failed job in under 20 seconds -> expands the job row -> sees the exact failing step and persisted metric -> retries the job or copies a truthful support reply without leaving the page.
+User reports failure → admin searches by email / `user_id` / `job_id` / `manuscript_id` / support ticket → admin finds the failed job in under 20 seconds → expands the job row → sees the exact failing step and persisted metric → retries the job or copies a truthful support reply without leaving the page.
 
 This document is the implementation authority for `/admin/pipeline-health`.
 
@@ -58,8 +56,6 @@ Missing Pass 4 / cross-check evidence must render as missing evidence, not as a 
 - `pipeline_health_kpi_24h`
 - `pipeline_step_observations`
 - `admin_audit_log`
-
-If a view or table is not provisioned yet, the API must return `available:false`; it must not synthesize fake data.
 
 ### Required UI sections
 
@@ -158,3 +154,13 @@ Expected visible diagnosis:
 ## Acceptance bar
 
 A support admin can paste a user email, find the failed job in under 20 seconds, expand it, see the failing step and persisted metric, copy a truthful support reply, and retry with audit logging — without leaving the page or reading logs.
+
+## Amendment rule
+
+Changes to this spec require:
+
+- a separate docs-only PR
+- a brief rationale block explaining the trigger (incident, fixture, scale issue)
+- no bundled runtime changes
+
+Implementation PRs (B–G) must cite this spec in their PR body.

--- a/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
+++ b/docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md
@@ -1,0 +1,158 @@
+# Pipeline Health Support Cockpit Spec
+
+Status: Canonical implementation authority for `/admin/pipeline-health`; does not supersede governed SIPOC canon.
+
+## Purpose
+
+`/admin/pipeline-health` is an admin-only support-ops cockpit.
+
+It is not a generic metrics dashboard.
+
+Primary workflow:
+
+User reports failure -> admin searches by email / `user_id` / `job_id` / `manuscript_id` / support ticket -> admin finds the failed job in under 20 seconds -> expands the job row -> sees the exact failing step and persisted metric -> retries the job or copies a truthful support reply without leaving the page.
+
+This document is the implementation authority for `/admin/pipeline-health`.
+
+## Canon rule
+
+The dashboard must not silently rewrite SIPOC canon.
+
+The governed SIPOC contract remains canonical. Dashboard cells are a support-facing projection over that contract.
+
+Each visual dashboard cell must include:
+
+- `canonicalStageId`
+- `displayLabel`
+
+Dashboard cells are allowed to group or split display labels only if they preserve a `canonicalStageId` mapping.
+
+If the UI groups or splits stages for readability, that is a dashboard projection only. It does not change canonical stage identity.
+
+## Truth rule
+
+No mocked truth. No fake zeroes. No invented failure explanations.
+
+If data is not currently backed by persisted storage, the API must return:
+
+- `available: false`
+- `reason: "view_missing" | "table_missing" | "field_not_persisted"`
+- `missingDependency: string`
+
+The UI must render unavailable states honestly.
+
+Missing Pass 4 / cross-check evidence must render as missing evidence, not as a zombie/heartbeat explanation or any other inferred narrative.
+
+## Required read surfaces
+
+### Required endpoints
+
+- `GET /api/admin/pipeline-health`
+- `GET /api/admin/pipeline-health/jobs`
+- `GET /api/admin/pipeline-health/jobs/[id]/steps`
+- `GET /api/admin/pipeline-health/jobs/[id]/steps/[k]/chunks`
+- `GET /api/admin/pipeline-health/taxonomy`
+
+### Required DB / read models
+
+- `pipeline_health_kpi_24h`
+- `pipeline_step_observations`
+- `admin_audit_log`
+
+### Required UI sections
+
+- Top persistent support search bar
+- Filter chips
+- KPI tiles
+- SIPOC strip / support projection
+- Recent jobs table
+- Coverage pill on every job row
+- Expandable step-contract panel
+- Pass timing strip
+- Pass 1 / Pass 2 chunk drilldown
+- Failure taxonomy tile
+- SIPOC fixtures tile
+- Self-recovery tile
+- Actions column: retry, copy support reply, open user history
+
+## Search and paging rules
+
+Search is the entry point, not an extra feature.
+
+The page must support search by:
+
+- email
+- `user_id`
+- `job_id`
+- `manuscript_id`
+- support ticket
+
+Default list view:
+
+- failed jobs
+- last 24 hours
+- newest first
+
+Pagination must be keyset-based, not offset-based.
+
+## KPI rule
+
+Top KPI tiles must read from a materialized 24-hour rollup, not from live aggregate scans on page load.
+
+## Audit and auth rule
+
+This page is admin-only.
+
+Required protections:
+
+- middleware role gate
+- RLS enforcement
+- audit log write on page load
+- audit log write on job-row expansion
+- audit log write on retry and reply actions
+
+## Step-contract rule
+
+The expanded job row is the canonical diagnostic surface.
+
+Each step row must render:
+
+- `input.spec`
+- `metric persisted`
+- `output.spec`
+- `last_event_at`
+
+The page must help support diagnose without requiring a log dive.
+
+## Acceptance fixtures
+
+### Fixture A — Cartel Babies
+
+Expected visible diagnosis:
+
+- low coverage is visible
+- Pass 1 failure is visible
+- truncation is visible
+- prompt-window chars are visible
+- chunk evidence scarcity is visible
+- admin can diagnose without docx autopsy or logs
+
+### Fixture B — Froggin
+
+Expected visible diagnosis:
+
+- missing Pass 4 / cross-check evidence is rendered as missing evidence
+- UI does not invent zombie/heartbeat explanation
+- required-mode contradiction is visible if present
+
+### Fixture C — Dominatus-style long-form coverage failure
+
+Expected visible diagnosis:
+
+- long-form coverage insufficiency is visible
+- front-loaded / partial analysis is visible
+- manuscript-wide certification cannot appear healthy when coverage is insufficient
+
+## Acceptance bar
+
+A support admin can paste a user email, find the failed job in under 20 seconds, expand it, see the failing step and persisted metric, copy a truthful support reply, and retry with audit logging — without leaving the page or reading logs.


### PR DESCRIPTION
## Summary

Formalizes `/admin/pipeline-health` as an admin-only support-ops cockpit, not a generic metrics dashboard.

Adds two docs:
- `docs/admin/PIPELINE_HEALTH_SUPPORT_COCKPIT_SPEC.md`
- `docs/admin/PIPELINE_HEALTH_PR_PLAN.md`

These docs lock:
- the primary support workflow
- canonical SIPOC vs dashboard projection rule
- truth/unavailable-data rule
- required read surfaces
- required UI sections
- acceptance fixtures
- staged implementation plan

## Scope

Docs only.

No runtime code changes.
No API route changes.
No SQL migrations.
No UI implementation changes.
No SIPOC canon rewrite.

## Risks & Anomalies

Low risk. This PR only formalizes implementation authority before dashboard work begins.

The main risk avoided is future agent drift: building a pretty static dashboard without search-first support workflow, step-contract drilldown, auditability, or truthful unavailable states.

No-Pipeline-Impact: true