### PR TITLE
fix(config): lower chunk pass concurrency to reduce rate-limit pressure

### DIFF
--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -41,7 +41,7 @@ const PASS1_LIMITS = {
   maxEvidencePerCriterion: 1,
   maxEvidenceSnippetChars: 180,
 } as const;
-const DEFAULT_CHUNK_PASS_CONCURRENCY = 5;
+const DEFAULT_CHUNK_PASS_CONCURRENCY = 3;
 const DEFAULT_CHUNK_RETRY_MAX = 3;
 const DEFAULT_CHUNK_RETRY_BASE_MS = 10000;
 

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -37,7 +37,7 @@ const PASS2_TEMPERATURE = 0.3;
 // Mirror of processor.ts STRUCTURAL_CHUNKING_THRESHOLD_WORDS. Kept duplicated
 // here to avoid a circular import — processor.ts pulls from pipeline modules.
 const STRUCTURAL_CHUNKING_THRESHOLD_WORDS = 3_000;
-const DEFAULT_CHUNK_PASS_CONCURRENCY = 5;
+const DEFAULT_CHUNK_PASS_CONCURRENCY = 3;
 const DEFAULT_CHUNK_RETRY_MAX = 3;
 const DEFAULT_CHUNK_RETRY_BASE_MS = 10000;
 // Pass 2 model is resolved via getCanonicalPass2Model(opts.model), allowing


### PR DESCRIPTION
## Summary

Supersedes closed PR #495.

Lowers the default chunk pass concurrency for Pass 1 and Pass 2 from 5 to 3 to reduce provider rate-limit pressure during long-form fan-out.

The prior #495 cleanup surfaced two corrections:
- the unrelated `package-lock.json` Playwright pin should not be part of this runtime config PR
- timeout guidance in #495 was wrong: Production already has `EVAL_PASS_TIMEOUT_MS=720000`, matching the in-code default, so this PR does not change timeout behavior

No-Pipeline-Impact: true

## Scope

- `lib/evaluation/pipeline/runPass1.ts`: `DEFAULT_CHUNK_PASS_CONCURRENCY` 5 → 3
- `lib/evaluation/pipeline/runPass2.ts`: `DEFAULT_CHUNK_PASS_CONCURRENCY` 5 → 3
- Env var overrides still take precedence through `EVAL_CHUNK_PASS_CONCURRENCY`

No changes to:
- timeout defaults
- Vercel/deployment env
- `package-lock.json`
- chunker logic
- pipeline orchestration
- retry policy
- Pass 4
- model config
- scoring
- persistence
- fan-out/fan-in design

## Risks & Anomalies

Low risk: config-default reduction only.

Expected trade-off: slightly slower long-form chunk fan-out, but lower risk of 429 cascades under tight provider limits.

Important correction: do **not** lower `EVAL_PASS_TIMEOUT_MS` to 180000. Production already shows `EVAL_PASS_TIMEOUT_MS=720000`, and the in-code default is also 720000.

## Tests Updated

None. Config-default-only change.

## Validation

Post-merge validation should be a fresh `pipeline-stress-tier2.yml` dispatch on `main`.