### PR TITLE
feat(tier2): clause-mapped assertions for long-form contract enforcement

### DIFF
--- a/.github/workflows/ci-guard.yml
+++ b/.github/workflows/ci-guard.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run CI Guard
         run: npm run ci-guard -- --base origin/${{ github.base_ref }} --head ${{ github.sha }} --artifact artifacts/ci-guard-report.json
 
+      - name: Enforce Tier2 contract import boundary
+        run: npm run guard:tier2-contract-import-boundary
+
       - name: Upload CI Guard Artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "verify:zero-drift": "bash scripts/verify-zero-drift.sh",
     "guard:clean-tree": "bash scripts/guard-clean-tree.sh",
     "guard:phase-integrity": "bash scripts/guard-phase-integrity.sh",
+    "guard:tier2-contract-import-boundary": "node scripts/guard-tier2-contract-import-boundary.mjs",
     "guard:u3-prereq": "bash scripts/guard-u3-prereq.sh",
     "u2:proof:validate": "node scripts/validate-u2-proof.mjs",
     "test": "jest",

--- a/scripts/guard-tier2-contract-import-boundary.mjs
+++ b/scripts/guard-tier2-contract-import-boundary.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { globSync } from "glob";
+
+const ROOT = process.cwd();
+const ALLOWED_SCRIPT = "scripts/pipeline-stress-tier2.ts";
+
+const SOURCE_FILES = globSync("**/*.{ts,tsx,js,mjs,cjs}", {
+  cwd: ROOT,
+  nodir: true,
+  ignore: [
+    "node_modules/**",
+    ".git/**",
+    ".next/**",
+    "coverage/**",
+    "dist/**",
+    "build/**",
+    "archive/**",
+    "base44-export/**",
+  ],
+});
+
+const IMPORT_PATTERNS = [
+  /from\s+["'][^"']*tests\/contract\//g,
+  /require\(\s*["'][^"']*tests\/contract\//g,
+  /import\(\s*["'][^"']*tests\/contract\//g,
+];
+
+function isAllowedImporter(relativePath) {
+  return relativePath.startsWith("tests/") || relativePath === ALLOWED_SCRIPT;
+}
+
+function lineForIndex(content, index) {
+  return content.slice(0, index).split("\n").length;
+}
+
+const violations = [];
+
+for (const relativePath of SOURCE_FILES) {
+  const absolutePath = path.join(ROOT, relativePath);
+  const content = fs.readFileSync(absolutePath, "utf8");
+
+  for (const pattern of IMPORT_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      if (!isAllowedImporter(relativePath)) {
+        violations.push({
+          relativePath,
+          line: lineForIndex(content, match.index),
+          snippet: match[0],
+        });
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "[guard:tier2-contract-import-boundary] Forbidden imports from tests/contract/** detected.",
+  );
+  console.error(
+    "Only tests/** and scripts/pipeline-stress-tier2.ts may import from tests/contract/**.",
+  );
+  for (const violation of violations) {
+    console.error(` - ${violation.relativePath}:${violation.line} :: ${violation.snippet}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  "[guard:tier2-contract-import-boundary] PASS — import boundary preserved.",
+);

--- a/scripts/guard-tier2-contract-import-boundary.mjs
+++ b/scripts/guard-tier2-contract-import-boundary.mjs
@@ -22,10 +22,11 @@ const SOURCE_FILES = globSync("**/*.{ts,tsx,js,mjs,cjs}", {
   ],
 });
 
+const CONTRACT_IMPORT_RE = String.raw`[^"']*tests\/contract(?:\/[^"']*)?`;
 const IMPORT_PATTERNS = [
-  /from\s+["'][^"']*tests\/contract\//g,
-  /require\(\s*["'][^"']*tests\/contract\//g,
-  /import\(\s*["'][^"']*tests\/contract\//g,
+  new RegExp(String.raw`from\s+["']${CONTRACT_IMPORT_RE}["']`, "g"),
+  new RegExp(String.raw`require\(\s*["']${CONTRACT_IMPORT_RE}["']\s*\)`, "g"),
+  new RegExp(String.raw`import\(\s*["']${CONTRACT_IMPORT_RE}["']\s*\)`, "g"),
 ];
 
 function isAllowedImporter(relativePath) {

--- a/scripts/pipeline-stress-tier2.ts
+++ b/scripts/pipeline-stress-tier2.ts
@@ -127,8 +127,14 @@ function hasNonEmptyString(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+type PipelineFailureResult = Extract<PipelineResult, { ok: false }>;
+
+function isPipelineFailureResult(result: PipelineResult | null): result is PipelineFailureResult {
+  return !!result && !result.ok;
+}
+
 function inferClauseFromPipelineFailure(result: PipelineResult | null): LongFormClauseId {
-  if (!result || result.ok) {
+  if (!isPipelineFailureResult(result)) {
     return "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET";
   }
 

--- a/scripts/pipeline-stress-tier2.ts
+++ b/scripts/pipeline-stress-tier2.ts
@@ -30,6 +30,7 @@ import { chunkManuscript } from "@/lib/manuscripts/chunking";
 import { TIER2_SCENARIOS, type Tier2Row } from "../tests/stress/tier2/scenarios";
 import {
   LONG_FORM_CLAUSE_IDS,
+  LONG_FORM_CLAUSE_TITLES,
   LONG_FORM_CLAUSE_TO_FAIL_CODE,
   formatClauseFailureMessage,
   type LongFormClauseId,
@@ -86,14 +87,13 @@ export interface RunOutcome {
   threw: Error | null;
 }
 
-const CLAUSE_IDS_BY_FAIL_CODE: Readonly<Record<LongFormFailCode, LongFormClauseId | null>> =
+const CLAUSE_IDS_BY_FAIL_CODE: Readonly<Partial<Record<LongFormFailCode, LongFormClauseId>>> =
   (() => {
-    const byFailCode = Object.create(null) as Record<LongFormFailCode, LongFormClauseId | null>;
+    const byFailCode = Object.create(null) as Partial<Record<LongFormFailCode, LongFormClauseId>>;
     for (const clauseId of LONG_FORM_CLAUSE_IDS) {
       const code = LONG_FORM_CLAUSE_TO_FAIL_CODE[clauseId];
       byFailCode[code] = clauseId;
     }
-    byFailCode.LAYER_INCOMPLETE = null;
     return Object.freeze(byFailCode);
   })();
 
@@ -109,9 +109,36 @@ function renderActual(value: unknown): string {
   }
 }
 
+function formatTier2ClauseFailure(
+  clauseId: LongFormClauseId,
+  detail: string,
+  failCodeOverride?: string,
+): string {
+  if (!failCodeOverride) {
+    return formatClauseFailureMessage(clauseId, detail);
+  }
+  return `[${clauseId}] ${LONG_FORM_CLAUSE_TITLES[clauseId]} (${failCodeOverride}): ${detail}`;
+}
+
 function pushClauseFailure(args: {
   failures: string[];
   clauseId: LongFormClauseId;
+  fieldPath: string;
+  expected: string;
+  actual: unknown;
+  note?: string;
+  failCodeOverride?: string;
+}): void {
+  const detail =
+    `${args.fieldPath}; expected=${args.expected}; actual=${renderActual(args.actual)}` +
+    (args.note ? `; ${args.note}` : "");
+  args.failures.push(formatTier2ClauseFailure(args.clauseId, detail, args.failCodeOverride));
+}
+
+function pushUnmappedFailure(args: {
+  failures: string[];
+  label: string;
+  failCode: string;
   fieldPath: string;
   expected: string;
   actual: unknown;
@@ -120,7 +147,7 @@ function pushClauseFailure(args: {
   const detail =
     `${args.fieldPath}; expected=${args.expected}; actual=${renderActual(args.actual)}` +
     (args.note ? `; ${args.note}` : "");
-  args.failures.push(formatClauseFailureMessage(args.clauseId, detail));
+  args.failures.push(`[${args.label}] Unmapped pipeline failure (${args.failCode}): ${detail}`);
 }
 
 function hasNonEmptyString(value: unknown): boolean {
@@ -129,26 +156,48 @@ function hasNonEmptyString(value: unknown): boolean {
 
 type PipelineFailureResult = Extract<PipelineResult, { ok: false }>;
 
+type PipelineFailureMapping =
+  | { kind: "clause"; clauseId: LongFormClauseId; failCodeOverride?: string }
+  | { kind: "unmapped"; label: string; failCode: string };
+
 function isPipelineFailureResult(result: PipelineResult | null): result is PipelineFailureResult {
   return !!result && !result.ok;
 }
 
-function inferClauseFromPipelineFailure(result: PipelineResult | null): LongFormClauseId {
+function fallbackClauseForFailedAt(failedAt: PipelineFailureResult["failed_at"]): LongFormClauseId {
+  return failedAt === "pass1"
+    ? "CLAUSE_3_PASS1_WITHIN_BUDGET"
+    : failedAt === "pass2"
+      ? "CLAUSE_4_PASS2_WITHIN_BUDGET"
+      : failedAt === "pass3"
+        ? "CLAUSE_5_PASS3_WITHIN_BUDGET"
+        : "CLAUSE_8_QUALITY_GATE_PASSES";
+}
+
+function inferPipelineFailureMapping(result: PipelineResult | null): PipelineFailureMapping {
   if (!isPipelineFailureResult(result)) {
-    return "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET";
+    return {
+      kind: "clause",
+      clauseId: "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET",
+      failCodeOverride: "NO_RESULT",
+    };
   }
 
-  const code = result.error_code as LongFormFailCode;
-  return (
-    CLAUSE_IDS_BY_FAIL_CODE[code] ??
-    (result.failed_at === "pass1"
-      ? "CLAUSE_3_PASS1_WITHIN_BUDGET"
-      : result.failed_at === "pass2"
-        ? "CLAUSE_4_PASS2_WITHIN_BUDGET"
-        : result.failed_at === "pass3"
-          ? "CLAUSE_5_PASS3_WITHIN_BUDGET"
-          : "CLAUSE_8_QUALITY_GATE_PASSES")
-  );
+  const actualCode = result.error_code;
+  const mappedClause = CLAUSE_IDS_BY_FAIL_CODE[actualCode as LongFormFailCode];
+  if (mappedClause) {
+    return { kind: "clause", clauseId: mappedClause };
+  }
+
+  if (actualCode === "LAYER_INCOMPLETE") {
+    return { kind: "unmapped", label: "LAYER_INCOMPLETE", failCode: actualCode };
+  }
+
+  return {
+    kind: "clause",
+    clauseId: fallbackClauseForFailedAt(result.failed_at),
+    failCodeOverride: actualCode,
+  };
 }
 
 async function executeRow(row: Tier2Row, env: ResolvedEnv): Promise<RunOutcome> {
@@ -233,14 +282,28 @@ export function assertRow(outcome: RunOutcome): string[] {
         result && "error_code" in result
           ? (result as { error_code: string }).error_code
           : "no-result";
+      const mapping = inferPipelineFailureMapping(result);
 
-      pushClauseFailure({
-        failures,
-        clauseId: inferClauseFromPipelineFailure(result),
-        fieldPath: "pipeline.outcome",
-        expected: "success",
-        actual: code,
-      });
+      if (mapping.kind === "clause") {
+        pushClauseFailure({
+          failures,
+          clauseId: mapping.clauseId,
+          fieldPath: "pipeline.outcome",
+          expected: "success",
+          actual: code,
+          failCodeOverride: mapping.failCodeOverride,
+        });
+      } else {
+        pushUnmappedFailure({
+          failures,
+          label: mapping.label,
+          failCode: mapping.failCode,
+          fieldPath: "pipeline.outcome",
+          expected: "success",
+          actual: code,
+          note: "not mapped to one of the 12 numbered long-form clauses",
+        });
+      }
       return failures;
     }
 

--- a/scripts/pipeline-stress-tier2.ts
+++ b/scripts/pipeline-stress-tier2.ts
@@ -28,6 +28,13 @@ import { runPipeline } from "@/lib/evaluation/pipeline/runPipeline";
 import type { PipelineResult } from "@/lib/evaluation/pipeline/types";
 import { chunkManuscript } from "@/lib/manuscripts/chunking";
 import { TIER2_SCENARIOS, type Tier2Row } from "../tests/stress/tier2/scenarios";
+import {
+  LONG_FORM_CLAUSE_IDS,
+  LONG_FORM_CLAUSE_TO_FAIL_CODE,
+  formatClauseFailureMessage,
+  type LongFormClauseId,
+  type LongFormFailCode,
+} from "@/tests/contract/long-form-contract";
 
 const PROD_SUPABASE_PROJECT_ID = "xtumxjnzdswuumndcbwc";
 const FIXTURES_DIR = path.resolve("tests/stress/tier2/fixtures/manuscripts");
@@ -72,11 +79,70 @@ function readFixture(fixtureName: string): string {
   return fs.readFileSync(fullPath, "utf8");
 }
 
-interface RunOutcome {
+export interface RunOutcome {
   row: Tier2Row;
   result: PipelineResult | null;
   total_ms: number;
   threw: Error | null;
+}
+
+const CLAUSE_IDS_BY_FAIL_CODE: Readonly<Record<LongFormFailCode, LongFormClauseId | null>> =
+  (() => {
+    const byFailCode = Object.create(null) as Record<LongFormFailCode, LongFormClauseId | null>;
+    for (const clauseId of LONG_FORM_CLAUSE_IDS) {
+      const code = LONG_FORM_CLAUSE_TO_FAIL_CODE[clauseId];
+      byFailCode[code] = clauseId;
+    }
+    byFailCode.LAYER_INCOMPLETE = null;
+    return Object.freeze(byFailCode);
+  })();
+
+function renderActual(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function pushClauseFailure(args: {
+  failures: string[];
+  clauseId: LongFormClauseId;
+  fieldPath: string;
+  expected: string;
+  actual: unknown;
+  note?: string;
+}): void {
+  const detail =
+    `${args.fieldPath}; expected=${args.expected}; actual=${renderActual(args.actual)}` +
+    (args.note ? `; ${args.note}` : "");
+  args.failures.push(formatClauseFailureMessage(args.clauseId, detail));
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function inferClauseFromPipelineFailure(result: PipelineResult | null): LongFormClauseId {
+  if (!result || result.ok) {
+    return "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET";
+  }
+
+  const code = result.error_code as LongFormFailCode;
+  return (
+    CLAUSE_IDS_BY_FAIL_CODE[code] ??
+    (result.failed_at === "pass1"
+      ? "CLAUSE_3_PASS1_WITHIN_BUDGET"
+      : result.failed_at === "pass2"
+        ? "CLAUSE_4_PASS2_WITHIN_BUDGET"
+        : result.failed_at === "pass3"
+          ? "CLAUSE_5_PASS3_WITHIN_BUDGET"
+          : "CLAUSE_8_QUALITY_GATE_PASSES")
+  );
 }
 
 async function executeRow(row: Tier2Row, env: ResolvedEnv): Promise<RunOutcome> {
@@ -131,19 +197,29 @@ function isNonEmptyObject(v: unknown): boolean {
   );
 }
 
-function assertRow(outcome: RunOutcome): string[] {
+export function assertRow(outcome: RunOutcome): string[] {
   const failures: string[] = [];
   const { row, result, total_ms, threw } = outcome;
 
   if (total_ms > row.expected.max_total_ms) {
-    failures.push(
-      `total_ms=${total_ms} > max_total_ms=${row.expected.max_total_ms}`,
-    );
+    pushClauseFailure({
+      failures,
+      clauseId: "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET",
+      fieldPath: "timing.total_ms",
+      expected: `<= ${row.expected.max_total_ms}`,
+      actual: total_ms,
+    });
   }
 
   if (row.expected.outcome === "success") {
     if (threw) {
-      failures.push(`threw: ${threw.message}`);
+      pushClauseFailure({
+        failures,
+        clauseId: "CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET",
+        fieldPath: "pipeline.execution",
+        expected: "no thrown error",
+        actual: threw.message,
+      });
       return failures;
     }
     if (!result || !result.ok) {
@@ -151,15 +227,61 @@ function assertRow(outcome: RunOutcome): string[] {
         result && "error_code" in result
           ? (result as { error_code: string }).error_code
           : "no-result";
-      failures.push(`expected success, got fail: ${code}`);
+
+      pushClauseFailure({
+        failures,
+        clauseId: inferClauseFromPipelineFailure(result),
+        fieldPath: "pipeline.outcome",
+        expected: "success",
+        actual: code,
+      });
       return failures;
+    }
+
+    if (!Array.isArray(result.synthesis?.criteria) || result.synthesis.criteria.length === 0) {
+      pushClauseFailure({
+        failures,
+        clauseId: "CLAUSE_9_SCORES_PRODUCED",
+        fieldPath: "evaluation_result.synthesis.criteria",
+        expected: "non-empty criteria array",
+        actual: result.synthesis?.criteria,
+      });
+    }
+
+    if (!hasNonEmptyString(result.synthesis?.overall?.one_paragraph_summary)) {
+      pushClauseFailure({
+        failures,
+        clauseId: "CLAUSE_10_SUMMARIES_PRODUCED",
+        fieldPath: "evaluation_result.synthesis.overall.one_paragraph_summary",
+        expected: "non-empty summary string",
+        actual: result.synthesis?.overall?.one_paragraph_summary,
+      });
+    }
+
+    const coverageScope = result.synthesis?.coverage_scope;
+    const coveragePct =
+      coverageScope && coverageScope.sourceWords > 0
+        ? (coverageScope.analyzedWords / coverageScope.sourceWords) * 100
+        : null;
+    if (coveragePct !== null && coveragePct < 100) {
+      pushClauseFailure({
+        failures,
+        clauseId: "CLAUSE_2_COVERAGE_SUFFICIENT",
+        fieldPath: "evaluation_result.synthesis.coverage_scope",
+        expected: "coverage_pct >= 100",
+        actual: coveragePct,
+      });
     }
 
     if (row.expected.cross_check_required) {
       if (!isNonEmptyObject((result as { cross_check?: unknown }).cross_check)) {
-        failures.push(
-          "evaluation_result.cross_check is missing or empty (silent-skip class)",
-        );
+        pushClauseFailure({
+          failures,
+          clauseId: "CLAUSE_7_CROSS_CHECK_PRESENT",
+          fieldPath: "evaluation_result.cross_check",
+          expected: "non-empty cross_check in required/veto mode",
+          actual: (result as { cross_check?: unknown }).cross_check,
+        });
       }
     }
 
@@ -169,9 +291,13 @@ function assertRow(outcome: RunOutcome): string[] {
           (result as { pass4_governance?: unknown }).pass4_governance,
         )
       ) {
-        failures.push(
-          "evaluation_result.pass4_governance is missing or empty",
-        );
+        pushClauseFailure({
+          failures,
+          clauseId: "CLAUSE_6_PASS4_GOVERNANCE_PRESENT",
+          fieldPath: "evaluation_result.pass4_governance",
+          expected: "non-empty pass4_governance in required/veto mode",
+          actual: (result as { pass4_governance?: unknown }).pass4_governance,
+        });
       }
     }
 
@@ -214,9 +340,11 @@ async function main(): Promise<number> {
   return failed === 0 ? 0 : 1;
 }
 
-void main()
-  .then((code) => process.exit(code))
-  .catch((err) => {
-    console.error("[stress-tier2] uncaught:", err);
-    process.exit(2);
-  });
+if (!process.env.JEST_WORKER_ID) {
+  void main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error("[stress-tier2] uncaught:", err);
+      process.exit(2);
+    });
+}

--- a/tests/scripts/pipeline-stress-tier2.assertions.test.ts
+++ b/tests/scripts/pipeline-stress-tier2.assertions.test.ts
@@ -1,0 +1,120 @@
+import { assertRow, type RunOutcome } from "@/scripts/pipeline-stress-tier2";
+import type { Tier2Row } from "@/tests/stress/tier2/scenarios";
+
+function makeRow(overrides?: Partial<Tier2Row>): Tier2Row {
+  return {
+    id: "tier2-test-row",
+    manuscript_fixture: "long-form-50k.txt",
+    work_type: "novel",
+    english_variant: "american",
+    expected: {
+      outcome: "success",
+      cross_check_required: true,
+      pass4_governance_required: true,
+      max_total_ms: 120_000,
+    },
+    notes: "unit-test",
+    ...overrides,
+  };
+}
+
+function makeSuccessOutcome(overrides?: Partial<RunOutcome>): RunOutcome {
+  return {
+    row: makeRow(),
+    total_ms: 10_000,
+    threw: null,
+    result: {
+      ok: true,
+      synthesis: {
+        criteria: [{ key: "character_depth", score_0_10: 7 }],
+        overall: {
+          one_paragraph_summary: "strong overall execution",
+        },
+        coverage_scope: {
+          sourceWords: 100,
+          analyzedWords: 100,
+        },
+      },
+      quality_gate: { pass: true, checks: [], warnings: [] },
+      cross_check: { verdict: "pass" },
+      pass4_governance: { pass: true },
+    } as any,
+    ...overrides,
+  };
+}
+
+describe("pipeline-stress-tier2 clause-mapped assertions", () => {
+  test("missing cross_check in required/veto mode emits Clause 7 prefixed message", () => {
+    const failures = assertRow(
+      makeSuccessOutcome({
+        result: {
+          ...(makeSuccessOutcome().result as any),
+          cross_check: {},
+        } as any,
+      }),
+    );
+
+    expect(failures.some((f) => f.includes("[CLAUSE_7_CROSS_CHECK_PRESENT]"))).toBe(true);
+    expect(failures.some((f) => f.includes("(CROSS_CHECK_MISSING)"))).toBe(true);
+    expect(failures.some((f) => f.includes("expected=non-empty cross_check in required/veto mode"))).toBe(true);
+  });
+
+  test("missing pass4_governance in required/veto mode emits Clause 6 prefixed message", () => {
+    const failures = assertRow(
+      makeSuccessOutcome({
+        result: {
+          ...(makeSuccessOutcome().result as any),
+          pass4_governance: null,
+        } as any,
+      }),
+    );
+
+    expect(failures.some((f) => f.includes("[CLAUSE_6_PASS4_GOVERNANCE_PRESENT]"))).toBe(true);
+    expect(failures.some((f) => f.includes("(PASS4_MISSING)"))).toBe(true);
+    expect(failures.some((f) => f.includes("expected=non-empty pass4_governance in required/veto mode"))).toBe(true);
+  });
+
+  test("missing scores and summary emit Clause 9 and Clause 10 messages", () => {
+    const failures = assertRow(
+      makeSuccessOutcome({
+        result: {
+          ...(makeSuccessOutcome().result as any),
+          synthesis: {
+            criteria: [],
+            overall: { one_paragraph_summary: "" },
+            coverage_scope: { sourceWords: 100, analyzedWords: 100 },
+          },
+        } as any,
+      }),
+    );
+
+    expect(failures.some((f) => f.includes("[CLAUSE_9_SCORES_PRODUCED]"))).toBe(true);
+    expect(failures.some((f) => f.includes("[CLAUSE_10_SUMMARIES_PRODUCED]"))).toBe(true);
+  });
+
+  test("coverage/runtime failures emit clause-prefixed diagnostics", () => {
+    const failures = assertRow(
+      makeSuccessOutcome({
+        total_ms: 180_001,
+        row: makeRow({
+          expected: {
+            outcome: "success",
+            cross_check_required: true,
+            pass4_governance_required: true,
+            max_total_ms: 180_000,
+          },
+        }),
+        result: {
+          ...(makeSuccessOutcome().result as any),
+          synthesis: {
+            ...(makeSuccessOutcome().result as any).synthesis,
+            coverage_scope: { sourceWords: 100, analyzedWords: 85 },
+          },
+        } as any,
+      }),
+    );
+
+    expect(failures.some((f) => f.includes("[CLAUSE_11_TOTAL_RUNTIME_WITHIN_BUDGET]"))).toBe(true);
+    expect(failures.some((f) => f.includes("[CLAUSE_2_COVERAGE_SUFFICIENT]"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR-C: enforcement/diagnostics-only Tier 2 harness update that maps failures to long-form contract clauses using `tests/contract/long-form-contract.ts`.

## Scope

- Update Tier 2 harness assertions (`scripts/pipeline-stress-tier2.ts`) to emit clause-prefixed failure diagnostics via `formatClauseFailureMessage(...)`.
- Add import-boundary guard so only `tests/**` and `scripts/pipeline-stress-tier2.ts` can import `tests/contract/**`.
- Add negative/self-tests for required/veto evidence assertions.
- No runtime behavior changes.

## CI/Infra Scope

- CI Guard workflow now runs `npm run guard:tier2-contract-import-boundary`.
- New guard script enforces import-boundary policy for `tests/contract/**` usage.
- No infrastructure runtime topology changes.

## Affected Workflows

- `.github/workflows/ci-guard.yml` (added Tier2 contract import-boundary step)

## Rollback Plan

- Revert commit(s) from PR #500 to remove the Tier2 diagnostics/guard updates.
- Specifically, remove:
  - `scripts/guard-tier2-contract-import-boundary.mjs`
  - CI Guard workflow step invoking `guard:tier2-contract-import-boundary`
  - Tier2 assertion message updates in `scripts/pipeline-stress-tier2.ts`
  - `tests/scripts/pipeline-stress-tier2.assertions.test.ts`

## Risks & Anomalies

- Low risk: changes are diagnostics/guard oriented and test-harness scoped.
- Guard risk: false positives if future files intentionally import `tests/contract/**` outside allowed boundaries; mitigated by explicit policy and single-script exception.

## Tests Updated

- Added `tests/scripts/pipeline-stress-tier2.assertions.test.ts`.
- Verified:
  - missing `cross_check` emits Clause 7 / `CROSS_CHECK_MISSING`
  - missing `pass4_governance` emits Clause 6 / `PASS4_MISSING`
  - missing score/summary emits Clause 9 / Clause 10
  - coverage/runtime breach emits Clause 2 / Clause 11

No-Pipeline-Impact: true

## Dependency context

- #496 merged
- #498 merged
- #499 merged
