### PR TITLE
fix(chunker): emitted chunk content respects adaptive maxChars

### DIFF
--- a/lib/evaluation/pipeline/__tests__/adaptive-chunker.emitted-size.test.ts
+++ b/lib/evaluation/pipeline/__tests__/adaptive-chunker.emitted-size.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression: emitted chunk content must respect adaptive bracket maxChars.
+ *
+ * Production failure that motivated this test (5/15/2026):
+ *   Chunker post-condition violated: chunk 23 has char_count=32100 which
+ *   exceeds adaptive bracket maxChars=30000 (bracket=mid).
+ *
+ * Root cause: the planner capped `cut <= cfg.maxChars`, but the emitter
+ * prepends `overlap` chars from the previous chunk:
+ *
+ *   content = text.slice(baseStart - overlap, baseEnd)
+ *
+ * So for non-first chunks, content.length = cut + overlap. With mid bracket
+ * maxChars=30000 and overlapChars=2100, capped chunks emitted 32100 chars,
+ * tripping the post-condition before pipeline dispatch.
+ *
+ * Fix: plan cuts overlap-aware so emitted content.length always respects
+ * cfg.maxChars. See lib/manuscripts/chunking.ts.
+ *
+ * Out of scope (separate PRs): Pass 4, Perplexity, evidence packet,
+ * post-condition wording.
+ */
+
+import {
+  chunkManuscript,
+  selectChunkerConfig,
+  selectChunkerBracket,
+} from "@/lib/manuscripts/chunking";
+
+/**
+ * Build a long, boundary-free synthetic manuscript of approximately
+ * `targetChars` characters. No chapter markers — forces a single segment
+ * so the planner produces back-to-back maxChars-capped chunks (the
+ * worst-case path that exposed the bug in production).
+ */
+function buildBoundaryFreeText(targetChars: number): string {
+  // Plausible-looking prose with no scene breaks, blank-line gaps, or
+  // chapter markers. The chunker's boundary detection sees only `{ index: 0,
+  // label: "Start" }` and `{ index: end, label: "End" }`, exercising the
+  // single-segment cut planner.
+  const sentence =
+    "The narrator drifted between two currents of thought while afternoon " +
+    "light settled over the city rooftops in patterns she had begun to " +
+    "recognize from memory though the shape of each evening remained " +
+    "always slightly different from the last and she wondered whether " +
+    "this small drift carried any meaning at all. ";
+  const reps = Math.ceil(targetChars / sentence.length);
+  return sentence.repeat(reps).slice(0, targetChars);
+}
+
+describe("emitted chunk size respects adaptive maxChars (regression)", () => {
+  test("MID bracket: capped non-first chunks emit <= 30000 chars (not 32100)", async () => {
+    // Single boundary-free segment forces back-to-back maxChars-capped chunks.
+    // Pre-fix production behavior: chunks 1+ emitted 32100 chars
+    //   (= maxChars 30000 + overlapChars 2100).
+    // Post-fix expectation: emitted content.length <= cfg.maxChars for ALL
+    // chunks, including those carrying overlap.
+    const cfg = selectChunkerConfig(120_000); // mid bracket
+    expect(cfg.maxChars).toBe(30_000);
+    expect(cfg.overlapChars).toBe(2_100);
+
+    // ~850k chars ≈ 142k words → mid bracket; many back-to-back capped chunks.
+    const text = buildBoundaryFreeText(850_000);
+    const chunks = await chunkManuscript(text);
+    expect(chunks.length).toBeGreaterThan(20);
+
+    // Strict emitted-content invariant — the contract the production
+    // post-condition enforces.
+    for (const c of chunks) {
+      expect(c.content.length).toBeLessThanOrEqual(cfg.maxChars);
+    }
+
+    // Overlap is still present on non-first chunks (we did NOT solve this
+    // by removing overlap). The first chunk has no overlap by design.
+    expect(chunks[0].overlap_chars).toBe(0);
+    expect(chunks[1].overlap_chars).toBe(cfg.overlapChars);
+
+    // The capped chunks compensate for overlap in their BASE span:
+    //   base = char_end - char_start
+    //   emitted = base + overlap
+    //   emitted == maxChars  =>  base == maxChars - overlapChars == 27900
+    // We assert there is at least one such capped chunk.
+    const capped = chunks.find(
+      (c) =>
+        c.overlap_chars === cfg.overlapChars &&
+        c.content.length === cfg.maxChars,
+    );
+    expect(capped).toBeDefined();
+    expect(capped!.char_end - capped!.char_start).toBe(
+      cfg.maxChars - cfg.overlapChars,
+    );
+  }, 180_000);
+
+  test("SMALL bracket: capped non-first chunks emit <= 24000 chars", async () => {
+    const cfg = selectChunkerConfig(40_000); // small bracket
+    expect(cfg.maxChars).toBe(24_000);
+    expect(cfg.overlapChars).toBe(1_800);
+
+    const text = buildBoundaryFreeText(200_000);
+    const chunks = await chunkManuscript(text);
+    for (const c of chunks) {
+      expect(c.content.length).toBeLessThanOrEqual(cfg.maxChars);
+    }
+  }, 120_000);
+
+  test("LARGE bracket: capped non-first chunks emit <= 42000 chars", async () => {
+    const cfg = selectChunkerConfig(200_000); // large bracket
+    expect(cfg.maxChars).toBe(42_000);
+    expect(cfg.overlapChars).toBe(3_000);
+
+    const text = buildBoundaryFreeText(1_500_000);
+    const chunks = await chunkManuscript(text);
+    for (const c of chunks) {
+      expect(c.content.length).toBeLessThanOrEqual(cfg.maxChars);
+    }
+  }, 180_000);
+
+  test("first chunk has no overlap and may use full maxChars", async () => {
+    // The first chunk in a manuscript has overlap_chars = 0, so its emitted
+    // content can equal cfg.maxChars exactly.
+    const text = buildBoundaryFreeText(100_000);
+    const chunks = await chunkManuscript(text);
+    expect(chunks[0].overlap_chars).toBe(0);
+    expect(chunks[0].content.length).toBeLessThanOrEqual(
+      selectChunkerConfig(20_000).maxChars,
+    );
+  }, 60_000);
+
+  test("short manuscript (single chunk) is unchanged", async () => {
+    // Chapter-length input that fits in one chunk: no overlap, no cap,
+    // behavior identical to pre-fix. Asserts the fix is overlap-aware
+    // and does not penalize short inputs.
+    const text = buildBoundaryFreeText(15_000);
+    const chunks = await chunkManuscript(text);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].overlap_chars).toBe(0);
+    expect(chunks[0].content.length).toBe(15_000);
+  }, 60_000);
+
+  test("bracket selector unchanged: 142k words → mid", () => {
+    // Sanity: the regression manuscript size lands in the same bracket the
+    // production failure observed (mid).
+    expect(selectChunkerBracket(142_000)).toBe("mid");
+  });
+});

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1919,9 +1919,17 @@ export async function processEvaluationJob(
       }
       if (chunkRouting.max_chunk_chars > adaptiveMaxChars) {
         const violatingIndex = chunkRouting.max_chunk_index ?? 0;
+        // The emitted chunk content includes any prepended overlap on non-first
+        // chunks (content = text.slice(baseStart - overlap, baseEnd)). For
+        // diagnostic clarity, surface BOTH the emitted size (which is what the
+        // contract enforces) and the implied base-span size, so a future
+        // overlap-vs-emitted accounting drift is immediately obvious.
+        const emittedChars = chunkRouting.max_chunk_chars;
+        const overlapBudget = chunkRouting.overlap_chars ?? 0;
+        const impliedBaseChars = Math.max(0, emittedChars - overlapBudget);
         const chunkBudgetError =
           `Chunker post-condition violated: chunk ${violatingIndex} has ` +
-          `char_count=${chunkRouting.max_chunk_chars} which exceeds adaptive ` +
+          `char_count=${emittedChars} which exceeds adaptive ` +
           `bracket maxChars=${adaptiveMaxChars} (bracket=${chunkRouting.bracket}). ` +
           `Failing closed before dispatch.`;
         await markFailed(chunkBudgetError, 'CHUNK_BUDGET_OVERFLOW', {
@@ -1930,7 +1938,10 @@ export async function processEvaluationJob(
           diagnostics: {
             chunk_routing: chunkRouting,
             violating_chunk_index: violatingIndex,
-            chunk_char_count: chunkRouting.max_chunk_chars,
+            chunk_char_count: emittedChars,
+            chunk_emitted_chars: emittedChars,
+            chunk_implied_base_chars: impliedBaseChars,
+            chunk_overlap_budget_chars: overlapBudget,
             adaptive_max_chars: adaptiveMaxChars,
             bracket: chunkRouting.bracket,
           },

--- a/lib/manuscripts/chunking.ts
+++ b/lib/manuscripts/chunking.ts
@@ -461,6 +461,16 @@ export async function chunkManuscript(
   // Pre-compute segment cut points using look-ahead tail-folding so we never
   // emit a sub-minChars chunk except when the entire segment itself is < minChars.
   // For each segment we plan all cuts before emitting any chunk.
+  //
+  // Overlap-aware planning: emitted chunk content is
+  //   text.slice(baseStart - overlap, baseEnd)
+  // so emitted length = cut + overlap. We honour cfg.maxChars as the
+  // EMITTED-content ceiling (the contract downstream prompt-budgeting and
+  // the chunker post-condition rely on). Therefore each cut is capped at
+  //   maxChars - overlapForThisChunk
+  // where overlapForThisChunk depends on global chunk index AND segment
+  // offset (chunkIndex 0 has no overlap; any chunk whose baseStart >= 0 in
+  // a non-first segment gets the full overlapChars).
   for (let s = 0; s < boundaries.length - 1; s++) {
     const segStart = boundaries[s].index;
     const segEnd = boundaries[s + 1].index;
@@ -468,37 +478,73 @@ export async function chunkManuscript(
 
     // Plan cuts within the segment so no chunk is < minChars except possibly
     // when the entire segment is < minChars (in which case there is no fix).
+    //
+    // Per-cut overlap calculation mirrors the emit-time logic below:
+    //   overlap = (plannedGlobalChunkIndex === 0) ? 0 : min(overlapChars, baseStart)
+    // baseStart inside this segment = segStart + cursor; for s > 0 (any non-
+    // first segment) baseStart >= segStart >= overlapChars in practice, so
+    // the min collapses to overlapChars. We keep the min(...) defensive.
     const cuts: number[] = [];
     let remaining = segLen;
+    let plannedCursor = 0;
+    let plannedGlobalIdx = chunkIndex;
     while (remaining > 0) {
-      const cut = Math.min(cfg.maxChars, remaining);
+      const baseStart = segStart + plannedCursor;
+      const overlapForThisChunk =
+        plannedGlobalIdx === 0 ? 0 : Math.min(cfg.overlapChars, baseStart);
+      const maxBaseCutForThisChunk = Math.max(1, cfg.maxChars - overlapForThisChunk);
+      const cut = Math.min(maxBaseCutForThisChunk, remaining);
       cuts.push(cut);
       remaining -= cut;
+      plannedCursor += cut;
+      plannedGlobalIdx += 1;
     }
     // Rebalance the last two cuts if the tail is < minChars.
     // Borrow from the second-to-last cut down to (but not below) minChars,
     // and give to the tail until it is ≥ minChars or no more can be borrowed.
+    //
+    // The rebalance must not push the tail's BASE cut past its own emitted
+    // ceiling. Since the tail is a non-first chunk in any multi-cut segment,
+    // its emitted ceiling is (maxChars - overlapChars). We compute the
+    // tail's emitted ceiling explicitly so we don't re-inflate a cut past
+    // the per-chunk emitted contract.
     if (cuts.length >= 2) {
       let i = cuts.length - 1;
       while (i > 0 && cuts[i] < cfg.minChars) {
         const need = cfg.minChars - cuts[i];
         const canBorrow = Math.max(0, cuts[i - 1] - cfg.minChars);
-        const borrow = Math.min(need, canBorrow);
+        // The cut at position i is a non-first chunk in this segment, so its
+        // emitted-content ceiling is (cfg.maxChars - cfg.overlapChars). Never
+        // borrow more than would push this cut past that ceiling.
+        const tailEmittedCeiling = Math.max(1, cfg.maxChars - cfg.overlapChars);
+        const headroom = Math.max(0, tailEmittedCeiling - cuts[i]);
+        const borrow = Math.min(need, canBorrow, headroom);
         if (borrow === 0) break;
         cuts[i - 1] -= borrow;
         cuts[i] += borrow;
       }
       // If even after rebalance the tail is still < minChars (segment too short
       // for two min-sized chunks), merge the tail into its predecessor when
-      // doing so doesn't push the predecessor above maxChars.
+      // doing so doesn't push the predecessor above its own emitted ceiling.
+      // Predecessor at index (cuts.length - 2): non-first chunk in this
+      // segment unless cuts.length === 2 AND segment s === 0 AND chunkIndex
+      // at planning start was 0. We use the conservative (maxChars -
+      // overlapChars) ceiling for any predecessor that could carry overlap;
+      // the first-chunk-of-manuscript case is rare and additively safe.
       while (cuts.length >= 2 && cuts[cuts.length - 1] < cfg.minChars) {
         const tail = cuts[cuts.length - 1];
         const prev = cuts[cuts.length - 2];
-        if (prev + tail <= cfg.maxChars) {
+        // The merged predecessor will be emitted at length (prev + tail) +
+        // its own overlap. For chunkIndex 0 there is no overlap; for any
+        // other chunk the overlap is cfg.overlapChars. Pick the conservative
+        // ceiling unconditionally — it is a no-op for the chunkIndex-0 case
+        // because (prev + tail) <= (maxChars - overlapChars) <= maxChars.
+        const prevEmittedCeiling = Math.max(1, cfg.maxChars - cfg.overlapChars);
+        if (prev + tail <= prevEmittedCeiling) {
           cuts[cuts.length - 2] = prev + tail;
           cuts.pop();
         } else {
-          break; // can't merge without exceeding maxChars
+          break; // can't merge without exceeding emitted-content ceiling
         }
       }
     }


### PR DESCRIPTION
<!-- pr-type: evaluation -->

## Summary

The chunker's planner capped chunks at `cfg.maxChars` for the BASE span, but the emitter prepends overlap on non-first chunks, so emitted `content.length = cut + overlap`. With mid-bracket `maxChars=30000` and `overlapChars=2100`, capped chunks emitted 32100 chars, tripping the production post-condition before pipeline dispatch on the live Froggin Noggin full-novel run (job `903d6e7f-c80a-443c-a510-5b10308c2892`, 5/15/2026):

    Chunker post-condition violated: chunk 23 has char_count=32100
    which exceeds adaptive bracket maxChars=30000 (bracket=mid).
    Failing closed before dispatch.

This PR makes the planner overlap-aware so emitted chunk content respects `cfg.maxChars` for every chunk in every bracket. The production post-condition is unchanged (it correctly enforces the emitted-content contract that downstream prompt-budgeting actually pays for). Post-condition diagnostics gain a base-vs-emitted breakdown so future drift is immediately obvious.

## Scope

Pass selection (CHECK EXACTLY ONE):

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

<!-- Pass 1 selected because chunking is Pass 1's prompt-window contract; the post-condition fails before Pass 1 dispatch. criteria_count_by_state included below as N/A (this PR runs upstream of Pass 3). -->

Changed files:

- `lib/manuscripts/chunking.ts` — overlap-aware cut planner; tail-rebalance + tail-merge logic clamps against the per-chunk emitted ceiling so they cannot re-inflate a cut past `cfg.maxChars - overlapForThisChunk`
- `lib/evaluation/processor.ts` — post-condition diagnostics enriched with `chunk_emitted_chars`, `chunk_implied_base_chars`, `chunk_overlap_budget_chars`; user-facing error message unchanged (B-style telemetry only)
- `lib/evaluation/pipeline/__tests__/adaptive-chunker.emitted-size.test.ts` — new regression; asserts `content.length <= cfg.maxChars` for every chunk across small/mid/large brackets on boundary-free synthetic manuscripts that previously produced the 32100 overflow

Out of scope:

- Pass 4 cross-check — separate lane (shipped in #503)
- Perplexity timeout / evidence packet — already shipped
- Removing overlap or raising maxChars — explicitly off the table; the contract is correct, the planner was wrong
- Post-condition relaxation — explicitly off the table; the guard catches real failures
- Supabase persistence / job lifecycle — covered by #487
- Fixture commits — full-novel stays gitignored
- `pass4_ms` observability misnaming — separate small PR
- `EVAL_CHUNK_MAX_PER_PASS="48\n"` cleanup — separate env-hygiene PR

## Contract Integrity

- **No-Pipeline-Impact: false** (chunker is Pass 1's input contract; impact is in chunk count and chunk size, both measured below).
- **Emitted-content contract preserved.** `chunk.content.length <= cfg.maxChars` for every chunk in every bracket. This is what the existing production post-condition (`processor.ts` line 1920, `runPipeline.ts` line 532) enforces and what downstream prompt-budgeting pays for.
- **Overlap behavior unchanged.** Non-first chunks still carry `overlapChars` of prepended context. The fix compensates by reducing the BASE span (`char_end - char_start`) by `overlapChars`, not by removing overlap.
- **First chunk semantics unchanged.** `chunkIndex === 0` has `overlap_chars = 0` and can emit up to `cfg.maxChars` exactly.
- **Short manuscripts unchanged.** Inputs that fit in one chunk are emitted as a single chunk with `overlap_chars = 0` and `content.length === input.length` (test asserts this).
- **Tail-rebalance contract.** When a tail cut is below `minChars`, borrowing from the predecessor cannot push the rebalanced tail past its own emitted ceiling. When merging the tail into the predecessor, the merged size cannot exceed the predecessor's emitted ceiling. Both paths now use `cfg.maxChars - cfg.overlapChars` as the conservative ceiling.
- **B-style diagnostics added.** The post-condition diagnostics object now surfaces `chunk_emitted_chars`, `chunk_implied_base_chars`, and `chunk_overlap_budget_chars` alongside the existing `chunk_char_count`. No change to the error string or `error_code`.

## Behavioral Quality

This PR is not reducing intelligence.

Quality preservation argument:

- The chunker now produces chunks that fit downstream prompt budgets without tripping the safety guard. Previously the full-novel path failed pre-dispatch — zero Pass 1 work happened. Post-fix, the pipeline can actually execute.
- The emitted content per chunk is at most `cfg.maxChars` instead of `cfg.maxChars + cfg.overlapChars`. Effective per-chunk prose decreases by ~7% (mid: 30000 → 27900 base + 2100 overlap = same 30000 emitted, vs prior 30000 base + 2100 overlap = 32100 emitted). Chunk count rises slightly to absorb the difference. For an 850k-char single-segment mid manuscript: ~28 chunks → ~31 chunks (synthetic test result).
- Slightly higher chunk count is the correct trade against silent prompt-window overflow. The bracket sweet spot (25–48 chunks) accommodates the increase across all production sizes; the existing fixture tests (`adaptive-chunker.test.ts` 51k/90k/113k/250k) continue to pass.
- No change to Pass 3, Pass 4, Perplexity, or evidence-packet logic. This PR's surface is upstream of all of those.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Pre-change Pass 1 never ran on full novel — pipeline failed pre-dispatch at chunk 23 char_count=32100 vs maxChars=30000. |
| Run 2 | N/A | N/A | Job `903d6e7f-c80a-443c-a510-5b10308c2892` is the documented pre-change failure. |

### Post-change Runs

| Run | pass1_ms | total_ms | Notes |
|---|---:|---:|---|
| Run 1 | N/A | N/A | Post-change full-novel chapter run runs against revisiongrade.com after merge; numbers append here. |
| Run 2 | N/A | N/A | Required to populate before declaring Gate 3 closed. |

criteria_count_by_state: N/A for this PR — Pass 3 telemetry is unaffected. Will report `{R, O, NA, C}` from `[Pass3][ReducerTelemetry]` log line on the post-merge full-novel run.

passX_ms metric: `pass1_ms` from `[Pipeline][PassTimings]` log line.

total_ms metric: stress harness emits `total_ms` per row.

Additional chunker telemetry (existing): `chunk_count`, `max_chunk_chars`, `max_chunk_index`, `overlap_chars`, `chunk_storage_chars`. New diagnostics on post-condition failures: `chunk_emitted_chars`, `chunk_implied_base_chars`, `chunk_overlap_budget_chars`.

## Quality Gate / Anomalies

QG_chunk_emitted_size: every emitted `chunk.content.length` must be `<= cfg.maxChars` for its bracket. The regression test asserts this directly across small/mid/large.

QG_chunk_overlap_preserved: every non-first chunk must still have `overlap_chars === cfg.overlapChars`. The regression test asserts this — we did not remove overlap.

QG_short_manuscript_passthrough: inputs that fit in one chunk emit as a single chunk with `overlap_chars = 0` and `content.length === input.length`. The regression test asserts this.

QG_post_condition_unchanged: `runPipeline.ts` and `processor.ts` post-conditions still fail closed if `max_chunk_chars > adaptiveMaxChars`. This PR does not relax the guard.

No QG_ regressions detected in unit suites. Existing `adaptive-chunker.test.ts` fixture tests (chunk-count ranges per bracket) continue to apply.

## Risks & Anomalies

- **Risk:** Chunk count rises by ~10% on capped-chunk-heavy manuscripts. **Mitigation:** the 25–48 sweet spot has headroom; synthetic 850k mid scenario produces 31 chunks (well under 48). The existing fixture tests assert chunk-count ranges per bracket.
- **Risk:** Rebalance loop's per-chunk emitted ceiling `(cfg.maxChars - cfg.overlapChars)` is conservative — it treats every cut as a non-first chunk. For the rare case where `cuts.length === 2` AND the segment is the first segment AND `chunkIndex` at planning start is 0, the predecessor is actually the first chunk of the manuscript (overlap = 0) and could in theory hold `cfg.maxChars` rather than `cfg.maxChars - cfg.overlapChars`. **Mitigation:** the conservative ceiling is additively safe — it never produces an oversized chunk, at most it leaves a few hundred chars unused in this corner case. The complexity to track first-chunk-of-manuscript through the rebalance loop is not worth it.
- **Risk:** `baseStart` for in-segment chunks is `segStart + cursor`. The defensive `Math.min(cfg.overlapChars, baseStart)` collapses to `cfg.overlapChars` for any chunk past offset `overlapChars`. **Mitigation:** the `Math.min(...)` is preserved exactly as in the emitter so planning and emission compute the same overlap.
- **Anomaly note (not in this PR):** the production failure surfaced because the live Froggin Noggin full-novel job was the first time a non-test manuscript hit the mid bracket at a single-segment scale. Pre-existing test coverage (`adaptive-chunker.test.ts`) used chapter-marked synthetic text which produced shorter segments and rarely capped to `maxChars` exactly. The new regression test uses boundary-free input specifically to exercise the worst-case path.

## Architecture Alignment

- Planner and emitter now share a single overlap-computation expression: `(chunkIndex === 0) ? 0 : Math.min(cfg.overlapChars, baseStart)`. Used at plan time as `overlapForThisChunk` and at emit time as `overlap`. Single source of truth.
- Tail-rebalance and tail-merge clamps use `cfg.maxChars - cfg.overlapChars` as the per-chunk emitted ceiling. Naming and computation are local to the segment loop; no new exports.
- `processor.ts` diagnostics keep the existing `chunk_char_count` key (back-compat for any log-grep consumer) and additively add the `chunk_emitted_chars` / `chunk_implied_base_chars` / `chunk_overlap_budget_chars` triple.
- Regression test lives next to `adaptive-chunker.test.ts` in `lib/evaluation/pipeline/__tests__/`, matching the existing chunker test home.

## Fixture policy

Regression test uses purely synthetic boundary-free text generated inline. No manuscript fixture committed. Full-novel manuscript remains at the gitignored path.
