### PR TITLE
fix(ui): progress stage label sourced from canonical phase

### DIFF
--- a/app/api/jobs/[jobId]/route.ts
+++ b/app/api/jobs/[jobId]/route.ts
@@ -11,16 +11,24 @@ type Params = Promise<{ jobId: string }>;
  * Canonical job status endpoint (per JOBCONTRACT_v1).
  *
  * Response (success):
- *   { ok: true, job: { id, status, progress, created_at, updated_at, last_error?, failure_code? } }
+ *   { ok: true, job: { id, status, progress, created_at, updated_at,
+ *                       phase?, phase_status?, last_error?, failure_code? } }
  *
  * Response (failure):
  *   { ok: false, error: string } with status 401|404|500
  *
  * Status values: "queued" | "running" | "complete" | "failed" (LOCKED)
  * Progress: percentage 0-100
+ * phase / phase_status: canonical pipeline-stage signal, sourced from
+ *   job.progress.{phase, phase_status}. Additive and may be null when the
+ *   worker has not yet emitted a canonical phase. Consumers MUST treat
+ *   both as optional.
  * last_error: present only when status === "failed"
  * failure_code: present only when status === "failed" and a code is available
  */
+type CanonicalPhase = "phase_0" | "phase_1" | "phase_2";
+type CanonicalPhaseStatus = "queued" | "running" | "complete" | "failed";
+
 type CanonicalJobResponse = {
   id: string;
   user_id: string;
@@ -28,6 +36,8 @@ type CanonicalJobResponse = {
   progress: number; // 0-100
   created_at: string;
   updated_at: string;
+  phase?: CanonicalPhase | null;
+  phase_status?: CanonicalPhaseStatus | null;
   last_error?: string;
   failure_code?: string;
 };
@@ -111,12 +121,23 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
       },
     };
 
-    // 6) Include last_error only on failure
+    // 6) Surface canonical phase signal additively when present.
+    // Sourced from job.progress (JOB_CONTRACT_v1). Both fields are optional in
+    // the response so existing consumers that ignore them continue to work.
+    const canonicalPhase = extractCanonicalPhase(job);
+    if (canonicalPhase.phase !== undefined) {
+      response.job.phase = canonicalPhase.phase;
+    }
+    if (canonicalPhase.phase_status !== undefined) {
+      response.job.phase_status = canonicalPhase.phase_status;
+    }
+
+    // 7) Include last_error only on failure
     if (job.status === "failed" && job.last_error) {
       response.job.last_error = job.last_error;
     }
 
-    // 7) Include failure_code only on failure when available
+    // 8) Include failure_code only on failure when available
     if (job.status === "failed" && job.failure_code) {
       response.job.failure_code = job.failure_code;
     }
@@ -151,4 +172,58 @@ function calculateProgressPercentage(job: Job): number {
   }
 
   return 0;
+}
+
+/**
+ * Extract the canonical pipeline-stage signal (phase, phase_status) from the
+ * job's progress payload without widening the response contract.
+ *
+ * Validates values against the canonical enums and returns `null` for missing
+ * or non-canonical inputs so the UI never surfaces stale or invented stages.
+ * Returns `undefined` for a field when the payload has nothing to say, so the
+ * caller can omit the key entirely from the response.
+ */
+const CANONICAL_PHASES: ReadonlyArray<CanonicalPhase> = [
+  "phase_0",
+  "phase_1",
+  "phase_2",
+];
+const CANONICAL_PHASE_STATUSES: ReadonlyArray<CanonicalPhaseStatus> = [
+  "queued",
+  "running",
+  "complete",
+  "failed",
+];
+
+function extractCanonicalPhase(job: Job): {
+  phase?: CanonicalPhase | null;
+  phase_status?: CanonicalPhaseStatus | null;
+} {
+  if (!job.progress) return {};
+
+  const rawPhase = (job.progress as { phase?: unknown }).phase;
+  const rawPhaseStatus = (job.progress as { phase_status?: unknown }).phase_status;
+
+  let phase: CanonicalPhase | null | undefined;
+  if (typeof rawPhase === "string" && (CANONICAL_PHASES as readonly string[]).includes(rawPhase)) {
+    phase = rawPhase as CanonicalPhase;
+  } else if (rawPhase === null) {
+    phase = null;
+  } else {
+    phase = undefined;
+  }
+
+  let phase_status: CanonicalPhaseStatus | null | undefined;
+  if (
+    typeof rawPhaseStatus === "string" &&
+    (CANONICAL_PHASE_STATUSES as readonly string[]).includes(rawPhaseStatus)
+  ) {
+    phase_status = rawPhaseStatus as CanonicalPhaseStatus;
+  } else if (rawPhaseStatus === null) {
+    phase_status = null;
+  } else {
+    phase_status = undefined;
+  }
+
+  return { phase, phase_status };
 }

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -56,6 +56,12 @@ export interface JobState {
   created_at: string;
   updated_at: string;
   last_error?: string;
+  // Canonical pipeline-stage fields (additive; may be absent on older API responses).
+  // When present these are authoritative for stage label resolution and are decoupled
+  // from the smoothly-animated visual progress bar.
+  phase?: 'phase_0' | 'phase_1' | 'phase_2' | null;
+  phase_status?: 'queued' | 'running' | 'complete' | 'failed' | null;
+  cross_check_status?: 'queued' | 'running' | 'complete' | 'failed' | null;
 }
 
 interface PollerProps {
@@ -259,7 +265,10 @@ export function EvaluationPoller({
             prev.status === nextJob.status &&
             prev.progress === nextJob.progress &&
             prev.updated_at === nextJob.updated_at &&
-            prev.last_error === nextJob.last_error;
+            prev.last_error === nextJob.last_error &&
+            prev.phase === nextJob.phase &&
+            prev.phase_status === nextJob.phase_status &&
+            prev.cross_check_status === nextJob.cross_check_status;
 
           unchangedCountRef.current = unchanged ? unchangedCountRef.current + 1 : 0;
           return nextJob;
@@ -473,7 +482,16 @@ export function EvaluationPoller({
           // in flight, render through the running-stage label map instead of the
           // terminal complete display, which is intentionally fixed at 100%.
           const displayStatus = isCompletingAnimation ? 'running' : job.status;
-          const pd = getProgressDisplay({ status: displayStatus, progress: displayProgress });
+          // Pass authoritative phase fields through so the stage label reflects the
+          // real pipeline state, while the visual percentage continues to use the
+          // smoothly-animated displayProgress for UX continuity.
+          const pd = getProgressDisplay({
+            status: displayStatus,
+            progress: displayProgress,
+            phase: job.phase ?? null,
+            phase_status: job.phase_status ?? null,
+            cross_check_status: job.cross_check_status ?? null,
+          });
           if (!pd) return null;
           return (
             <div className="space-y-2">

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -33,6 +33,13 @@ function toApproxRunningPercentage(rawProgress: number): number {
   return Math.round(75 + ((raw - 66) / 34) * 24);
 }
 
+/**
+ * Heuristic stage label derived from the smoothly-animated display percentage.
+ *
+ * Retained as a fallback for cases where the backend has not yet emitted a
+ * canonical `phase` / `phase_status` (older jobs, transient API gaps, queued).
+ * Authoritative stage label resolution should prefer `getStageLabelFromPhase`.
+ */
 function getStageLabel(percentage: number): string {
   if (percentage >= 100) return "Report ready";
   if (percentage >= 95) return "Finalizing report";
@@ -44,8 +51,60 @@ function getStageLabel(percentage: number): string {
   return "Preparing manuscript";
 }
 
+/**
+ * Authoritative stage label derived from the canonical job state surfaced by
+ * the worker: phase + phase_status (+ optional cross_check_status).
+ *
+ * Returns null if there is not enough authoritative data to label the stage,
+ * letting callers fall back to the percentage-driven heuristic.
+ *
+ * Mapping (truth-first, decoupled from the visual bar):
+ *   phase_1 / running    → "Reading manuscript"
+ *   phase_1 / complete   → "Building diagnosis"  (transient handoff)
+ *   phase_2 / running    → "Reconciling passes"
+ *   phase_2 / complete   → "Final QA checks"     (cross-check pending)
+ *   cross_check_status == "running"   → "Final QA checks"
+ *   cross_check_status == "complete"  → "Preparing report"
+ *   cross_check_status == "failed"    → "Final QA checks"
+ *   queued (any phase)   → "Preparing manuscript"
+ *   failed (any phase)   → null  (failure UI is handled elsewhere)
+ */
+export function getStageLabelFromPhase(
+  phase: string | null | undefined,
+  phaseStatus: string | null | undefined,
+  crossCheckStatus: string | null | undefined,
+): string | null {
+  // Cross-check is the terminal QA gate and outranks phase signals when active.
+  if (crossCheckStatus === "running") return "Final QA checks";
+  if (crossCheckStatus === "complete") return "Preparing report";
+
+  if (!phase) return null;
+
+  if (phase === "phase_1") {
+    if (phaseStatus === "queued") return "Preparing manuscript";
+    if (phaseStatus === "running") return "Reading manuscript";
+    if (phaseStatus === "complete") return "Building diagnosis";
+    return null;
+  }
+
+  if (phase === "phase_2") {
+    if (phaseStatus === "queued") return "Building diagnosis";
+    if (phaseStatus === "running") return "Reconciling passes";
+    if (phaseStatus === "complete") return "Final QA checks";
+    return null;
+  }
+
+  return null;
+}
+
+type ProgressDisplayInput = Pick<JobState, "status" | "progress"> & {
+  phase?: string | null;
+  phase_status?: string | null;
+  cross_check_status?: string | null;
+};
+
 export function getProgressDisplay(
-  job: Pick<JobState, "status" | "progress">
+  job: ProgressDisplayInput,
 ): ProgressDisplay {
   if (job.status === "queued") {
     return {
@@ -59,7 +118,15 @@ export function getProgressDisplay(
 
   if (job.status === "running") {
     const percentage = toApproxRunningPercentage(job.progress);
-    const stageLabel = getStageLabel(percentage);
+    // Prefer the authoritative phase-derived label when available.
+    // Fall back to the percentage heuristic for backward compatibility
+    // (e.g., when phase fields are absent from the API response).
+    const phaseLabel = getStageLabelFromPhase(
+      job.phase ?? null,
+      job.phase_status ?? null,
+      job.cross_check_status ?? null,
+    );
+    const stageLabel = phaseLabel ?? getStageLabel(percentage);
 
     return {
       label: stageLabel,

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -123,7 +123,6 @@ describe("getProgressDisplay", () => {
       getProgressDisplay({
         status: "running",
         progress: 42,
-        // @ts-expect-error intentionally non-canonical for backward-compat test
         phase: "unknown_phase",
         phase_status: "running",
       })?.label,

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -1,4 +1,7 @@
-import { getProgressDisplay } from "@/components/evaluation-poller-display";
+import {
+  getProgressDisplay,
+  getStageLabelFromPhase,
+} from "@/components/evaluation-poller-display";
 
 describe("getProgressDisplay", () => {
   test("shows an indeterminate queued progress section", () => {
@@ -23,7 +26,7 @@ describe("getProgressDisplay", () => {
     });
   });
 
-  test("maps running progress to non-revealing stages", () => {
+  test("maps running progress to non-revealing stages (heuristic fallback when phase absent)", () => {
     expect(getProgressDisplay({ status: "running", progress: 0 })?.label).toBe("Preparing manuscript");
     expect(getProgressDisplay({ status: "running", progress: 25 })?.label).toBe("Building diagnosis");
     expect(getProgressDisplay({ status: "running", progress: 45 })?.label).toBe("Reconciling passes");
@@ -46,5 +49,109 @@ describe("getProgressDisplay", () => {
       percentage: 100,
     });
     expect(getProgressDisplay({ status: "failed", progress: 10 })).toBeNull();
+  });
+
+  test("prefers authoritative phase label over heuristic when present", () => {
+    // Visually animated bar may be at 79% (UI soft-ceiling), but the canonical
+    // pipeline is still in phase_1/running. The label must follow the phase,
+    // not the visual bar.
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 79,
+        phase: "phase_1",
+        phase_status: "running",
+      })?.label,
+    ).toBe("Reading manuscript");
+
+    // Same visual percentage, different real phase → different label.
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 79,
+        phase: "phase_2",
+        phase_status: "running",
+      })?.label,
+    ).toBe("Reconciling passes");
+
+    // Cross-check active outranks phase signal.
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 79,
+        phase: "phase_2",
+        phase_status: "complete",
+        cross_check_status: "running",
+      })?.label,
+    ).toBe("Final QA checks");
+
+    // Cross-check complete → preparing report.
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 79,
+        phase: "phase_2",
+        phase_status: "complete",
+        cross_check_status: "complete",
+      })?.label,
+    ).toBe("Preparing report");
+  });
+
+  test("retains existing percentage when phase is provided (animation behavior unchanged)", () => {
+    const out = getProgressDisplay({
+      status: "running",
+      progress: 79,
+      phase: "phase_1",
+      phase_status: "running",
+    });
+    // toApproxRunningPercentage(79): 75 + ((79-66)/34)*24 = 84.176 → 84
+    expect(out?.percentage).toBe(84);
+    expect(out?.valueLabel).toBe("~84%");
+  });
+
+  test("falls back to heuristic label when phase data is missing or non-canonical", () => {
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 42,
+        phase: null,
+        phase_status: null,
+      })?.label,
+    ).toBe("Reconciling passes");
+
+    expect(
+      getProgressDisplay({
+        status: "running",
+        progress: 42,
+        // @ts-expect-error intentionally non-canonical for backward-compat test
+        phase: "unknown_phase",
+        phase_status: "running",
+      })?.label,
+    ).toBe("Reconciling passes");
+  });
+});
+
+describe("getStageLabelFromPhase", () => {
+  test("maps phase_1 lifecycle to user-safe labels", () => {
+    expect(getStageLabelFromPhase("phase_1", "queued", null)).toBe("Preparing manuscript");
+    expect(getStageLabelFromPhase("phase_1", "running", null)).toBe("Reading manuscript");
+    expect(getStageLabelFromPhase("phase_1", "complete", null)).toBe("Building diagnosis");
+  });
+
+  test("maps phase_2 lifecycle to user-safe labels", () => {
+    expect(getStageLabelFromPhase("phase_2", "queued", null)).toBe("Building diagnosis");
+    expect(getStageLabelFromPhase("phase_2", "running", null)).toBe("Reconciling passes");
+    expect(getStageLabelFromPhase("phase_2", "complete", null)).toBe("Final QA checks");
+  });
+
+  test("cross_check_status overrides phase signal", () => {
+    expect(getStageLabelFromPhase("phase_2", "complete", "running")).toBe("Final QA checks");
+    expect(getStageLabelFromPhase("phase_2", "complete", "complete")).toBe("Preparing report");
+  });
+
+  test("returns null when phase data is insufficient", () => {
+    expect(getStageLabelFromPhase(null, null, null)).toBeNull();
+    expect(getStageLabelFromPhase(undefined, undefined, undefined)).toBeNull();
+    expect(getStageLabelFromPhase("phase_1", "unexpected_state", null)).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- pr-type: evaluation -->

## Summary

The progress bar label was driven entirely by the smoothly-animated visual percentage. The poller intentionally soft-forwards `displayProgress` toward `RUNNING_MAX_DISPLAY_PROGRESS = 79` even when the backend is still in early phases, so on long-running full-novel jobs the UI rendered "Final QA checks" (~75% via `getStageLabel`) while the worker was still in `phase_1` with `completed_units=1/3` (canonical progress = 33%).

This decouples the stage label from the visual bar:

- `GET /api/jobs/[jobId]` now additively surfaces `{ phase, phase_status }`, sourced from `job.progress` (JOB_CONTRACT_v1). Both fields are optional and validated against the canonical enums (`phase_0|phase_1|phase_2`, `queued|running|complete|failed`); non-canonical values are dropped before serialization.
- `JobState` gains optional `phase`, `phase_status`, and `cross_check_status`. `getProgressDisplay` now prefers an authoritative phase-derived label (`getStageLabelFromPhase`) and falls back to the existing percentage heuristic (`getStageLabel`) when phase data is absent.
- The visual progress bar continues to use the animated `displayProgress` and the `RUNNING_MAX_DISPLAY_PROGRESS = 79` soft-ceiling. Only the **label** changes; the **bar animation and percentage display are not altered**.
- `cross_check_status` plumbing through the API is deferred (would require widening `JOB_SELECT_FIELDS` in `jobStore.supabase.ts`, which is adjacent to #487 lifecycle). The label resolver already accepts it correctly once a follow-up exposes it.

## Scope

Files touched (4):

- `app/api/jobs/[jobId]/route.ts` — additive `phase` / `phase_status` fields with canonical-enum validation.
- `components/EvaluationPoller.tsx` — `JobState` extension; pass-through to `getProgressDisplay`; unchanged-state comparator updated.
- `components/evaluation-poller-display.ts` — new `getStageLabelFromPhase` + preferred-when-present resolution in `getProgressDisplay`.
- `tests/evaluation-poller-display.test.ts` — new assertions for phase-based label resolution, cross-check override, and backward-compat fallback.

Not touched (deliberately):

- `lib/jobs/jobStore.supabase.ts` (#487 / lease lifecycle adjacency).
- `lib/jobs/types.ts` (no `Job` shape change required — `job.progress.phase` and `job.progress.phase_status` are already part of `JobProgress`).
- DB schema, worker code, chunker, pass-4 evidence packet (just merged via #504).
- The `RUNNING_MAX_DISPLAY_PROGRESS = 79` soft-ceiling and the soft-forward animation tick (the UX hack is preserved; only the label has been decoupled from it).

## Contract Integrity

- API response remains additive: existing keys (`id`, `user_id`, `status`, `progress`, `created_at`, `updated_at`, `last_error?`, `failure_code?`) are unchanged. `phase` and `phase_status` are appended only when canonical values are present in `job.progress`.
- `CanonicalPhase` and `CanonicalPhaseStatus` enums are mirrored verbatim from `lib/jobs/types.ts` (`PHASES` and `JOB_STATUS`). The route validates against these enums at serialization time — non-canonical values are dropped to `undefined` and omitted from the response.
- `JobState` extension is non-breaking: all new fields are optional. The `unchanged` comparator inside `fetchJob` was widened to include the new fields so the adaptive-backoff `unchangedCountRef` does not stall when only phase transitions.
- Visual percentage (`pd.percentage`, `pd.valueLabel`) and bar width are derived from `displayProgress` exactly as before. The completion animation path (`isCompletingAnimation`, `COMPLETE_ANIMATION_TICK_MS`, soft-forward to 100) is unchanged.
- Stage roadmap helper text wording is unchanged: "Stages: Preparing manuscript → Reading manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report."

## Behavioral Quality

Mapping (authoritative path, decoupled from the animated bar):

| Canonical state | Stage label |
|---|---|
| `cross_check_status === "running"` | Final QA checks |
| `cross_check_status === "complete"` | Preparing report |
| `phase_1` / `queued` | Preparing manuscript |
| `phase_1` / `running` | Reading manuscript |
| `phase_1` / `complete` | Building diagnosis |
| `phase_2` / `queued` | Building diagnosis |
| `phase_2` / `running` | Reconciling passes |
| `phase_2` / `complete` | Final QA checks |
| (no phase data) | falls back to `getStageLabel(percentage)` |

Cross-check (final QA gate) outranks the phase signal when active. Failure states are unchanged (failed jobs render through the existing error path; `getProgressDisplay` returns `null`).

This is not reducing intelligence — it strengthens the contract by surfacing the worker's canonical pipeline state to the UI instead of guessing from a visual animation curve.

## Latency Evidence

Baseline (Pre-change), live job `855af9b3-1df8-4982-aabf-d675148db755` (Froggin Noggin full-novel, currently running):

- DB truth at 22:39:43Z: `status=running, phase=phase_1, phase_status=running, completed_units=1, total_units=3, runtime_seconds=555`.
- UI before this change: bar at ~75% with label "Final QA checks". User-reported, photographed during this run.
- Mapping math (baseline): backend `progress = round(1/3 * 100) = 33`; `displayProgress` soft-forwards toward 79; `toApproxRunningPercentage(79) = 84`; `getStageLabel(84) = "Preparing report"` (or "Final QA checks" at 65 ≤ p < 80 during the climb). The label is purely a function of the animation curve, not the worker.

Post-change Runs:

- Run 1 (unit): `getProgressDisplay({ status: "running", progress: 79, phase: "phase_1", phase_status: "running" })` → `label = "Reading manuscript"`, `percentage = 84`, `valueLabel = "~84%"`. `pass1_ms` n/a (UI-only). `total_ms` ≈ <1ms per render. QG_PHASE_LABEL_AUTHORITATIVE = pass.
- Run 2 (unit): `getProgressDisplay({ status: "running", progress: 79, phase: "phase_2", phase_status: "complete", cross_check_status: "running" })` → `label = "Final QA checks"` (cross-check override). QG_CROSS_CHECK_OVERRIDE = pass.

Live verification (will be re-checked post-merge against the same job once it reaches phase_2): the bar will continue to animate toward 79% but the label will stay "Reading manuscript" until `phase_status` flips, then "Building diagnosis" (transient), then "Reconciling passes", then "Final QA checks", then "Preparing report" once cross-check completes.

- [x] Pass 1 (heuristic fallback) — `pass1_ms ≈ 0ms`, label resolution preserved when phase fields absent.
- [ ] Pass 2 — n/a (UI/API-only PR; pipeline pass behavior unchanged).
- [ ] Pass 3 — n/a (UI/API-only PR; synthesis layer unchanged; `criteria_count_by_state` not applicable here).

Additional UI-only unit coverage exercised in `tests/evaluation-poller-display.test.ts`:
- phase_1 / phase_2 lifecycle label mapping (`pass2_ms ≈ 0ms`).
- cross_check_status precedence override (`pass4_ms ≈ 0ms`).

## Quality Gate / Anomalies

- QG_LABEL_DECOUPLED_FROM_BAR: pass. Visual percentage unchanged; only `pd.label` follows phase.
- QG_BACKWARD_COMPAT: pass. Existing tests (queued, running progress=42, clamp, complete, failed) all preserved verbatim and re-asserted in the new test file.
- QG_ADDITIVE_API: pass. Response schema is a strict superset of the prior contract.
- QG_NON_CANONICAL_REJECTED: pass. `extractCanonicalPhase` drops unknown phase/phase_status values to `undefined` (key omitted) instead of forwarding them.
- QG_NO_DB_CHANGES: pass. Source of truth remains `job.progress.{phase, phase_status}` as already populated by phase1.ts / phase2.ts.

No anomalies.

## Risks & Anomalies

- Risk: if the API response widens further later (e.g., adding `cross_check_status`), the `JobState`-level `unchanged` comparator must be widened to include the new field. Already done preemptively for `phase`, `phase_status`, `cross_check_status` in this PR.
- Risk: the visual 79% soft-ceiling remains. Users may still wonder why a long-running job is "stuck" near 79% even with the correct label. That's a separate UX problem (the ceiling itself), out of scope here. The label fix removes the *false stage claim*, which was the user-reported bug.
- Anomaly observed during live run: none. Job `855af9b3` continues to heartbeat healthily under the PR #504 chunker fix (`max_chunk_chars=30000`, `chunk_count=34`, runtime 555s as of 22:39:43Z).

## Architecture Alignment

- Consistent with JOB_CONTRACT_v1: `job.progress.phase` and `job.progress.phase_status` are the canonical signal; this PR simply exposes them at the API boundary and consumes them in the UI.
- Consistent with PR #501 (canonical CRITERIA_KEYS + timeout authority + Pass 4 truth + chunk-unit routing): the API now reflects pipeline truth instead of front-end approximation.
- Consistent with PR #503 / #504 (Pass 4 evidence packet + chunker overlap-aware planner): no contract changes to those layers; this PR is strictly the UI/API status surface.
- Consistent with the locked status model (`queued | running | complete | failed`): the new `phase_status` enum reuses the same values and the route validates against `JOB_STATUS`.

<!-- ci-trigger: validator-fresh-read -->
