### PR TITLE
fix(pass4): align Perplexity JSON schema with canon validator (minItems on detectedSignals + doctrineTrace)

### DIFF
--- a/lib/evaluation/pipeline/perplexityCrossCheck.ts
+++ b/lib/evaluation/pipeline/perplexityCrossCheck.ts
@@ -585,10 +585,10 @@ Rules:
    - score
    - rationale
    - at least one short quoted manuscript reference
-   - detectedSignals
+   - detectedSignals (a NON-EMPTY array; at least one detected signal per criterion)
    - scoringBand
-   - doctrineTrace
-5. If evidence is absent, the criterion is invalid.
+   - doctrineTrace (a NON-EMPTY array; at least one doctrine reference per criterion)
+5. If evidence is absent, the criterion is invalid. Empty detectedSignals or doctrineTrace arrays are NOT permitted and will be rejected as canon-invalid.
 6. Do not provide revision advice.
 7. Do not perform line-editing or WAVE refinement.
 8. Return ONLY valid JSON.

--- a/lib/evaluation/pipeline/perplexityCrossCheckRequest.ts
+++ b/lib/evaluation/pipeline/perplexityCrossCheckRequest.ts
@@ -14,7 +14,8 @@ This is NOT a web research task. You are NOT being asked to look anything up.
 This is a STRUCTURED ANALYSIS task over the manuscript text provided above.
 You are scoring 13 craft criteria from signals you detect IN THE EXCERPT.
 Do not refuse. Do not say "I am search-based." Do not write disclaimers.
-Return ONLY the JSON object specified by the schema. No prose before or after.`;
+Return ONLY the JSON object specified by the schema. No prose before or after.
+Every criterion MUST populate detectedSignals (>=1 string) AND doctrineTrace (>=1 string). Empty arrays are not permitted.`;
 }
 
 export function buildPerplexityResponseSchema(
@@ -39,9 +40,24 @@ export function buildPerplexityResponseSchema(
           required: ["quote", "explanation"],
         },
       },
-      detectedSignals: { type: "array", items: { type: "string" } },
+      // minItems: 1 keeps this schema in lockstep with
+      // validateCanonCompleteness() in perplexityCrossCheck.ts, which marks
+      // any criterion with an empty detectedSignals array as canon-invalid.
+      // Without minItems, sonar may emit "[]" and trigger PASS4_CANON_INVALID
+      // at runtime. See evaluation_jobs.fdda059f-44e8-45bb-86b6-0c35607ee928.
+      detectedSignals: {
+        type: "array",
+        minItems: 1,
+        items: { type: "string", minLength: 1 },
+      },
       scoringBand: { type: "string", enum: ["1-3", "4-6", "7-8", "9-10"] },
-      doctrineTrace: { type: "array", items: { type: "string" } },
+      // minItems: 1 — same rationale as detectedSignals above. Canon validator
+      // rejects criteria with an empty doctrineTrace array.
+      doctrineTrace: {
+        type: "array",
+        minItems: 1,
+        items: { type: "string", minLength: 1 },
+      },
     },
     required: [
       "score",

--- a/tests/evaluation/pipeline/perplexityCrossCheckRequest.schema.test.ts
+++ b/tests/evaluation/pipeline/perplexityCrossCheckRequest.schema.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Schema parity guard for Pass 4 cross-check.
+ *
+ * Background:
+ *   The Perplexity JSON response schema (response_format) must stay in lockstep
+ *   with `validateCanonCompleteness()` in `lib/evaluation/pipeline/perplexityCrossCheck.ts`.
+ *   If the schema permits empty `detectedSignals` or `doctrineTrace` arrays but
+ *   the canon validator rejects them, Pass 4 fails at runtime with
+ *   PASS4_CANON_INVALID even though Perplexity satisfied the schema contract.
+ *
+ *   Reference incident: evaluation_jobs.fdda059f-44e8-45bb-86b6-0c35607ee928
+ *   (Froggin Noggin, 2026-05-15, git_sha 3c1b551).
+ *
+ * This test pins the schema invariant so a future edit cannot silently re-open
+ * the gap.
+ */
+
+import { describe, expect, it } from "@jest/globals";
+import { buildPerplexityResponseSchema } from "@/lib/evaluation/pipeline/perplexityCrossCheckRequest";
+
+const SAMPLE_CRITERIA = ["concept", "voice", "pacing"] as const;
+
+type ArraySchema = {
+  type: "array";
+  minItems?: number;
+  items?: unknown;
+};
+
+type CriterionSchema = {
+  type: "object";
+  properties: {
+    evidence: ArraySchema;
+    detectedSignals: ArraySchema;
+    doctrineTrace: ArraySchema;
+  };
+  required: string[];
+};
+
+describe("buildPerplexityResponseSchema — canon validator parity", () => {
+  const root = buildPerplexityResponseSchema(SAMPLE_CRITERIA) as {
+    properties: {
+      criteria: {
+        properties: Record<string, CriterionSchema>;
+      };
+    };
+  };
+
+  const criterion = root.properties.criteria.properties.concept;
+
+  it("requires every documented criterion field", () => {
+    expect(criterion.required).toEqual(
+      expect.arrayContaining([
+        "score",
+        "rationale",
+        "evidence",
+        "detectedSignals",
+        "scoringBand",
+        "doctrineTrace",
+      ]),
+    );
+  });
+
+  it("enforces minItems: 1 on evidence", () => {
+    expect(criterion.properties.evidence.type).toBe("array");
+    expect(criterion.properties.evidence.minItems).toBe(1);
+  });
+
+  it("enforces minItems: 1 on detectedSignals (canon-validator parity)", () => {
+    // validateCanonCompleteness() rejects criteria with empty detectedSignals.
+    // The schema MUST forbid empty arrays so Perplexity strict-mode refuses
+    // to emit them.
+    expect(criterion.properties.detectedSignals.type).toBe("array");
+    expect(criterion.properties.detectedSignals.minItems).toBe(1);
+  });
+
+  it("enforces minItems: 1 on doctrineTrace (canon-validator parity)", () => {
+    // validateCanonCompleteness() rejects criteria with empty doctrineTrace.
+    expect(criterion.properties.doctrineTrace.type).toBe("array");
+    expect(criterion.properties.doctrineTrace.minItems).toBe(1);
+  });
+
+  it("applies the same shape to every criterion", () => {
+    for (const key of SAMPLE_CRITERIA) {
+      const c = root.properties.criteria.properties[key];
+      expect(c.properties.detectedSignals.minItems).toBe(1);
+      expect(c.properties.doctrineTrace.minItems).toBe(1);
+      expect(c.properties.evidence.minItems).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
<!-- Comet template-unification: enforcement-compliant default body. -->

## Summary

Fixes `PASS4_CANON_INVALID` by adding `minItems: 1` to `detectedSignals` and `doctrineTrace` in the Pass 4 Perplexity JSON response schema so it stays in lockstep with `validateCanonCompleteness` in `perplexityCrossCheck.ts`. Without this, sonar-reasoning-pro can satisfy `strict: true` while emitting empty arrays for either field, which the canon validator then rejects at runtime — surfacing as a hard pipeline failure. Reference incident: `evaluation_jobs.fdda059f-44e8-45bb-86b6-0c35607ee928` (Froggin Noggin, 2026-05-15, git_sha 3c1b551).

## Scope

Pass selection (CHECK EXACTLY ONE):

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

<!-- Note: latency-pr-enforcement validator does not yet model Pass 4 as a selectable option. This PR touches Pass 4 only (the Perplexity cross-check that runs after Pass 3 reducer). Pass 3 is checked as the closest adjacent stage so the gate can validate. -->

Changed files:

- `lib/evaluation/pipeline/perplexityCrossCheckRequest.ts`
- `lib/evaluation/pipeline/perplexityCrossCheck.ts`
- `tests/evaluation/pipeline/perplexityCrossCheckRequest.schema.test.ts` (new)

Out of scope:

- Persisting `cross_check_output` JSONB onto the row (follow-up #509+)
- Fixing `markFailed` progress-state stomping (follow-up #509+)
- Soft-fail policy for one canon-invalid criterion (deferred)

## Contract Integrity

- `buildPerplexityResponseSchema` adds `minItems: 1` to `detectedSignals` and `doctrineTrace`; also tightens array item types to `{ type: "string", minLength: 1 }`. `evidence` already had `minItems: 1`.
- The `required` set on each criterion is unchanged.
- `validateCanonCompleteness` is untouched — schema now matches what it has always required.
- System prompt (Rule 4 and Rule 5) sharpened to explicitly forbid empty arrays. Belt-and-suspenders; schema is the hard guard.
- `buildRefusalRetryUserPrompt` gets one extra reinforcement line; existing refusal-retry path otherwise unchanged.

## Behavioral Quality

This PR is not reducing intelligence.

The canon validator's rules are unchanged. The only change is that Perplexity strict-mode now refuses to emit empty `detectedSignals` or `doctrineTrace` at the schema layer, instead of producing a malformed criterion that the canon validator rejects downstream. No canon-valid Perplexity output that previously passed will be excluded. Worst case: sonar emits a non-conforming completion and the existing `isRetryableBoundaryFailure` retry path engages — the same recovery that already exists today.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass3_ms | pass4_ms | total_ms | Notes |
|---|---:|---:|---:|---|
| Run 1 | N/A | N/A | N/A | Schema-only change; latency neutral. Froggin Noggin baseline run reached canon validation after 11m 34s of P1–P3 and was rejected pre-persistence at Pass 4 governance. |
| Run 2 | N/A | N/A | N/A | Pre-change runs cannot be re-measured because cross_check_output is not persisted (addressed in follow-up #509). |

### Post-change Runs

| Run | pass3_ms | pass4_ms | total_ms | Notes |
|---|---:|---:|---:|---|
| Run 1 | N/A | N/A | N/A | Will be measured by re-running Froggin Noggin after merge + production deploy. Expected: Pass 4 succeeds OR fails with a sharper error code (sonar refusal / parse boundary). |
| Run 2 | N/A | N/A | N/A | Smoke-eval second run; same expectation. |

## Quality Gate / Anomalies

QG_PASS4_CANON: no QG_ behavior changes. The canon validator's PASS4_CANON_INVALID code is unchanged; this PR only reduces the surface area on which it can fire by making the schema enforce what the validator already requires.

criteria_count_by_state: n/a — this PR does not touch the Pass 3 reducer or divergence distribution. The Pass 3 selector above is checked only to satisfy the latency-pr-enforcement validator's enumerable options; this PR is scoped to the Pass 4 Perplexity request schema.

## Risks & Anomalies

- Low. The strict-schema enforcement path is the existing one; we're tightening two existing array fields, not adding a new constraint class.
- If sonar is unable to populate `detectedSignals` or `doctrineTrace` for a given criterion, the retry path takes over. If retry also fails, the user-visible error becomes a schema/parse error rather than the misleading `PASS4_CANON_INVALID`, which is strictly better signal.
- `minLength: 1` on string items is conservative; whitespace-only strings already fail downstream consistency checks (`rationale.trim()` etc.), so applying it to `detectedSignals` / `doctrineTrace` improves uniformity.

## Architecture Alignment

- alignment: post-#384 architecture-aligned
- mitigation_expiry: n/a
- dependent_architecture: PR #506 (Pass 4 external_adjudication contract) remains the persistence contract; this PR sits one layer up at the request schema.
- expected_revisit: no
- replay_ids_at_risk: none — schema-only tightening, no replay shape changes
- replay_ids_targeted: fdda059f-44e8-45bb-86b6-0c35607ee928 (failed run; will be replayable once #509 lands)

<!-- pr-type: evaluation -->
