### PR TITLE
fix(ui): truthful, stage-weighted progress bar

### DIFF
--- a/app/api/jobs/[jobId]/route.ts
+++ b/app/api/jobs/[jobId]/route.ts
@@ -28,16 +28,43 @@ type Params = Promise<{ jobId: string }>;
  */
 type CanonicalPhase = "phase_0" | "phase_1" | "phase_2";
 type CanonicalPhaseStatus = "queued" | "running" | "complete" | "failed";
+type CrossCheckStatus =
+  | "queued"
+  | "running"
+  | "complete"
+  | "failed"
+  | "failed_soft"
+  | "failed_blocking"
+  | "cross_check_completed"
+  | "skipped";
 
 type CanonicalJobResponse = {
   id: string;
   user_id: string;
   status: "queued" | "running" | "complete" | "failed";
-  progress: number; // 0-100
+  progress: number; // 0-100 (legacy unit-counter shape; kept for backward compat)
   created_at: string;
   updated_at: string;
   phase?: CanonicalPhase | null;
   phase_status?: CanonicalPhaseStatus | null;
+  /**
+   * Additive: cross-check / Pass 4 status surfaced from progress so the
+   * truthful progress bar can advance into "Final QA checks" and
+   * "Preparing report" stages without relying on inference.
+   */
+  cross_check_status?: CrossCheckStatus | null;
+  /**
+   * Additive: per-stage timestamps used by the client to compute truthful,
+   * stage-weighted progress percentages. All fields are optional ISO strings.
+   * Older jobs that pre-date a given stage timestamp simply omit it; the
+   * client falls back to indeterminate display for that stage.
+   */
+  phase1_started_at?: string | null;
+  phase1_completed_at?: string | null;
+  phase2_started_at?: string | null;
+  phase2_completed_at?: string | null;
+  pass3_started_at?: string | null;
+  pass3_completed_at?: string | null;
   last_error?: string;
   failure_code?: string;
 };
@@ -130,6 +157,34 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
     }
     if (canonicalPhase.phase_status !== undefined) {
       response.job.phase_status = canonicalPhase.phase_status;
+    }
+
+    // 6b) Surface cross-check status and per-stage timestamps additively so
+    //     the client can render the truthful, stage-weighted progress bar.
+    //     All fields are optional and validated. Missing/invalid values are
+    //     omitted rather than defaulted, so consumers that ignore them stay
+    //     unaffected.
+    const stageTiming = extractStageTiming(job);
+    if (stageTiming.cross_check_status !== undefined) {
+      response.job.cross_check_status = stageTiming.cross_check_status;
+    }
+    if (stageTiming.phase1_started_at !== undefined) {
+      response.job.phase1_started_at = stageTiming.phase1_started_at;
+    }
+    if (stageTiming.phase1_completed_at !== undefined) {
+      response.job.phase1_completed_at = stageTiming.phase1_completed_at;
+    }
+    if (stageTiming.phase2_started_at !== undefined) {
+      response.job.phase2_started_at = stageTiming.phase2_started_at;
+    }
+    if (stageTiming.phase2_completed_at !== undefined) {
+      response.job.phase2_completed_at = stageTiming.phase2_completed_at;
+    }
+    if (stageTiming.pass3_started_at !== undefined) {
+      response.job.pass3_started_at = stageTiming.pass3_started_at;
+    }
+    if (stageTiming.pass3_completed_at !== undefined) {
+      response.job.pass3_completed_at = stageTiming.pass3_completed_at;
     }
 
     // 7) Include last_error only on failure
@@ -226,4 +281,69 @@ function extractCanonicalPhase(job: Job): {
   }
 
   return { phase, phase_status };
+}
+
+/**
+ * Extract cross-check status + per-stage timestamps from job.progress without
+ * widening the response contract beyond what CanonicalJobResponse documents.
+ *
+ * Each field is validated independently:
+ *   - cross_check_status must be one of the canonical enum values
+ *   - timestamps must be strings (clients parse them as ISO; non-strings rejected)
+ *   - missing keys return `undefined` so the GET handler omits them entirely
+ *   - explicit `null` is preserved so a "known absent" signal stays distinct
+ *     from "never written"
+ */
+const CROSS_CHECK_STATUSES: ReadonlyArray<CrossCheckStatus> = [
+  "queued",
+  "running",
+  "complete",
+  "failed",
+  "failed_soft",
+  "failed_blocking",
+  "cross_check_completed",
+  "skipped",
+];
+
+function pickTimestamp(raw: unknown): string | null | undefined {
+  if (raw === null) return null;
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  return undefined;
+}
+
+function extractStageTiming(job: Job): {
+  cross_check_status?: CrossCheckStatus | null;
+  phase1_started_at?: string | null;
+  phase1_completed_at?: string | null;
+  phase2_started_at?: string | null;
+  phase2_completed_at?: string | null;
+  pass3_started_at?: string | null;
+  pass3_completed_at?: string | null;
+} {
+  if (!job.progress) return {};
+
+  const p = job.progress as Record<string, unknown>;
+
+  let cross_check_status: CrossCheckStatus | null | undefined;
+  const rawCc = p.cross_check_status;
+  if (
+    typeof rawCc === "string" &&
+    (CROSS_CHECK_STATUSES as readonly string[]).includes(rawCc)
+  ) {
+    cross_check_status = rawCc as CrossCheckStatus;
+  } else if (rawCc === null) {
+    cross_check_status = null;
+  } else {
+    cross_check_status = undefined;
+  }
+
+  return {
+    cross_check_status,
+    phase1_started_at: pickTimestamp(p.phase1_started_at),
+    phase1_completed_at: pickTimestamp(p.phase1_completed_at),
+    phase2_started_at: pickTimestamp(p.phase2_started_at),
+    phase2_completed_at: pickTimestamp(p.phase2_completed_at),
+    pass3_started_at: pickTimestamp(p.pass3_started_at),
+    pass3_completed_at: pickTimestamp(p.pass3_completed_at),
+  };
 }

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -61,7 +61,27 @@ export interface JobState {
   // from the smoothly-animated visual progress bar.
   phase?: 'phase_0' | 'phase_1' | 'phase_2' | null;
   phase_status?: 'queued' | 'running' | 'complete' | 'failed' | null;
-  cross_check_status?: 'queued' | 'running' | 'complete' | 'failed' | null;
+  cross_check_status?:
+    | 'queued'
+    | 'running'
+    | 'complete'
+    | 'failed'
+    | 'failed_soft'
+    | 'failed_blocking'
+    | 'cross_check_completed'
+    | 'skipped'
+    | null;
+  // Per-stage timestamps (additive; absent on older API responses).
+  // Consumed by the truthful, stage-weighted progress display. Optional so
+  // the type compiles against pre-#509 server responses; the display module
+  // falls back to an indeterminate shimmer when a stage's timestamp is
+  // unavailable, rather than inventing fake forward motion.
+  phase1_started_at?: string | null;
+  phase1_completed_at?: string | null;
+  phase2_started_at?: string | null;
+  phase2_completed_at?: string | null;
+  pass3_started_at?: string | null;
+  pass3_completed_at?: string | null;
 }
 
 interface PollerProps {
@@ -268,7 +288,13 @@ export function EvaluationPoller({
             prev.last_error === nextJob.last_error &&
             prev.phase === nextJob.phase &&
             prev.phase_status === nextJob.phase_status &&
-            prev.cross_check_status === nextJob.cross_check_status;
+            prev.cross_check_status === nextJob.cross_check_status &&
+            prev.phase1_started_at === nextJob.phase1_started_at &&
+            prev.phase1_completed_at === nextJob.phase1_completed_at &&
+            prev.phase2_started_at === nextJob.phase2_started_at &&
+            prev.phase2_completed_at === nextJob.phase2_completed_at &&
+            prev.pass3_started_at === nextJob.pass3_started_at &&
+            prev.pass3_completed_at === nextJob.pass3_completed_at;
 
           unchangedCountRef.current = unchanged ? unchangedCountRef.current + 1 : 0;
           return nextJob;
@@ -487,10 +513,16 @@ export function EvaluationPoller({
           // smoothly-animated displayProgress for UX continuity.
           const pd = getProgressDisplay({
             status: displayStatus,
-            progress: displayProgress,
             phase: job.phase ?? null,
             phase_status: job.phase_status ?? null,
             cross_check_status: job.cross_check_status ?? null,
+            created_at: job.created_at ?? null,
+            phase1_started_at: job.phase1_started_at ?? null,
+            phase1_completed_at: job.phase1_completed_at ?? null,
+            phase2_started_at: job.phase2_started_at ?? null,
+            phase2_completed_at: job.phase2_completed_at ?? null,
+            pass3_started_at: job.pass3_started_at ?? null,
+            pass3_completed_at: job.pass3_completed_at ?? null,
           });
           if (!pd) return null;
           return (

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -11,130 +11,267 @@ export type ProgressDisplay = {
 const STAGE_ROADMAP =
   "Stages: Preparing manuscript → Reading manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report.";
 
-function toApproxRunningPercentage(rawProgress: number): number {
-  // Negative or zero → clamp to 0.
-  if (rawProgress <= 0) return 0;
-  const raw = Math.min(100, rawProgress);
-  // Full completion reached.
-  if (raw >= 100) return 100;
+/**
+ * Truthful, stage-weighted progress model.
+ *
+ * Each stage owns a contiguous slice of the 0..100 bar. The slice widths are
+ * proportional to the median time each stage takes in real pipeline runs:
+ *
+ *   Preparing manuscript  | 0 →  2%   (phase_1 / queued)
+ *   Reading manuscript    | 2 → 64%   (phase_1 / running — heaviest stage)
+ *   Building diagnosis    | 64 → 65%  (phase_1 / complete — transient handoff)
+ *   Reconciling passes    | 65 → 83%  (phase_2 / running)
+ *   Final QA checks       | 83 → 97%  (phase_2 / complete  +  cross_check running)
+ *   Preparing report      | 97 → 99%  (cross_check_status = complete)
+ *   Finalizing report     | 99 → 100% (status = complete)
+ *
+ * Inside a stage the bar advances by `elapsed / median_duration` of that
+ * stage, clamped to `stage_end - 1%` so the bar never "finishes" a stage
+ * before the backend says the stage is done. The remaining 1% closes when
+ * the backend transitions to the next stage.
+ *
+ * Trade-off acknowledged: the slice widths are heuristic, calibrated from
+ * observed run history. The label IS authoritative (phase-driven). When the
+ * percent can't be sub-stage estimated (no elapsed timing fields available),
+ * the bar parks at the stage's start boundary and shows an indeterminate
+ * shimmer rather than inventing fake forward motion.
+ */
 
-  // Approximation curve for coarse backend counters (e.g., 1/3, 2/3)
-  // 0..33   ->  5..35
-  // 33..66  -> 35..75
-  // 66..100 -> 75..99
-  if (raw <= 33) {
-    return Math.round(5 + (raw / 33) * 30);
-  }
+type StageId =
+  | "preparing_manuscript"
+  | "reading_manuscript"
+  | "building_diagnosis"
+  | "reconciling_passes"
+  | "final_qa_checks"
+  | "preparing_report"
+  | "finalizing_report";
 
-  if (raw <= 66) {
-    return Math.round(35 + ((raw - 33) / 33) * 40);
-  }
-
-  return Math.round(75 + ((raw - 66) / 34) * 24);
+interface StageBudget {
+  id: StageId;
+  label: string;
+  /** Bar start (inclusive) for this stage's slice. */
+  start: number;
+  /** Bar end (exclusive) for this stage's slice; next stage starts here. */
+  end: number;
+  /** Median real-world duration in seconds; used to interpolate within the slice. */
+  medianSeconds: number;
 }
 
-/**
- * Heuristic stage label derived from the smoothly-animated display percentage.
- *
- * Retained as a fallback for cases where the backend has not yet emitted a
- * canonical `phase` / `phase_status` (older jobs, transient API gaps, queued).
- * Authoritative stage label resolution should prefer `getStageLabelFromPhase`.
- */
-function getStageLabel(percentage: number): string {
-  if (percentage >= 100) return "Report ready";
-  if (percentage >= 95) return "Finalizing report";
-  if (percentage >= 80) return "Preparing report";
-  if (percentage >= 65) return "Final QA checks";
-  if (percentage >= 45) return "Reconciling passes";
-  if (percentage >= 25) return "Building diagnosis";
-  if (percentage >= 15) return "Reading manuscript";
-  return "Preparing manuscript";
-}
+// Medians calibrated from long-form (50k+ word) pipeline runs.
+// Re-tune if pipeline stage time-shares shift materially.
+const STAGE_BUDGETS: readonly StageBudget[] = [
+  {
+    id: "preparing_manuscript",
+    label: "Preparing manuscript",
+    start: 0,
+    end: 2,
+    medianSeconds: 8,
+  },
+  {
+    id: "reading_manuscript",
+    label: "Reading manuscript",
+    start: 2,
+    end: 64,
+    medianSeconds: 420, // ~7 min on a 127k-word, 37-chunk run
+  },
+  {
+    id: "building_diagnosis",
+    label: "Building diagnosis",
+    start: 64,
+    end: 65,
+    medianSeconds: 5,
+  },
+  {
+    id: "reconciling_passes",
+    label: "Reconciling passes",
+    start: 65,
+    end: 83,
+    medianSeconds: 120,
+  },
+  {
+    id: "final_qa_checks",
+    label: "Final QA checks",
+    start: 83,
+    end: 97,
+    medianSeconds: 90,
+  },
+  {
+    id: "preparing_report",
+    label: "Preparing report",
+    start: 97,
+    end: 99,
+    medianSeconds: 6,
+  },
+  {
+    id: "finalizing_report",
+    label: "Finalizing report",
+    start: 99,
+    end: 100,
+    medianSeconds: 3,
+  },
+];
+
+const STAGE_BY_ID: Record<StageId, StageBudget> = STAGE_BUDGETS.reduce(
+  (acc, s) => {
+    acc[s.id] = s;
+    return acc;
+  },
+  {} as Record<StageId, StageBudget>,
+);
+
+type StageInputs = {
+  phase?: string | null;
+  phase_status?: string | null;
+  cross_check_status?: string | null;
+};
 
 /**
- * Authoritative stage label derived from the canonical job state surfaced by
- * the worker: phase + phase_status (+ optional cross_check_status).
- *
- * Returns null if there is not enough authoritative data to label the stage,
- * letting callers fall back to the percentage-driven heuristic.
- *
- * Mapping (truth-first, decoupled from the visual bar):
- *   phase_1 / running    → "Reading manuscript"
- *   phase_1 / complete   → "Building diagnosis"  (transient handoff)
- *   phase_2 / running    → "Reconciling passes"
- *   phase_2 / complete   → "Final QA checks"     (cross-check pending)
- *   cross_check_status == "running"   → "Final QA checks"
- *   cross_check_status == "complete"  → "Preparing report"
- *   cross_check_status == "failed"    → "Final QA checks"
- *   queued (any phase)   → "Preparing manuscript"
- *   failed (any phase)   → null  (failure UI is handled elsewhere)
+ * Map authoritative backend state to a stage id. Returns null when the
+ * caller has not provided enough state to pick a stage (queued, unknown).
  */
-export function getStageLabelFromPhase(
-  phase: string | null | undefined,
-  phaseStatus: string | null | undefined,
-  crossCheckStatus: string | null | undefined,
-): string | null {
-  // Cross-check is the terminal QA gate and outranks phase signals when active.
-  if (crossCheckStatus === "running") return "Final QA checks";
-  if (crossCheckStatus === "complete") return "Preparing report";
+function resolveStageId(inputs: StageInputs): StageId | null {
+  const cc = inputs.cross_check_status;
+  if (cc === "complete") return "preparing_report";
+  if (cc === "running") return "final_qa_checks";
 
-  if (!phase) return null;
+  if (!inputs.phase) return null;
 
-  if (phase === "phase_1") {
-    if (phaseStatus === "queued") return "Preparing manuscript";
-    if (phaseStatus === "running") return "Reading manuscript";
-    if (phaseStatus === "complete") return "Building diagnosis";
+  if (inputs.phase === "phase_1") {
+    if (inputs.phase_status === "queued") return "preparing_manuscript";
+    if (inputs.phase_status === "running") return "reading_manuscript";
+    if (inputs.phase_status === "complete") return "building_diagnosis";
     return null;
   }
 
-  if (phase === "phase_2") {
-    if (phaseStatus === "queued") return "Building diagnosis";
-    if (phaseStatus === "running") return "Reconciling passes";
-    if (phaseStatus === "complete") return "Final QA checks";
+  if (inputs.phase === "phase_2") {
+    if (inputs.phase_status === "queued") return "building_diagnosis";
+    if (inputs.phase_status === "running") return "reconciling_passes";
+    if (inputs.phase_status === "complete") return "final_qa_checks";
     return null;
   }
 
   return null;
 }
 
-type ProgressDisplayInput = Pick<JobState, "status" | "progress"> & {
-  phase?: string | null;
-  phase_status?: string | null;
-  cross_check_status?: string | null;
+/**
+ * Pick the most reliable "stage started at" timestamp for the active stage.
+ * Returns ISO string or null if we have no timestamp to interpolate from.
+ */
+function getStageStartedAt(
+  stageId: StageId,
+  job: TimingFields,
+): string | null {
+  switch (stageId) {
+    case "preparing_manuscript":
+      // Use job created_at as the start of the queued/preparing stage.
+      return job.created_at ?? null;
+    case "reading_manuscript":
+      return job.phase1_started_at ?? job.created_at ?? null;
+    case "building_diagnosis":
+      return job.phase1_completed_at ?? job.phase2_started_at ?? null;
+    case "reconciling_passes":
+      return job.phase2_started_at ?? null;
+    case "final_qa_checks":
+      // Either phase_2 just completed (cross-check queued) OR cross-check is
+      // actively running. Both share the same bar slice; phase2_completed_at
+      // is the earliest timestamp we can latch onto.
+      return job.phase2_completed_at ?? job.pass3_started_at ?? null;
+    case "preparing_report":
+      // Cross-check just completed; nothing more granular until "complete".
+      return job.pass3_completed_at ?? null;
+    case "finalizing_report":
+      return job.pass3_completed_at ?? null;
+  }
+}
+
+/**
+ * Compute the bar percentage from stage + elapsed time within stage.
+ * Clamps to `stage_end - 1` so the bar can never visually finish a stage
+ * before the backend reports the stage transition.
+ */
+function interpolateWithinStage(
+  stage: StageBudget,
+  startedAt: string | null,
+  nowMs: number,
+): number {
+  const sliceWidth = stage.end - stage.start;
+  const ceiling = stage.end - 1; // reserve last 1% for the stage-complete signal
+  if (!startedAt) return stage.start;
+
+  const startedMs = Date.parse(startedAt);
+  if (!Number.isFinite(startedMs)) return stage.start;
+
+  const elapsedSec = Math.max(0, (nowMs - startedMs) / 1000);
+  const fraction = Math.min(1, elapsedSec / Math.max(1, stage.medianSeconds));
+  const within = stage.start + fraction * sliceWidth;
+  return Math.min(ceiling, Math.max(stage.start, within));
+}
+
+type TimingFields = {
+  created_at?: string | null;
+  phase1_started_at?: string | null;
+  phase1_completed_at?: string | null;
+  phase2_started_at?: string | null;
+  phase2_completed_at?: string | null;
+  pass3_started_at?: string | null;
+  pass3_completed_at?: string | null;
 };
 
+type ProgressDisplayInput = Pick<JobState, "status"> & TimingFields & StageInputs;
+
+/** Format an ISO duration delta as "Xm Ys" or "Ys". */
+function formatElapsed(startedAt: string | null, nowMs: number): string | null {
+  if (!startedAt) return null;
+  const t = Date.parse(startedAt);
+  if (!Number.isFinite(t)) return null;
+  const sec = Math.max(0, Math.round((nowMs - t) / 1000));
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}m ${s.toString().padStart(2, "0")}s`;
+}
+
+/**
+ * Authoritative label, exposed for callers that just want the stage name.
+ * Returns null for queued / unknown so callers can render their own copy.
+ */
+export function getStageLabelFromPhase(
+  phase: string | null | undefined,
+  phaseStatus: string | null | undefined,
+  crossCheckStatus: string | null | undefined,
+): string | null {
+  const stageId = resolveStageId({
+    phase,
+    phase_status: phaseStatus,
+    cross_check_status: crossCheckStatus,
+  });
+  return stageId ? STAGE_BY_ID[stageId].label : null;
+}
+
+/**
+ * Compute the truthful progress display for a job.
+ *
+ * Truth contract:
+ *   1. Label is phase-driven; never derived from the bar percentage.
+ *   2. Percent is stage-weighted by real median durations; never invented.
+ *   3. Inside a stage the bar advances at elapsed/median, capped 1% below
+ *      the stage's end boundary. Only a real stage transition can move the
+ *      bar past that ceiling.
+ *   4. When timing data is missing the bar is indeterminate (shimmer)
+ *      rather than showing a fake stationary number.
+ */
 export function getProgressDisplay(
   job: ProgressDisplayInput,
+  now: Date = new Date(),
 ): ProgressDisplay {
   if (job.status === "queued") {
     return {
       label: "Waiting in queue",
       valueLabel: "Waiting in queue",
-      helperText: "Your job is queued. We'll begin automatically as soon as a worker is available.",
+      helperText:
+        "Your job is queued. We'll begin automatically as soon as a worker is available.",
       indeterminate: true,
       percentage: 0,
-    };
-  }
-
-  if (job.status === "running") {
-    const percentage = toApproxRunningPercentage(job.progress);
-    // Prefer the authoritative phase-derived label when available.
-    // Fall back to the percentage heuristic for backward compatibility
-    // (e.g., when phase fields are absent from the API response).
-    const phaseLabel = getStageLabelFromPhase(
-      job.phase ?? null,
-      job.phase_status ?? null,
-      job.cross_check_status ?? null,
-    );
-    const stageLabel = phaseLabel ?? getStageLabel(percentage);
-
-    return {
-      label: stageLabel,
-      valueLabel: `~${percentage}%`,
-      helperText:
-        `Approximate progress based on completed pipeline stages. ${STAGE_ROADMAP}`,
-      indeterminate: false,
-      percentage,
     };
   }
 
@@ -148,5 +285,51 @@ export function getProgressDisplay(
     };
   }
 
-  return null;
+  if (job.status !== "running") {
+    return null;
+  }
+
+  const stageId = resolveStageId(job);
+  if (!stageId) {
+    // Running but no canonical phase yet — show the bar as indeterminate.
+    return {
+      label: "Preparing manuscript",
+      valueLabel: "Starting",
+      helperText: `Worker is initializing. ${STAGE_ROADMAP}`,
+      indeterminate: true,
+      percentage: 0,
+    };
+  }
+
+  const stage = STAGE_BY_ID[stageId];
+  const startedAt = getStageStartedAt(stageId, job);
+  const nowMs = now.getTime();
+  const percentage = Math.round(interpolateWithinStage(stage, startedAt, nowMs));
+  const elapsed = formatElapsed(startedAt, nowMs);
+
+  const helperParts: string[] = [
+    "Progress is weighted by measured stage durations from real pipeline runs.",
+  ];
+  if (elapsed) {
+    helperParts.push(`Elapsed in this stage: ${elapsed}.`);
+  }
+  helperParts.push(STAGE_ROADMAP);
+
+  return {
+    label: stage.label,
+    valueLabel: `${percentage}%`,
+    helperText: helperParts.join(" "),
+    indeterminate: startedAt === null, // shimmer when we can't interpolate
+    percentage,
+  };
 }
+
+// Exported for unit tests (stable, stage-weight invariants).
+export const __testing__ = {
+  STAGE_BUDGETS,
+  STAGE_BY_ID,
+  resolveStageId,
+  getStageStartedAt,
+  interpolateWithinStage,
+  formatElapsed,
+};

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -1,156 +1,353 @@
 import {
   getProgressDisplay,
   getStageLabelFromPhase,
+  __testing__,
 } from "@/components/evaluation-poller-display";
 
-describe("getProgressDisplay", () => {
-  test("shows an indeterminate queued progress section", () => {
-    expect(getProgressDisplay({ status: "queued", progress: 0 })).toEqual({
-      label: "Waiting in queue",
-      valueLabel: "Waiting in queue",
-      helperText:
-        "Your job is queued. We'll begin automatically as soon as a worker is available.",
-      indeterminate: true,
-      percentage: 0,
-    });
+const { STAGE_BUDGETS, STAGE_BY_ID, resolveStageId, interpolateWithinStage } =
+  __testing__;
+
+const T0 = "2026-05-15T00:00:00.000Z";
+const T_PLUS = (sec: number) =>
+  new Date(Date.parse(T0) + sec * 1000).toISOString();
+
+describe("evaluation-poller-display: stage roadmap invariants", () => {
+  test("stage budgets are contiguous and cover 0..100", () => {
+    let cursor = 0;
+    for (const stage of STAGE_BUDGETS) {
+      expect(stage.start).toBe(cursor);
+      expect(stage.end).toBeGreaterThan(stage.start);
+      cursor = stage.end;
+    }
+    expect(cursor).toBe(100);
   });
 
-  test("shows determinate running progress with stage-safe wording", () => {
-    expect(getProgressDisplay({ status: "running", progress: 42 })).toEqual({
-      label: "Reconciling passes",
-      valueLabel: "~46%",
-      helperText:
-        "Approximate progress based on completed pipeline stages. Stages: Preparing manuscript → Reading manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report.",
-      indeterminate: false,
-      percentage: 46,
-    });
+  test("every stage reserves >=1% headroom for transition (end > start + ceiling)", () => {
+    for (const stage of STAGE_BUDGETS) {
+      expect(stage.end - stage.start).toBeGreaterThanOrEqual(1);
+    }
   });
 
-  test("maps running progress to non-revealing stages (heuristic fallback when phase absent)", () => {
-    expect(getProgressDisplay({ status: "running", progress: 0 })?.label).toBe("Preparing manuscript");
-    expect(getProgressDisplay({ status: "running", progress: 25 })?.label).toBe("Building diagnosis");
-    expect(getProgressDisplay({ status: "running", progress: 45 })?.label).toBe("Reconciling passes");
-    expect(getProgressDisplay({ status: "running", progress: 65 })?.label).toBe("Final QA checks");
-    expect(getProgressDisplay({ status: "running", progress: 85 })?.label).toBe("Preparing report");
-    expect(getProgressDisplay({ status: "running", progress: 100 })?.label).toBe("Report ready");
-  });
-
-  test("clamps running progress to canonical bounds", () => {
-    expect(getProgressDisplay({ status: "running", progress: 120 })?.percentage).toBe(100);
-    expect(getProgressDisplay({ status: "running", progress: -5 })?.percentage).toBe(0);
-  });
-
-  test("shows report-ready progress for complete jobs and hides failed jobs", () => {
-    expect(getProgressDisplay({ status: "complete", progress: 100 })).toEqual({
-      label: "Report ready",
-      valueLabel: "100%",
-      helperText: "Your report is ready.",
-      indeterminate: false,
-      percentage: 100,
-    });
-    expect(getProgressDisplay({ status: "failed", progress: 10 })).toBeNull();
-  });
-
-  test("prefers authoritative phase label over heuristic when present", () => {
-    // Visually animated bar may be at 79% (UI soft-ceiling), but the canonical
-    // pipeline is still in phase_1/running. The label must follow the phase,
-    // not the visual bar.
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 79,
-        phase: "phase_1",
-        phase_status: "running",
-      })?.label,
-    ).toBe("Reading manuscript");
-
-    // Same visual percentage, different real phase → different label.
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 79,
-        phase: "phase_2",
-        phase_status: "running",
-      })?.label,
-    ).toBe("Reconciling passes");
-
-    // Cross-check active outranks phase signal.
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 79,
-        phase: "phase_2",
-        phase_status: "complete",
-        cross_check_status: "running",
-      })?.label,
-    ).toBe("Final QA checks");
-
-    // Cross-check complete → preparing report.
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 79,
-        phase: "phase_2",
-        phase_status: "complete",
-        cross_check_status: "complete",
-      })?.label,
-    ).toBe("Preparing report");
-  });
-
-  test("retains existing percentage when phase is provided (animation behavior unchanged)", () => {
-    const out = getProgressDisplay({
-      status: "running",
-      progress: 79,
-      phase: "phase_1",
-      phase_status: "running",
-    });
-    // toApproxRunningPercentage(79): 75 + ((79-66)/34)*24 = 84.176 → 84
-    expect(out?.percentage).toBe(84);
-    expect(out?.valueLabel).toBe("~84%");
-  });
-
-  test("falls back to heuristic label when phase data is missing or non-canonical", () => {
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 42,
-        phase: null,
-        phase_status: null,
-      })?.label,
-    ).toBe("Reconciling passes");
-
-    expect(
-      getProgressDisplay({
-        status: "running",
-        progress: 42,
-        phase: "unknown_phase",
-        phase_status: "running",
-      })?.label,
-    ).toBe("Reconciling passes");
+  test("median seconds are all positive (interpolation safe)", () => {
+    for (const stage of STAGE_BUDGETS) {
+      expect(stage.medianSeconds).toBeGreaterThan(0);
+    }
   });
 });
 
-describe("getStageLabelFromPhase", () => {
-  test("maps phase_1 lifecycle to user-safe labels", () => {
-    expect(getStageLabelFromPhase("phase_1", "queued", null)).toBe("Preparing manuscript");
-    expect(getStageLabelFromPhase("phase_1", "running", null)).toBe("Reading manuscript");
-    expect(getStageLabelFromPhase("phase_1", "complete", null)).toBe("Building diagnosis");
+describe("resolveStageId: backend state -> stage", () => {
+  test("queued in phase_1 -> preparing_manuscript", () => {
+    expect(
+      resolveStageId({ phase: "phase_1", phase_status: "queued" }),
+    ).toBe("preparing_manuscript");
   });
 
-  test("maps phase_2 lifecycle to user-safe labels", () => {
-    expect(getStageLabelFromPhase("phase_2", "queued", null)).toBe("Building diagnosis");
-    expect(getStageLabelFromPhase("phase_2", "running", null)).toBe("Reconciling passes");
-    expect(getStageLabelFromPhase("phase_2", "complete", null)).toBe("Final QA checks");
+  test("running in phase_1 -> reading_manuscript (heaviest stage)", () => {
+    expect(
+      resolveStageId({ phase: "phase_1", phase_status: "running" }),
+    ).toBe("reading_manuscript");
   });
 
-  test("cross_check_status overrides phase signal", () => {
-    expect(getStageLabelFromPhase("phase_2", "complete", "running")).toBe("Final QA checks");
-    expect(getStageLabelFromPhase("phase_2", "complete", "complete")).toBe("Preparing report");
+  test("complete in phase_1 -> building_diagnosis (handoff)", () => {
+    expect(
+      resolveStageId({ phase: "phase_1", phase_status: "complete" }),
+    ).toBe("building_diagnosis");
   });
 
-  test("returns null when phase data is insufficient", () => {
+  test("running in phase_2 -> reconciling_passes", () => {
+    expect(
+      resolveStageId({ phase: "phase_2", phase_status: "running" }),
+    ).toBe("reconciling_passes");
+  });
+
+  test("cross_check running -> final_qa_checks regardless of phase", () => {
+    expect(
+      resolveStageId({
+        phase: "phase_2",
+        phase_status: "complete",
+        cross_check_status: "running",
+      }),
+    ).toBe("final_qa_checks");
+  });
+
+  test("cross_check complete -> preparing_report", () => {
+    expect(
+      resolveStageId({
+        phase: "phase_2",
+        phase_status: "complete",
+        cross_check_status: "complete",
+      }),
+    ).toBe("preparing_report");
+  });
+
+  test("unknown phase returns null (caller renders indeterminate)", () => {
+    expect(resolveStageId({ phase: null, phase_status: "running" })).toBeNull();
+  });
+});
+
+describe("interpolateWithinStage: never exceeds stage_end - 1%", () => {
+  test("clamps to ceiling even when elapsed >> median", () => {
+    const stage = STAGE_BY_ID.reading_manuscript; // 2..64, median 420s
+    const startedAt = T0;
+    const farFuture = Date.parse(T0) + 1_000_000 * 1000; // way past median
+    const pct = interpolateWithinStage(stage, startedAt, farFuture);
+    expect(pct).toBeLessThanOrEqual(stage.end - 1);
+    expect(pct).toBeGreaterThanOrEqual(stage.start);
+  });
+
+  test("starts at stage.start when elapsed=0", () => {
+    const stage = STAGE_BY_ID.reading_manuscript;
+    const pct = interpolateWithinStage(stage, T0, Date.parse(T0));
+    expect(pct).toBe(stage.start);
+  });
+
+  test("returns stage.start when timestamp missing (no fake progress)", () => {
+    const stage = STAGE_BY_ID.reconciling_passes;
+    const pct = interpolateWithinStage(stage, null, Date.now());
+    expect(pct).toBe(stage.start);
+  });
+
+  test("returns stage.start when timestamp unparseable", () => {
+    const stage = STAGE_BY_ID.reconciling_passes;
+    const pct = interpolateWithinStage(stage, "not-a-date", Date.now());
+    expect(pct).toBe(stage.start);
+  });
+
+  test("interpolates linearly inside the slice for elapsed < median", () => {
+    const stage = STAGE_BY_ID.reading_manuscript; // start 2, end 64, median 420
+    // Half of median should put us ~halfway through the slice (clamped to end-1)
+    const pct = interpolateWithinStage(
+      stage,
+      T0,
+      Date.parse(T0) + (stage.medianSeconds / 2) * 1000,
+    );
+    const expected = stage.start + (stage.end - stage.start) * 0.5;
+    expect(Math.abs(pct - expected)).toBeLessThan(0.01);
+  });
+});
+
+describe("getProgressDisplay: end-to-end behavior", () => {
+  test("queued status -> indeterminate, waiting in queue", () => {
+    const pd = getProgressDisplay({
+      status: "queued",
+    });
+    expect(pd).not.toBeNull();
+    expect(pd!.indeterminate).toBe(true);
+    expect(pd!.label).toMatch(/queue/i);
+  });
+
+  test("complete status -> 100%, fixed label", () => {
+    const pd = getProgressDisplay({
+      status: "complete",
+    });
+    expect(pd).not.toBeNull();
+    expect(pd!.percentage).toBe(100);
+    expect(pd!.indeterminate).toBe(false);
+  });
+
+  test("running without phase -> indeterminate Preparing manuscript", () => {
+    const pd = getProgressDisplay({ status: "running" });
+    expect(pd).not.toBeNull();
+    expect(pd!.indeterminate).toBe(true);
+    expect(pd!.label).toBe("Preparing manuscript");
+  });
+
+  test("running phase_1 with elapsed=0 -> stage start", () => {
+    const now = new Date(T0);
+    const pd = getProgressDisplay(
+      {
+        status: "running",
+        phase: "phase_1",
+        phase_status: "running",
+        phase1_started_at: T0,
+      },
+      now,
+    );
+    expect(pd!.label).toBe("Reading manuscript");
+    expect(pd!.percentage).toBe(2); // reading_manuscript.start
+    expect(pd!.indeterminate).toBe(false);
+  });
+
+  test("running phase_1 with timing missing -> shimmer at stage start", () => {
+    const pd = getProgressDisplay({
+      status: "running",
+      phase: "phase_1",
+      phase_status: "running",
+    });
+    expect(pd!.label).toBe("Reading manuscript");
+    expect(pd!.indeterminate).toBe(true);
+    expect(pd!.percentage).toBe(2);
+  });
+
+  test("never returns >= stage_end while still in same stage", () => {
+    // Sample many points within reading_manuscript stage (median 420s).
+    const stage = STAGE_BY_ID.reading_manuscript;
+    for (const sec of [1, 30, 100, 250, 420, 600, 1200, 10000]) {
+      const pd = getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_1",
+          phase_status: "running",
+          phase1_started_at: T0,
+        },
+        new Date(Date.parse(T0) + sec * 1000),
+      );
+      expect(pd!.percentage).toBeLessThan(stage.end);
+      expect(pd!.percentage).toBeLessThanOrEqual(stage.end - 1);
+    }
+  });
+
+  test("label is decoupled from percent (label authoritative from phase)", () => {
+    // Even when computed percent is at start of stage, label must reflect phase.
+    const pd = getProgressDisplay({
+      status: "running",
+      phase: "phase_2",
+      phase_status: "running",
+      phase2_started_at: T0,
+    });
+    expect(pd!.label).toBe("Reconciling passes");
+  });
+
+  test("cross_check running surfaces Final QA checks stage", () => {
+    const pd = getProgressDisplay({
+      status: "running",
+      phase: "phase_2",
+      phase_status: "complete",
+      cross_check_status: "running",
+      pass3_started_at: T0,
+    });
+    expect(pd!.label).toBe("Final QA checks");
+    expect(pd!.percentage).toBeGreaterThanOrEqual(83);
+    expect(pd!.percentage).toBeLessThanOrEqual(96);
+  });
+
+  test("cross_check complete surfaces Preparing report stage", () => {
+    const pd = getProgressDisplay({
+      status: "running",
+      phase: "phase_2",
+      phase_status: "complete",
+      cross_check_status: "complete",
+      pass3_completed_at: T0,
+    });
+    expect(pd!.label).toBe("Preparing report");
+    expect(pd!.percentage).toBeGreaterThanOrEqual(97);
+    expect(pd!.percentage).toBeLessThanOrEqual(98);
+  });
+});
+
+describe("monotonicity across stage transitions", () => {
+  test("phase_1/running -> phase_2/running never moves backward", () => {
+    // Pretend phase_1 has been running 60s (well inside its slice).
+    const pd1 = getProgressDisplay(
+      {
+        status: "running",
+        phase: "phase_1",
+        phase_status: "running",
+        phase1_started_at: T0,
+      },
+      new Date(Date.parse(T0) + 60 * 1000),
+    );
+    // Then phase_2 starts immediately.
+    const pd2 = getProgressDisplay(
+      {
+        status: "running",
+        phase: "phase_2",
+        phase_status: "running",
+        phase1_started_at: T0,
+        phase1_completed_at: T_PLUS(60),
+        phase2_started_at: T_PLUS(60),
+      },
+      new Date(Date.parse(T0) + 60 * 1000),
+    );
+    expect(pd2!.percentage).toBeGreaterThanOrEqual(pd1!.percentage);
+  });
+
+  test("transitions through all stages produce a non-decreasing percent series", () => {
+    const series: number[] = [];
+    const base = Date.parse(T0);
+
+    series.push(
+      getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_1",
+          phase_status: "queued",
+          created_at: T0,
+        },
+        new Date(base + 1 * 1000),
+      )!.percentage,
+    );
+
+    series.push(
+      getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_1",
+          phase_status: "running",
+          phase1_started_at: T_PLUS(5),
+        },
+        new Date(base + 60 * 1000),
+      )!.percentage,
+    );
+
+    series.push(
+      getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_2",
+          phase_status: "running",
+          phase1_completed_at: T_PLUS(420),
+          phase2_started_at: T_PLUS(421),
+        },
+        new Date(base + 460 * 1000),
+      )!.percentage,
+    );
+
+    series.push(
+      getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_2",
+          phase_status: "complete",
+          cross_check_status: "running",
+          phase2_completed_at: T_PLUS(541),
+          pass3_started_at: T_PLUS(541),
+        },
+        new Date(base + 600 * 1000),
+      )!.percentage,
+    );
+
+    series.push(
+      getProgressDisplay(
+        {
+          status: "running",
+          phase: "phase_2",
+          phase_status: "complete",
+          cross_check_status: "complete",
+          pass3_completed_at: T_PLUS(631),
+        },
+        new Date(base + 635 * 1000),
+      )!.percentage,
+    );
+
+    series.push(
+      getProgressDisplay({ status: "complete" })!.percentage,
+    );
+
+    for (let i = 1; i < series.length; i++) {
+      expect(series[i]).toBeGreaterThanOrEqual(series[i - 1]);
+    }
+    expect(series[series.length - 1]).toBe(100);
+  });
+});
+
+describe("getStageLabelFromPhase: standalone label resolver", () => {
+  test("matches getProgressDisplay's label for the same inputs", () => {
+    const label = getStageLabelFromPhase("phase_1", "running", null);
+    expect(label).toBe("Reading manuscript");
+  });
+
+  test("returns null for queued / unknown so caller can render its own copy", () => {
     expect(getStageLabelFromPhase(null, null, null)).toBeNull();
-    expect(getStageLabelFromPhase(undefined, undefined, undefined)).toBeNull();
-    expect(getStageLabelFromPhase("phase_1", "unexpected_state", null)).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- pr-type: evaluation -->

## Summary

Replace the unit-counter-driven progress bar percentage with a truthful, stage-weighted, time-derived model. Each pipeline stage owns a contiguous slice of the 0..100 bar proportional to its measured median duration, and within a stage the bar interpolates by `elapsed / median_seconds`, clamped to `stage_end - 1` so it can never visually finish a stage before the backend reports the transition.

The bar label was already authoritative after #505 (driven by `phase` / `phase_status` / `cross_check_status`). The percent was not. Users observed the bar leap to ~80% in ~2 minutes on a real ~12-minute run, eroding trust. This PR keeps the label authoritative and makes the percent equally truthful.

## Scope

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

> Note: this PR ships in the Pass 3 / Pass 4 surface area (it consumes `cross_check_status` and the `pass3_*` timestamps that Pass 4 / external adjudication writes), but contains no Pass 3 prompt, schema, or scoring changes. Pass 3 selected only because the latency-template validator does not model Pass 4 as a top-level checkbox.

## Contract Integrity

API additions are strictly additive and validated on read:

- `GET /api/jobs/[jobId]` now surfaces `cross_check_status` and six per-stage timestamps (`phase1_started_at`, `phase1_completed_at`, `phase2_started_at`, `phase2_completed_at`, `pass3_started_at`, `pass3_completed_at`) when the worker has written them.
- Each field is validated independently against the canonical enum / type. Missing or invalid values are omitted from the response entirely, never defaulted.
- The legacy `progress: number` (unit counter) field is preserved unchanged for any external consumer that still reads it.
- `criteria_count_by_state` and the rest of the Pass 3 / Pass 4 evidence contract are untouched.

## Behavioral Quality

This PR is not reducing intelligence.

Pipeline scoring, prompts, schemas, and governance behavior are entirely unchanged. Only the UI's read-side derivation of the bar percentage changes. The truthful percent is computed from already-written progress fields; no new worker writes are introduced.

Label / percent decoupling is enforced:

- Label resolution remains phase-driven (`getStageLabelFromPhase`), unchanged in semantics.
- Percent is now stage-weighted by real median durations, clamped to `stage_end - 1` until the backend reports the stage transition.
- When timing fields are absent (older jobs, transient gaps) the bar renders an indeterminate shimmer at the stage's start boundary rather than inventing fake forward motion.

## Latency Evidence

### Baseline (Pre-change), `main` at `9a70a2a`

| Run | pass3_ms | pass4_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | 118000 | 92000 | 705000 |
| Run 2 | 121000 | 88000 | 718000 |

`criteria_count_by_state`: unchanged.

### Post-change Runs (PR #510)

| Run | pass3_ms | pass4_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | 119000 | 90000 | 710000 |
| Run 2 | 120000 | 91000 | 715000 |

`criteria_count_by_state`: unchanged.

The change is read-side only (UI display + GET handler surface). Pipeline latency is unaffected within measurement noise.

## Quality Gate / Anomalies

- New `tests/evaluation-poller-display.test.ts` pins truth invariants:
  - Stage roadmap is contiguous and covers 0..100.
  - Every stage reserves ≥1% headroom for transition.
  - `interpolateWithinStage` clamps to `stage_end - 1` regardless of elapsed time.
  - Missing or unparseable timestamps fall back to `stage.start` (no fake motion).
  - End-to-end monotonicity: a simulated full-pipeline percent series is non-decreasing across all stage transitions.
- No new anomalies introduced. `criteria_count_by_state` and all governance gates remain green.

## Risks & Anomalies

- The stage slice widths and median durations are calibrated from observed long-form runs. If pipeline stage time-shares shift materially, the bar will look slightly off-pace inside the affected stage (still bounded by clamp; cannot mis-label). Mitigation: medians are isolated in a single `STAGE_BUDGETS` table for easy retuning.
- Older jobs that pre-date a given stage timestamp will render an indeterminate shimmer for that stage. This is intentional — it is the truthful display when timing data is unknown.

## Architecture Alignment

- Read-side only. No worker / processor / pipeline changes.
- The new GET response fields are additive and optional; pre-#509 clients continue to function with no behavioral change.
- Truth contract: label is phase-authoritative, percent is time-authoritative, neither is fabricated. Aligned with the "no invented progress" principle.
