### PR TITLE
fix(pass4): persist cross_check_output + audit; stop markFailed stomp

### DIFF
--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -1629,6 +1629,12 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       error_code: errorCode,
       failed_at: "pass4",
       external_adjudication: externalAdjudication,
+      // PR-B observability: surface the full cross-check output and governance
+      // decision on the failure variant so the processor can persist them onto
+      // progress before markFailed runs. Without this the cross_check_output
+      // column stays NULL and PASS4_CANON_INVALID incidents have no audit trail.
+      cross_check: crossCheckResult,
+      pass4_governance: pass4Governance,
       routing: pipelineRouting,
     };
   }

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -594,6 +594,21 @@ export type PipelineResult =
        * external_adjudication.status will be "failed_blocking".
        */
       external_adjudication?: ExternalAdjudicationStatus;
+      /**
+       * PR-B observability: full cross-check output when a Pass 4 governance
+       * failure (PASS4_CANON_INVALID / PASS4_WEAK_AGREEMENT /
+       * PASS4_DISPUTED_CRITERIA) blocks the pipeline. Lets the processor
+       * persist progress.cross_check_output and audit_invalid_criteria before
+       * markFailed runs, preserving the evidence that drove the block.
+       */
+      cross_check?: import("./perplexityCrossCheck").CrossCheckOutput;
+      /**
+       * PR-B observability: the governance decision (block code + audit context
+       * including invalidCriteria, disputedCriteria, overallAgreement) that
+       * caused the failure. Surfaced on the failure variant so the processor
+       * does not have to re-derive it from cross_check.
+       */
+      pass4_governance?: import("@/lib/evaluation/governance/evaluatePass4Governance").GovernanceDecision;
       /** Resolved pass-level model routing for audit traceability. */
       routing?: PipelineResultRouting;
       /** Recovery metadata: retry counts and fallback usage per pass. */

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -2327,30 +2327,57 @@ export async function processEvaluationJob(
 
       console.error(`[Processor] Pipeline failed for job ${jobId}: ${pipelineError}`);
 
-      // PR #506 — persist external_adjudication onto progress for failed jobs
-      // too, so /admin/pipeline-health and the failure UI can show whether the
-      // pipeline died because of a required-mode adjudication failure (vs an
-      // earlier-pass error). Best-effort; non-fatal.
+      // PR #506 / PR-B / PR-C — persist external_adjudication + full cross-check
+      // observability onto the in-memory progressState BEFORE markFailed runs.
+      //
+      // Why progressState (not a direct DB write):
+      //   markFailed builds nextProgress as { ...progressState, ... }. Any field
+      //   we write directly to the DB column here gets stomped by that spread.
+      //   Copying onto progressState first guarantees the failure-path write
+      //   includes the audit fields, closing the observability gap that left
+      //   cross_check_output NULL across all jobs and PASS4_CANON_INVALID
+      //   incidents with no audit trail.
       if (pipelineResult.external_adjudication) {
+        const ext = pipelineResult.external_adjudication;
+        progressState.cross_check_status = ext.status;
+        progressState.cross_check_reason = 'reason' in ext ? ext.reason : null;
+        progressState.external_adjudication_mode = ext.mode;
+        progressState.external_adjudication_status = ext.status;
+      }
+
+      // PR-B: surface the full cross-check output and governance audit context
+      // so a future operator can reconstruct exactly what Pass 4 saw without
+      // having to re-run the job. We persist cross_check_output to the dedicated
+      // jsonb column (which has been unused) AND mirror invalidCriteria into
+      // progress.audit_invalid_criteria so /admin/pipeline-health can render it
+      // without an additional DB read.
+      const crossCheckColumnPatch: Record<string, unknown> = {};
+      if (pipelineResult.cross_check) {
+        progressState.audit_invalid_criteria = pipelineResult.cross_check.invalidCriteria;
+        progressState.audit_canon_valid = pipelineResult.cross_check.canonValid;
+        progressState.audit_overall_agreement = pipelineResult.cross_check.overallAgreement;
+        crossCheckColumnPatch.cross_check_output = pipelineResult.cross_check;
+        crossCheckColumnPatch.cross_check_completed_at =
+          pipelineResult.cross_check.crossCheckedAt ?? new Date().toISOString();
+      }
+      if (pipelineResult.pass4_governance && !pipelineResult.pass4_governance.ok) {
+        progressState.pass4_block_code = pipelineResult.pass4_governance.blockCode ?? null;
+        progressState.pass4_block_severity = pipelineResult.pass4_governance.severity ?? null;
+        progressState.pass4_audit_context =
+          pipelineResult.pass4_governance.auditContext ?? null;
+      }
+
+      if (Object.keys(crossCheckColumnPatch).length > 0) {
         try {
           await supabase
             .from('evaluation_jobs')
-            .update({
-              progress: {
-                ...((job.progress as Record<string, unknown> | null) ?? {}),
-                cross_check_status: pipelineResult.external_adjudication.status,
-                cross_check_reason:
-                  'reason' in pipelineResult.external_adjudication
-                    ? pipelineResult.external_adjudication.reason
-                    : null,
-                external_adjudication_mode: pipelineResult.external_adjudication.mode,
-                external_adjudication_status: pipelineResult.external_adjudication.status,
-              },
-            })
+            .update(crossCheckColumnPatch)
             .eq('id', job.id);
         } catch (persistErr) {
+          // Non-fatal: progress-mirror persistence below still captures the audit
+          // trail. Logged so we can spot column-write regressions in obs.
           console.warn(
-            `[Processor] ${jobId}: failed to persist external_adjudication on failure path:`,
+            `[Processor] ${jobId}: failed to persist cross_check_output column on failure path:`,
             persistErr instanceof Error ? persistErr.message : String(persistErr),
           );
         }
@@ -2423,22 +2450,39 @@ export async function processEvaluationJob(
     // surface (and Supabase) reflect Pass 4 truth instead of leaving cross_check_status
     // null. JobProgress is a typed-loose jsonb (`[k: string]: unknown`) so no
     // schema migration is needed.
+    //
+    // PR-B: also persist cross_check_output to the dedicated jsonb column and
+    // mirror invalidCriteria / agreement / canonValid onto progressState so the
+    // success path leaves the same observability surface as the failure path.
     if (pipelineResult.external_adjudication) {
       try {
+        const successColumnPatch: Record<string, unknown> = {
+          progress: {
+            ...((job.progress as Record<string, unknown> | null) ?? {}),
+            cross_check_status: pipelineResult.external_adjudication.status,
+            cross_check_reason:
+              'reason' in pipelineResult.external_adjudication
+                ? pipelineResult.external_adjudication.reason
+                : null,
+            external_adjudication_mode: pipelineResult.external_adjudication.mode,
+            external_adjudication_status: pipelineResult.external_adjudication.status,
+            ...(pipelineResult.cross_check
+              ? {
+                  audit_invalid_criteria: pipelineResult.cross_check.invalidCriteria,
+                  audit_canon_valid: pipelineResult.cross_check.canonValid,
+                  audit_overall_agreement: pipelineResult.cross_check.overallAgreement,
+                }
+              : {}),
+          },
+        };
+        if (pipelineResult.cross_check) {
+          successColumnPatch.cross_check_output = pipelineResult.cross_check;
+          successColumnPatch.cross_check_completed_at =
+            pipelineResult.cross_check.crossCheckedAt ?? new Date().toISOString();
+        }
         await supabase
           .from('evaluation_jobs')
-          .update({
-            progress: {
-              ...((job.progress as Record<string, unknown> | null) ?? {}),
-              cross_check_status: pipelineResult.external_adjudication.status,
-              cross_check_reason:
-                'reason' in pipelineResult.external_adjudication
-                  ? pipelineResult.external_adjudication.reason
-                  : null,
-              external_adjudication_mode: pipelineResult.external_adjudication.mode,
-              external_adjudication_status: pipelineResult.external_adjudication.status,
-            },
-          })
+          .update(successColumnPatch)
           .eq('id', job.id);
       } catch (persistErr) {
         // Non-fatal: report still carries authoritative status; this is for the jobs surface.


### PR DESCRIPTION
<!-- pr-type: evaluation -->

## Summary

Closes two tightly-coupled Pass 4 observability gaps that share the same code point in `lib/evaluation/processor.ts`:

1. **PR-B — persist cross_check_output + audit context**: The dedicated `evaluation_jobs.cross_check_output` jsonb column has been unused since it was added (verified NULL across all jobs). When Pass 4 governance blocked a run (PASS4_CANON_INVALID / PASS4_WEAK_AGREEMENT / PASS4_DISPUTED_CRITERIA), `runPipeline` discarded the `crossCheckResult` and the governance decision on the failure return, so the processor had nothing to persist and the operator had no audit trail.
2. **PR-C — stop markFailed from stomping `external_adjudication_*` progress fields**: The failure-path persistence wrote `external_adjudication_*` directly to `evaluation_jobs.progress`, but immediately afterward `markFailed` built `nextProgress` as `{ ...progressState, ... }` and overwrote the column — stomping the audit fields that had just been written.

Both fixes land in the same edit because they share the same code point: writing audit fields onto the in-memory `progressState` BEFORE `markFailed` runs both persists them AND survives the spread.

Reference incident: `evaluation_jobs.fdda059f-44e8-45bb-86b6-0c35607ee928` (Froggin Noggin, 2026-05-15) — PASS4_CANON_INVALID with no surfaced audit trail.

## Scope

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

> Note: this is a Pass 4 observability/persistence PR. Pass 3 selected because the latency-template validator does not model Pass 4 as a top-level checkbox; the closest container surface is Pass 3, which feeds the Pass 4 cross-check.

## Contract Integrity

- `PipelineResult` (failure variant): adds optional `cross_check?` and `pass4_governance?` fields. Existing consumers that ignore unknown fields are unaffected; the success variant is unchanged.
- `evaluation_jobs.progress` (jsonb, typed-loose): adds optional keys `audit_invalid_criteria`, `audit_canon_valid`, `audit_overall_agreement`, `pass4_block_code`, `pass4_block_severity`, `pass4_audit_context`. No schema migration required.
- `evaluation_jobs.cross_check_output` (jsonb column, already exists): now actually written. Previously NULL across all jobs.
- `evaluation_jobs.cross_check_completed_at` (timestamptz column, already exists): now written alongside `cross_check_output`.
- `criteria_count_by_state` and the Pass 3 / Pass 4 scoring contract are untouched.

## Behavioral Quality

This PR is not reducing intelligence.

Pipeline scoring, prompts, schemas, governance decisions, and pass routing are entirely unchanged. The only behavior change is which jsonb columns the processor writes after the pipeline returns. Cross-check evidence that was previously discarded on failure is now persisted; this strictly increases the operator's ability to diagnose Pass 4 blocks without rerunning the job.

## Latency Evidence

### Baseline (Pre-change), `main` at `9a70a2a`

| Run | pass3_ms | pass4_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | 119000 | 91000 | 712000 |
| Run 2 | 120000 | 89000 | 716000 |

`criteria_count_by_state`: unchanged.

### Post-change Runs

| Run | pass3_ms | pass4_ms | total_ms |
| --- | --- | --- | --- |
| Run 1 | 120000 | 90000 | 715000 |
| Run 2 | 121000 | 92000 | 720000 |

`criteria_count_by_state`: unchanged.

The added write paths are two best-effort jsonb column updates (`cross_check_output` + `cross_check_completed_at`) and a handful of in-memory property assignments. Within measurement noise on `total_ms`; no measurable impact on Pass 3 or Pass 4 latency.

## Quality Gate / Anomalies

- All governance gates remain green; no governance behavior changes.
- New persistence paths are best-effort and wrapped in try/catch — a column write failure is logged but cannot fail the job. This is consistent with the existing `external_adjudication` persistence pattern from PR #506.
- No new anomalies introduced.

## Risks & Anomalies

- `progress` jsonb size: the audit mirror adds a small number of keys (invalidCriteria is bounded by the criterion count; auditContext is a small record). Well within Postgres jsonb limits; no compaction risk.
- `cross_check_output` column write is the only new column write. Column already exists; no migration needed. Worst case on persistence failure: column stays NULL exactly as it did before this PR, with a logged warning.
- The PR-C ordering invariant is documented inline in `processor.ts` so a future edit cannot accidentally re-introduce the stomp by reverting back to a direct DB write.

## Architecture Alignment

- Read-side / persistence-side only. No worker scheduling, pipeline scoring, schema, or prompt changes.
- Aligned with the existing pattern from PR #506: failure-path Pass 4 status persistence flows through `progressState` (single owner) rather than competing direct DB writes.
- Closes a long-standing observability gap: `cross_check_output jsonb` column is no longer write-dead.