### PR TITLE
fix(chunker): raise inputCharBudget 40000 -> 50000 to align with LARGE bracket (CHUNK_BUDGET_OVERFLOW repro: job a8d3723c)

### DIFF
--- a/__tests__/lib/evaluation/coverage-truth-enforcement.test.ts
+++ b/__tests__/lib/evaluation/coverage-truth-enforcement.test.ts
@@ -29,27 +29,29 @@ beforeEach(() => {
 
 describe("Coverage-Truth Enforcement — No Silent Truncation", () => {
   test("summarizePromptCoverage uses runtime default budget when maxChars is omitted", () => {
-    const text = "a".repeat(40_001);
+    // Default budget raised from 40_000 → 50_000 to align with the LARGE
+    // adaptive chunker bracket (see lib/config/envContract.ts).
+    const text = "a".repeat(50_001);
 
     const coverage = summarizePromptCoverage(text);
 
-    expect(coverage.budgetChars).toBe(40_000);
+    expect(coverage.budgetChars).toBe(50_000);
     expect(coverage.truncated).toBe(true);
     expect(coverage.strategy).toBe("sampled_beginning_middle_end");
   });
 
   test("truncated is false for text under the default budget", () => {
-    const text = "a".repeat(39_999);
+    const text = "a".repeat(49_999);
 
     const coverage = summarizePromptCoverage(text);
 
-    expect(coverage.budgetChars).toBe(40_000);
+    expect(coverage.budgetChars).toBe(50_000);
     expect(coverage.truncated).toBe(false);
     expect(coverage.strategy).toBe("full_text");
   });
 
   test("truncated is true for text over the default budget", () => {
-    const text = "a".repeat(40_001);
+    const text = "a".repeat(50_001);
 
     const coverage = summarizePromptCoverage(text);
 

--- a/docs/env-contract.md
+++ b/docs/env-contract.md
@@ -12,7 +12,7 @@ This module imports `'server-only'`. It must never be imported from client compo
 
 | Variable | Required | Default | Description |
 | :--- | :---: | :---: | :--- |
-| `EVAL_PIPELINE_INPUT_CHAR_BUDGET` | No | `40000` | Max characters of manuscript fed to Pass 1. Must be 12 000–100 000. |
+| `EVAL_PIPELINE_INPUT_CHAR_BUDGET` | No | `50000` | Max characters of manuscript fed to Pass 1. Must be 12 000–100 000. Raised from 40 000 → 50 000 so the chunker post-condition ceiling (`floor(budget * 0.95) = 47 500`) accommodates the LARGE adaptive chunker bracket emitting up to 42 000-char chunks. |
 | `EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET` | No | `8000` | Max characters of synthesis reference material. Must be 1 000–50 000. |
 | `EVAL_OPENAI_MODEL` | No | `gpt-4o` | OpenAI model identifier for evaluation runs. o-series reasoning models (o3, o1, etc.) are rejected in production unless `EVAL_ALLOW_REASONING_MODELS=true`. |
 | `EVAL_ALLOW_REASONING_MODELS` | No | `false` | Operator override that permits o-series models (`/^o[0-9]/`) in `NODE_ENV=production`. When unset/`false`, the contract throws during resolution before any API call if the resolved model is o-series. Set to `true` only for explicit, time-boxed evaluations (not steady-state production). |

--- a/lib/config/__tests__/envContract.test.ts
+++ b/lib/config/__tests__/envContract.test.ts
@@ -18,7 +18,7 @@ describe('resolveEvalEnvContract', () => {
   describe('clean defaults', () => {
     it('returns canonical defaults when no env vars are set', () => {
       const contract = resolveEvalEnvContract(BASE_ENV);
-      expect(contract.inputCharBudget).toBe(40_000);
+      expect(contract.inputCharBudget).toBe(50_000);
       expect(contract.synthesisRefCharBudget).toBe(8_000);
       expect(contract.openAiModel).toBe('gpt-5.1');
       expect(contract.adjudicationMode).toBe('optional');
@@ -30,13 +30,13 @@ describe('resolveEvalEnvContract', () => {
     it('accepts explicit valid values matching defaults', () => {
       const env: NodeJS.ProcessEnv = {
         ...BASE_ENV,
-        EVAL_PIPELINE_INPUT_CHAR_BUDGET: '40000',
+        EVAL_PIPELINE_INPUT_CHAR_BUDGET: '50000',
         EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET: '8000',
         EVAL_OPENAI_MODEL: 'gpt-4o',
         EVAL_EXTERNAL_ADJUDICATION_MODE: 'optional',
       };
       const contract = resolveEvalEnvContract(env);
-      expect(contract.inputCharBudget).toBe(40_000);
+      expect(contract.inputCharBudget).toBe(50_000);
       expect(contract.openAiModel).toBe('gpt-4o');
       expect(contract.adjudicationMode).toBe('optional');
     });
@@ -96,7 +96,7 @@ describe('resolveEvalEnvContract', () => {
     it('uses default when EVAL_PIPELINE_INPUT_CHAR_BUDGET is empty string', () => {
       const env = { ...BASE_ENV, EVAL_PIPELINE_INPUT_CHAR_BUDGET: '' };
       const contract = resolveEvalEnvContract(env);
-      expect(contract.inputCharBudget).toBe(40_000);
+      expect(contract.inputCharBudget).toBe(50_000);
     });
 
     it('uses default when EVAL_PIPELINE_SYNTHESIS_REF_CHAR_BUDGET is empty string', () => {

--- a/lib/config/__tests__/evaluationRuntimeConfig.test.ts
+++ b/lib/config/__tests__/evaluationRuntimeConfig.test.ts
@@ -18,7 +18,7 @@ describe("resolveEvaluationRuntimeConfig", () => {
     expect(config.pass.pass2MaxTokens).toBe(8000);
     expect(config.pass.pass3MaxTokens).toBe(20000);
     expect(config.pass.pass3PromptMaxChars).toBe(40000);
-    expect(config.pass.inputCharBudget).toBe(40000);
+    expect(config.pass.inputCharBudget).toBe(50000);
     expect(config.pass.synthesisRefCharBudget).toBe(8000);
     expect(config.worker.batchSize).toBe(5);
     expect(config.worker.leaseMs).toBe(800000);

--- a/lib/config/envContract.ts
+++ b/lib/config/envContract.ts
@@ -50,7 +50,16 @@ const VALID_NODE_ENVS: NodeEnv[] = ['development', 'test', 'production'];
 
 const INPUT_CHAR_BUDGET_MIN = 12_000;
 const INPUT_CHAR_BUDGET_MAX = 100_000;
-const INPUT_CHAR_BUDGET_DEFAULT = 40_000;
+// Raised from 40_000 → 50_000 so the chunker post-condition
+// (chunk ≤ floor(inputCharBudget * 0.95) = 47_500) accommodates the LARGE
+// adaptive bracket's emitted-content ceiling (chunking.ts BRACKET_LARGE
+// maxChars=42_000). Without this, 150k+ word manuscripts fail closed at
+// Pass 1 dispatch with CHUNK_BUDGET_OVERFLOW (e.g. job a8d3723c). Pass 1
+// model windows (gpt-5.1) are >> 50_000 chars so this is a budgeting
+// alignment, not a token-window expansion. Per-chunk prompt cost grows by
+// at most ~25% on the largest chunks. Invariant asserted in
+// lib/evaluation/pipeline/__tests__/chunker-budget-invariant.test.ts.
+const INPUT_CHAR_BUDGET_DEFAULT = 50_000;
 
 const SYNTHESIS_REF_CHAR_BUDGET_MIN = 1_000;
 const SYNTHESIS_REF_CHAR_BUDGET_MAX = 50_000;

--- a/lib/evaluation/pipeline/__tests__/chunker-budget-invariant.test.ts
+++ b/lib/evaluation/pipeline/__tests__/chunker-budget-invariant.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Chunker / Pass 1 prompt budget alignment invariant.
+ *
+ * Mistake-proofs against the failure mode observed in job
+ * a8d3723c-b034-404a-a497-155d56ebc7e1 (Froggin Noggin, 2026-05-16): the
+ * LARGE adaptive bracket emitted a 42_000-char chunk, but the Pass 1
+ * chunker post-condition fails closed when any chunk exceeds
+ * `floor(inputCharBudget * 0.95)`. With the default budget at 40_000 the
+ * ceiling was 38_000, so the bracket's own max was *guaranteed* to overflow
+ * before Pass 1 ever dispatched.
+ *
+ * After PR (chunker-budget-alignment) the default budget is 50_000 and the
+ * ceiling is floor(50000 * 0.95) = 47_500. This test asserts that every
+ * bracket's emitted-content ceiling (`cfg.maxChars`) stays at or below that
+ * ceiling, so any future re-tuning of either side trips a unit-test failure
+ * before it can ship.
+ *
+ * Fix history:
+ *   - PR #471 introduced the post-condition (`runPipeline` + `processor`).
+ *   - PR (this) raised inputCharBudget 40_000 → 50_000 so LARGE bracket fits.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { selectChunkerConfig } from "@/lib/manuscripts/chunking";
+import { getDefaultPassInputCharBudget } from "../promptInput";
+
+// Mirrors the constant in lib/evaluation/pipeline/runPipeline.ts and the 0.95
+// literal in lib/evaluation/processor.ts. Kept as a local literal here on
+// purpose: the invariant we are protecting IS the alignment of these two
+// numbers, so duplicating the literal makes any silent drift loud.
+const CHUNK_BUDGET_RATIO = 0.95;
+
+// Word counts that exercise every bracket in selectChunkerConfig:
+//   <= 60k → SMALL, 60k–150k → MID, > 150k → LARGE.
+const BRACKET_SAMPLE_WORD_COUNTS = [
+  20_000,   // SMALL bracket
+  100_000,  // MID bracket
+  200_000,  // LARGE bracket — the production failure case
+  290_000,  // LARGE bracket near the hard ceiling
+];
+
+describe("chunker / Pass 1 prompt budget alignment invariant", () => {
+  test("every adaptive bracket maxChars fits inside the Pass 1 chunker post-condition ceiling", () => {
+    const budget = getDefaultPassInputCharBudget();
+    const ceiling = Math.floor(budget * CHUNK_BUDGET_RATIO);
+
+    expect(ceiling).toBeGreaterThan(0);
+
+    for (const words of BRACKET_SAMPLE_WORD_COUNTS) {
+      const cfg = selectChunkerConfig(words);
+      // The chunker emits content up to cfg.maxChars (the first chunk has no
+      // overlap; later chunks are capped at (maxChars - overlap) base + overlap
+      // = maxChars emitted). Either way the worst case is cfg.maxChars.
+      expect({
+        words,
+        maxChars: cfg.maxChars,
+        ceiling,
+        budget,
+      }).toEqual({
+        words,
+        maxChars: cfg.maxChars,
+        ceiling,
+        budget,
+      });
+      expect(cfg.maxChars).toBeLessThanOrEqual(ceiling);
+    }
+  });
+
+  test("documented default budget (50_000) yields the documented ceiling (47_500)", () => {
+    // Anchor the documented numbers so docs/env-contract.md and the constants
+    // in lib/config/envContract.ts cannot drift silently apart.
+    const budget = getDefaultPassInputCharBudget();
+    expect(budget).toBe(50_000);
+    expect(Math.floor(budget * CHUNK_BUDGET_RATIO)).toBe(47_500);
+  });
+
+  test("LARGE bracket has non-trivial headroom under the ceiling", () => {
+    // Defends against a future re-tuning that would push LARGE.maxChars
+    // exactly onto the ceiling and leave zero slack for chunker rebalance
+    // logic. Require at least 5_000 chars of headroom (≈ 800 words).
+    const budget = getDefaultPassInputCharBudget();
+    const ceiling = Math.floor(budget * CHUNK_BUDGET_RATIO);
+    const largeCfg = selectChunkerConfig(200_000);
+    expect(ceiling - largeCfg.maxChars).toBeGreaterThanOrEqual(5_000);
+  });
+});


### PR DESCRIPTION
<!-- pr-type: evaluation -->

## Summary

Raises the default `EVAL_PIPELINE_INPUT_CHAR_BUDGET` from 40 000 → 50 000 so the Pass 1 chunker post-condition ceiling (`floor(budget × 0.95) = 47 500`) accommodates the LARGE adaptive chunker bracket (`BRACKET_LARGE.maxChars = 42 000`). Without this alignment, every 150 k+ word manuscript hit `CHUNK_BUDGET_OVERFLOW` and failed closed before Pass 1 dispatch — most recently job `a8d3723c-b034-404a-a497-155d56ebc7e1` (Froggin Noggin, 154 320 words, chunk 27 emitted at 42 000 chars).

Mistake-proofs the alignment via a new invariant test (`chunker-budget-invariant.test.ts`) that asserts every adaptive bracket's `maxChars` fits inside the post-condition ceiling at config-resolution time, so any future re-tuning of either side trips a unit-test failure before it can ship.

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3
- [ ] Pass 4

## Scope

- `lib/config/envContract.ts` — `INPUT_CHAR_BUDGET_DEFAULT` 40 000 → 50 000 (within existing min/max 12 000–100 000).
- `lib/config/__tests__/envContract.test.ts` — update three default-budget assertions.
- `lib/config/__tests__/evaluationRuntimeConfig.test.ts` — update default-budget assertion.
- `__tests__/lib/evaluation/coverage-truth-enforcement.test.ts` — update `budgetChars` assertions and threshold inputs to the new 50 000 budget.
- `docs/env-contract.md` — update default + add alignment rationale.
- `lib/evaluation/pipeline/__tests__/chunker-budget-invariant.test.ts` (NEW) — invariant test (mistake-proofing).

No runtime code changes outside config defaults. Chunker (`lib/manuscripts/chunking.ts`) brackets, `CHUNK_BUDGET_RATIO`, and the post-condition guard are unchanged.

## Contract Integrity

- Chunker post-condition (`runPipeline` + `processor`) unchanged: still fails closed when any emitted chunk exceeds `floor(inputCharBudget × 0.95)`.
- `CHUNK_BUDGET_OVERFLOW` failure code, `failed_at='chunking'`, and pipeline failure envelope shape unchanged.
- SIPOC fixture `s04_chunker_budget_overflow.json` still trips: stub chunk 50 000 > new ceiling 47 500 → CHUNK_BUDGET_OVERFLOW (regression `processor.chunk-routing.test.ts` "Cartel Babies" scenario remains green: `char_count=50000` > 47 500).
- `INPUT_CHAR_BUDGET_MIN=12 000` and `INPUT_CHAR_BUDGET_MAX=100 000` unchanged; explicit env overrides still parse.

## Behavioral Quality

This PR is not reducing intelligence.

Per-chunk Pass 1 input grows by at most 25 % on the largest chunks (only the LARGE bracket emits > 40 000 chars). gpt-5.1's context window (>> 50 000 chars) absorbs this without truncation. Pass 1 sees *more* manuscript content per call, not less. Quality Gate / QG signal is unaffected because Quality Gate evaluates synthesis output, not Pass 1 input size. Pass 2/3 and Quality Gate prompts are independently sized (`pass3PromptMaxChars`, `synthesisRefCharBudget`) and are not touched by this change.

## Latency Evidence

### Baseline (Pre-change)

LARGE-bracket manuscripts (>150 k words) fail closed at chunking stage in < 2 s with `CHUNK_BUDGET_OVERFLOW` — they never reach Pass 1.

| Run | Stage | pass1_ms | pass2_ms | pass3_ms | total_ms |
| :-- | :-- | --: | --: | --: | --: |
| Run 1 (job a8d3723c, 154 k words) | failed at chunking | 0 | 0 | 0 | ~1 800 |
| Run 2 (job a33adf30, prior pre-#508 run) | failed at chunking | 0 | 0 | 0 | ~2 100 |

Pre-change latency is degenerate: total_ms is dominated by the post-condition check, not real evaluation work. Quality Gate / QG never runs.

### Post-change Runs

After raising the budget, LARGE-bracket chunks (≤ 42 000 chars) clear the 47 500-char ceiling and dispatch into Pass 1 normally. Expected per-pass latency mirrors prior MID-bracket runs scaled by chunk count.

| Run | Stage | pass1_ms | pass2_ms | pass3_ms | total_ms |
| :-- | :-- | --: | --: | --: | --: |
| Run 1 (expected, 33-chunk manuscript) | full pipeline | ~110 000 | ~85 000 | ~60 000 | ~260 000 |
| Run 2 (expected, 33-chunk manuscript) | full pipeline | ~115 000 | ~88 000 | ~62 000 | ~270 000 |

Real Run 1/Run 2 numbers will be measured against Froggin Noggin re-evaluation immediately after merge; this PR unblocks measurement. Quality Gate / QG runs unchanged at the end of Pass 3.

## Risks & Anomalies

- Token cost: per-Pass 1 chunk grows by ≤ 25 % on LARGE-bracket chunks. Total Pass 1 cost across a 33-chunk manuscript grows roughly proportionally for the chunks that previously sat between 38 000 and 42 000 chars (a minority — `targetChars` stays 30 000).
- Latency baselines for LARGE-bracket runs reset (none existed — every prior LARGE run failed closed).
- Invariant test (`chunker-budget-invariant.test.ts`) requires future LARGE-bracket re-tuning to keep ≥ 5 000-char headroom under the ceiling — intentional, prevents zero-slack regressions.
- No schema, DB, or API surface changes.
