### PR TITLE
docs(benchmarks): commit Froggin Noggin gold-standard + canonical-13 shape smoke test

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,224 +1,57 @@
-# Ancient Bloodlines — Evaluation Benchmark Package
-
-## Overview
-
-This package contains a complete calibration fixture for the RevisionGrade evaluation system, using *Ancient Bloodlines—Love Between Species* as a gold-standard reference. The benchmark ensures RevisionGrade maintains consistent behavior across code changes, prompt updates, and new evaluator training.
-
-## What's in this package
-
-### Documentation
-- **[ancient-bloodlines-shortform-model.md](ancient-bloodlines-shortform-model.md)** — Human-readable reference evaluation (merged template format) with full criterion scoring and canonical governance notes.
-- **[ancient-bloodlines-longform-layered-template.md](ancient-bloodlines-longform-layered-template.md)** — Repository-ready multi-layer / multi-voice long-form template.
-- **[ancient-bloodlines-longform-layered.md](ancient-bloodlines-longform-layered.md)** — Completed Ancient Bloodlines long-form gold standard with layer map, score grid, and continuity audit.
-
-### Test Fixtures
-- **[ancient-bloodlines.shortform.model.json](../../testdata/evaluation/ancient-bloodlines.shortform.model.json)** — Machine-checkable expected output (CriterionBlock schema) with score targets, emotional bands, and governance metadata.
-
-- **[ancient-bloodlines.evidence-anchors.json](../../testdata/evaluation/ancient-bloodlines.evidence-anchors.json)** — 20 evidence anchors (scenes, dialogues, thematic moments) used for validation and few-shot training.
-
-- **[ancient-bloodlines.canon-presence.json](../../testdata/evaluation/ancient-bloodlines.canon-presence.json)** — Required recurring cast and canon continuity enforcement metadata.
-
-### Regression Tests
-- **[ancient-bloodlines.shortform.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.shortform.spec.ts)** — Comprehensive Jest test suite validating:
-  - Score band compliance (±1 tolerance)
-  - Canon character preservation (Twillow, Snappy, Thorander, Rana, Newton)
-  - Closure non-scorability enforcement
-  - CRAFT vs. INTELLIGENCE separation
-  - Emotional band consistency
-  - Revision priority governance
-
-- **[ancient-bloodlines.fixture.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.fixture.spec.ts)** — Sanity checks validating the fixture itself respects governance invariants.
-
-- **[ancient-bloodlines.governance.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.governance.spec.ts)** — Behavior-governance suite validating computed coverage certification, fail-closed long-form downgrade semantics, criterion-scope locking, and quality-gate rejection before persistence when uncertified manuscript-wide scores remain SCORABLE.
-
-- **[ancient-bloodlines.longform.layered.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.longform.layered.spec.ts)** — Gold-standard documentation regression suite validating that the layered long-form template and completed Ancient Bloodlines evaluation remain present, structured, and canon-anchored in the repo.
-
-- **[github-ancient-bloodlines-gold-standard-brief.md](github-ancient-bloodlines-gold-standard-brief.md)** — Gold-standard acceptance brief for GitHub/PR discussions: benchmark passes only when truth-governance behavior is enforced, not merely fixture presence.
-
-## Why this benchmark exists
-
-The original RevisionGrade Job 3463bb26 reported a score of 20/100 for this novella, but root cause analysis revealed the issue was not manuscript quality but **packet design failure**: Pass 3 received only a lossy "compressed reference window" and could not score five categories responsibly.
-
-This benchmark documents:
-1. **Corrected ground truth**: 62–67/100 when all 12 categories are scored responsibly
-2. **System gaps**: Packet design, rubric conflation (CRAFT/INTELLIGENCE merge), score semantics (0/10 ambiguity)
-3. **Validation gates**: Regression tests that prevent future corruptions
-
-## How to use this benchmark
-
-### For validation (during CI/CD)
-
-Run the test suites to catch regressions:
-
-```bash
-npm run test:benchmark:ancient-bloodlines
-```
-
-These tests will fail if:
-- Any criterion score drifts outside tolerance (±1)
-- Canon characters (Twillow, Snappy, Thorander) are dropped from commentary
-- Closure is re-scored as numeric despite insufficient coverage
-- CRAFT and INTELLIGENCE scores collapse to the same value
-- Emotional banding becomes implausible
-
-### For training new evaluators
-
-Use the evidence anchors to show good behavior:
-
-```json
-// From ancient-bloodlines.evidence-anchors.json
-{
-  "anchorId": "AB-005",
-  "topic": "Cross-species healing / care work",
-  "criterionLinks": ["character_depth_psychology", "theme_intelligence"],
-  "whyItMatters": "Dramatizes the theme (cross-species cooperation). Shows Newton's interiority as engagement, not narration.",
-  "revisionLever": "This scene is where Newton's choice to care feels most real..."
-}
-```
-
-The 20 anchors show:
-- Where CRAFT (prose, pacing, dialogue) is weak but fixable
-- Where INTELLIGENCE (theme, world-building, concept) is strong
-- Canon continuity requirements (all 13 named characters)
-- Dramatized vs. expository delivery patterns
-
-### For future calibration (PR #2)
-
-Once PR #458 is merged and one production run with v12 is complete:
-
-1. Compare actual Froggin Noggin ledger output against the structured context fixture
-2. Validate heuristic NER noise profile on real character_ledger data
-3. Use this corrected Ancient Bloodlines eval as baseline when setting PR #2 gates
-
-## Governance rules encoded here
-
-### Closure handling
-- Status must be `INSUFFICIENT_SIGNAL` (not `SCORABLE`) when full manuscript is unavailable
-- Score must be `null` (not numeric 0)
-- Confidence must be `LOW`
-- Tests will fail if anyone tries to re-score closure as numeric
-
-### Canon continuity
-- All 13 characters in `canonicalCharacters` should appear in Character Depth, World-Building, and Theme commentary
-- Exception: Secondary characters may be omitted if truly minor, but antagonists (Twillow, Snappy) and authority figures (Thorander) must appear
-- Test requires minimum 70% mention rate (≥9 of 13 characters)
-
-### Craft vs. Intelligence separation
-- CRAFT criteria (dialogue, prose, scene construction, pacing): typically 5–6/10 "needs work but fixable"
-- INTELLIGENCE criteria (theme, world-building, concept): typically 7–8/10 "conceptually strong"
-- Tests enforce that intelligence average differs meaningfully from craft average (>0.5 points difference)
-
-### Emotional banding
-- Most criteria: `STRENGTH_PLUS_GROWTH` (promising work with clear improvement path)
-- Lower craft areas: `GROWTH` (focus on revision)
-- Non-scorable closure: `INSUFFICIENT_SIGNAL_REASSURANCE` (not claiming false certainty)
-
-## Test execution checklist
-
-Before deploying any RevisionGrade updates:
-
-- [ ] Run `npm run test:benchmark:ancient-bloodlines`
-- [ ] All 50+ tests pass (fixture validation + regression suite)
-- [ ] Verify no canonical character names are dropped from commentary
-- [ ] Confirm closure score is still `null`, not numeric
-- [ ] Check that craft/intelligence score averages differ (> 0.5 points)
-
-## Release gate policy
-
-No RevisionGrade release is valid unless the Ancient Bloodlines benchmark gate is green on main.
-
-- Required gate command: `npm run test:benchmark:ancient-bloodlines`
-- CI enforcement: workflow step `Ancient Bloodlines benchmark gate` in `.github/workflows/ci.yml`
-- The benchmark must remain non-flaky; any flaky behavior blocks release until resolved.
-
-## Implementation notes
-
-### Wiring the actual evaluator
-
-When you integrate the actual RevisionGrade SHORTFORM pipeline:
-
-Replace this in `ancient-bloodlines.shortform.spec.ts`:
-```typescript
-// MOCK: Replace with real call
-report = JSON.parse(JSON.stringify(expected));
-```
-
-With this:
-```typescript
-report = await runEvaluation({
-  route: 'SHORTFORM',
-  manuscriptId: 'ancient-bloodlines-3463bb26',
-});
-```
-
-Then run tests. If they fail, the fixture alerts you to the divergence.
-
-### Score tolerance guidance
-
-The `SCORE_TOLERANCE = 1` allows ±1 point per criterion. This accounts for:
-- Slight variation in how heuristic NER extracts character names
-- Minor prompt wording changes
-- Different random seeds in Pass 3 if present
-
-If you see consistent +0.5 drift, consider adjusting baseline. If you see wild swings (±2+), investigate prompt corruption.
-
-### Extending the benchmark
-
-To add another manuscript as a calibration case:
-
-1. Create a new markdown evaluation in `docs/benchmarks/`
-2. Create a JSON fixture in `testdata/evaluation/` following the CriterionBlock schema
-3. Create evidence anchors in `testdata/evaluation/`
-4. Create test file in `tests/evaluation/benchmarks/`
-5. Wire the new tests into CI
-6. Add governance notes documenting what the new manuscript teaches (e.g., "this tests POV consistency in first-person horror")
-
-## Reading the fixtures for context
-
-### If a field in the fixture says...
-
-- `status: "SCORABLE"` → Expect a numeric score (0–10)
-- `status: "INSUFFICIENT_SIGNAL"` → Expect `score: null` and `confidence: "LOW"`
-- `confidence: "MODERATE"` → ±1 variation is acceptable
-- `confidence: "HIGH"` → Convergence should be tighter (±0.5 preferred)
-- `emotionalBand: "STRENGTH_PLUS_GROWTH"` → Supportive, constructive tone recommended
-- `emotionalBand: "GROWTH"` → Honest about weaknesses; clear revision path still accessible
-
-### Canon / open promises
-
-The fixture documents:
-- **13 named characters** who must appear in commentary
-- **6 open story promises** that the novella sets up and should resolve
-- **Missing-evidence rule**: Omitted sections → label as `INSUFFICIENT_SIGNAL`, don't score blind
-
-## Troubleshooting
-
-### Test fails: "Canon loss detected"
-
-**Symptom**: `REGRESSION: Canon loss detected. Expected at least 9 characters; found 5.`
-
-**Cause**: Your evaluator is not mentioning major characters (Twillow, Snappy, Thorander) in Character Depth / World-Building / Theme commentary.
-
-**Fix**: Check that your prompt includes character roster and that your Pass 2a structured context populates character_ledger with full names. If NER is stripping names, recalibrate the heuristic.
-
-### Test fails: "Closure has been re-scored"
-
-**Symptom**: `REGRESSION: Closure has been re-scored. This breaks governance rule...`
-
-**Cause**: A code or prompt change caused Pass 3 to emit a numeric score for Narrative Closure & Promises.
-
-**Fix**: Verify that your governance gate checks `coverage.mode` and downgrades closure to `INSUFFICIENT_SIGNAL` if full manuscript is unavailable. Do not allow numeric scores for partial-coverage criteria.
-
-### Test fails: "Craft and intelligence scores collapse"
-
-**Symptom**: `Expected difference to be greater than 0.5...`
-
-**Cause**: Your evaluator is treating dialogue, prose, and pacing the same as theme and world-building.
-
-**Fix**: Audit your prompt to ensure it explicitly separates CRAFT (line-level execution) from INTELLIGENCE (systemic thinking). The rubric should make this distinction clear.
-
----
-
-**Last updated**: 2026-05-13  
-**Benchmark status**: ✅ Locked (Ancient Bloodlines v1 corrected evaluation 62–67/100)  
-**Related PRs**: #458 (v12 structured context), #459 (PacketV2 + INTELLIGENCE axis), #2 (gate calibration)
+# Benchmarks — Gold-Standard Reference Evaluations
+
+This directory holds manual gold-standard reference evaluations that define the **target quality bar** for RevisionGrade long-form output.
+
+## The Gold Standard
+
+**[`froggin-noggin-dream.md`](./froggin-noggin-dream.md)** — *Froggin Noggin* (Michael J. Me Raw). Full long-form gold-standard evaluation: 13-criteria score grid, layered architecture analysis, canon/doctrine audit, revision plan, releasability assessment. This is THE calibration target — when a production evaluation disputes a criterion against the Pass 4 cross-checker, this file is the reference for which side is closer to ground truth.
+
+Schema: `canonical-13-v1` (front-matter opt-in; validated by `tests/evaluation/benchmarks/gold-standard-shape.test.ts`).
+
+## What gold-standard files are for
+
+- **Calibration target.** Pass 4 disputes resolve against the gold standard — this is the ground truth we tune toward.
+- **Quality bar.** Pass 1 / Pass 2 / Pass 3 prompt and schema work should converge primary-evaluator output toward this depth, format, and rigor.
+- **Documentation.** Captures the kind of structural, thematic, and architectural analysis the platform aspires to produce, in a form that survives prompt churn.
+
+## What gold-standard files are NOT
+
+- **Not test fixtures.** No production assertion compares live output to these scores or text. The shape smoke test only validates structural conformance, not scoring outcomes.
+- **Not a claim of current capability.** The repo note in each file states this explicitly.
+- **Not versioned with the schema.** They are human-authored reference documents that anchor calibration over time.
+
+## Adding a new gold-standard benchmark
+
+New gold-standard files MUST opt in to the **canonical-13-v1** schema. This binds the file to the same 13 criterion names the production pipeline emits, so the benchmark stays comparable to live output across prompt changes.
+
+1. Place the file at `docs/benchmarks/<work-slug>.md`.
+2. Add YAML front-matter at the very top:
+   ```yaml
+   ---
+   benchmark-schema: canonical-13-v1
+   ---
+   ```
+3. Include a score-grid table with rows for all 13 canonical criteria using the production names exactly as defined in `schemas/criteria-keys.ts` (`CRITERIA_METADATA`):
+   - Concept & Core Premise
+   - Narrative Drive & Momentum
+   - Character Depth & Psychological Coherence
+   - Point of View & Voice Control
+   - Scene Construction & Function
+   - Dialogue Authenticity & Subtext
+   - Thematic Integration
+   - World-Building & Environmental Logic
+   - Pacing & Structural Balance
+   - Prose Control & Line-Level Craft
+   - Tonal Authority & Consistency
+   - Narrative Closure & Promises Kept
+   - Professional Readiness & Market Positioning
+
+   Layered architecture rows beyond the 13 are allowed.
+4. Score column uses the format `N.N / 10` (bold optional).
+5. Confidence column uses one of: High, Moderate-High, Moderate, Moderate-Low, Low.
+6. Include a disclaimer (Repo note or equivalent) stating this is a manual reference, not a production assertion.
+7. The smoke test at [`tests/evaluation/benchmarks/gold-standard-shape.test.ts`](../../tests/evaluation/benchmarks/gold-standard-shape.test.ts) automatically validates files with the canonical-13-v1 front-matter and ignores everything else.
+
+## Legacy reference material
+
+Older reference material for *Ancient Bloodlines* — predates the canonical-13 schema and uses short-label conventions (`Theme / Intelligence`, `POV, Voice & Tone`, etc.). Retained for historical context only; not used as the primary calibration target. See [`ancient-bloodlines-README.md`](./ancient-bloodlines-README.md) for the full ancient-bloodlines package documentation.

--- a/docs/benchmarks/ancient-bloodlines-README.md
+++ b/docs/benchmarks/ancient-bloodlines-README.md
@@ -1,0 +1,224 @@
+# Ancient Bloodlines — Evaluation Benchmark Package
+
+## Overview
+
+This package contains a complete calibration fixture for the RevisionGrade evaluation system, using *Ancient Bloodlines—Love Between Species* as a gold-standard reference. The benchmark ensures RevisionGrade maintains consistent behavior across code changes, prompt updates, and new evaluator training.
+
+## What's in this package
+
+### Documentation
+- **[ancient-bloodlines-shortform-model.md](ancient-bloodlines-shortform-model.md)** — Human-readable reference evaluation (merged template format) with full criterion scoring and canonical governance notes.
+- **[ancient-bloodlines-longform-layered-template.md](ancient-bloodlines-longform-layered-template.md)** — Repository-ready multi-layer / multi-voice long-form template.
+- **[ancient-bloodlines-longform-layered.md](ancient-bloodlines-longform-layered.md)** — Completed Ancient Bloodlines long-form gold standard with layer map, score grid, and continuity audit.
+
+### Test Fixtures
+- **[ancient-bloodlines.shortform.model.json](../../testdata/evaluation/ancient-bloodlines.shortform.model.json)** — Machine-checkable expected output (CriterionBlock schema) with score targets, emotional bands, and governance metadata.
+
+- **[ancient-bloodlines.evidence-anchors.json](../../testdata/evaluation/ancient-bloodlines.evidence-anchors.json)** — 20 evidence anchors (scenes, dialogues, thematic moments) used for validation and few-shot training.
+
+- **[ancient-bloodlines.canon-presence.json](../../testdata/evaluation/ancient-bloodlines.canon-presence.json)** — Required recurring cast and canon continuity enforcement metadata.
+
+### Regression Tests
+- **[ancient-bloodlines.shortform.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.shortform.spec.ts)** — Comprehensive Jest test suite validating:
+  - Score band compliance (±1 tolerance)
+  - Canon character preservation (Twillow, Snappy, Thorander, Rana, Newton)
+  - Closure non-scorability enforcement
+  - CRAFT vs. INTELLIGENCE separation
+  - Emotional band consistency
+  - Revision priority governance
+
+- **[ancient-bloodlines.fixture.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.fixture.spec.ts)** — Sanity checks validating the fixture itself respects governance invariants.
+
+- **[ancient-bloodlines.governance.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.governance.spec.ts)** — Behavior-governance suite validating computed coverage certification, fail-closed long-form downgrade semantics, criterion-scope locking, and quality-gate rejection before persistence when uncertified manuscript-wide scores remain SCORABLE.
+
+- **[ancient-bloodlines.longform.layered.spec.ts](../../tests/evaluation/benchmarks/ancient-bloodlines.longform.layered.spec.ts)** — Gold-standard documentation regression suite validating that the layered long-form template and completed Ancient Bloodlines evaluation remain present, structured, and canon-anchored in the repo.
+
+- **[github-ancient-bloodlines-gold-standard-brief.md](github-ancient-bloodlines-gold-standard-brief.md)** — Gold-standard acceptance brief for GitHub/PR discussions: benchmark passes only when truth-governance behavior is enforced, not merely fixture presence.
+
+## Why this benchmark exists
+
+The original RevisionGrade Job 3463bb26 reported a score of 20/100 for this novella, but root cause analysis revealed the issue was not manuscript quality but **packet design failure**: Pass 3 received only a lossy "compressed reference window" and could not score five categories responsibly.
+
+This benchmark documents:
+1. **Corrected ground truth**: 62–67/100 when all 12 categories are scored responsibly
+2. **System gaps**: Packet design, rubric conflation (CRAFT/INTELLIGENCE merge), score semantics (0/10 ambiguity)
+3. **Validation gates**: Regression tests that prevent future corruptions
+
+## How to use this benchmark
+
+### For validation (during CI/CD)
+
+Run the test suites to catch regressions:
+
+```bash
+npm run test:benchmark:ancient-bloodlines
+```
+
+These tests will fail if:
+- Any criterion score drifts outside tolerance (±1)
+- Canon characters (Twillow, Snappy, Thorander) are dropped from commentary
+- Closure is re-scored as numeric despite insufficient coverage
+- CRAFT and INTELLIGENCE scores collapse to the same value
+- Emotional banding becomes implausible
+
+### For training new evaluators
+
+Use the evidence anchors to show good behavior:
+
+```json
+// From ancient-bloodlines.evidence-anchors.json
+{
+  "anchorId": "AB-005",
+  "topic": "Cross-species healing / care work",
+  "criterionLinks": ["character_depth_psychology", "theme_intelligence"],
+  "whyItMatters": "Dramatizes the theme (cross-species cooperation). Shows Newton's interiority as engagement, not narration.",
+  "revisionLever": "This scene is where Newton's choice to care feels most real..."
+}
+```
+
+The 20 anchors show:
+- Where CRAFT (prose, pacing, dialogue) is weak but fixable
+- Where INTELLIGENCE (theme, world-building, concept) is strong
+- Canon continuity requirements (all 13 named characters)
+- Dramatized vs. expository delivery patterns
+
+### For future calibration (PR #2)
+
+Once PR #458 is merged and one production run with v12 is complete:
+
+1. Compare actual Froggin Noggin ledger output against the structured context fixture
+2. Validate heuristic NER noise profile on real character_ledger data
+3. Use this corrected Ancient Bloodlines eval as baseline when setting PR #2 gates
+
+## Governance rules encoded here
+
+### Closure handling
+- Status must be `INSUFFICIENT_SIGNAL` (not `SCORABLE`) when full manuscript is unavailable
+- Score must be `null` (not numeric 0)
+- Confidence must be `LOW`
+- Tests will fail if anyone tries to re-score closure as numeric
+
+### Canon continuity
+- All 13 characters in `canonicalCharacters` should appear in Character Depth, World-Building, and Theme commentary
+- Exception: Secondary characters may be omitted if truly minor, but antagonists (Twillow, Snappy) and authority figures (Thorander) must appear
+- Test requires minimum 70% mention rate (≥9 of 13 characters)
+
+### Craft vs. Intelligence separation
+- CRAFT criteria (dialogue, prose, scene construction, pacing): typically 5–6/10 "needs work but fixable"
+- INTELLIGENCE criteria (theme, world-building, concept): typically 7–8/10 "conceptually strong"
+- Tests enforce that intelligence average differs meaningfully from craft average (>0.5 points difference)
+
+### Emotional banding
+- Most criteria: `STRENGTH_PLUS_GROWTH` (promising work with clear improvement path)
+- Lower craft areas: `GROWTH` (focus on revision)
+- Non-scorable closure: `INSUFFICIENT_SIGNAL_REASSURANCE` (not claiming false certainty)
+
+## Test execution checklist
+
+Before deploying any RevisionGrade updates:
+
+- [ ] Run `npm run test:benchmark:ancient-bloodlines`
+- [ ] All 50+ tests pass (fixture validation + regression suite)
+- [ ] Verify no canonical character names are dropped from commentary
+- [ ] Confirm closure score is still `null`, not numeric
+- [ ] Check that craft/intelligence score averages differ (> 0.5 points)
+
+## Release gate policy
+
+No RevisionGrade release is valid unless the Ancient Bloodlines benchmark gate is green on main.
+
+- Required gate command: `npm run test:benchmark:ancient-bloodlines`
+- CI enforcement: workflow step `Ancient Bloodlines benchmark gate` in `.github/workflows/ci.yml`
+- The benchmark must remain non-flaky; any flaky behavior blocks release until resolved.
+
+## Implementation notes
+
+### Wiring the actual evaluator
+
+When you integrate the actual RevisionGrade SHORTFORM pipeline:
+
+Replace this in `ancient-bloodlines.shortform.spec.ts`:
+```typescript
+// MOCK: Replace with real call
+report = JSON.parse(JSON.stringify(expected));
+```
+
+With this:
+```typescript
+report = await runEvaluation({
+  route: 'SHORTFORM',
+  manuscriptId: 'ancient-bloodlines-3463bb26',
+});
+```
+
+Then run tests. If they fail, the fixture alerts you to the divergence.
+
+### Score tolerance guidance
+
+The `SCORE_TOLERANCE = 1` allows ±1 point per criterion. This accounts for:
+- Slight variation in how heuristic NER extracts character names
+- Minor prompt wording changes
+- Different random seeds in Pass 3 if present
+
+If you see consistent +0.5 drift, consider adjusting baseline. If you see wild swings (±2+), investigate prompt corruption.
+
+### Extending the benchmark
+
+To add another manuscript as a calibration case:
+
+1. Create a new markdown evaluation in `docs/benchmarks/`
+2. Create a JSON fixture in `testdata/evaluation/` following the CriterionBlock schema
+3. Create evidence anchors in `testdata/evaluation/`
+4. Create test file in `tests/evaluation/benchmarks/`
+5. Wire the new tests into CI
+6. Add governance notes documenting what the new manuscript teaches (e.g., "this tests POV consistency in first-person horror")
+
+## Reading the fixtures for context
+
+### If a field in the fixture says...
+
+- `status: "SCORABLE"` → Expect a numeric score (0–10)
+- `status: "INSUFFICIENT_SIGNAL"` → Expect `score: null` and `confidence: "LOW"`
+- `confidence: "MODERATE"` → ±1 variation is acceptable
+- `confidence: "HIGH"` → Convergence should be tighter (±0.5 preferred)
+- `emotionalBand: "STRENGTH_PLUS_GROWTH"` → Supportive, constructive tone recommended
+- `emotionalBand: "GROWTH"` → Honest about weaknesses; clear revision path still accessible
+
+### Canon / open promises
+
+The fixture documents:
+- **13 named characters** who must appear in commentary
+- **6 open story promises** that the novella sets up and should resolve
+- **Missing-evidence rule**: Omitted sections → label as `INSUFFICIENT_SIGNAL`, don't score blind
+
+## Troubleshooting
+
+### Test fails: "Canon loss detected"
+
+**Symptom**: `REGRESSION: Canon loss detected. Expected at least 9 characters; found 5.`
+
+**Cause**: Your evaluator is not mentioning major characters (Twillow, Snappy, Thorander) in Character Depth / World-Building / Theme commentary.
+
+**Fix**: Check that your prompt includes character roster and that your Pass 2a structured context populates character_ledger with full names. If NER is stripping names, recalibrate the heuristic.
+
+### Test fails: "Closure has been re-scored"
+
+**Symptom**: `REGRESSION: Closure has been re-scored. This breaks governance rule...`
+
+**Cause**: A code or prompt change caused Pass 3 to emit a numeric score for Narrative Closure & Promises.
+
+**Fix**: Verify that your governance gate checks `coverage.mode` and downgrades closure to `INSUFFICIENT_SIGNAL` if full manuscript is unavailable. Do not allow numeric scores for partial-coverage criteria.
+
+### Test fails: "Craft and intelligence scores collapse"
+
+**Symptom**: `Expected difference to be greater than 0.5...`
+
+**Cause**: Your evaluator is treating dialogue, prose, and pacing the same as theme and world-building.
+
+**Fix**: Audit your prompt to ensure it explicitly separates CRAFT (line-level execution) from INTELLIGENCE (systemic thinking). The rubric should make this distinction clear.
+
+---
+
+**Last updated**: 2026-05-13  
+**Benchmark status**: ✅ Locked (Ancient Bloodlines v1 corrected evaluation 62–67/100)  
+**Related PRs**: #458 (v12 structured context), #459 (PacketV2 + INTELLIGENCE axis), #2 (gate calibration)

--- a/docs/benchmarks/froggin-noggin-dream.md
+++ b/docs/benchmarks/froggin-noggin-dream.md
@@ -1,0 +1,872 @@
+---
+benchmark-schema: canonical-13-v1
+---
+
+# Froggin Noggin — DREAM Long-Form Gold Standard Evaluation
+
+**Repository target:** `docs/benchmarks/froggin-noggin-dream.md`  
+**Benchmark role:** Gold-standard long-form evaluation reference for RevisionGrade report quality  
+**Evaluation type:** Manual reference evaluation, WAVE-informed, repo-ready  
+**Source manuscript:** `Froggin Noggin FULL NOVEL (25 Apr 2022)`  
+**Author:** Michael J. Me Raw  
+**Scope:** Full manuscript / full novel  
+**Observed production word count:** 127,036  
+**Chapter count:** 25  
+**Route:** `LONG_FORM`  
+**Output mode:** `multi_layer_long_form`  
+**Coverage statement:** Full-manuscript evaluation using chapter-level structure, recurring systems, character arcs, ending material, and cross-layer integration.  
+**Confidence:** High for architecture, concept, worldbuilding, theme, and closure diagnosis; Moderate for line-level prose because this reference does not quote every chapter at paragraph density.  
+**Current readiness posture:** Not yet submission-ready; one major architecture/revision pass away from a stronger “close” posture.  
+**Overall quality score:** **66 / 100**  
+**Readiness score:** **58 / 100**  
+**Primary causal weakness:** The manuscript has more invention than control: its ecology, doctrine, satire, violence, sex, myth, and chemical-crime plotlines are all alive, but the story often explains, proliferates, or digresses before converting pressure into irreversible consequence.
+
+---
+
+## Executive verdict
+
+*Froggin Noggin* is an ambitious, strange, adult eco-satirical myth in which human addiction, environmental violence, frog theology, amphibian politics, and interspecies social reform collide around the shard / toadstone mythology. The governing ambition is strong: to make “frog world” and “human world” mirror each other so that domination, exploitation, doctrine, addiction, survival, and spiritual hunger become one moral ecology. The manuscript’s greatest assets are its originality, its amphibian world-system, its appetite for taboo material, and its willingness to make comedy, disgust, violence, theology, and tenderness occupy the same imaginative swamp. The principal drag is not lack of material; it is an overabundance of material without enough hierarchy. The reader is repeatedly given vivid set pieces, but the book does not always clarify which pressure line is primary, which promise is being paid off, and when a scene has changed the story state. The revision task is therefore architectural before stylistic: preserve the weirdness, the adult bite, and the mythic ecology, but reorganize the manuscript around a cleaner collision spine, a clearer payoff ledger, and tighter transitions between human crime, frog doctrine, salamander/newt counter-world, and Dominatus-scale moral frame.
+
+---
+
+## One-line market / shelf description
+
+Adult literary eco-fable / weird satirical fantasy about meth culture, environmental contamination, and an amphibian civilization whose theology and survival systems are destabilized when human violence releases a transformative shard into their world.
+
+---
+
+## What this manuscript should not become
+
+Do not revise this into a sanitized children’s animal fantasy, a generic addiction novel, or a tidy environmental parable. The manuscript’s commercial problem is not that it is too strange. Its problem is that the strangeness is not yet governed tightly enough. Revision should preserve:
+
+- the amphibian polity and its ritual language;
+- the grotesque human thread around Brutus and Chey;
+- the toadstone / shard / Gorf system;
+- the collision of satire, myth, ecological horror, and testimony;
+- the adult discomfort of the material;
+- the cross-species tenderness in the Rana / Newton and Chey-facing moments.
+
+The target is not simplification. The target is legibility under pressure.
+
+---
+
+## Structural stack
+
+### Layer & voice map
+
+| Layer | Plane / arena | Dominant voice / mode | Function in book | Primary stakes | Major dependencies |
+|---|---|---|---|---|---|
+| Human damage layer | Brutus, Chey, campsite, mine, drug production, chemical dumping | Slang-heavy, profane, satirical, grotesque, comic-horror | Introduces human appetite, addiction, ecological harm, and the casual violence that destabilizes Aqua World | Harm, complicity, contamination, predation, moral numbness | Brutus’s meth behavior, Chey’s partial conscience, campsite violence, mineshaft waste, “frog heads” song |
+| Columbian frog polity | Aqua World, Hyla’s monarchy, council, sentinels, sanctuary | Mythic-political, ceremonial, doctrinal, biological | Builds the primary nonhuman civilization and its moral contradictions | Survival, hierarchy, disease, taboo, divine legitimacy, power transfer | Hyla, Zimeon, Enoch, Maximilian, Arcana, Gorf, toadstone, Sanctuary |
+| Orgon / rogue frog reform layer | Thorander, Rana, Orgon teachings, healing knowledge | Patriarchal, pedagogical, strategic, self-mythologizing | Pressures the Columbian system from outside and supplies alternate survival logic | Reform vs domination, knowledge vs control, sexual/political power | Thorander’s origin, Rana’s curiosity, Orgon doctrine, disease knowledge |
+| Salamander / newt counter-world | Newton, Twillow, Lacerta, rough-skinned newt society | Vulnerable, social, biologically grounded, tenderness-forward | Provides the clearest emotional counterweight and cross-species cooperation possibility | Bullying, disability, care, trust, interspecies alliance | Newton’s injury, Rana’s relationship, slime/remedy cooperation |
+| Shard / toadstone symbolic system | Dead Zone, Maalik, shard, toadstone, transference, changelings | Mythic, occult-scientific, ecological horror | Converts environmental contamination into spiritual and biological consequence | Power, mutation, fertility, death, false miracle, sacred technology | Zimeon’s exposure, Hyla’s toadstone, Brutus’s extraction fantasy, shard release |
+| Paratext / Dominatus frame | Epigraphs, chapter-closing questions, Dominatus reversal | Aphoristic, theological, meta-moral | Frames the story as an argument about creation, dominion, and human authorship of catastrophe | Meaning, indictment, cosmic irony | “That which giveth light...,” chapter questions, eighth-day creation reversal |
+
+### Stack diagnosis
+
+The emotional anchor is currently divided between **Zimeon’s curiosity**, **Hyla’s authoritarian maternal rule**, **Chey’s partial conscience**, and **Newton / Rana’s tenderness**. Of these, the Newton / Rana layer is the most emotionally accessible, while the Zimeon / shard layer is the strongest plot engine. The manuscript will become more powerful if revision makes that hierarchy explicit: Zimeon’s shard discovery should drive the ecological and political crisis; Hyla and Thorander should embody rival governance responses; Newton and Rana should humanize the possibility of cross-species repair; Brutus and Chey should remain the contaminating human mirror.
+
+The interpretive frame is the Gorf / toadstone / Dominatus system. The canon-bearing layer is active and often compelling, but it occasionally competes with scene pressure because the reader is asked to absorb doctrine, biology, sexual custom, environmental commentary, and satire all at once.
+
+The most fragile layer is **transition governance**. The manuscript can support multiple registers, but it needs cleaner handoffs between:
+- profane human comedy and mythic frog ceremony;
+- ecological science and theological interpretation;
+- sexual satire and genuine trauma / vulnerability;
+- frog worldbuilding and forward plot movement;
+- chapter-closing aphorisms and scene consequence.
+
+---
+
+## Arc map
+
+| Arc | Chapters / areas | What it does | Current strength | Current risk |
+|---|---|---|---|---|
+| Opening collision setup | Ch. 1–3 | Establishes Brutus/Chey, frog civilization, Dead Zone, shard, Orgon backstory | Highly original; rich premise; strong tonal signature | Opening density may overwhelm before reader knows the governing story spine |
+| Shard / toadstone escalation | Ch. 4–10 | Brutus seeks an amulet; Zimeon encounters shard; frogs/humans enter direct violence | Strongest premise engine; clear symbolic object | Object rules and stakes need earlier, cleaner articulation |
+| Council / governance crisis | Ch. 11–13 | Aqua World responds to danger; Hyla’s rule and Zimeon’s knowledge collide | Strong political fable material | Meetings risk becoming explanation unless every council scene changes state |
+| Cross-species reform / healing | Ch. 14–18 | Rana/Newton, Thorander, Hyla, illness, cooperation, reform pressure | Emotional and thematic heart; best route to reader attachment | Needs a clearer throughline so it does not feel like a second book |
+| Sexual / patriarchal pressure | Ch. 19–20 | Thorander’s desire, pedagogy, power, and lies intensify | Bold adult material; thematically coherent with domination | Risks feeling overextended if not tied tightly to plot consequences |
+| Doctrine / sanctuary / endgame | Ch. 21–25 | Rancient Code, Sanctuary, human netting, catastrophe, New World promise | Big finish; moral and symbolic ambition visible | Closure is open but not fully shaped; several promises remain partially discharged |
+
+---
+
+## Score grid — canonical 13 criteria plus layered architecture rows
+
+| Criterion | Score | Confidence | Summary finding |
+|---|---:|---|---|
+| Concept & Core Premise | **8.0 / 10** | High | The collision of human drug culture, ecological contamination, and amphibian theology is genuinely distinctive and narratively fertile. |
+| Narrative Drive & Momentum | **6.0 / 10** | High | The manuscript has strong engines — shard, toadstone, disease, human predation, political reform — but momentum diffuses when explanation precedes consequence. |
+| Character Depth & Psychological Coherence | **6.5 / 10** | Moderate-High | Hyla, Zimeon, Thorander, Chey, Rana, and Newton have legible drives, but several turning points need more interior state-change rather than expository rationale. |
+| Point of View & Voice Control | **6.0 / 10** | Moderate | The register range is intentional and often memorable; the control problem is transition, not lack of voice. |
+| Scene Construction & Function | **6.0 / 10** | High | Many scenes have vivid premises, but some scenes carry too many functions at once: exposition, comedy, biology, doctrine, satire, and plot. |
+| Dialogue Authenticity & Subtext | **6.0 / 10** | Moderate | The human banter and doctrinal frog speech are distinct; dialogue sometimes states thesis rather than weaponizing subtext. |
+| Thematic Integration | **7.5 / 10** | High | Domination, faith, addiction, environmental violation, sexuality, and survival interlock into a serious moral system. |
+| World-Building & Environmental Logic | **8.0 / 10** | High | The amphibian ecology, ritual systems, hibernation logic, disease logic, and predator/prey structures are the manuscript’s strongest craft asset. |
+| Pacing & Structural Balance | **5.5 / 10** | High | The book is over-rich. It needs stronger compression, clearer act turns, and more disciplined information release. |
+| Prose Control & Line-Level Craft | **5.5 / 10** | Moderate | The prose is vivid and inventive, but over-composition, stacked metaphor, and tonal excess blunt pressure moments. |
+| Tonal Authority & Consistency | **6.0 / 10** | Moderate | The tonal palette is bold and defensible; the issue is calibration between grotesque comedy, sacred register, sexual satire, and trauma. |
+| Narrative Closure & Promises Kept | **5.5 / 10** | High | The ending gestures toward transformation and continuation but does not yet fully resolve the shard, New World, political reform, and human harm ledgers. |
+| Professional Readiness & Market Positioning | **6.0 / 10** | Moderate | The manuscript has a rare hook and a strong adult weird-literary identity, but needs a sharper pitch spine and cleaner reader contract. |
+| Layer & Mode Integration | **6.5 / 10** | Moderate | The layers belong together, but the connective tissue needs strengthening so the novel feels inevitable rather than proliferating. |
+| Layer Coherence | **6.5 / 10** | Moderate | Human, frog, Orgon, newt, and theological layers are coherent individually; their sequence needs stronger hierarchy. |
+| Doctrine / Symbolic System Integrity | **7.0 / 10** | High | Gorf, toadstone, shard, transference, sanctuary, and Rancient Code systems are consequential, though some obligations remain underpaid. |
+| Canon & Continuity Integrity | **6.5 / 10** | Moderate-High | Major recurring systems retain identity, but the manuscript needs a promise ledger to ensure late material pays early setup. |
+
+---
+
+## Criterion-by-criterion analysis
+
+### 1. Concept & Core Premise — 8.0 / 10
+
+**What is working**
+
+The premise is unusually strong: humans seeking a “froggin noggin” / toadstone collide with an amphibian civilization that already possesses theology, class structure, sexuality, law, disease management, mythology, and political violence. The book’s central object — the shard / toadstone complex — is not decorative. It joins ecology, superstition, power, reproduction, and human predation.
+
+The human and frog worlds mirror each other effectively. Brutus’s hunger for intoxication, mystical objects, domination, and spectacle mirrors Hyla’s hunger for legitimacy, control, and divine authorization. Chey’s partial conscience mirrors the possibility that human beings can recognize nonhuman life as kin without fully escaping complicity.
+
+**What weakens impact**
+
+The premise arrives with so much associated material that the reader may not know what story question to prioritize. Is the core question:
+- Will Brutus destroy the frog world?
+- Will Zimeon’s shard exposure transform Aqua World?
+- Will Hyla preserve or reform her authoritarian order?
+- Will Rana / Newton prove cross-species cooperation possible?
+- Will the toadstone / shard reveal a metaphysical truth?
+- Will the human world be judged by Dominatus?
+
+All of these are viable. The revision must create a governing hierarchy.
+
+**Evidence anchors**
+
+- Ch. 1: Brutus sings about frog heads and introduces the toadstone / changeling myth.
+- Ch. 2: Zimeon reaches the Dead Zone and experiences the shard.
+- Ch. 10: the shard is released into the lake.
+- Ch. 25: the “New World” gesture and Dominatus reversal widen the book’s moral frame.
+
+**Revision target**
+
+Open with a sharper premise contract. Within the first two chapters, the reader should understand: **human extraction releases a sacred/poisonous force into an amphibian civilization, forcing that civilization to choose between doctrine, reform, and survival.**
+
+---
+
+### 2. Narrative Drive & Momentum — 6.0 / 10
+
+**What is working**
+
+The book has multiple strong engines:
+- Brutus’s escalating violence and drug-driven appetite;
+- Zimeon’s curiosity and shard exposure;
+- Hyla’s political control;
+- Thorander’s reform / domination agenda;
+- disease and ecological contamination;
+- the Sanctuary and leper colony;
+- the final netting / end-times threat.
+
+The strongest forward movement occurs when a concrete action changes the shared world: Brutus dumping chemicals, Zimeon touching the shard, the release into the lake, the council response, the Rana/Newton alliance, and the late human capture attempt.
+
+**What weakens impact**
+
+Momentum is repeatedly slowed by explanatory expansion. Many scenes begin with a live pressure line but detour into lore, taxonomy, sexual custom, doctrine, or metaphor before the consequence lands. The information is often interesting, but not always timed.
+
+**Evidence anchors**
+
+- Ch. 2: Brutus’s chemical process and Zimeon’s Dead Zone discovery both carry strong forward pressure.
+- Ch. 12: Emergency Council Meeting has necessary plot function but risks over-discussion.
+- Ch. 21: Rancient Code material deepens doctrine but delays endgame pressure.
+- Ch. 22: Sanctuary is atmospherically strong and structurally important, but long.
+
+**Revision target**
+
+Convert expository blocks into consequence-led sequence. Each chapter should answer: **What changed by the end that cannot be unchanged?**
+
+---
+
+### 3. Character Depth & Psychological Coherence — 6.5 / 10
+
+**What is working**
+
+The character system has real variety:
+- Brutus is appetite, damage, domination, and comic-horror id.
+- Chey is complicity with conscience; he is not innocent, but he can perceive harm.
+- Zimeon is curiosity, boundary-crossing, and emerging moral intelligence.
+- Hyla is maternal authoritarianism: protective, cruel, divine-right rationalizer.
+- Thorander is charismatic patriarchal reformer whose reform is contaminated by domination.
+- Rana and Newton carry tenderness, vulnerability, and the possibility of cooperation.
+- Enoch, Maximilian, Arcana, Twillow, and Lacerta add social texture.
+
+Hyla is one of the most compelling figures because her cruelty is tied to governance, motherhood, theology, and survival. Thorander is compelling because his intelligence is not morally clean.
+
+**What weakens impact**
+
+Some characters explain themselves or are explained by the narrator before the reader gets enough dramatized turning points. The major psychological pivots — Hyla softening, Thorander adapting, Chey recognizing kinship, Zimeon learning deception, Rana and Newton bonding — should be given more scene pressure and less interpretive scaffolding.
+
+**Evidence anchors**
+
+- Ch. 1: Hyla rationalizes murder and maiming as divine / political necessity.
+- Ch. 9: Zimeon recognizes lying as a way to advance interests.
+- Ch. 15: Chey acknowledges kinship with frogs and warns them.
+- Ch. 19–20: Thorander’s sexual frustration and political theology reveal his danger.
+
+**Revision target**
+
+At each major character turn, add a before/after state. The reader should be able to say: **Before this scene, Hyla/Thorander/Zimeon/Chey believed X; after it, they act under Y pressure.**
+
+---
+
+### 4. Point of View & Voice Control — 6.0 / 10
+
+**What is working**
+
+The manuscript has a brave voice architecture. Human scenes use slang, profane humor, drug-culture texture, grotesque analogy, and comic rhythm. Frog scenes use sacred diction, biological specificity, political ceremony, and mythic absurdity. The tonal divide is intentional and helps distinguish worlds.
+
+**What weakens impact**
+
+The manuscript sometimes changes register inside a scene before the reader has reoriented. Grotesque comedy, theological elevation, sexual explicitness, ecological science, and trauma language may occur in close proximity. That can be powerful, but when the transition is not governed, the reader experiences noise rather than design.
+
+**Evidence anchors**
+
+- Ch. 1: “Yo, yo, Chey” human banter collides with frog observational anthropology.
+- Ch. 3: high mythoamphibian lore sits beside classroom-style instruction.
+- Ch. 14–15: shard theology, Rana/Newton tenderness, and human recognition move in quick sequence.
+- Ch. 25: final catastrophe, Dominatus frame, and aphoristic closure stack quickly.
+
+**Revision target**
+
+Use deliberate tonal handoff beats. Before moving from human comedy to frog myth, insert one stabilizing image or consequence that carries the reader across the threshold.
+
+---
+
+### 5. Scene Construction & Function — 6.0 / 10
+
+**What is working**
+
+Many scenes are built around vivid situations: Brutus cooking meth and dumping waste; Zimeon entering the Dead Zone; Hyla’s hibernation punishments; emergency council; Polliwog Games; the Sanctuary; the final netting. The book rarely lacks imagination at the scene premise level.
+
+**What weakens impact**
+
+Individual scenes often do too much. A single scene may attempt:
+- plot advancement,
+- species biology,
+- worldbuilding,
+- political doctrine,
+- comedy,
+- sexual custom,
+- thematic reflection,
+- and symbolic setup.
+
+That density can make scenes feel like containers rather than engines.
+
+**Evidence anchors**
+
+- Ch. 2: chemical procedure and shard discovery are both strong but intensely dense.
+- Ch. 16–17: healing / disease / social reform material is important but needs sharper scene state changes.
+- Ch. 22: Sanctuary material has strong atmosphere but should be sequenced around one dominant emotional and plot function.
+
+**Revision target**
+
+Assign each scene a primary function and one secondary function. Everything else either becomes subtext, later payoff, or cut/relocated material.
+
+---
+
+### 6. Dialogue Authenticity & Subtext — 6.0 / 10
+
+**What is working**
+
+The book gives different groups different speech worlds. Brutus and Chey sound distinct from Hyla, Thorander, Rana, Newton, and council members. Dialogue frequently reveals power: Brutus pressures Chey; Hyla controls subjects; Thorander teaches and seduces; Rana questions; Newton pleads and hopes.
+
+**What weakens impact**
+
+Dialogue often carries exposition directly. Characters sometimes speak as worldbuilding delivery systems rather than as people trying to get something from each other. Doctrine scenes in particular should become more adversarial, evasive, or costly.
+
+**Evidence anchors**
+
+- Ch. 1: Brutus/Chey banter around toadstones and superstition.
+- Ch. 3: Thorander’s mythoamphibian teaching.
+- Ch. 12: council discussion after the shard disturbance.
+- Ch. 15–17: Rana/Newton/Thorander cross-species material.
+
+**Revision target**
+
+Convert doctrine dialogue into conflict dialogue. Every long explanation should be interrupted by a question, resistance, threat, desire, or consequence.
+
+---
+
+### 7. Thematic Integration — 7.5 / 10
+
+**What is working**
+
+The thematic system is rich and materially embedded. The book is not merely “about” environmental harm; environmental harm changes bodies, water, disease, politics, sexuality, and belief. It is not merely “about” domination; domination appears as addiction, monarchy, patriarchy, species hierarchy, human extraction, religious law, and sexual coercion.
+
+The best thematic bridge is the repeated question: **Who gets to decide what life is for?** Brutus answers through appetite. Hyla answers through divine monarchy. Thorander answers through superiority and reproductive ambition. Rana and Newton answer through curiosity, care, and cooperation. Chey hovers between harm and recognition.
+
+**What weakens impact**
+
+The manuscript sometimes states thematic conclusions before dramatic evidence has had time to accumulate. Chapter-ending aphorisms are often strong, but they can also overframe the preceding chapter.
+
+**Evidence anchors**
+
+- Ch. 10: “sacrifice of a few for the many” becomes both doctrine and violence.
+- Ch. 17–18: healing and reform pressure test whether cooperation can improve survival.
+- Ch. 21: Rancient Code frames ecological and spiritual obligations.
+- Ch. 25: Dominatus reverses creation into human dominion and ecological catastrophe.
+
+**Revision target**
+
+Let theme emerge from irreversible choices. Preserve the aphorisms, but use fewer of them or make them answer specific scene consequences.
+
+---
+
+### 8. World-Building & Environmental Logic — 8.0 / 10
+
+**What is working**
+
+This is the manuscript’s strongest dimension. The amphibian world is not generic fantasy. It is built from hibernation, skin permeability, predator pressure, amplexus, disease, toxins, egg clusters, tadpole survival, environmental gradients, migration, water quality, and interspecies observation. The theology grows out of biological experience: Sun Gorf, Water Gorf, Fire Gorf, Fertility Gorf, and Terra Firma Gorf feel like a species-specific interpretation of environment.
+
+The world also contains social law: monarchy, council, scouts, sentinels, shaming, sanctuary, training, games, sexual control, exile, maiming, and burial. These systems have consequence.
+
+**What weakens impact**
+
+Some worldbuilding is introduced as encyclopedia rather than pressure. The reader does not need less world; the reader needs the world sorted into what must be known now, what can be discovered later, and what should remain implied.
+
+**Evidence anchors**
+
+- Ch. 1: frog observation of humans through species-specific assumptions.
+- Ch. 2: Dead Zone water effect and Zimeon’s bodily response.
+- Ch. 12: emergency response and council structure.
+- Ch. 22: Sanctuary as social and biological quarantine.
+
+**Revision target**
+
+Use “rule through obstacle.” If a biological or social rule matters, make a character fail because of it or exploit it under pressure.
+
+---
+
+### 9. Pacing & Structural Balance — 5.5 / 10
+
+**What is working**
+
+The manuscript has a strong macro-escalation path: human harm → shard exposure → frog political response → disease/reform → sanctuary/end-times threat → New World gesture. The problem is not absence of structure.
+
+**What weakens impact**
+
+The structure is under-prioritized. The manuscript’s middle accumulates lore and social systems faster than it escalates the central collision. The late chapters introduce and resolve major elements, but the reader may not feel enough countdown pressure because the book has trained them to expect digression.
+
+**Evidence anchors**
+
+- Ch. 1–3: opening premise expands in many directions before one spine dominates.
+- Ch. 14–18: strong emotional and reform material, but the main shard/human threat recedes.
+- Ch. 21–22: doctrine and Sanctuary deepen the world but slow the approach to catastrophe.
+- Ch. 23–25: human netting and end-times material restore urgency.
+
+**Revision target**
+
+Create an act-level pressure map:
+1. **Act I:** Human extraction releases / reveals shard crisis.
+2. **Act II:** Frog society misreads, exploits, or weaponizes the crisis.
+3. **Act III:** Cross-species cooperation becomes the only survival path.
+4. **Act IV:** Human force and ecological consequence force irreversible choice.
+5. **Coda:** New World is promise, cost, or indictment — not merely continuation.
+
+---
+
+### 10. Prose Control & Line-Level Craft — 5.5 / 10
+
+**What is working**
+
+The prose is alive. It generates memorable images, comic turns, grotesque metaphors, and surprising personifications. The book has far more voice than most manuscripts at this stage. The language is willing to be ugly, funny, lyrical, profane, and sacred.
+
+**What weakens impact**
+
+The line often keeps adding after the point has landed. Extended metaphor sometimes outruns scene urgency. Some sentences pile comparison upon comparison until the reader is admiring invention instead of feeling consequence. The most intense moments need fewer ornaments, not more.
+
+**Evidence anchors**
+
+- Ch. 1: Mother Earth extended metaphor is inventive but long.
+- Ch. 2: chemical process language is vivid but procedural density is high.
+- Ch. 11: nature-as-sonata passage is beautiful but risks pausing plot.
+- Ch. 25: final theological aphorism has force but arrives after a densely stacked ending.
+
+**Revision target**
+
+At pressure peaks, choose one controlling image. Cut the second and third metaphor unless they change the emotional meaning.
+
+---
+
+### 11. Tonal Authority & Consistency — 6.0 / 10
+
+**What is working**
+
+The tonal mixture is part of the work’s identity. The book’s ability to move from absurd frog theology to meth horror to ecological grief to sexual satire is a feature, not a defect. The manuscript wants discomfort.
+
+**What weakens impact**
+
+Tonal authority depends on sequence. If the manuscript places a crude joke, sacred invocation, sexual threat, and ecological warning too close together without a transition, the reader may not know whether to laugh, recoil, mourn, or interpret. That confusion is not always productive.
+
+**Evidence anchors**
+
+- Ch. 1: frog-head comedy and meth use beside frog communal observation.
+- Ch. 14: Maalik / shard material beside Rana/Newton tenderness.
+- Ch. 19: sexual frustration and pedagogy.
+- Ch. 25: end-times scene and Dominatus coda.
+
+**Revision target**
+
+Add tonal contracts at chapter openings and major handoffs. A single sentence can signal whether the next scene should be read as comic, sacred, grotesque, intimate, or catastrophic.
+
+---
+
+### 12. Narrative Closure & Promises Kept — 5.5 / 10
+
+**What is working**
+
+The ending is thematically consistent. It gestures toward New World, wisdom, love, commitment, and the theological indictment of human dominion. The final Dominatus reversal is conceptually strong and belongs to the book.
+
+**What weakens impact**
+
+Several major promises are not yet cleanly paid:
+- What exactly has the shard changed in the lake?
+- What is the durable consequence of Zimeon’s exposure?
+- What becomes of Hyla’s authority?
+- What does Thorander’s reform / domination agenda cost?
+- What is the fate of Rana and Newton as emotional anchors?
+- What does Chey’s recognition of frog life alter, if anything?
+- Is the New World a literal migration, a changed social order, a spiritual evolution, or an ironic impossibility?
+
+Open endings are acceptable. Under-specified ledgers are not.
+
+**Evidence anchors**
+
+- Ch. 10: shard release into the lake.
+- Ch. 18: protectorate / reform idea.
+- Ch. 22: Sanctuary death and intimacy.
+- Ch. 25: New World coda and Dominatus.
+
+**Revision target**
+
+Add a promise/payoff ledger. The ending does not need to close every future arc, but it must tell the reader which promises have been fulfilled, which have been transformed, and which are intentionally left open.
+
+---
+
+### 13. Professional Readiness & Market Positioning — 6.0 / 10
+
+**What is working**
+
+The manuscript has a hook. It is not derivative in premise, world, or voice. It could be positioned as adult weird literary eco-fantasy / satirical animal civilization fiction / transgressive environmental allegory. The title is memorable. The concept is commercially legible once compressed.
+
+**What weakens impact**
+
+The market contract is unclear. A reader may wonder whether the book is primarily:
+- adult satire,
+- ecological fable,
+- drug-culture grotesque,
+- mythic animal fantasy,
+- theological allegory,
+- trauma/testimony-adjacent fiction,
+- or weird literary epic.
+
+It can be several of these, but the jacket-level promise must name the hierarchy.
+
+**Evidence anchors**
+
+- Opening trigger warnings and adult content.
+- Human drug / chemical crime thread.
+- Frog civilization and Gorf theology.
+- Rana/Newton tenderness and cross-species cooperation.
+- Dominatus coda.
+
+**Revision target**
+
+Develop a one-paragraph positioning statement that foregrounds the collision spine: **when human chemical violence releases a sacred/poisonous shard into an amphibian civilization, rival species must decide whether doctrine, domination, or cooperation will govern survival.**
+
+---
+
+## Layer-by-layer analysis
+
+### Human damage layer — Brutus / Chey / chemical world
+
+**Function in the whole**
+
+This layer embodies human dominion at its most casual and grotesque. Brutus is not simply “bad”; he is appetite ungoverned by reverence. He converts landscape into laboratory, animals into objects, spirituality into acquisition, and danger into entertainment. Chey gives the layer moral friction because he is complicit but not fully numb.
+
+**What is working**
+
+- Brutus is vivid, disgusting, comic, and dangerous.
+- The meth / waste / mineshaft material makes ecological harm concrete.
+- Chey’s moments of recognition prevent the human thread from becoming a flat villain lane.
+- The language of songs, jokes, and “frog heads” turns harm into performative culture.
+
+**What is weakening impact**
+
+- Brutus can become one-note if every beat confirms the same appetite without escalation.
+- Procedural drug-making detail risks overwhelming narrative necessity.
+- Chey needs a clearer arc from complicity to recognition or cowardice.
+- The human plot should more visibly trigger the frog plot at regular intervals.
+
+**Revision priorities**
+
+1. Give Chey one irreversible choice late in the manuscript.
+2. Reduce procedural density where it does not later alter plot.
+3. Tie each Brutus escalation to a specific amphibian-world consequence.
+
+**Evidence anchors**
+
+- Ch. 1: frog-head song / toadstone fixation.
+- Ch. 2: mineshaft chemical disposal.
+- Ch. 10: frogs captured and shard released.
+- Ch. 15: Chey’s goodbye / recognition of frogs as earthlings.
+- Ch. 23–25: netting and end-times threat.
+
+---
+
+### Columbian frog polity — Hyla / Zimeon / council
+
+**Function in the whole**
+
+This is the primary civilization layer. It transforms the book from “humans harm frogs” into a political and theological drama about how a species interprets danger. Hyla’s kingdom is both victimized and morally compromised.
+
+**What is working**
+
+- Hyla is a powerful authoritarian figure with maternal and theological complexity.
+- Zimeon’s curiosity gives the world a forward-looking energy.
+- Council, sentinels, sanctuary, hibernation, punishment, and training create social density.
+- Gorf theology feels species-specific rather than imported human religion with frog names.
+
+**What is weakening impact**
+
+- Council scenes can become doctrinal exposition.
+- Hyla’s internal conflict needs sharper scene turns.
+- Zimeon’s shard transformation needs clearer long-term consequences.
+- The political stakes of reform need to be tracked more explicitly.
+
+**Revision priorities**
+
+1. Define Hyla’s arc: preservationist tyrant, reforming monarch, or tragic failed guardian.
+2. Let Zimeon’s shard experience create escalating social consequences, not only private knowledge.
+3. Turn council meetings into decisions with winners, losers, and costs.
+
+**Evidence anchors**
+
+- Ch. 1: Hyla’s hibernation punishments and transference.
+- Ch. 9: Zimeon learns deception.
+- Ch. 12: Emergency Council Meeting.
+- Ch. 18: protectorate / reform discussion.
+- Ch. 21: Rancient Code.
+
+---
+
+### Orgon / rogue reform layer — Thorander / Rana
+
+**Function in the whole**
+
+This layer supplies alternate doctrine, survival knowledge, and patriarchal danger. Thorander is useful because he is partly right and morally contaminated. Rana is useful because she can inherit knowledge without inheriting all of his domination.
+
+**What is working**
+
+- Thorander is intelligent, charismatic, and threatening.
+- Rana’s questions challenge inherited hatred.
+- Orgon lore broadens frog history without entirely leaving the central world.
+- The healing / education material gives reform practical stakes.
+
+**What is weakening impact**
+
+- Thorander’s teaching can become lecture.
+- His sexual and political appetite must be integrated into the plot, not merely repeated.
+- Rana needs more agency independent of Thorander’s pedagogy.
+
+**Revision priorities**
+
+1. Make each Thorander lesson create a later action by Rana.
+2. Clarify whether Thorander is a reformer, infiltrator, predator, or all three in sequence.
+3. Let Rana’s ethical intelligence visibly diverge from his power logic.
+
+**Evidence anchors**
+
+- Ch. 3: mythoamphibian teaching.
+- Ch. 16: cross-species cooperation discussion.
+- Ch. 17: disease/healing action.
+- Ch. 19–20: sexual and ideological pressure.
+
+---
+
+### Salamander / newt counter-world — Newton / Twillow / Lacerta
+
+**Function in the whole**
+
+This layer gives the book its gentlest and most emotionally accessible material. Newton’s vulnerability and Rana’s connection to him make cooperation feel lived rather than theoretical. The newt world also mirrors frog prejudice, hierarchy, and bodily vulnerability.
+
+**What is working**
+
+- Newton is immediately sympathetic.
+- Bullying and disability material create embodied stakes.
+- Lacerta’s care grounds the world emotionally.
+- Rana/Newton material shows the alternative to dominance.
+
+**What is weakening impact**
+
+- The newt layer risks feeling like a secondary novella unless tied tightly to the main shard / survival crisis.
+- Twillow can become a social-type villain unless his function sharpens.
+- Newton’s late role should be more central to the final survival logic.
+
+**Revision priorities**
+
+1. Make Newton / Rana cooperation indispensable to resolving the central crisis.
+2. Tie newt biology / toxin / slime directly to the survival plot.
+3. Give Newton one decisive action, not only symbolic tenderness.
+
+**Evidence anchors**
+
+- Ch. 2: Newton bullied and comforted by Lacerta.
+- Ch. 14–15: Rana/Newton bond.
+- Ch. 17: newt slime cooperation.
+- Ch. 22: Sanctuary / death and intimacy.
+
+---
+
+### Shard / toadstone / Gorf / Dominatus symbolic layer
+
+**Function in the whole**
+
+This is the manuscript’s mythic and metaphysical engine. It interprets ecological contamination as sacred/poisonous power and frames human dominion as a theological catastrophe.
+
+**What is working**
+
+- The toadstone idea is memorable and story-bearing.
+- The shard has bodily, ecological, and symbolic consequence.
+- Gorf theology is coherent enough to govern behavior.
+- Dominatus gives the ending a cosmic indictment.
+
+**What is weakening impact**
+
+- The relationship among shard, toadstone, Maalik, transference, fertility, and mutation needs clearer rule articulation.
+- Dominatus is powerful but under-seeded; it may feel like a late thesis unless more lightly braided earlier.
+- Chapter aphorisms sometimes tell the reader the intended meaning instead of letting the system demonstrate it.
+
+**Revision priorities**
+
+1. Create a sacred-object ledger: what the shard does, what the toadstone does, what each costs.
+2. Seed Dominatus logic earlier through recurring language or human dominion imagery.
+3. Pay the shard’s late consequences more concretely.
+
+**Evidence anchors**
+
+- Opening epigraph: “That which giveth light also giveth darkness.”
+- Ch. 2: Zimeon’s shard exposure.
+- Ch. 10: shard release into lake.
+- Ch. 14: Maalik frame.
+- Ch. 25: Dominatus eighth-day reversal.
+
+---
+
+## Cross-layer integration
+
+### Transition analysis
+
+The best transitions occur when the book lets one layer physically affect another: chemical dumping contaminates water; Brutus’s violence releases the shard; Zimeon’s discovery creates political crisis; newt slime becomes healing possibility; human capture threatens frog end-times. These are strong because they make the layers causal.
+
+The weaker transitions are tonal or expository rather than causal. A human scene may end and a frog doctrine scene may begin, but the connective tissue is not always a specific pressure transfer. The reader should feel the baton moving: **human act → ecological effect → frog interpretation → political decision → cross-species consequence.**
+
+### Echoes and mirrors
+
+Important echoes already present:
+
+- Human addiction / frog shard intoxication.
+- Human domination / Hyla monarchy / Thorander patriarchy.
+- Toadstone superstition / sacred object governance.
+- Chemical contamination / spiritual corruption.
+- Changelings / transformation / identity substitution.
+- Sanctuary / leper colony / social quarantine.
+- Shaming / slurs / species hierarchy.
+- Fire, water, mud, slime, blood, white scum, shard-glint.
+- “New World” as geography, reform, afterlife, and moral possibility.
+
+### Architectural risk
+
+The manuscript risks splitting into four adjacent books:
+1. Brutus/Chey drug-crime eco-horror.
+2. Hyla/Zimeon frog monarchy epic.
+3. Thorander/Rana reform-and-patriarchy saga.
+4. Newton/newt tenderness and disease-cooperation fable.
+
+The fix is not to remove layers. The fix is to make the shard crisis and ecological survival question the load-bearing spine for all four.
+
+---
+
+## Canon, doctrine, and symbolic system audit
+
+| System element | Role | First major appearance | Later obligations | Status |
+|---|---|---|---|---|
+| Toadstone / froggin noggin | Sacred object, superstition, extraction target, divine legitimacy | Ch. 1 | Must govern Hyla’s authority and Brutus’s desire; must pay off as more than premise | Strong but needs clearer rules |
+| Shard | Poison/light/darkness object, transformation source | Ch. 2 | Must have escalating ecological and bodily consequences | Strong; payoff needs sharpening |
+| Gorf system | Species theology and interpretation of natural forces | Ch. 1 onward | Must shape decisions, not only vocabulary | Stable and active |
+| Maalik | Dark-angle/light-darkness frame | Epigraph / Ch. 14 | Must connect shard power to moral ambiguity | Underused but promising |
+| Transference | Royal blood/power transfer | Ch. 1 | Must affect Zimeon / Hyla stakes later | Underpaid |
+| Sanctuary | Quarantine / leper colony / graveyard | Ch. 22 | Must alter political and moral decisions | Strong atmosphere; needs earlier setup |
+| Rancient Code / Order Anura | Historical-doctrinal law | Ch. 21 | Must pressure final political choices | Useful but late-heavy |
+| Dominatus | Human dominion theological reversal | Ch. 11 / Ch. 25 | Must frame human harm and ending | Powerful; needs more seeding |
+| New World | Migration, reform, afterlife, alternative order | Recurs throughout | Must be defined by ending as literal/ethical/spiritual | Promising but ambiguous |
+| Changelings | Folklore and identity-replacement motif | Ch. 1 / Ch. 23 | Must connect human myth to amphibian transformation | Underdeveloped relative to title/premise |
+
+### Integrity questions
+
+**Does the symbolic system change decisions or only explain them?**  
+It changes decisions. Hyla’s authority, Thorander’s claims, Zimeon’s curiosity, and Brutus’s violence are all affected by sacred-object logic.
+
+**Do the relics maintain stable identity and consequence?**  
+Mostly, but the shard/toadstone distinction should be clarified. If they are separate forces, state the functional difference through action. If they are linked, dramatize the link.
+
+**Does doctrine illuminate the emotional core or compete with it?**  
+Both. Doctrine is meaningful when it shapes Hyla, Rana, Newton, and Thorander’s choices. It competes when delivered as lecture before scene consequence.
+
+**Does late metaphysical resolution answer early embodied conflict?**  
+Partially. Dominatus answers the human-dominion thread. It does not yet fully answer the shard, Hyla, Zimeon, or Newton/Rana ledgers.
+
+**Are canon-bearing sections overbuilt relative to payoff?**  
+Not conceptually. They are sometimes overexplained relative to immediate scene need.
+
+---
+
+## Reader experience
+
+### What a strong reader is likely to feel
+
+A strong reader is likely to feel that the book is audacious, weird, adult, morally angry, biologically inventive, and unlike conventional animal fantasy. The best reader will enjoy the grotesque comedy, the species-specific theology, the environmental indictment, the amphibian sociology, and the way tenderness appears inside an otherwise brutal system.
+
+### What an average reader may struggle with
+
+An average reader may struggle with:
+- density of exposition;
+- frequent tonal pivots;
+- explicit sexual and drug material;
+- heavy metaphor stacking;
+- uncertainty about which plotline is primary;
+- late-arriving doctrine;
+- open or diffuse closure.
+
+### What should not be simplified away
+
+- The adult grotesque quality.
+- The amphibian biology and ecological specificity.
+- The theology built from species experience.
+- The moral indictment of human dominion.
+- The tenderness of cross-species cooperation.
+- The chapter-ending philosophical questions, though they may need pruning or retiming.
+- The unsettling humor.
+
+---
+
+## Prioritized revision plan
+
+### Top 5 actions
+
+1. **Build a promise/payoff ledger around shard, toadstone, Hyla, Zimeon, Thorander, Rana/Newton, Chey, and New World.**  
+   This comes first because closure weakness is downstream of promise tracking. The ending can remain open, but the reader must know which promises have landed.
+
+2. **Restructure the middle around causal pressure transfer.**  
+   Human action should produce ecological effect; ecological effect should produce frog interpretation; frog interpretation should produce political decision; political decision should force cross-species consequence. This will solve much of the pacing problem without cutting the book’s identity.
+
+3. **Convert lore and doctrine into scene turns.**  
+   Keep the systems, but make every council, classroom, myth, or doctrine sequence change a relationship, law, plan, or danger state.
+
+4. **Stabilize tonal handoffs.**  
+   Add small transition beats between human grotesque comedy, frog ceremony, sexual satire, ecological grief, and Dominatus-scale theology.
+
+5. **Compress line-level overgrowth after architecture is fixed.**  
+   Do not start with prose polish. First fix structure, then cut stacked metaphors, redundant explanations, and extended procedural passages that do not pay later.
+
+### Sequence recommendation
+
+**Revision order:** architecture → promise ledger → layer transitions → doctrine dramatization → tonal calibration → line compression.
+
+Line editing before the promise ledger would be premature. The manuscript’s most important problems are not sentence-level mistakes; they are hierarchy, payoff, and pressure sequencing.
+
+---
+
+## Top 12 concrete revision tasks
+
+1. Add a one-page “collision spine” note for yourself: what changes in the frog world because humans release or disturb the shard?
+2. Mark every chapter ending with one state-change sentence: “By the end of this chapter, X is no longer true.”
+3. Reduce at least 20% of explanatory paragraphs that arrive before a scene consequence.
+4. Give Chey one irreversible late choice that clarifies whether recognition becomes action.
+5. Add a shard/toadstone rule scene where a character tests, misunderstands, or pays for the object’s power.
+6. Make Zimeon’s shard exposure visibly alter later politics, body, or belief.
+7. Define Hyla’s end-state: ruler preserved, ruler reformed, ruler exposed, ruler displaced, or ruler tragically unchanged.
+8. Give Rana one decision that contradicts Thorander’s ideology.
+9. Give Newton one indispensable contribution to survival or reform.
+10. Seed Dominatus language earlier in human-dominion moments.
+11. Cut or relocate the densest procedural drug-making material unless it returns as plot evidence or consequence.
+12. Recast the “New World” ending so the reader knows whether it is literal migration, ethical transformation, spiritual afterlife, or deliberately all three.
+
+---
+
+## Releasability assessment
+
+| Surface | Current state | Releasability |
+|---|---|---|
+| Concept | Distinctive, high-potential | Releasable after pitch sharpening |
+| Architecture | Rich but overdistributed | Not yet |
+| Character system | Strong cast with uneven turn clarity | Close |
+| Worldbuilding | Major strength | Releasable with compression |
+| Theme | Strong and integrated | Close |
+| Pacing | Weakest major craft surface | Not yet |
+| Closure | Promising but under-ledgered | Not yet |
+| Prose | Vivid but overgrown | Needs post-architecture polish |
+| Market | Memorable but hard to position | Close after spine rewrite |
+
+**Overall readiness:** Not yet.  
+**Most efficient path to “close”:** Promise ledger + structural compression pass.  
+**Most efficient path to “queryable”:** After the structural pass, produce a 1-page pitch that foregrounds adult weird eco-fable rather than trying to explain every layer.
+
+---
+
+## Acceptance checks
+
+Before calling the manuscript substantially improved, confirm:
+
+- The reader can state the central conflict by the end of Chapter 2.
+- The shard/toadstone distinction or relationship is clear through action.
+- Every major layer affects the final quarter.
+- Hyla’s authority has a visible late consequence.
+- Zimeon’s shard exposure pays off.
+- Rana/Newton cooperation is necessary, not ornamental.
+- Chey’s conscience produces a cost or failure.
+- The Sanctuary material changes the political/reform stakes.
+- Dominatus feels seeded rather than appended.
+- The ending clarifies what “New World” means.
+- The prose at danger peaks uses fewer metaphors than the current draft.
+- The book still feels strange after revision.
+
+---
+
+## Gold-standard output lessons for RevisionGrade
+
+This benchmark should teach the evaluator to:
+
+1. Recognize layered / multi-voice long-form structure before scoring.
+2. Preserve canonical 13-criteria scoring.
+3. Identify the primary causal weakness, not merely list weak criteria.
+4. Separate “too strange” from “under-governed.”
+5. Avoid generic advice like “improve pacing” without naming the pressure-transfer problem.
+6. Diagnose symbolic systems as systems with obligations.
+7. Treat closure as a promise ledger, not only an ending mood.
+8. Protect authorial ambition while demanding clearer hierarchy.
+9. Surface the difference between worldbuilding richness and plot momentum.
+10. Recommend revision order: architecture first, prose last.
+
+---
+
+## Repo note
+
+This file is intended as a **manual gold-standard benchmark**, not a production output claim. It should not be used to assert that the current app already emits this level of detail. It defines the target quality bar for future long-form output and should be paired with a smaller fixture or sanitized artifact if used in automated tests.
+
+Recommended path:
+
+```text
+docs/benchmarks/froggin-noggin-dream.md
+```
+
+Recommended PR label:
+
+```text
+governance(benchmarks): add Froggin Noggin dream long-form evaluation
+```

--- a/tests/evaluation/benchmarks/gold-standard-shape.test.ts
+++ b/tests/evaluation/benchmarks/gold-standard-shape.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Gold-standard benchmark structural smoke test
+ *
+ * Validates the SHAPE of any benchmark file in `docs/benchmarks/*.md`
+ * that opts in to the canonical-13 schema by setting front-matter:
+ *
+ *   ---
+ *   benchmark-schema: canonical-13-v1
+ *   ---
+ *
+ * For files that opt in we require:
+ *   - the canonical 13 named criteria are all present in the score grid
+ *   - every score is a number in [0, 10]
+ *   - every confidence value is one of the allowed labels
+ *   - a disclaimer is present stating the file is a manual reference,
+ *     not a production assertion
+ *
+ * Files without the opt-in are ignored. This lets legacy benchmark
+ * variants (e.g. the original Ancient Bloodlines files, which use
+ * abbreviated criterion names) coexist with newer canonical-13 files.
+ *
+ * This test does NOT compare any production output to these scores.
+ * The benchmarks are manual reference quality bars (see
+ * `docs/benchmarks/README.md`).
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+const BENCHMARKS_DIR = join(__dirname, "..", "..", "..", "docs", "benchmarks");
+
+const CANONICAL_13_CRITERIA = [
+  "Concept & Core Premise",
+  "Narrative Drive & Momentum",
+  "Character Depth & Psychological Coherence",
+  "Point of View & Voice Control",
+  "Scene Construction & Function",
+  "Dialogue Authenticity & Subtext",
+  "Thematic Integration",
+  "World-Building & Environmental Logic",
+  "Pacing & Structural Balance",
+  "Prose Control & Line-Level Craft",
+  "Tonal Authority & Consistency",
+  "Narrative Closure & Promises Kept",
+  "Professional Readiness & Market Positioning",
+];
+
+const ALLOWED_CONFIDENCE = new Set([
+  "High",
+  "Moderate",
+  "Moderate-High",
+  "Moderate-Low",
+  "Low",
+]);
+
+const SCHEMA_TAG = "canonical-13-v1";
+
+interface ParsedRow {
+  criterion: string;
+  score: number;
+  confidence: string;
+}
+
+function hasCanonical13FrontMatter(markdown: string): boolean {
+  const fm = markdown.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return false;
+  return new RegExp(`benchmark-schema:\\s*${SCHEMA_TAG}\\b`).test(fm[1]);
+}
+
+function parseScoreGrid(markdown: string): ParsedRow[] {
+  const rows: ParsedRow[] = [];
+  for (const line of markdown.split("\n")) {
+    if (!line.startsWith("|")) continue;
+    const cells = line
+      .split("|")
+      .map((c) => c.trim())
+      .filter((c, i, arr) => !(i === 0 || i === arr.length - 1));
+    if (cells.length < 4) continue;
+    if (/^-+:?$/.test(cells[1]) || cells[1].toLowerCase() === "score") continue;
+
+    const scoreCell = cells[1].replace(/\*\*/g, "").trim();
+    const scoreMatch = scoreCell.match(/^([\d.]+)\s*\/\s*10$/);
+    if (!scoreMatch) continue;
+
+    rows.push({
+      criterion: cells[0],
+      score: parseFloat(scoreMatch[1]),
+      confidence: cells[2],
+    });
+  }
+  return rows;
+}
+
+function listCanonical13Files(): string[] {
+  if (!existsSync(BENCHMARKS_DIR)) return [];
+  return readdirSync(BENCHMARKS_DIR)
+    .filter((f) => f.endsWith(".md") && f.toLowerCase() !== "readme.md")
+    .map((f) => join(BENCHMARKS_DIR, f))
+    .filter((p) => hasCanonical13FrontMatter(readFileSync(p, "utf8")));
+}
+
+describe("docs/benchmarks canonical-13 gold-standard shape", () => {
+  const files = listCanonical13Files();
+
+  it("at least one canonical-13-v1 benchmark exists", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  describe.each(files)("%s", (filePath) => {
+    const markdown = readFileSync(filePath, "utf8");
+    const rows = parseScoreGrid(markdown);
+
+    it("score grid parses to at least 13 rows", () => {
+      expect(rows.length).toBeGreaterThanOrEqual(13);
+    });
+
+    it("contains all 13 canonical criteria by name", () => {
+      const criterionNames = new Set(rows.map((r) => r.criterion));
+      const missing = CANONICAL_13_CRITERIA.filter(
+        (name) => !criterionNames.has(name),
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it("every score is a number in [0, 10]", () => {
+      for (const row of rows) {
+        expect(typeof row.score).toBe("number");
+        expect(Number.isNaN(row.score)).toBe(false);
+        expect(row.score).toBeGreaterThanOrEqual(0);
+        expect(row.score).toBeLessThanOrEqual(10);
+      }
+    });
+
+    it("every confidence value is in the allowed set", () => {
+      for (const row of rows) {
+        expect(ALLOWED_CONFIDENCE.has(row.confidence)).toBe(true);
+      }
+    });
+
+    it("includes a manual-reference disclaimer (not a production claim)", () => {
+      const lower = markdown.toLowerCase();
+      const hasDisclaimer =
+        lower.includes("manual gold-standard benchmark") ||
+        lower.includes("not a production output claim") ||
+        lower.includes("manual reference quality bar");
+      expect(hasDisclaimer).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What

Commits the **Froggin Noggin DREAM Long-Form Gold Standard Evaluation** as the primary calibration anchor at `docs/benchmarks/froggin-noggin-dream.md`. Establishes Froggin Noggin as THE gold standard for RevisionGrade long-form output. Adds a benchmarks README that defines what these files are (and are not), and a structural smoke test that validates the shape of any benchmark file that opts in to the canonical-13-v1 schema.

This is **documentation only**. No runtime code, no schema, no pipeline behavior changes.

## Why

The Froggin Noggin gold standard is the calibration anchor for upcoming Pass 4 governance work and Pass 1 signal-detection work (separate PRs, in that order). Without committing it as a repo artifact first, those PRs would land without a reference point.

The benchmark scores Froggin Noggin at **66/100 overall** with high confidence on architecture, concept, worldbuilding, theme, and closure diagnosis. It explicitly identifies that the manuscript is evaluable as a serious long-form work but is not yet submission-ready — the kind of nuanced judgment the platform aims to surface.

## Pass 1 evaluation latency budget

- [ ] Pass 1: ≤ 12.0 minutes per call (720000 ms) — N/A, this PR is docs-only
- [ ] Pass 2: ≤ 12.0 minutes per call (720000 ms) — N/A
- [ ] Pass 3: ≤ 12.0 minutes per call (720000 ms) — N/A
- [ ] Pass 4: ≤ 12.17 minutes per call (730000 ms) — N/A

## Scope

**Added:**
- `docs/benchmarks/froggin-noggin-dream.md` — full gold-standard evaluation (committed byte-identical to the source artifact, with a 3-line YAML front-matter added to opt in to the canonical-13-v1 schema).
- `tests/evaluation/benchmarks/gold-standard-shape.test.ts` — structural smoke test (6 assertions) that validates only files opting in via `benchmark-schema: canonical-13-v1` front-matter.

**Modified / moved:**
- `docs/benchmarks/README.md` — replaced with a Froggin-Noggin-first index that explains gold-standard semantics and rules for adding new canonical-13-v1 benchmarks.
- `docs/benchmarks/ancient-bloodlines-README.md` — the prior ancient-bloodlines-specific README, retained byte-identical at this new path for historical reference (linked from the new README under "Legacy reference material"). No content lost.

**Not touched:**
- Zero changes to `lib/`, `app/`, `schemas/`, `supabase/`, or any runtime code.
- Zero changes to the production prompt, governance, scoring, or persistence paths.
- Existing ancient-bloodlines benchmark files and test suites are untouched and explicitly out of scope of the new smoke test (they predate the canonical-13 schema and continue to be ignored by it).

## Test plan

Local run against the full benchmarks test directory:

```
PASS tests/evaluation/benchmarks/ancient-bloodlines.longform.layered.test.ts
PASS tests/evaluation/benchmarks/ancient-bloodlines.governance.test.ts
PASS tests/evaluation/benchmarks/ancient-bloodlines.shortform.test.ts
PASS tests/evaluation/benchmarks/ancient-bloodlines.fixture.test.ts
PASS tests/evaluation/benchmarks/gold-standard-shape.test.ts

Test Suites: 5 passed, 5 total
Tests:       97 passed, 97 total
```

The new test asserts, for every file opting in to `canonical-13-v1`:
1. The score grid parses to at least 13 rows.
2. All 13 canonical criterion names are present.
3. Every score is a number in [0, 10].
4. Every confidence value is in {High, Moderate-High, Moderate, Moderate-Low, Low}.
5. A disclaimer is present stating the file is a manual reference, not a production assertion.

## Risk

Minimal. Docs-only PR with a single new test file whose scope is gated by opt-in front-matter. No existing file is modified in place — the old ancient-bloodlines README content is preserved byte-identical at a new path.

## Follow-ups (separate PRs, in this order)

1. **PR A — `fix/pass4-governance-honor-severity-and-mode`**: `PASS4_DISPUTED_CRITERIA` (severity warning) in `EVAL_EXTERNAL_ADJUDICATION_MODE=optional` ships as `completed_with_warnings` instead of failing the job. `PASS4_CANON_INVALID` and `PASS4_WEAK_AGREEMENT` stay fatal.
2. **PR B — `feat/pass1-detected-signals-required`**: Add `detectedSignals` and `doctrineTrace` to the Pass 1 JSON schema with `minItems: 1` for theme/worldbuilding/concept. Pass 1 currently emits empty arrays where Perplexity emits 5+ named signals; this is the root cause of GPT-5.1 under-scoring those criteria. Acceptance test will measure GPT scores converging toward this benchmark's 7.5/8.0/8.0 on theme/worldbuilding/concept.
