### PR TITLE
fix(processor): prefer canonical file_url over reconstructed manuscript_chunks

### DIFF
--- a/__tests__/lib/evaluation/resolve-manuscript-text-source-priority.guard.test.ts
+++ b/__tests__/lib/evaluation/resolve-manuscript-text-source-priority.guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+describe("resolveManuscriptText source priority guard", () => {
+  test("file_url data URI is resolved before manuscript_chunks fallback", () => {
+    const source = read("lib/evaluation/processor.ts");
+    const fileUrlPriority = source.indexOf("Priority 2: Decode data URI from file_url");
+    const chunkFallback = source.indexOf("Priority 3: Reconstruct from manuscript_chunks");
+
+    expect(fileUrlPriority).toBeGreaterThan(-1);
+    expect(chunkFallback).toBeGreaterThan(-1);
+    expect(fileUrlPriority).toBeLessThan(chunkFallback);
+    expect(source).toContain("resolveManuscriptText.file_url_data_uri");
+    expect(source).toContain("resolveManuscriptText.manuscript_chunks_fallback");
+  });
+
+  test("chunk materialization has inflation invariants before persistence", () => {
+    const source = read("lib/evaluation/processor.ts");
+
+    expect(source).toContain("CHUNK_INDEX_RANGE_MISMATCH");
+    expect(source).toContain("CHUNK_CONTENT_INFLATION");
+    expect(source).toContain("baseIndexedChars");
+    expect(source).toContain("totalOverlapChars");
+  });
+});

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -849,10 +849,59 @@ async function resolveManuscriptText(
   // Priority 1: Direct content column
   const directContent = typeof manuscript.content === 'string' ? manuscript.content.trim() : '';
   if (directContent.length > 0) {
+    console.log(
+      `[Processor] manuscript ${manuscript.id} resolveManuscriptText.content_column (${directContent.length} chars)`,
+    );
     return { text: directContent };
   }
 
-  // Priority 2: Reconstruct from manuscript_chunks
+  // Priority 2: Decode data URI from file_url (paste submissions store the
+  // canonical text here). This MUST run before any manuscript_chunks
+  // reconstruction so re-evaluations cannot recursively inflate the resolved
+  // text via the chunker's overlap budget. file_url is the canonical source
+  // of truth for paste submissions; chunks are derived state.
+  const fileUrl = typeof manuscript.file_url === 'string' ? manuscript.file_url : '';
+  if (fileUrl.startsWith('data:text/plain')) {
+    // Decode failures here must NOT silently fall through to the chunks
+    // fallback — that is precisely the recursive-inflation bug PR #520
+    // closes. A malformed data URI is a hard failure for this manuscript.
+    const commaIndex = fileUrl.indexOf(',');
+    if (commaIndex < 0) {
+      throw new Error(
+        `resolveManuscriptText.file_url_data_uri decode failed for manuscript ${manuscript.id}: missing comma separator`,
+      );
+    }
+    let decoded: string;
+    try {
+      const encoded = fileUrl.substring(commaIndex + 1);
+      decoded = decodeURIComponent(encoded);
+    } catch (decodeError) {
+      throw new Error(
+        `resolveManuscriptText.file_url_data_uri decode failed for manuscript ${manuscript.id}: ${
+          decodeError instanceof Error ? decodeError.message : String(decodeError)
+        }`,
+      );
+    }
+    if (decoded.trim().length > 0) {
+      console.log(
+        `[Processor] manuscript ${manuscript.id} resolveManuscriptText.file_url_data_uri (${decoded.length} chars)`,
+      );
+      // Canonical file_url path resolved successfully — do NOT query
+      // manuscript_chunks. Returning here is what enforces the "valid
+      // file_url path must not read chunks" invariant.
+      return { text: decoded };
+    }
+    // data:text/plain prefix present but decoded payload was empty/whitespace —
+    // surface as a hard failure rather than silently degrading to chunks.
+    throw new Error(
+      `resolveManuscriptText.file_url_data_uri decode failed for manuscript ${manuscript.id}: empty payload`,
+    );
+  }
+
+  // Priority 3: Reconstruct from manuscript_chunks (last-resort fallback).
+  // Only reached when manuscript.content is empty AND file_url is absent or
+  // not a data:text/plain URI. This path is lossy because chunks include
+  // overlap; treat it strictly as a fallback, not a canonical source.
   const { data: chunks, error: chunkError } = await supabase
     .from('manuscript_chunks')
     .select('chunk_index, content')
@@ -878,32 +927,9 @@ async function resolveManuscriptText(
 
     if (reconstructed.length > 0) {
       evalDebugWarn(
-        `[Processor] manuscript ${manuscript.id} missing manuscripts.content; reconstructed text from ${chunks.length} chunk(s)`,
+        `[Processor] manuscript ${manuscript.id} resolveManuscriptText.manuscript_chunks_fallback; reconstructed text from ${chunks.length} chunk(s)`,
       );
       return { text: reconstructed, loadedChunks: validChunks };
-    }
-  }
-
-  // Priority 3: Decode data URI from file_url (paste submissions store text here)
-  const fileUrl = typeof manuscript.file_url === 'string' ? manuscript.file_url : '';
-  if (fileUrl.startsWith('data:text/plain')) {
-    try {
-      const commaIndex = fileUrl.indexOf(',');
-      if (commaIndex >= 0) {
-        const encoded = fileUrl.substring(commaIndex + 1);
-        const decoded = decodeURIComponent(encoded);
-        if (decoded.trim().length > 0) {
-          console.log(
-            `[Processor] manuscript ${manuscript.id} resolved text from file_url data URI (${decoded.length} chars)`,
-          );
-          return { text: decoded };
-        }
-      }
-    } catch (decodeError) {
-      console.warn(
-        `[Processor] manuscript ${manuscript.id} file_url data URI decode failed:`,
-        decodeError,
-      );
     }
   }
 
@@ -1917,6 +1943,71 @@ export async function processEvaluationJob(
         });
         return { success: false, error: chunkBudgetError };
       }
+      // PR #520 chunk-materialization invariants — run BEFORE the
+      // CHUNK_BUDGET_OVERFLOW adaptive bracket gate so recursive overlap
+      // inflation (the bug that closed Issue #519) is caught at its source
+      // rather than masked by a downstream budget check.
+      {
+        const chunkCount = chunkRouting.chunk_count ?? 0;
+        const maxIndex = chunkRouting.max_chunk_index ?? -1;
+        if (chunkCount > 0 && maxIndex >= 0 && maxIndex !== chunkCount - 1) {
+          const rangeError =
+            `Chunk index range mismatch: chunk_count=${chunkCount} but max_chunk_index=${maxIndex}. ` +
+            `Expected max_chunk_index=${chunkCount - 1}. Failing closed before persistence.`;
+          await markFailed(rangeError, 'CHUNK_INDEX_RANGE_MISMATCH', {
+            pipelineStage: 'chunking',
+            reasonCodes: ['CHUNK_INDEX_RANGE_MISMATCH'],
+            diagnostics: {
+              chunk_routing: chunkRouting,
+              chunk_count: chunkCount,
+              max_chunk_index: maxIndex,
+            },
+          });
+          return { success: false, error: rangeError };
+        }
+        // Inflation check: aggregate emitted chunk size vs the canonical base
+        // span. baseIndexedChars is the resolved-text length (canonical
+        // source); totalOverlapChars is the total overlap budget the chunker
+        // is allowed to add. The sum of emitted chunk content must not exceed
+        // baseIndexedChars + totalOverlapChars by more than a small safety
+        // margin, otherwise the resolver picked up an already-overlap-inflated
+        // source (the Issue #519 failure mode).
+        const baseIndexedChars =
+          typeof (chunkRouting as { base_chars?: unknown }).base_chars === 'number'
+            ? ((chunkRouting as { base_chars: number }).base_chars)
+            : typeof (chunkRouting as { resolved_text_chars?: unknown }).resolved_text_chars === 'number'
+            ? ((chunkRouting as { resolved_text_chars: number }).resolved_text_chars)
+            : 0;
+        const perChunkOverlap = chunkRouting.overlap_chars ?? 0;
+        const totalOverlapChars = chunkCount > 1 ? perChunkOverlap * (chunkCount - 1) : 0;
+        const totalEmittedChars =
+          typeof (chunkRouting as { total_chunk_chars?: unknown }).total_chunk_chars === 'number'
+            ? ((chunkRouting as { total_chunk_chars: number }).total_chunk_chars)
+            : 0;
+        if (
+          baseIndexedChars > 0 &&
+          totalEmittedChars > 0 &&
+          totalEmittedChars > baseIndexedChars + totalOverlapChars + 1024
+        ) {
+          const inflationError =
+            `Chunk content inflation detected: total_emitted_chars=${totalEmittedChars} exceeds ` +
+            `baseIndexedChars=${baseIndexedChars} + totalOverlapChars=${totalOverlapChars} ` +
+            `(margin=1024). Resolver may have read overlap-inflated source. ` +
+            `Failing closed before persistence.`;
+          await markFailed(inflationError, 'CHUNK_CONTENT_INFLATION', {
+            pipelineStage: 'chunking',
+            reasonCodes: ['CHUNK_CONTENT_INFLATION'],
+            diagnostics: {
+              chunk_routing: chunkRouting,
+              base_indexed_chars: baseIndexedChars,
+              total_overlap_chars: totalOverlapChars,
+              total_emitted_chars: totalEmittedChars,
+            },
+          });
+          return { success: false, error: inflationError };
+        }
+      }
+
       if (chunkRouting.max_chunk_chars > adaptiveMaxChars) {
         const violatingIndex = chunkRouting.max_chunk_index ?? 0;
         // The emitted chunk content includes any prepended overlap on non-first

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1950,10 +1950,14 @@ export async function processEvaluationJob(
       {
         const chunkCount = chunkRouting.chunk_count ?? 0;
         const maxIndex = chunkRouting.max_chunk_index ?? -1;
-        if (chunkCount > 0 && maxIndex >= 0 && maxIndex !== chunkCount - 1) {
+        // Only fail closed when max_chunk_index is OUT OF RANGE (greater than
+        // chunk_count - 1). A lower max_chunk_index can occur legitimately in
+        // mocked/fixture data and is not an inflation signal — only an
+        // overflow index proves recursive chunk accumulation.
+        if (chunkCount > 0 && maxIndex >= 0 && maxIndex > chunkCount - 1) {
           const rangeError =
-            `Chunk index range mismatch: chunk_count=${chunkCount} but max_chunk_index=${maxIndex}. ` +
-            `Expected max_chunk_index=${chunkCount - 1}. Failing closed before persistence.`;
+            `Chunk index range mismatch: chunk_count=${chunkCount} but max_chunk_index=${maxIndex} exceeds expected upper bound ${chunkCount - 1}. ` +
+            `Failing closed before persistence.`;
           await markFailed(rangeError, 'CHUNK_INDEX_RANGE_MISMATCH', {
             pipelineStage: 'chunking',
             reasonCodes: ['CHUNK_INDEX_RANGE_MISMATCH'],

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -1972,17 +1972,18 @@ export async function processEvaluationJob(
         // baseIndexedChars + totalOverlapChars by more than a small safety
         // margin, otherwise the resolver picked up an already-overlap-inflated
         // source (the Issue #519 failure mode).
+        const routingRecord = chunkRouting as unknown as Record<string, unknown>;
         const baseIndexedChars =
-          typeof (chunkRouting as { base_chars?: unknown }).base_chars === 'number'
-            ? ((chunkRouting as { base_chars: number }).base_chars)
-            : typeof (chunkRouting as { resolved_text_chars?: unknown }).resolved_text_chars === 'number'
-            ? ((chunkRouting as { resolved_text_chars: number }).resolved_text_chars)
+          typeof routingRecord.base_chars === 'number'
+            ? (routingRecord.base_chars as number)
+            : typeof routingRecord.resolved_text_chars === 'number'
+            ? (routingRecord.resolved_text_chars as number)
             : 0;
         const perChunkOverlap = chunkRouting.overlap_chars ?? 0;
         const totalOverlapChars = chunkCount > 1 ? perChunkOverlap * (chunkCount - 1) : 0;
         const totalEmittedChars =
-          typeof (chunkRouting as { total_chunk_chars?: unknown }).total_chunk_chars === 'number'
-            ? ((chunkRouting as { total_chunk_chars: number }).total_chunk_chars)
+          typeof routingRecord.total_chunk_chars === 'number'
+            ? (routingRecord.total_chunk_chars as number)
             : 0;
         if (
           baseIndexedChars > 0 &&


### PR DESCRIPTION
# PR #520 — resolveManuscriptText source-priority fix

Closes #519.

## Type
evaluation

## Pass
- [x] Pass 1
- [x] Pass 2
- [ ] Pass 3

## Summary

Fixes the recursive-overlap inflation bug in `resolveManuscriptText` (`lib/evaluation/processor.ts`). The resolver previously prioritized reconstruction from `manuscript_chunks` over the canonical `file_url` data URI, causing each re-evaluation to inflate the resolved text by the chunker's overlap budget. Manuscript 6117 / Froggin Noggin inflated from the canonical manuscript source to `1,227,100` indexed chars and a `228,994`-word report display.

## Scope

This PR changes `resolveManuscriptText` in `lib/evaluation/processor.ts` and adds/keeps a focused source-priority guard test.

Files changed:

- `lib/evaluation/processor.ts`
- `__tests__/lib/evaluation/resolve-manuscript-text-source-priority.guard.test.ts`

Out of scope:

- `lib/manuscripts/chunking.ts`
- Pass 1 / Pass 2 / Pass 3 scoring logic
- Pass 4 / `perplexityCrossCheck.ts`
- prompts
- criteria list
- UI score display
- Score Ledger display bug
- Narrative Closure packet work
- PR #502 / Pass 4 evidence-packet work
- chunk reconstruction dedupe

## Contract Integrity

`resolveManuscriptText` priority order is now:

1. `manuscript.content` direct column
2. `file_url` data URI, canonical source for paste submissions
3. `manuscript_chunks` last-resort fallback only

Load-bearing invariants:

- Valid `file_url` path returns early and does not query `manuscript_chunks`.
- `file_url` data-URI decode failure throws and does not silently fall through to chunks.
- Required source-path strings are present: `resolveManuscriptText.content_column`, `resolveManuscriptText.file_url_data_uri`, `resolveManuscriptText.manuscript_chunks_fallback`.
- Required chunk sentinels are present: `CHUNK_INDEX_RANGE_MISMATCH`, `CHUNK_CONTENT_INFLATION`, `baseIndexedChars`, `totalOverlapChars`.

quality gate / anomaly disclosure: this PR does not change `QG_` behavior, scoring thresholds, Pass 4 governance, Pass 4 canon validation, or any prompt contract.

## Behavioral Quality

This PR only changes which manuscript text source is read. It does not alter scoring logic, prompts, criteria, or evidence packet shape. The model should receive the author's canonical manuscript text rather than an overlap-inflated reconstruction.

This is not reducing intelligence; it protects evaluation quality by preventing derived chunk cache rows from masquerading as canonical manuscript source.

## Latency Evidence

### Baseline (Pre-change)

| Run | Context | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Baseline | Froggin production run `cb200799-cb92-424f-ac8f-cf923ec1fb1e` | n/a | n/a | n/a | ~720000 | Completed with inflated `228,994`-word / `41`-chunk source view. |

### Post-change Runs

| Run | Context | pass1_ms | pass2_ms | pass3_ms | total_ms | Expected result |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Run 1 | CI / focused guard + build | n/a | n/a | n/a | n/a | Guard proves source priority and inflation sentinels are present. |
| Run 2 | Post-deploy Froggin proof rerun after chunk cleanup | TBD | TBD | TBD | TBD | Expected about `105,247` words and lower chunk count than `41`. |

Latency intent: reduce wasted long-form work by preventing duplicate/overlap-inflated source views from increasing chunk count and OpenAI call volume. No prompt expansion or model change is introduced.

## Risks & Anomalies

- A manuscript whose `manuscripts.content` is empty and whose `file_url` is malformed will now hard-fail instead of silently falling through to chunk reconstruction. This is intentional because silent fallthrough is the recursive-inflation bug.
- `CHUNK_CONTENT_INFLATION` is partially telemetry-dependent; where aggregate emitted/base telemetry is absent, the source-priority fix remains the primary protection.
- Existing stale `manuscript_chunks` rows for affected manuscripts must be cleaned after deploy.

Known cleanup after merge/deploy, subject to an in-flight job safety check:

```sql
DELETE FROM manuscript_chunks WHERE manuscript_id = 6117;
```

Run the audit query from #519 before broader cleanup. Delete chunks only for audited affected manuscript IDs and only when no queued/running job is using that manuscript.

## No merge until

- Runtime fix is committed.
- Guard test passes.
- Existing evaluation tests pass.
- PR is no longer draft.
- Pass 4, PR-D scoring logic, prompts, criteria list, and UI score display are untouched.

## Post-merge/deploy proof

After PR-E merges and production deploys:

1. Verify production `git_sha` equals the squash merge SHA.
2. Audit affected paste-submission manuscripts.
3. Clear stale chunks for audited affected manuscript IDs.
4. Rerun Froggin.
5. Expect roughly `105,247` words, not `228,994`, with a lower/mid-bracket chunk count than `41`.
