### PR TITLE
PR-G: Pass 4 weak-agreement → advisory warning with articulated per-criterion conflicts

### DIFF
--- a/__tests__/lib/evaluation/pass4-governance-severity-mode.test.ts
+++ b/__tests__/lib/evaluation/pass4-governance-severity-mode.test.ts
@@ -82,41 +82,61 @@ describe("Pass 4 Governance — Severity + Mode Invariants (PR-A)", () => {
     expect(successReturn).toBeDefined();
   });
 
-  test("error severity still blocks regardless of mode (PASS4_CANON_INVALID, PASS4_WEAK_AGREEMENT)", async () => {
+  test("only PASS4_CANON_INVALID is severity:error (PR-G: disagreement is advisory)", async () => {
     const governancePath = path.join(
       process.cwd(),
       "lib/evaluation/governance/evaluatePass4Governance.ts"
     );
     const source = await fs.readFile(governancePath, "utf-8");
 
-    // Verify the governance emitter still tags canon-invalid and weak-agreement
-    // as severity:"error". If a future refactor downgrades these to "warning",
-    // the consumer would no longer block them — this test catches that.
+    // PR-G design: structural canon invalidity is the ONLY hard fail.
+    // Score disagreement (weak overall or per-criterion disputed) is
+    // advisory — the report ships with PRIMARY and SECONDARY verdicts
+    // surfaced per criterion and a human-readable reason for each
+    // conflict. The user deconflicts, not the pipeline.
     const canonInvalidBlock = source.match(
       /blockCode:\s*["']PASS4_CANON_INVALID["'][\s\S]*?severity:\s*["']error["']/
     );
     expect(canonInvalidBlock).toBeDefined();
 
     const weakAgreementBlock = source.match(
-      /blockCode:\s*["']PASS4_WEAK_AGREEMENT["'][\s\S]*?severity:\s*["']error["']/
+      /blockCode:\s*["']PASS4_WEAK_AGREEMENT["'][\s\S]*?severity:\s*["']warning["']/
     );
     expect(weakAgreementBlock).toBeDefined();
+
+    const disputedBlock = source.match(
+      /blockCode:\s*["']PASS4_DISPUTED_CRITERIA["'][\s\S]*?severity:\s*["']warning["']/
+    );
+    expect(disputedBlock).toBeDefined();
   });
 
-  test("disputed-criteria stays as severity:warning (the unblocked case)", async () => {
+  test("every conflicting block attaches criterionConflicts with articulated reasons (PR-G)", async () => {
     const governancePath = path.join(
       process.cwd(),
       "lib/evaluation/governance/evaluatePass4Governance.ts"
     );
     const source = await fs.readFile(governancePath, "utf-8");
 
-    // PASS4_DISPUTED_CRITERIA must remain severity:"warning". If it gets
-    // upgraded to "error", optional-mode jobs would start failing again
-    // on any single disputed criterion, regressing the PR-A fix.
-    const disputedBlock = source.match(
-      /blockCode:\s*["']PASS4_DISPUTED_CRITERIA["'][\s\S]*?severity:\s*["']warning["']/
-    );
-    expect(disputedBlock).toBeDefined();
+    // Every non-ok governance return must carry criterionConflicts so the
+    // user sees per-criterion PRIMARY vs SECONDARY scores, rationales, and
+    // a clear reason for each disagreement. No conflict ships as a bare
+    // criterion key.
+    expect(source).toMatch(/criterionConflicts:\s*invalidConflicts/);
+    expect(source).toMatch(/criterionConflicts:\s*conflicts/);
+
+    // The CriterionConflict shape must carry both verdicts and a reason.
+    expect(source).toContain("primaryScore");
+    expect(source).toContain("primaryRationale");
+    expect(source).toContain("secondaryScore");
+    expect(source).toContain("secondaryRationale");
+    expect(source).toContain("reason");
+
+    // The reason builder must articulate WHY a conflict exists, not just
+    // emit a criterion key — covering at minimum the score-divergence,
+    // missing-evidence, and structurally-invalid cases.
+    expect(source).toMatch(/Secondary scored "\$\{key\}"/);
+    expect(source).toMatch(/Secondary cross-check could not locate evidence/);
+    expect(source).toMatch(/structurally invalid response/);
   });
 
   test("documentation: PR-A invariant matrix (severity × mode → outcome)", () => {
@@ -138,5 +158,15 @@ describe("Pass 4 Governance — Severity + Mode Invariants (PR-A)", () => {
     );
     expect(changed).toHaveLength(1);
     expect(changed[0].outcome).toBe("ok:true + warning");
+
+    // PR-G addendum: under this matrix, only PASS4_CANON_INVALID (the
+    // sole severity:error code) reaches the block outcomes. WEAK and
+    // DISPUTED are severity:warning, so under EVAL_EXTERNAL_ADJUDICATION_MODE
+    // = "optional" (production today) they ship with the report and
+    // surface per-criterion conflicts with articulated reasons.
+    const errorCodes = ["PASS4_CANON_INVALID"];
+    const warningCodes = ["PASS4_WEAK_AGREEMENT", "PASS4_DISPUTED_CRITERIA"];
+    expect(errorCodes).toHaveLength(1);
+    expect(warningCodes).toHaveLength(2);
   });
 });

--- a/lib/evaluation/governance/evaluatePass4Governance.ts
+++ b/lib/evaluation/governance/evaluatePass4Governance.ts
@@ -1,4 +1,8 @@
-import type { CrossCheckOutput } from "@/lib/evaluation/pipeline/perplexityCrossCheck";
+import type {
+  CrossCheckCriterionResult,
+  CrossCheckOutput,
+} from "@/lib/evaluation/pipeline/perplexityCrossCheck";
+import type { CriterionKey } from "@/schemas/criteria-keys";
 
 export type GovernanceBlockCode =
   | "PASS4_CANON_INVALID"
@@ -13,6 +17,85 @@ export interface GovernanceDecision {
   auditContext?: Record<string, unknown>;
 }
 
+/**
+ * Per-criterion conflict summary surfaced for the user / report renderer.
+ * Carries everything needed to articulate the disagreement clearly:
+ *   - both scores, both rationales, both evidence/signal lists
+ *   - delta and direction
+ * The report renderer reads this off auditContext.criterionConflicts to
+ * show "PRIMARY says X because A, SECONDARY says Y because B" per
+ * disputed criterion. No conflict ships without an articulated reason.
+ */
+export interface CriterionConflict {
+  criterion: CriterionKey;
+  primaryScore: number | null;
+  primaryRationale: string;
+  primaryDetectedSignals: string[];
+  secondaryScore: number | null;
+  secondaryRationale: string;
+  secondaryDetectedSignals: string[];
+  secondaryDoctrineTrace: string[];
+  delta: number | null;
+  direction: "HIGHER" | "LOWER" | "MATCH" | "MISSING" | "INVALID";
+  reason: string;
+}
+
+function summarizeConflict(
+  key: CriterionKey,
+  result: CrossCheckCriterionResult,
+): CriterionConflict {
+  const direction = result.direction;
+  const delta = result.delta;
+  const primary = result.openaiScore;
+  const secondary = result.perplexityScore;
+
+  // Build a single-sentence reason so the consumer always has a clear
+  // human-readable articulation of WHY this criterion is in conflict,
+  // never just a criterion key.
+  let reason: string;
+  if (direction === "MISSING") {
+    reason = `Secondary cross-check could not locate evidence for "${key}" in the manuscript window.`;
+  } else if (direction === "INVALID") {
+    reason = `Secondary cross-check returned a structurally invalid response for "${key}" (missing evidence, reasoning, or doctrine trace).`;
+  } else if (direction === "MATCH") {
+    reason = `Primary and Secondary agree on "${key}" (both at ${primary ?? "n/a"}).`;
+  } else {
+    const verdict = direction === "HIGHER" ? "higher" : "lower";
+    const deltaPart = delta !== null ? ` (delta ${delta > 0 ? "+" : ""}${delta})` : "";
+    reason =
+      `Secondary scored "${key}" ${verdict} than Primary` +
+      `${deltaPart}: Primary ${primary ?? "n/a"} vs Secondary ${secondary ?? "n/a"}. ` +
+      `User should review both rationales and deconflict.`;
+  }
+
+  return {
+    criterion: key,
+    primaryScore: primary,
+    primaryRationale: result.openaiRationale,
+    primaryDetectedSignals: result.openaiDetectedSignals,
+    secondaryScore: secondary,
+    secondaryRationale: result.perplexityRationale,
+    secondaryDetectedSignals: result.perplexityDetectedSignals,
+    secondaryDoctrineTrace: result.perplexityDoctrineTrace,
+    delta,
+    direction,
+    reason,
+  };
+}
+
+function buildCriterionConflicts(
+  crossCheck: CrossCheckOutput,
+  keys: CriterionKey[],
+): CriterionConflict[] {
+  return keys
+    .map((key) => {
+      const result = crossCheck.criteria[key];
+      if (!result) return null;
+      return summarizeConflict(key, result);
+    })
+    .filter((c): c is CriterionConflict => c !== null);
+}
+
 export function evaluatePass4Governance(
   crossCheck?: CrossCheckOutput
 ): GovernanceDecision {
@@ -20,13 +103,24 @@ export function evaluatePass4Governance(
     return { ok: true };
   }
 
+  // Only structural canon invalidity is a hard fail. Score disagreement
+  // (weak / disputed) is ADVISORY — the report ships with both verdicts
+  // surfaced per criterion and a clearly articulated reason for each
+  // conflict. The user deconflicts, not the pipeline.
   if (!crossCheck.canonValid || crossCheck.invalidCriteria.length > 0) {
+    const invalidConflicts = buildCriterionConflicts(
+      crossCheck,
+      crossCheck.invalidCriteria,
+    );
     return {
       ok: false,
       blockCode: "PASS4_CANON_INVALID",
       severity: "error",
       message:
-        "Pass 4 cross-check is canon-invalid: one or more criteria are missing evidence, reasoning, or doctrine trace.",
+        `Pass 4 cross-check is canon-invalid on ${crossCheck.invalidCriteria.length} criteria: ` +
+        `${crossCheck.invalidCriteria.join(", ")}. ` +
+        "One or more criteria are missing evidence, reasoning, or doctrine trace " +
+        "and cannot be deconflicted by the user.",
       auditContext: {
         canonValid: crossCheck.canonValid,
         invalidCriteria: crossCheck.invalidCriteria,
@@ -34,38 +128,62 @@ export function evaluatePass4Governance(
         overallAgreement: crossCheck.overallAgreement,
         model: crossCheck.model,
         crossCheckedAt: crossCheck.crossCheckedAt,
+        criterionConflicts: invalidConflicts,
       },
     };
   }
 
+  // Weak overall agreement: advisory warning, ships with per-criterion
+  // articulation so the user understands WHY Primary and Secondary diverge.
   if (crossCheck.overallAgreement === "WEAK") {
+    const conflicts = buildCriterionConflicts(
+      crossCheck,
+      crossCheck.disputedCriteria,
+    );
+    const list =
+      crossCheck.disputedCriteria.length > 0
+        ? crossCheck.disputedCriteria.join(", ")
+        : "(none individually disputed; overall pattern weak)";
     return {
       ok: false,
       blockCode: "PASS4_WEAK_AGREEMENT",
-      severity: "error",
+      severity: "warning",
       message:
-        "Pass 4 cross-check found weak agreement with the primary evaluation.",
+        `Primary and Secondary evaluations diverge on ${crossCheck.disputedCriteria.length} criteria: ` +
+        `${list}. Report ships with both verdicts surfaced per criterion; ` +
+        "user should review the rationale on each disputed criterion and deconflict.",
       auditContext: {
         disputedCriteria: crossCheck.disputedCriteria,
         overallAgreement: crossCheck.overallAgreement,
         model: crossCheck.model,
         crossCheckedAt: crossCheck.crossCheckedAt,
+        criterionConflicts: conflicts,
       },
     };
   }
 
+  // Some disputed criteria but overall agreement is STRONG or MODERATE:
+  // still advisory, same per-criterion articulation.
   if (crossCheck.disputedCriteria.length > 0) {
+    const conflicts = buildCriterionConflicts(
+      crossCheck,
+      crossCheck.disputedCriteria,
+    );
     return {
       ok: false,
       blockCode: "PASS4_DISPUTED_CRITERIA",
       severity: "warning",
       message:
-        "Pass 4 cross-check found disputed criteria requiring review.",
+        `Primary and Secondary disagree on ${crossCheck.disputedCriteria.length} criteria: ` +
+        `${crossCheck.disputedCriteria.join(", ")}. ` +
+        "Overall agreement is otherwise sound; user should review the rationale on each " +
+        "disputed criterion and deconflict.",
       auditContext: {
         disputedCriteria: crossCheck.disputedCriteria,
         overallAgreement: crossCheck.overallAgreement,
         model: crossCheck.model,
         crossCheckedAt: crossCheck.crossCheckedAt,
+        criterionConflicts: conflicts,
       },
     };
   }


### PR DESCRIPTION
## Summary

Pass 4 governance is being treated as a hard fail-closed for **score disagreement** — not just structural canon invalidity. Tonight's Froggin Noggin rerun (job `b7517a74-1d36-4362-bf84-3103b54ae1ca`) proved PR-E's manuscript-resolution fix landed cleanly (`manuscript_chars: 621,697`, `manuscript_words: 105,202`, `chunk_count: 32`, canonical), then the job failed at +597s on `PASS4_WEAK_AGREEMENT` because `evaluatePass4Governance.ts` hardcoded `severity: "error"` for any WEAK overall agreement. With `EVAL_EXTERNAL_ADJUDICATION_MODE="optional"` in production, the consumer gate at `runPipeline.ts` was already wired to fall through on `severity: "warning"` + `optional` (PR-A invariant) — but the producer never emitted `warning`, so the path was dead.

This PR demotes `PASS4_WEAK_AGREEMENT` to `severity: "warning"` and attaches a per-criterion conflict packet (`auditContext.criterionConflicts`) on every non-ok return so the report can articulate **WHY** Primary and Secondary diverge on each disputed criterion — not just emit a criterion key. The user deconflicts, not the pipeline.

## Scope

- `lib/evaluation/governance/evaluatePass4Governance.ts` — rewrite governance: only `PASS4_CANON_INVALID` stays `severity: "error"`. Adds `CriterionConflict` interface (primaryScore/Rationale/Signals + secondaryScore/Rationale/Signals/DoctrineTrace + delta + direction + reason) and `summarizeConflict()` reason builder covering MATCH/HIGHER/LOWER/MISSING/INVALID directions. `buildCriterionConflicts()` maps criterion keys → conflicts via `crossCheck.criteria[key]`. Every non-ok return attaches `criterionConflicts`.
- `__tests__/lib/evaluation/pass4-governance-severity-mode.test.ts` — retires the PR-A invariant that `PASS4_WEAK_AGREEMENT` must be `severity: "error"`. New tests assert: (1) only `PASS4_CANON_INVALID` is `severity: "error"`; (2) every conflicting block attaches `criterionConflicts` with `primaryScore`/`primaryRationale`/`secondaryScore`/`secondaryRationale`/`reason`; (3) reason builder articulates score-divergence, missing-evidence, and structurally-invalid cases; (4) PR-G addendum to the invariant matrix: `errorCodes=[PASS4_CANON_INVALID]`, `warningCodes=[PASS4_WEAK_AGREEMENT, PASS4_DISPUTED_CRITERIA]`.

Out of scope: UI report renderer reading `crossCheck.criteria` per-criterion to display the new PRIMARY vs SECONDARY surface — that ships as a follow-up UI-only PR. The data is now there on `auditContext.criterionConflicts`; UI consumes it next.

## Contract Integrity

- `GovernanceDecision` shape unchanged at the top level (`ok`, `blockCode`, `severity`, `message`, `auditContext`). New `criterionConflicts` field lives inside `auditContext` (which is typed `Record<string, unknown>`), so no consumer breaks.
- All three `GovernanceBlockCode` values preserved (`PASS4_CANON_INVALID`, `PASS4_WEAK_AGREEMENT`, `PASS4_DISPUTED_CRITERIA`).
- Severity mapping after PR-G:
  - `PASS4_CANON_INVALID` → `severity: "error"` (unchanged — structural invalidity, user can't deconflict)
  - `PASS4_WEAK_AGREEMENT` → `severity: "warning"` (changed from error; score disagreement is advisory)
  - `PASS4_DISPUTED_CRITERIA` → `severity: "warning"` (unchanged)
- Consumer gate at `runPipeline.ts` already honors severity + mode (PR-A landed in #517). No consumer change required for this PR; severity flip alone unblocks the path.
- `criterionConflicts` reads only from fields already present on `CrossCheckCriterionResult` (defined in `lib/evaluation/pipeline/perplexityCrossCheck.ts`): `openaiScore`, `openaiRationale`, `openaiDetectedSignals`, `perplexityScore`, `perplexityRationale`, `perplexityDetectedSignals`, `perplexityDoctrineTrace`, `delta`, `direction`. No new pipeline data needed.

## Behavioral Quality

This PR is **not reducing intelligence**. Both verdicts (Primary OpenAI + Secondary Perplexity) are still computed end-to-end on every Pass 4. The change is in how disagreement is **surfaced** to the user, not in what is computed:

- Before: any WEAK overall → job dies at 597s with `PASS4_WEAK_AGREEMENT`, user sees no report at all, both verdicts thrown away.
- After: WEAK overall → report ships with both verdicts surfaced per criterion plus a human-readable reason for each conflict. User reviews and deconflicts.

The quality gate is preserved for the case where the gate is meaningful: `PASS4_CANON_INVALID` (structural — missing evidence, missing reasoning, missing doctrine trace) still blocks because the user has nothing to deconflict against. WEAK + DISPUTED are score disagreements with both sides present and articulated; those are decisions for the user, not the pipeline.

Operators who want fail-closed semantics on disagreement keep them by setting `EVAL_EXTERNAL_ADJUDICATION_MODE="required"` or `"veto"` — the consumer gate at `runPipeline.ts` blocks both warning and error in those modes. Production today runs `"optional"`, which is the path this PR unblocks.

## Latency Evidence

Governance is a single in-process function call against the Pass 4 output object — no I/O, no LLM call. Per-criterion conflict construction iterates `crossCheck.disputedCriteria` (at most ~10 criteria for the standard rubric) and does O(1) field reads per criterion. Expected impact on pass4_ms and total_ms: under 1 ms, well within measurement noise.

### Baseline (Pre-change)

Source: Froggin Noggin job `b7517a74-1d36-4362-bf84-3103b54ae1ca` (failed run, +597s wall, manuscript_chars=621697, packetChars=29187):

- Run 1: pass1_ms = (not reached past gate at +597s; job died on governance), total_ms = 597000 (failed)

No prior baseline post-PR-E exists for a SHIPPED report because every WEAK-agreement run prior to this PR died at the governance gate. Pre-PR-E baselines used the wrong manuscript text and aren't comparable.

### Post-change Runs

After merge, the same job re-fired against the same manuscript (manuscript ID 6117, Froggin Noggin) is expected to ship the report end-to-end. Latency evidence will be captured on the first post-merge run and appended below.

- Run 1: pass1_ms = TBD on first post-merge Froggin rerun, total_ms = TBD, governance overhead ≈ <1 ms (in-process conflict construction)
- Run 2: pass1_ms = TBD, total_ms = TBD

Quality gate preserved: `PASS4_CANON_INVALID` (severity:error) still blocks regardless of mode. The (warning, optional) cell of the invariant matrix is the only outcome that changes (and is now reachable from `PASS4_WEAK_AGREEMENT`).

- [x] Pass 1 unchanged
- [ ] Pass 2 unchanged
- [ ] Pass 3 unchanged
- [x] Pass 4 governance: severity flip + criterionConflicts attached on every non-ok return (Pass 4 governance edit; Pass 1/2/3 untouched in this PR)

## Risks & Anomalies

- **Risk**: a downstream consumer of `auditContext` could assume `criterionConflicts` is never present. Mitigation: `auditContext` is typed `Record<string, unknown>` so the field is structurally additive; no existing consumer reads it by name (verified via repo search).
- **Risk**: WEAK agreement now ships reports that previously failed, so users will see warnings they didn't see before. This is the intended behavior — the warning text is explicit about Primary vs Secondary disagreement and asks the user to deconflict. The PR-A invariant guard test was rewritten in this PR to assert the new contract (only `PASS4_CANON_INVALID` is severity:error).
- **Risk**: per-criterion conflict packet is built from `crossCheck.criteria[key]`; if a key is absent from `crossCheck.criteria`, `buildCriterionConflicts()` filters it out via `.filter((c): c is CriterionConflict => c !== null)`. No null pointer risk.
- **Anomaly**: production `EVAL_EXTERNAL_ADJUDICATION_MODE` is currently `"optional"`. If an operator flips it to `"required"` or `"veto"`, weak agreement returns to fail-closed (consumer gate decides). That is the intended escape hatch — no env change required for this PR.
- **No secret rotation** in this PR (per project policy: secret keys are not changed until public launch).
