### PR TITLE
PR-J: Display + language fixes (Normalized denom, certification language, TESTIMONY proposal)

### DIFF
--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -752,9 +752,12 @@ export default async function EvaluationReportPage({
               <div className="mt-3 rounded-md border bg-gray-50 p-3 text-xs text-gray-700">
                 <p>
                   <span className="font-medium">Score Ledger:</span>{" "}
-                  Raw {artifact.governance.transparency.score_ledger.raw_total} / {artifact.governance.transparency.score_ledger.max_total},
-                  Normalized {artifact.governance.transparency.score_ledger.normalized_total} / 100,
+                  Raw {artifact.governance.transparency.score_ledger.raw_total} / {artifact.governance.transparency.score_ledger.max_total},{" "}
+                  Weighted composite {artifact.governance.transparency.score_ledger.normalized_total} / 10,{" "}
                   Weighting {artifact.governance.transparency.score_ledger.weighting}
+                </p>
+                <p className="mt-1 text-[11px] text-gray-500">
+                  Weighted composite is the canonical 0–10 score (weighted across 13 criteria). The Overall Score above is the same value rescaled to 0–100 for ease of reading.
                 </p>
               </div>
             )}

--- a/components/evaluation/ModeConfirmationBlock.tsx
+++ b/components/evaluation/ModeConfirmationBlock.tsx
@@ -78,8 +78,29 @@ export default function ModeConfirmationBlock({ jobId, detectedMode, confirmedMo
       </div>
 
       <p className="mt-2 text-sm text-gray-700">
-        Proposed: <span className="font-semibold">{detectedMode.proposedEvaluationMode}</span> ·{" "}
-        <span className="font-semibold">{detectedMode.proposedVoicePreservationMode}</span>
+        {/*
+          PR-J (2026-05-16): TESTIMONY mode was previously surfaced as a confident
+          "Proposed: TESTIMONY · MAXIMUM" which over-stated the system's certainty
+          and risked appearing to label real lived events. TESTIMONY/STANDARD/
+          TRANSGRESSIVE detection runs on textual markers alone and cannot, by
+          design, distinguish a memoir from a novel that mimics one. The softer
+          "Possible … — confirmation required" wording communicates that this is
+          a triage hint pending author confirmation, not a classification.
+        */}
+        {detectedMode.proposedEvaluationMode === "TESTIMONY" ? (
+          <>
+            Possible testimony / sensitive-material content — confirmation required.{" "}
+            <span className="text-gray-600">
+              Suggested voice preservation:{" "}
+              <span className="font-semibold">{detectedMode.proposedVoicePreservationMode}</span>.
+            </span>
+          </>
+        ) : (
+          <>
+            Proposed: <span className="font-semibold">{detectedMode.proposedEvaluationMode}</span> ·{" "}
+            <span className="font-semibold">{detectedMode.proposedVoicePreservationMode}</span>
+          </>
+        )}
       </p>
 
       <ul className="mt-3 list-disc pl-5 text-sm text-gray-700 space-y-1">

--- a/lib/evaluation/reportCriterionDisplay.ts
+++ b/lib/evaluation/reportCriterionDisplay.ts
@@ -125,9 +125,22 @@ export function getCriterionRationalePresentation(
 }
 
 export function getCertifiedCriteriaSummary(criteria: RenderableCriterion[]): string {
+  // PR-J (2026-05-16): the legacy label "N of N certified" misled readers into
+  // thinking every criterion carried equally strong evidence. "Certified" here
+  // means scorable (the criterion had at least minimal observable signal), not
+  // that it reached high confidence. Confidence is reported per-criterion via
+  // getConfidencePresentation. The new label keeps the count but makes the
+  // confidence variance explicit so readers do not over-trust uniform-looking
+  // scores (e.g. Prose Control rendered alongside a Low Confidence badge).
   const total = criteria.length;
-  const certified = criteria.filter((criterion) => isCertifiedCriterion(criterion)).length;
-  return `${certified} of ${total} criteria certified`;
+  const scorable = criteria.filter((criterion) => isCertifiedCriterion(criterion)).length;
+  if (total === 0) {
+    return "No criteria scored";
+  }
+  if (scorable === total) {
+    return `${scorable} of ${total} criteria scored — confidence varies per criterion (see badges below)`;
+  }
+  return `${scorable} of ${total} criteria scored — ${total - scorable} non-scorable; confidence varies per criterion (see badges below)`;
 }
 
 export function sanitizeRenderData<T>(value: T): T {

--- a/tests/lib/evaluation/reportCriterionDisplay.test.ts
+++ b/tests/lib/evaluation/reportCriterionDisplay.test.ts
@@ -34,13 +34,39 @@ describe('reportCriterionDisplay helpers', () => {
   });
 
   test('certified-count summary is correct', () => {
+    // PR-J (2026-05-16): updated label semantics. "Certified" misled readers
+    // into assuming every criterion carried equally strong evidence. Replaced
+    // with "scored" + explicit per-criterion confidence variance disclosure.
     const criteria: RenderableCriterion[] = [
       { status: 'SCORABLE', score_0_10: 7, scorable: true },
       { status: 'SCORABLE', score_0_10: 8, scorable: true },
       { status: 'INSUFFICIENT_SIGNAL', score_0_10: null, scorable: false },
     ];
 
-    expect(getCertifiedCriteriaSummary(criteria)).toBe('2 of 3 criteria certified');
+    expect(getCertifiedCriteriaSummary(criteria)).toBe(
+      '2 of 3 criteria scored — 1 non-scorable; confidence varies per criterion (see badges below)',
+    );
+  });
+
+  test('all-scorable summary surfaces confidence variance disclosure', () => {
+    // PR-J: explicit smoke test for the all-scorable branch — ensures the
+    // "confidence varies" wording is present even when every criterion scored,
+    // preventing readers from over-trusting a uniform-looking '13 of 13' line.
+    const criteria: RenderableCriterion[] = Array.from({ length: 13 }, () => ({
+      status: 'SCORABLE' as const,
+      score_0_10: 7,
+      scorable: true,
+    }));
+
+    expect(getCertifiedCriteriaSummary(criteria)).toBe(
+      '13 of 13 criteria scored — confidence varies per criterion (see badges below)',
+    );
+  });
+
+  test('empty criteria yields safe fallback summary', () => {
+    // PR-J: defensive branch for empty input — must not divide-by-zero or
+    // emit '0 of 0 ... 0 non-scorable; confidence varies' nonsense.
+    expect(getCertifiedCriteriaSummary([])).toBe('No criteria scored');
   });
 
   test('scorable criteria still render numeric score normally', () => {


### PR DESCRIPTION
## Summary
PR-J fixes three report-surface defects flagged by independent QA on the live Froggin Noggin ship (job `0e6734be-a476-433a-a19d-3ecb9d64eea5`). Display layer only — no pipeline, scoring, or governance changes.

## Scope
4 files: 2 UI (evaluate page, ModeConfirmationBlock) + 1 lib (reportCriterionDisplay) + 1 unit test.

## Fix 1: Score Ledger normalization label (flag #3)
ScoreLedger rendered `Normalized 6.17 / 100`. Per `lib/evaluation/pipeline/buildScoreLedger.ts:156-178`, the `normalized` field is the **weighted composite on the 0-10 scale**, not 0-100. The display denominator literal was wrong, not the value.

**Fix:** relabel as `Weighted composite X / 10` and add one-line explanation that the Overall Score above is the same value rescaled to 0-100. No data-layer changes.

## Fix 2: certified-criteria summary language (flag #2)
The summary `13 of 13 criteria certified` implied uniform high evidence support. In practice, `certified` here only means SCORABLE — a criterion can be SCORABLE yet carry a Low Confidence badge (the Froggin Noggin Prose Control row was exactly this case).

**Fix:** rephrase to `N of N criteria scored — confidence varies per criterion (see badges below)` and surface non-scorable counts when present. Defensive empty-input branch added.

## Fix 3: TESTIMONY mode proposal language (flag #4)
`ModeConfirmationBlock` rendered `Proposed: TESTIMONY · MAXIMUM` as the headline label. This overstated certainty and risked labeling a novel as factual testimony (the detector is marker-based and cannot distinguish memoir from a novel that imitates one).

**Fix:** when `proposedEvaluationMode === 'TESTIMONY'`, render the softer `Possible testimony / sensitive-material content — confirmation required.` STANDARD and TRANSGRESSIVE renderings unchanged.

## Contract Integrity
- score_ledger payload schema unchanged.
- isCertifiedCriterion semantics unchanged.
- ModeConfirmationBlock dropdown options unchanged.

## Behavioral Quality
Removes three reader-confidence flags. **Not reducing intelligence**; clarifying intelligence the pipeline already produces correctly.

## Latency Evidence
Baseline (Pre-change): N/A (UI-only).
Post-change Runs:
- Run 1: pass1_ms / pass2_ms / pass3_ms / total_ms unchanged by construction.
- Run 2: SSR / client render impact negligible (three short conditional branches added).

[x] Pass 1: not touched.
[x] Pass 2: not touched.

## Risks & Anomalies
- Unit test asserts new literal string → updated in this PR.
- Canon docs still say "certified" → reconcile in follow-up docs-only PR.

Quality Gate: not reducing intelligence; making it legible.