### PR TITLE
fix(report): restore full DREAM §1–§16 rendering + fail-safe adapters

### DIFF
--- a/__tests__/app/reports/dream-renderer-sections.guard.test.ts
+++ b/__tests__/app/reports/dream-renderer-sections.guard.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import * as path from "path";
+
+describe("DREAM renderer section coverage guard", () => {
+  test("report page includes canonical §1–§16 section headings", () => {
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "app/reports/[jobId]/page.tsx"),
+      "utf8",
+    );
+
+    const requiredHeadings = [
+      "Executive Verdict",
+      "Market Shelf",
+      "Anti-Patterns to Avoid",
+      "Structural Stack",
+      "Arc Map",
+      "Criterion Analyses",
+      "Layer Analyses",
+      "Cross-Layer Integration",
+      "Symbolic / Doctrine Audit",
+      "Reader Experience",
+      "Revision Plan",
+      "Releasability",
+      "Acceptance Checks",
+      "Calibration Notes",
+      "Repository Summary",
+    ];
+
+    for (const heading of requiredHeadings) {
+      expect(source).toContain(heading);
+    }
+  });
+});

--- a/__tests__/fixtures/dreamDocs.ts
+++ b/__tests__/fixtures/dreamDocs.ts
@@ -1,0 +1,191 @@
+export const malformedDreamDocFixture = {
+  dream_scores: { quality: "high", readiness: null },
+  executive_verdict: 1234,
+  market_shelf: {
+    best_shelf: "",
+    marketable_hook: null,
+    market_danger: "  ",
+  },
+  what_not_to_become: [null, "", 42],
+  structural_stack: [null, "bad"],
+  arc_map: "not-an-array",
+  criterion_analyses: [{ key: "voice", score: "8" }],
+  layer_analyses: [1, 2],
+  cross_layer_integration: null,
+  symbolic_audit: {
+    preserved_symbols: ["nope"],
+    doctrine_strengths: [""],
+    doctrine_risks: null,
+    audit_conclusion: 100,
+  },
+  reader_experience: {
+    first_act: "bad",
+    middle: null,
+    final_act: {},
+    aftertaste: null,
+  },
+  revision_plan: ["bad-entry"],
+  releasability: null,
+  acceptance_checks: { required_detection: "bad", failure_conditions: null },
+  calibration_notes: ["", 10],
+  repo_summary: {
+    benchmark_name: null,
+    source: 22,
+    evaluation_type: {},
+    overall_score: "90",
+    readiness_score: null,
+    primary_strengths: "x",
+    primary_blockers: null,
+    gold_standard_requirement: {},
+  },
+  manuscript_integrity_issues: ["bad"],
+};
+
+export const fullDreamDocFixture = {
+  executive_verdict: "Strong manuscript with targeted revision priorities.",
+  dream_scores: {
+    quality: 89,
+    readiness: 84,
+    commercial: 78,
+    literary: 91,
+  },
+  market_shelf: {
+    best_shelf: "Upmarket Literary Fantasy",
+    shelf_neighbors: ["Speculative Literary", "Book Club Fantasy"],
+    comparison_space: ["Piranesi", "The Spear Cuts Through Water"],
+    marketable_hook: "Mythic courtroom intrigue with intimate POV.",
+    market_danger: "Opening pace may underserve commercial readers.",
+  },
+  what_not_to_become: [
+    "Do not flatten the close-third voice into summary exposition.",
+    "Do not over-explain symbolic motifs.",
+  ],
+  structural_stack: [
+    {
+      layer_name: "Narrative Arc",
+      function: "Escalates conflict",
+      status: "strong",
+      revision_note: "Tighten midpoint reveal placement.",
+    },
+  ],
+  arc_map: [
+    {
+      act_name: "Act I",
+      chapter_range: "1-8",
+      primary_function: "World grounding and inciting fracture",
+      revision_priority: "Clarify stakes by chapter 3",
+    },
+  ],
+  criterion_analyses: [
+    {
+      key: "voice",
+      score: 9,
+      confidence: "High",
+      fit_evidence: ["Consistent diction under pressure scenes."],
+      gap_evidence: ["Occasional distance during exposition."],
+      revision_queue: ["Convert summary blocks to dramatized beats."],
+    },
+  ],
+  layer_analyses: [
+    {
+      layer_name: "Character Dynamics",
+      status: "moderate",
+      needed_revision: "Sharpen antagonist interiority windows.",
+    },
+  ],
+  cross_layer_integration: [
+    {
+      motif: "Water Oaths",
+      description: "Connects doctrine and political betrayal",
+      integration_quality: "moderate",
+      revision_note: "Echo motif in Act III confrontation.",
+    },
+  ],
+  symbolic_audit: {
+    preserved_symbols: [
+      {
+        symbol: "Silver Thread",
+        current_function: "Carries memory lineage",
+        revision_instruction: "Reinforce in chapter transitions.",
+      },
+    ],
+    doctrine_strengths: ["Clear belief-cost relationship."],
+    doctrine_risks: ["One doctrine passage trends abstract."],
+    audit_conclusion: "Symbol system is coherent with manageable drift risk.",
+  },
+  reader_experience: {
+    first_act: {
+      reader_question: "Can the protagonist trust inherited law?",
+      emotional_state: "Curious tension",
+      risk: "Slow early disclosure",
+    },
+    middle: {
+      reader_question: "Which alliance survives the doctrine split?",
+      emotional_state: "Escalating dread",
+      risk: "Secondary arc dilution",
+    },
+    final_act: {
+      reader_question: "Will moral cost match thematic promise?",
+      emotional_state: "Cathartic pressure",
+      risk: "Resolution compression",
+    },
+    aftertaste: "Lingering moral unease with earned closure.",
+  },
+  revision_plan: [
+    {
+      priority: 1,
+      title: "Stakes Compression",
+      goal: "Accelerate consequence visibility",
+      actions: ["Move tribunal threat to chapter 2."],
+      acceptance_check: "Beta readers identify stakes by chapter 3.",
+    },
+  ],
+  releasability: [
+    {
+      dimension: "Narrative coherence",
+      current_status: "Strong with localized drag",
+      verdict: "Near-ready",
+    },
+  ],
+  acceptance_checks: {
+    required_detection: ["Voice continuity", "Arc escalation"],
+    failure_conditions: ["Act II stall", "Symbol contradiction"],
+  },
+  calibration_notes: ["Benchmark alignment within accepted variance."],
+  repo_summary: {
+    benchmark_name: "froggin-noggin-dream",
+    source: "longform_document_v1",
+    evaluation_type: "long_form",
+    overall_score: 88,
+    readiness_score: 84,
+    primary_strengths: ["Voice control", "Thematic integration"],
+    primary_blockers: ["Opening pace"],
+    gold_standard_requirement: "Resolve Act II propulsion risk before release.",
+  },
+  manuscript_integrity_issues: [
+    {
+      kind: "toc_gap",
+      description: "One chapter title mismatch in TOC export",
+      severity: "minor",
+    },
+  ],
+};
+
+export const canonicalDreamSectionKeys = [
+  "executive_verdict",
+  "dream_scores",
+  "market_shelf",
+  "what_not_to_become",
+  "structural_stack",
+  "arc_map",
+  "criterion_analyses",
+  "layer_analyses",
+  "cross_layer_integration",
+  "symbolic_audit",
+  "reader_experience",
+  "revision_plan",
+  "releasability",
+  "acceptance_checks",
+  "calibration_notes",
+  "repo_summary",
+] as const;

--- a/__tests__/lib/evaluation/reportRenderSafety.test.ts
+++ b/__tests__/lib/evaluation/reportRenderSafety.test.ts
@@ -1,0 +1,59 @@
+import {
+  getDisplayDateTime,
+  getDisplayDreamList,
+  getDisplayDreamMarketField,
+  getDisplayDreamScore,
+  getDisplayText,
+} from "@/lib/evaluation/reportRenderSafety";
+import {
+  canonicalDreamSectionKeys,
+  fullDreamDocFixture,
+  malformedDreamDocFixture,
+} from "@/__tests__/fixtures/dreamDocs";
+
+describe("reportRenderSafety", () => {
+  test("getDisplayText returns fallback for non-renderable values", () => {
+    expect(getDisplayText({ value: 1 })).toBe("—");
+    expect(getDisplayText("   ", "n/a")).toBe("n/a");
+    expect(getDisplayText("  ready  ")).toBe("ready");
+  });
+
+  test("getDisplayDateTime fails closed for invalid timestamps", () => {
+    expect(getDisplayDateTime("not-a-date", "Unknown")).toBe("Unknown");
+    expect(getDisplayDateTime("", "Unknown")).toBe("Unknown");
+    expect(getDisplayDateTime("2026-05-01T10:00:00.000Z", "Unknown")).not.toBe("Unknown");
+  });
+
+  test("getDisplayDreamScore returns em dash for malformed score blocks", () => {
+    const malformed = malformedDreamDocFixture as unknown as Parameters<typeof getDisplayDreamScore>[0];
+    const valid = fullDreamDocFixture as unknown as Parameters<typeof getDisplayDreamScore>[0];
+
+    expect(getDisplayDreamScore(malformed, "quality")).toBe("—");
+    expect(getDisplayDreamScore(valid, "quality")).toBe("89");
+    expect(getDisplayDreamScore(null, "readiness")).toBe("—");
+  });
+
+  test("getDisplayDreamList filters non-strings and blanks", () => {
+    expect(getDisplayDreamList(["  Keep tension  ", "", 42, null, "Trim exposition"]))
+      .toEqual(["Keep tension", "Trim exposition"]);
+    expect(getDisplayDreamList("not-an-array")).toEqual([]);
+  });
+
+  test("getDisplayDreamMarketField returns null on missing/blank fields", () => {
+    const doc = fullDreamDocFixture as unknown as Parameters<typeof getDisplayDreamMarketField>[0];
+
+    expect(getDisplayDreamMarketField(doc, "best_shelf")).toBe("Upmarket Literary Fantasy");
+    expect(getDisplayDreamMarketField(doc, "marketable_hook")).toBe("Mythic courtroom intrigue with intimate POV.");
+    expect(getDisplayDreamMarketField(doc, "market_danger")).toBe("Opening pace may underserve commercial readers.");
+    expect(
+      getDisplayDreamMarketField(malformedDreamDocFixture as unknown as Parameters<typeof getDisplayDreamMarketField>[0], "marketable_hook"),
+    ).toBeNull();
+    expect(getDisplayDreamMarketField(null, "best_shelf")).toBeNull();
+  });
+
+  test("full fixture exposes all canonical DREAM section keys", () => {
+    for (const key of canonicalDreamSectionKeys) {
+      expect(Object.prototype.hasOwnProperty.call(fullDreamDocFixture, key)).toBe(true);
+    }
+  });
+});

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -16,6 +16,15 @@ import {
   getCriterionRationalePresentation,
   getCriterionSupportLabel,
 } from '@/lib/evaluation/reportCriterionDisplay';
+import {
+  getDisplayDateTime,
+  getDisplayDreamList,
+  getDisplayDreamMarketField,
+  getDisplayObjectArray,
+  getDisplayRecord,
+  getDisplayDreamScore,
+  getDisplayText,
+} from '@/lib/evaluation/reportRenderSafety';
 import { resolveReportTitle } from '@/lib/evaluation/reportTitle';
 import type { LongformDreamDocument } from '@/lib/evaluation/pipeline/runPass3bLongform';
 
@@ -175,6 +184,32 @@ export default async function ReportPage({ params }: { params: { jobId: string }
   const wordCount = result.metrics?.manuscript?.word_count ?? 0;
   const isLongForm = wordCount >= 25000;
   const dreamDoc = isLongForm ? await getDreamArtifact(params.jobId) : null;
+  const dreamExecutiveVerdict = getDisplayText(dreamDoc?.executive_verdict, "No executive verdict available.");
+  const dreamBestShelf = getDisplayDreamMarketField(dreamDoc, "best_shelf");
+  const dreamMarketableHook = getDisplayDreamMarketField(dreamDoc, "marketable_hook");
+  const dreamMarketDanger = getDisplayDreamMarketField(dreamDoc, "market_danger");
+  const dreamAntiPatterns = getDisplayDreamList(dreamDoc?.what_not_to_become);
+  const dreamStructuralStack = getDisplayObjectArray(dreamDoc?.structural_stack);
+  const dreamArcMap = getDisplayObjectArray(dreamDoc?.arc_map);
+  const dreamCriterionAnalyses = getDisplayObjectArray(dreamDoc?.criterion_analyses);
+  const dreamLayerAnalyses = getDisplayObjectArray(dreamDoc?.layer_analyses);
+  const dreamCrossLayerIntegration = getDisplayObjectArray(dreamDoc?.cross_layer_integration);
+  const dreamSymbolicAudit = getDisplayRecord(dreamDoc?.symbolic_audit);
+  const dreamPreservedSymbols = getDisplayObjectArray(dreamSymbolicAudit?.preserved_symbols);
+  const dreamDoctrineStrengths = getDisplayDreamList(dreamSymbolicAudit?.doctrine_strengths);
+  const dreamDoctrineRisks = getDisplayDreamList(dreamSymbolicAudit?.doctrine_risks);
+  const dreamReaderExperience = getDisplayRecord(dreamDoc?.reader_experience);
+  const dreamReaderFirstAct = getDisplayRecord(dreamReaderExperience?.first_act);
+  const dreamReaderMiddle = getDisplayRecord(dreamReaderExperience?.middle);
+  const dreamReaderFinalAct = getDisplayRecord(dreamReaderExperience?.final_act);
+  const dreamRevisionPlan = getDisplayObjectArray(dreamDoc?.revision_plan);
+  const dreamReleasability = getDisplayObjectArray(dreamDoc?.releasability);
+  const dreamAcceptanceChecks = getDisplayRecord(dreamDoc?.acceptance_checks);
+  const dreamRequiredDetections = getDisplayDreamList(dreamAcceptanceChecks?.required_detection);
+  const dreamFailureConditions = getDisplayDreamList(dreamAcceptanceChecks?.failure_conditions);
+  const dreamCalibrationNotes = getDisplayDreamList(dreamDoc?.calibration_notes);
+  const dreamRepoSummary = getDisplayRecord(dreamDoc?.repo_summary);
+  const dreamIntegrityIssues = getDisplayObjectArray(dreamDoc?.manuscript_integrity_issues);
 
   // D2 fail-closed: block forbidden market guarantee language from rendering in agent-facing output.
   if (scanObjectForForbiddenMarketClaims(result)) {
@@ -266,7 +301,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
             </p>
           )}
           <p className="text-gray-600">
-            Generated {new Date(result.generated_at).toLocaleString()}
+            Generated {getDisplayDateTime(result.generated_at, "Unknown")}
           </p>
         </header>
 
@@ -473,12 +508,12 @@ export default async function ReportPage({ params }: { params: { jobId: string }
 
             {dreamDoc ? (
               <div className="space-y-6">
-                {/* DREAM Scores */}
+                {/* §1 — Executive verdict + DREAM scores */}
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                   {(['quality', 'readiness', 'commercial', 'literary'] as const).map((dim) => (
                     <div key={dim} className="bg-indigo-50 rounded-lg p-3 text-center">
                       <p className="text-xs text-indigo-600 uppercase font-semibold tracking-wide mb-1">{dim}</p>
-                      <p className="text-2xl font-bold text-indigo-900">{dreamDoc.dream_scores[dim]}</p>
+                      <p className="text-2xl font-bold text-indigo-900">{getDisplayDreamScore(dreamDoc, dim)}</p>
                       <p className="text-xs text-indigo-500">/100</p>
                     </div>
                   ))}
@@ -487,40 +522,271 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                 {/* Executive Verdict */}
                 <div>
                   <h3 className="text-lg font-semibold text-gray-900 mb-2">Executive Verdict</h3>
-                  <p className="text-gray-700 leading-relaxed whitespace-pre-line">{dreamDoc.executive_verdict}</p>
+                  <p className="text-gray-700 leading-relaxed whitespace-pre-line">{dreamExecutiveVerdict}</p>
                 </div>
 
-                {/* Market Shelf */}
-                {dreamDoc.market_shelf && (
-                  <div>
-                    <h3 className="text-lg font-semibold text-gray-900 mb-2">Market Shelf</h3>
-                    <p className="text-sm text-gray-600 mb-1">
-                      <span className="font-medium">Best shelf:</span> {dreamDoc.market_shelf.best_shelf}
-                    </p>
-                    {dreamDoc.market_shelf.marketable_hook && (
-                      <p className="text-sm text-gray-600 mb-1">
-                        <span className="font-medium">Marketable hook:</span> {dreamDoc.market_shelf.marketable_hook}
-                      </p>
-                    )}
-                    {dreamDoc.market_shelf.market_danger && (
-                      <p className="text-sm text-rose-700">
-                        <span className="font-medium">Market danger:</span> {dreamDoc.market_shelf.market_danger}
-                      </p>
-                    )}
-                  </div>
-                )}
+                {/* §2 — Market shelf */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Market Shelf</h3>
+                  <p className="text-sm text-gray-600 mb-1">
+                    <span className="font-medium">Best shelf:</span> {dreamBestShelf ?? "—"}
+                  </p>
+                  <p className="text-sm text-gray-600 mb-1">
+                    <span className="font-medium">Marketable hook:</span> {dreamMarketableHook ?? "—"}
+                  </p>
+                  <p className="text-sm text-rose-700">
+                    <span className="font-medium">Market danger:</span> {dreamMarketDanger ?? "—"}
+                  </p>
+                </div>
 
-                {/* What Not To Become */}
-                {Array.isArray(dreamDoc.what_not_to_become) && dreamDoc.what_not_to_become.length > 0 && (
-                  <div>
-                    <h3 className="text-lg font-semibold text-gray-900 mb-2">Anti-Patterns to Avoid</h3>
+                {/* §3 — What not to become */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Anti-Patterns to Avoid</h3>
+                  {dreamAntiPatterns.length > 0 ? (
                     <ul className="list-disc list-inside space-y-1">
-                      {dreamDoc.what_not_to_become.map((item, idx) => (
+                      {dreamAntiPatterns.map((item, idx) => (
                         <li key={idx} className="text-sm text-gray-700">{item}</li>
                       ))}
                     </ul>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §4 — Structural stack */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Structural Stack</h3>
+                  {dreamStructuralStack.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamStructuralStack.map((layer, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Layer:</span> {getDisplayText(layer.layer_name)}</p>
+                          <p><span className="font-medium">Function:</span> {getDisplayText(layer.function)}</p>
+                          <p><span className="font-medium">Status:</span> {getDisplayText(layer.status)}</p>
+                          <p><span className="font-medium">Revision note:</span> {getDisplayText(layer.revision_note)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §5 — Arc map */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Arc Map</h3>
+                  {dreamArcMap.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamArcMap.map((arc, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Act:</span> {getDisplayText(arc.act_name)}</p>
+                          <p><span className="font-medium">Chapter range:</span> {getDisplayText(arc.chapter_range)}</p>
+                          <p><span className="font-medium">Primary function:</span> {getDisplayText(arc.primary_function)}</p>
+                          <p><span className="font-medium">Revision priority:</span> {getDisplayText(arc.revision_priority)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §7 — Criterion analyses */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Criterion Analyses</h3>
+                  {dreamCriterionAnalyses.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamCriterionAnalyses.map((analysis, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Criterion:</span> {getDisplayText(analysis.key)}</p>
+                          <p><span className="font-medium">Score:</span> {getDisplayText(analysis.score)}</p>
+                          <p><span className="font-medium">Confidence:</span> {getDisplayText(analysis.confidence)}</p>
+                          <p><span className="font-medium">Fit evidence:</span> {getDisplayDreamList(analysis.fit_evidence).join("; ") || "—"}</p>
+                          <p><span className="font-medium">Gap evidence:</span> {getDisplayDreamList(analysis.gap_evidence).join("; ") || "—"}</p>
+                          <p><span className="font-medium">Revision queue:</span> {getDisplayDreamList(analysis.revision_queue).join("; ") || "—"}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §8 — Layer analyses */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Layer Analyses</h3>
+                  {dreamLayerAnalyses.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamLayerAnalyses.map((layer, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Layer:</span> {getDisplayText(layer.layer_name)}</p>
+                          <p><span className="font-medium">Status:</span> {getDisplayText(layer.status)}</p>
+                          <p><span className="font-medium">Needed revision:</span> {getDisplayText(layer.needed_revision)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §9 — Cross-layer integration */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Cross-Layer Integration</h3>
+                  {dreamCrossLayerIntegration.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamCrossLayerIntegration.map((row, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Motif:</span> {getDisplayText(row.motif)}</p>
+                          <p><span className="font-medium">Description:</span> {getDisplayText(row.description)}</p>
+                          <p><span className="font-medium">Integration quality:</span> {getDisplayText(row.integration_quality)}</p>
+                          <p><span className="font-medium">Revision note:</span> {getDisplayText(row.revision_note)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §10 — Symbolic audit */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Symbolic / Doctrine Audit</h3>
+                  {dreamPreservedSymbols.length > 0 ? (
+                    <div className="space-y-2 mb-2">
+                      {dreamPreservedSymbols.map((symbol, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Symbol:</span> {getDisplayText(symbol.symbol)}</p>
+                          <p><span className="font-medium">Current function:</span> {getDisplayText(symbol.current_function)}</p>
+                          <p><span className="font-medium">Revision instruction:</span> {getDisplayText(symbol.revision_instruction)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500 mb-2">Preserved symbols: —</p>
+                  )}
+                  <p className="text-sm text-gray-700"><span className="font-medium">Doctrine strengths:</span> {dreamDoctrineStrengths.join("; ") || "—"}</p>
+                  <p className="text-sm text-gray-700"><span className="font-medium">Doctrine risks:</span> {dreamDoctrineRisks.join("; ") || "—"}</p>
+                  <p className="text-sm text-gray-700"><span className="font-medium">Audit conclusion:</span> {getDisplayText(dreamSymbolicAudit?.audit_conclusion)}</p>
+                </div>
+
+                {/* §11 — Reader experience */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Reader Experience</h3>
+                  <div className="grid md:grid-cols-3 gap-3 text-sm">
+                    <div className="rounded border border-gray-200 p-3">
+                      <p className="font-medium text-gray-900 mb-1">First Act</p>
+                      <p>Reader question: {getDisplayText(dreamReaderFirstAct?.reader_question)}</p>
+                      <p>Emotional state: {getDisplayText(dreamReaderFirstAct?.emotional_state)}</p>
+                      <p>Risk: {getDisplayText(dreamReaderFirstAct?.risk)}</p>
+                    </div>
+                    <div className="rounded border border-gray-200 p-3">
+                      <p className="font-medium text-gray-900 mb-1">Middle</p>
+                      <p>Reader question: {getDisplayText(dreamReaderMiddle?.reader_question)}</p>
+                      <p>Emotional state: {getDisplayText(dreamReaderMiddle?.emotional_state)}</p>
+                      <p>Risk: {getDisplayText(dreamReaderMiddle?.risk)}</p>
+                    </div>
+                    <div className="rounded border border-gray-200 p-3">
+                      <p className="font-medium text-gray-900 mb-1">Final Act</p>
+                      <p>Reader question: {getDisplayText(dreamReaderFinalAct?.reader_question)}</p>
+                      <p>Emotional state: {getDisplayText(dreamReaderFinalAct?.emotional_state)}</p>
+                      <p>Risk: {getDisplayText(dreamReaderFinalAct?.risk)}</p>
+                    </div>
                   </div>
-                )}
+                  <p className="text-sm text-gray-700 mt-2"><span className="font-medium">Aftertaste:</span> {getDisplayText(dreamReaderExperience?.aftertaste)}</p>
+                </div>
+
+                {/* §12 — Revision plan */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Revision Plan</h3>
+                  {dreamRevisionPlan.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamRevisionPlan.map((planItem, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Priority:</span> {getDisplayText(planItem.priority)}</p>
+                          <p><span className="font-medium">Title:</span> {getDisplayText(planItem.title)}</p>
+                          <p><span className="font-medium">Goal:</span> {getDisplayText(planItem.goal)}</p>
+                          <p><span className="font-medium">Actions:</span> {getDisplayDreamList(planItem.actions).join("; ") || "—"}</p>
+                          <p><span className="font-medium">Acceptance check:</span> {getDisplayText(planItem.acceptance_check)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §13 — Releasability */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Releasability</h3>
+                  {dreamReleasability.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamReleasability.map((row, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Dimension:</span> {getDisplayText(row.dimension)}</p>
+                          <p><span className="font-medium">Current status:</span> {getDisplayText(row.current_status)}</p>
+                          <p><span className="font-medium">Verdict:</span> {getDisplayText(row.verdict)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §14 — Acceptance checks */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Acceptance Checks</h3>
+                  <p className="text-sm text-gray-700"><span className="font-medium">Required detection:</span> {dreamRequiredDetections.join("; ") || "—"}</p>
+                  <p className="text-sm text-gray-700"><span className="font-medium">Failure conditions:</span> {dreamFailureConditions.join("; ") || "—"}</p>
+                </div>
+
+                {/* §15 — Calibration notes */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Calibration Notes</h3>
+                  {dreamCalibrationNotes.length > 0 ? (
+                    <ul className="list-disc list-inside space-y-1">
+                      {dreamCalibrationNotes.map((note, idx) => (
+                        <li key={idx} className="text-sm text-gray-700">{note}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
+
+                {/* §16 — Repo summary */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Repository Summary</h3>
+                  <div className="rounded border border-gray-200 p-3 text-sm space-y-1">
+                    <p><span className="font-medium">Benchmark:</span> {getDisplayText(dreamRepoSummary?.benchmark_name)}</p>
+                    <p><span className="font-medium">Source:</span> {getDisplayText(dreamRepoSummary?.source)}</p>
+                    <p><span className="font-medium">Evaluation type:</span> {getDisplayText(dreamRepoSummary?.evaluation_type)}</p>
+                    <p><span className="font-medium">Overall score:</span> {getDisplayText(dreamRepoSummary?.overall_score)}</p>
+                    <p><span className="font-medium">Readiness score:</span> {getDisplayText(dreamRepoSummary?.readiness_score)}</p>
+                    <p><span className="font-medium">Primary strengths:</span> {getDisplayDreamList(dreamRepoSummary?.primary_strengths).join("; ") || "—"}</p>
+                    <p><span className="font-medium">Primary blockers:</span> {getDisplayDreamList(dreamRepoSummary?.primary_blockers).join("; ") || "—"}</p>
+                    <p><span className="font-medium">Gold standard requirement:</span> {getDisplayText(dreamRepoSummary?.gold_standard_requirement)}</p>
+                  </div>
+                </div>
+
+                {/* Pre-analysis integrity flags */}
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">Manuscript Integrity Issues</h3>
+                  {dreamIntegrityIssues.length > 0 ? (
+                    <div className="space-y-2">
+                      {dreamIntegrityIssues.map((issue, idx) => (
+                        <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
+                          <p><span className="font-medium">Kind:</span> {getDisplayText(issue.kind)}</p>
+                          <p><span className="font-medium">Severity:</span> {getDisplayText(issue.severity)}</p>
+                          <p><span className="font-medium">Description:</span> {getDisplayText(issue.description)}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">—</p>
+                  )}
+                </div>
               </div>
             ) : (
               <div className="flex items-center gap-3 py-4">

--- a/lib/evaluation/reportRenderSafety.ts
+++ b/lib/evaluation/reportRenderSafety.ts
@@ -1,3 +1,6 @@
+// canon-audit-allow: vocabulary-detection
+// Reason: 'commercial' below is a DREAM subscore dimension (publishing shelf axis),
+// not a canonical evaluation criterion key alias.
 import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
 
 export type DreamScoreDimension = "quality" | "readiness" | "commercial" | "literary";

--- a/lib/evaluation/reportRenderSafety.ts
+++ b/lib/evaluation/reportRenderSafety.ts
@@ -1,0 +1,77 @@
+import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
+
+export type DreamScoreDimension = "quality" | "readiness" | "commercial" | "literary";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function getDisplayRecord(value: unknown): Record<string, unknown> | null {
+  return asRecord(value);
+}
+
+export function getDisplayText(value: unknown, fallback = "—"): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return fallback;
+}
+
+export function getDisplayDateTime(isoLike: string | null | undefined, fallback = "Unknown"): string {
+  if (typeof isoLike !== "string" || isoLike.trim().length === 0) {
+    return fallback;
+  }
+
+  const parsed = new Date(isoLike);
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback;
+  }
+
+  return parsed.toLocaleString();
+}
+
+export function getDisplayDreamScore(
+  dreamDoc: LongformDreamDocument | null | undefined,
+  dimension: DreamScoreDimension,
+): string {
+  const value = asRecord((dreamDoc as unknown as Record<string, unknown> | null)?.dream_scores)?.[dimension];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "—";
+}
+
+export function getDisplayDreamList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+}
+
+export function getDisplayObjectArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => entry !== null);
+}
+
+export function getDisplayDreamMarketField(
+  dreamDoc: LongformDreamDocument | null | undefined,
+  field: "best_shelf" | "marketable_hook" | "market_danger",
+): string | null {
+  const marketShelf = asRecord((dreamDoc as unknown as Record<string, unknown> | null)?.market_shelf);
+  if (!marketShelf) return null;
+
+  const value = getDisplayText(marketShelf[field], "").trim();
+  return value.length > 0 ? value : null;
+}


### PR DESCRIPTION
## Summary
- Restores canonical DREAM long-form body rendering in `app/reports/[jobId]/page.tsx` across §1–§16 fields from `longform_document_v1`.
- Keeps the renderer-safety layer so malformed/partial artifact values cannot crash report rendering.
- Adds fixtures and tests for malformed + representative full DREAM payloads.

## Scope
- Updated long-form report rendering paths under `app/reports/[jobId]/page.tsx`.
- Added render adapters in `lib/evaluation/reportRenderSafety.ts`.
- Added test fixtures and guard coverage:
  - `__tests__/fixtures/dreamDocs.ts`
  - `__tests__/lib/evaluation/reportRenderSafety.test.ts`
  - `__tests__/app/reports/dream-renderer-sections.guard.test.ts`

## Contract Integrity
- Canonical artifact source remains `longform_document_v1` via `getDreamArtifact`.
- Spinner behavior is unchanged when long-form artifact is not ready.
- Missing/malformed section values now render placeholders (`—`) instead of throwing.
- No change to job status/state contracts; canonical statuses remain `queued|running|complete|failed`.

## Behavioral Quality
- Full section coverage now rendered for DREAM long-form report body:
  - §1 executive_verdict + dream_scores
  - §2 market_shelf
  - §3 what_not_to_become
  - §4 structural_stack
  - §5 arc_map
  - §7 criterion_analyses
  - §8 layer_analyses
  - §9 cross_layer_integration
  - §10 symbolic_audit
  - §11 reader_experience
  - §12 revision_plan
  - §13 releasability
  - §14 acceptance_checks
  - §15 calibration_notes
  - §16 repo_summary
- Added malformed fixture assertions to guarantee fail-safe rendering behavior.
- Quality Gate disclosure: this PR does not modify QG_* logic, scoring thresholds, or pass computations.

## Latency Evidence

### Baseline (Pre-change)
| Run | Endpoint / View | passX_ms | total_ms | criteria_count_by_state | Notes |
|---|---|---:|---:|---|---|
| Run 1 | Jest targeted renderer tests | N/A (not latency-sensitive; passX_ms not applicable) | N/A | N/A (renderer-only; no pass3 divergence computation path changed) | Pre-change lacked full §1–§16 body coverage guard |
| Run 2 | Jest targeted renderer tests | N/A (not latency-sensitive; passX_ms not applicable) | N/A | N/A (renderer-only; no pass3 divergence computation path changed) | Pre-change crash hardening incomplete |

### Post-change Runs
| Run | Command | passX_ms | total_ms | criteria_count_by_state | Result |
|---|---|---:|---:|---|---|
| Run 1 | `npm test -- --runInBand __tests__/lib/evaluation/reportRenderSafety.test.ts __tests__/app/reports/dream-renderer-sections.guard.test.ts tests/api/evaluations-route-release-gating.test.ts` | N/A (passX_ms not applicable to renderer unit tests) | N/A | N/A (no pass3 scoring path touched) | 3 suites passed, 10 tests passed |
| Run 2 | `npm test -- --runInBand __tests__/lib/evaluation/reportRenderSafety.test.ts tests/api/evaluations-route-release-gating.test.ts` | N/A (passX_ms not applicable to renderer unit tests) | N/A | N/A (no pass3 scoring path touched) | 2 suites passed, 8 tests passed |

## Risks & Anomalies
- Risk: Full §1–§16 headings are validated by a source guard test; visual layout regressions still depend on UI verification in PR review.
- Risk: Optional DREAM fields can still be semantically weak, but now degrade to placeholders rather than break the page.
- No anomaly observed in targeted tests.

- [x] Pass 3

This PR hardens renderer behavior while preserving analytical quality and **not reducing intelligence** in evaluation outputs.