### PR TITLE
docs(ui): annotate §6 in Detailed Scores / Score Grid (follow-up to #557)

### DIFF
--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -374,7 +374,9 @@ export default async function ReportPage({ params }: { params: { jobId: string }
 
         {/* Criteria Scores */}
         <section className="bg-white rounded-lg shadow-sm p-6 mb-6">
-          <h2 className="text-2xl font-semibold text-gray-900 mb-6">Detailed Scores</h2>
+          <h2 className="text-2xl font-semibold text-gray-900 mb-6">
+            §6 — Detailed Scores / Score Grid
+          </h2>
           <div className="mb-4 rounded-md border bg-gray-50 p-3 text-xs text-gray-700">
             <p className="font-medium">Confidence Guide</p>
             <p className="mt-1">


### PR DESCRIPTION
## Summary
Annotates the report score-grid heading so the existing 13-criteria grid is explicitly mapped to DREAM §6.

## Scope
- UI label-only change in `app/reports/[jobId]/page.tsx`.
- Follow-up to #557 DREAM renderer restoration.
- No evaluation logic, scoring, prompts, worker behavior, DB schema, artifact generation, or report data flow changes.

No-Pipeline-Impact: true (UI heading text only; no pipeline/runtime behavior changes)

## Visual Evidence
- Before: `Detailed Scores`
- After: `§6 — Detailed Scores / Score Grid`
- Diff scope: 1 file, heading text only.

## Accessibility
- Semantic heading level unchanged (`h2`).
- No contrast, focus, keyboard, ARIA, or screen-reader behavior changes.
- Existing spinner/fallback states remain unchanged.

## Browser Targets
- No browser-specific behavior introduced.
- Expected unchanged behavior on supported project targets (Chromium, Firefox, WebKit/Safari equivalents).

## Risks & Anomalies
- Risk is minimal: single label annotation.
- No rendering logic changed.
- No QG_* / quality-gate behavior changed.
- No runtime evaluation path changed.
- No anomaly observed.
