### PR TITLE
canon(pr1): add canon-audit-allow exemption to Pass4WindowLabel

### DIFF
--- a/lib/evaluation/pipeline/pass4EvidencePacket.ts
+++ b/lib/evaluation/pipeline/pass4EvidencePacket.ts
@@ -28,6 +28,13 @@
  * No side effects, no I/O. Pure function.
  */
 
+/**
+ * canon-audit-allow: window-label
+ * "close" here is a manuscript structural window label (the closing pages of the manuscript),
+ * NOT the deprecated submission_readiness criterion alias. The AST governance guard must
+ * exempt this type and any Record/array literals keyed from it.
+ * See: https://github.com/Mmeraw/literary-ai-partner/issues/TBD (PR 4 governance spec)
+ */
 export type Pass4WindowLabel =
   | "full"
   | "opening"


### PR DESCRIPTION
## Summary

Adds a JSDoc `canon-audit-allow: window-label` exemption comment to the `Pass4WindowLabel` type in `pass4EvidencePacket.ts`. This prevents the future AST governance guard (PR 4 / issue #565) from false-positiving on the `"close"` window label.

## Why This PR Does NOT Rename "close" to "narrativeClosure"

A planning session from another AI proposed renaming Pass4WindowLabel `"close"` to `"narrativeClosure"` (labelled "A1"). **That rename is incorrect and must not be applied.**

### What Pass4WindowLabel actually represents

Pass4WindowLabel defines structural manuscript text windows — physical regions of the manuscript used as evidence buckets for Pass 4 adjudication:

```
"opening" → opening pages of the manuscript
"early"   → early section
"middle"  → middle section
"late"    → late section
"close"   → closing pages of the manuscript  ← this is a LOCATION, not a criterion
"full"    → full-text fallback (short manuscripts)
```

These are text-window labels, not criterion keys. The actual test file (`tests/evaluation/pipeline/pass4EvidencePacket.test.ts`) makes this explicit:

```ts
it("always includes the close window (required for narrativeClosure)", () => {
  // Even at the threshold (just over 25k words), the close must
  // be present because narrativeClosure adjudication depends on it.
```

The `"close"` window must exist **so that** the `narrativeClosure` criterion has evidence to adjudicate against. Renaming the window to `narrativeClosure` would conflate the evidence container with the criterion it serves — a category error.

### What the referenced test files actually are

The other AI cited `__tests__/fixtures/pass4-criteria.json` and `__tests__/lib/evaluation/pipeline/pass4.test.ts` as justification. **Neither file exists in the repo.** Both are hallucinated. The real test file (`tests/evaluation/pipeline/pass4EvidencePacket.test.ts`) correctly expects `"close"` as the window label and documents why.

## Scope

| File | Change |
|------|--------|
| `lib/evaluation/pipeline/pass4EvidencePacket.ts` | Add `// canon-audit-allow: window-label` JSDoc comment to `Pass4WindowLabel` type |

One file, one comment added. Zero behavior change.

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

No-Pipeline-Impact: true

pass1_ms: N/A — no evaluation logic modified. Pass 4 evidence packet behavior is unchanged.
total_ms: N/A

criteria_count_by_state: N/A — no Pass 3 divergence distribution affected.

## Contract Integrity

- `Pass4WindowLabel` type is unchanged — `"close"` remains the correct window label
- `pass4EvidencePacket.ts` exports are unchanged — no interface or function signature changes
- All existing tests continue to pass with `"close"` as the window label
- JSDoc comment is advisory for the governance guard only; it has no runtime effect

## Behavioral Quality

This PR is not reducing intelligence.

The `"close"` window is required for `narrativeClosure` adjudication. This PR preserves that contract exactly as-is. The exemption comment documents the reason so the AST guard (when implemented in PR 4) knows this is intentional use, not a violation.

## Latency Evidence

No latency impact — comment-only change to a TypeScript type alias.

### Baseline (Pre-change)

| Run | pass1_ms | total_ms | Notes |
|-----|----------|----------|-------|
| Run 1 | N/A | N/A | Comment-only change; no pipeline execution path modified |
| Run 2 | N/A | N/A | Pass 4 evidence packet selection logic unchanged |

### Post-change Runs

| Run | pass1_ms | total_ms | Notes |
|-----|----------|----------|-------|
| Run 1 | N/A | N/A | Identical to baseline — zero runtime delta |
| Run 2 | N/A | N/A | All pass4EvidencePacket tests continue to pass |

## Risks & Anomalies

- Risk: none. One JSDoc comment added to a type alias. No runtime code changed.
- The `canon-audit-allow: window-label` annotation is advisory. If the AST guard in PR 4 is not implemented, this comment has no effect.
- QG_PASS4_WINDOW: no change — `"close"` window label is preserved, all Pass 4 evidence packet tests pass.
- This change is not reducing intelligence.

## Closes / References

References #565 (PR4 AST governance guard spec — this exemption is pre-registered for when that guard ships)
References #541 (pipeline-health cockpit — Pass 4 context)