### PR TITLE
feat(pipeline-health): DREAM synthesis queue + Pass 4 fields + artifact coverage (closes #541)

### DIFF
--- a/app/admin/pipeline-health/page.tsx
+++ b/app/admin/pipeline-health/page.tsx
@@ -42,6 +42,28 @@ interface RecentJob {
   pipelineStage: string;
   durationMs: number | null;
   diagnosticStatus: "available" | "missing" | "blocked_by_307" | "not_applicable";
+  // Section A — Pass 4
+  crossCheckStatus: string | null;
+  crossCheckError: string | null;
+  crossCheckCompletedAt: string | null;
+  // Section C — artifact coverage
+  hasEvalV2: boolean;
+  hasDream: boolean;
+  hasPassDiag: boolean;
+}
+
+interface DreamPendingJob {
+  jobId: string;
+  title: string;
+  wordCount: number;
+  updatedAt: string;
+}
+
+interface DreamSynthesisData {
+  pendingCount: number;
+  coveredCount: number;
+  lastSynthesizedAt: string | null;
+  pendingJobs: DreamPendingJob[];
 }
 
 interface Summary {
@@ -73,6 +95,7 @@ interface PipelineHealthData {
   sipoc: SipocStage[];
   failureHeatmap: HeatmapEntry[];
   recentJobs: RecentJob[];
+  dreamSynthesis?: DreamSynthesisData;
   diagnostics: Diagnostics;
   filters?: PipelineHealthFilters;
 }
@@ -96,6 +119,24 @@ function diagBadge(ds: RecentJob["diagnosticStatus"]) {
   if (ds === "blocked_by_307") return `${base} bg-orange-100 text-orange-800`;
   if (ds === "missing") return `${base} bg-red-100 text-red-800`;
   return `${base} bg-gray-100 text-gray-500`;
+}
+
+function crossCheckBadge(status: string | null) {
+  const base = "inline-block px-2 py-0.5 rounded text-xs font-medium";
+  if (status === "completed") return `${base} bg-green-100 text-green-800`;
+  if (status === "skipped") return `${base} bg-gray-100 text-gray-600`;
+  if (status === "failed_soft") return `${base} bg-orange-100 text-orange-800`;
+  if (status === null) return `${base} bg-red-100 text-red-700`;
+  return `${base} bg-gray-100 text-gray-600`;
+}
+
+function artifactDot(has: boolean, isLongForm?: boolean) {
+  if (isLongForm === false) return <span className="text-gray-300 text-xs">n/a</span>;
+  return has ? (
+    <span className="text-green-600 font-bold text-sm">✓</span>
+  ) : (
+    <span className="text-red-500 font-bold text-sm">✗</span>
+  );
 }
 
 function healthDot(health: SipocStage["health"]) {
@@ -165,7 +206,6 @@ export default function PipelineHealthPage() {
     fetchData(windowParam, showTestManuscripts);
   }, [windowParam, showTestManuscripts, fetchData]);
 
-  // --- Loading ---
   if (loading) {
     return (
       <main className="p-6">
@@ -174,7 +214,6 @@ export default function PipelineHealthPage() {
     );
   }
 
-  // --- Error ---
   if (error) {
     return (
       <main className="p-6">
@@ -188,7 +227,7 @@ export default function PipelineHealthPage() {
 
   if (!data) return null;
 
-  const { summary, sipoc, failureHeatmap, recentJobs, diagnostics } = data;
+  const { summary, sipoc, failureHeatmap, recentJobs, diagnostics, dreamSynthesis } = data;
   const failedJobs = recentJobs.filter((j) => j.status === "failed");
 
   return (
@@ -207,7 +246,6 @@ export default function PipelineHealthPage() {
           </p>
         </div>
 
-        {/* Window selector + test-manuscript toggle */}
         <div className="flex gap-4 items-center flex-wrap">
           <div className="flex gap-2">
             {(["1h", "24h", "7d"] as const).map((w) => (
@@ -264,6 +302,109 @@ export default function PipelineHealthPage() {
           {" "}over last {windowParam}
         </p>
       </section>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Section B — DREAM Synthesis Queue                                  */}
+      {/* ------------------------------------------------------------------ */}
+      {dreamSynthesis && (
+        <section className="rounded-lg border border-gray-200 p-5 space-y-4">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <h2 className="text-lg font-semibold">DREAM Synthesis Queue</h2>
+            <div className="flex gap-6 text-sm">
+              <span>
+                <span className="font-semibold text-gray-800">{dreamSynthesis.coveredCount}</span>
+                <span className="text-gray-500 ml-1">long-form jobs with DREAM artifact</span>
+              </span>
+              <span>
+                <span
+                  className={`font-semibold ${
+                    dreamSynthesis.pendingCount > 0 ? "text-red-700" : "text-green-700"
+                  }`}
+                >
+                  {dreamSynthesis.pendingCount}
+                </span>
+                <span className="text-gray-500 ml-1">pending (no artifact yet)</span>
+              </span>
+            </div>
+          </div>
+
+          {dreamSynthesis.pendingCount > 0 && (
+            <div className="rounded bg-amber-50 border border-amber-300 px-4 py-3 text-sm text-amber-900">
+              <strong>⚠ {dreamSynthesis.pendingCount} long-form job{dreamSynthesis.pendingCount !== 1 ? "s" : ""} complete but missing DREAM artifact</strong>
+              {" "}— check <code className="font-mono text-xs bg-amber-100 px-1 rounded">process-dream</code> cron.
+              If this count is stuck, the cron may be silently skipping jobs (see post-mortem{" "}
+              <a
+                href="https://github.com/Mmeraw/literary-ai-partner/issues/561"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                #561
+              </a>
+              ).
+            </div>
+          )}
+
+          {dreamSynthesis.pendingCount === 0 && dreamSynthesis.coveredCount > 0 && (
+            <div className="rounded bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800">
+              ✓ All complete long-form jobs have DREAM artifacts. Last synthesized:{" "}
+              {dreamSynthesis.lastSynthesizedAt ? fmtDate(dreamSynthesis.lastSynthesizedAt) : "—"}
+            </div>
+          )}
+
+          <div className="text-xs text-gray-500">
+            Last DREAM synthesis:{" "}
+            <span className="font-medium text-gray-700">
+              {dreamSynthesis.lastSynthesizedAt ? fmtDate(dreamSynthesis.lastSynthesizedAt) : "Never"}
+            </span>
+            {" "}· Threshold: ≥25,000 words
+          </div>
+
+          {dreamSynthesis.pendingJobs.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm border border-gray-200">
+                <thead className="bg-gray-50">
+                  <tr>
+                    {["Job ID", "Title", "Word Count", "Completed At", "Report"].map((h) => (
+                      <th
+                        key={h}
+                        className="px-3 py-2 text-left font-medium text-gray-600 whitespace-nowrap"
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {dreamSynthesis.pendingJobs.map((j) => (
+                    <tr key={j.jobId} className="hover:bg-amber-50">
+                      <td className="px-3 py-2 font-mono text-xs text-gray-600">
+                        {j.jobId.slice(0, 8)}…
+                      </td>
+                      <td className="px-3 py-2 text-sm font-medium">{j.title}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {j.wordCount.toLocaleString()} words
+                      </td>
+                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                        {fmtDate(j.updatedAt)}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        <Link
+                          href={`/reports/${j.jobId}`}
+                          className="text-blue-600 underline"
+                          target="_blank"
+                        >
+                          /reports/{j.jobId.slice(0, 8)}…
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
 
       {/* SIPOC strip */}
       <section>
@@ -400,6 +541,9 @@ export default function PipelineHealthPage() {
                     "Chunks",
                     "Duration",
                     "Diagnostics",
+                    "Pass 4",
+                    "P4 Error",
+                    "Artifacts",
                   ].map((h) => (
                     <th
                       key={h}
@@ -411,7 +555,132 @@ export default function PipelineHealthPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200">
-                {failedJobs.map((job) => (
+                {failedJobs.map((job) => {
+                  const isLongForm =
+                    job.manuscriptWords !== null && job.manuscriptWords >= 25000;
+                  return (
+                    <tr key={job.jobId} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 font-mono text-xs">
+                        <Link
+                          href={`/evaluate/${job.jobId}`}
+                          className="text-blue-600 underline"
+                        >
+                          {job.jobId.slice(0, 8)}…
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-gray-700">
+                        {job.manuscriptId ?? "—"}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                        {fmtDate(job.createdAt)}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+                        {fmtDate(job.updatedAt)}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs">{job.pipelineStage}</td>
+                      <td className="px-3 py-2">
+                        {job.errorCode ? (
+                          <span
+                            className={`font-mono text-xs ${
+                              job.errorCode.startsWith("QG_")
+                                ? "text-orange-700 font-semibold"
+                                : "text-red-700"
+                            }`}
+                          >
+                            {job.errorCode}
+                          </span>
+                        ) : (
+                          <span className="text-gray-400 text-xs">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-xs">
+                        <span title={job.lastError ?? "No detail available"}>
+                          {truncateStr(job.lastError)}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-xs">{job.phase ?? "—"}</td>
+                      <td className="px-3 py-2 text-xs">{job.phaseStatus ?? "—"}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {job.manuscriptWords !== null ? job.manuscriptWords.toLocaleString() : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-xs">{job.route ?? "—"}</td>
+                      <td className="px-3 py-2 text-xs">
+                        {job.chunkCount !== null ? job.chunkCount : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-xs">{fmtMs(job.durationMs)}</td>
+                      <td className="px-3 py-2">
+                        <span className={diagBadge(job.diagnosticStatus)}>
+                          {job.diagnosticStatus}
+                        </span>
+                      </td>
+                      {/* Section A — Pass 4 */}
+                      <td className="px-3 py-2">
+                        <span className={crossCheckBadge(job.crossCheckStatus)}>
+                          {job.crossCheckStatus ?? "null"}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-xs text-red-700">
+                        {truncateStr(job.crossCheckError, 40)}
+                      </td>
+                      {/* Section C — artifacts */}
+                      <td className="px-3 py-2 text-xs">
+                        <div className="flex gap-1 items-center">
+                          <span title="eval_v2">{artifactDot(job.hasEvalV2)}</span>
+                          <span className="text-gray-300">|</span>
+                          <span title="dream">{artifactDot(job.hasDream, isLongForm)}</span>
+                          <span className="text-gray-300">|</span>
+                          <span title="pass_diag">{artifactDot(job.hasPassDiag)}</span>
+                        </div>
+                        <div className="text-gray-400 text-xs mt-0.5">v2|drm|diag</div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* All recent jobs — with Pass 4 + artifact coverage columns */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">
+          Recent Jobs{" "}
+          <span className="text-sm font-normal text-gray-500">
+            (last {recentJobs.length}, sorted by updated_at desc)
+          </span>
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border border-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                {[
+                  "Job ID",
+                  "Status",
+                  "Created",
+                  "Updated",
+                  "Stage",
+                  "Error Code",
+                  "Failure Detail",
+                  "Diagnostics",
+                  "Duration",
+                  "Pass 4",
+                  "Artifacts",
+                ].map((h) => (
+                  <th
+                    key={h}
+                    className="px-3 py-2 text-left font-medium text-gray-600 whitespace-nowrap"
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {recentJobs.map((job) => {
+                const isLongForm =
+                  job.manuscriptWords !== null && job.manuscriptWords >= 25000;
+                return (
                   <tr key={job.jobId} className="hover:bg-gray-50">
                     <td className="px-3 py-2 font-mono text-xs">
                       <Link
@@ -421,8 +690,10 @@ export default function PipelineHealthPage() {
                         {job.jobId.slice(0, 8)}…
                       </Link>
                     </td>
-                    <td className="px-3 py-2 text-xs text-gray-700">
-                      {job.manuscriptId ?? "—"}
+                    <td className="px-3 py-2">
+                      <span className={statusBadge(String(job.status ?? ""))}>
+                        {String(job.status ?? "")}
+                      </span>
                     </td>
                     <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
                       {fmtDate(job.createdAt)}
@@ -451,104 +722,32 @@ export default function PipelineHealthPage() {
                         {truncateStr(job.lastError)}
                       </span>
                     </td>
-                    <td className="px-3 py-2 text-xs">{job.phase ?? "—"}</td>
-                    <td className="px-3 py-2 text-xs">{job.phaseStatus ?? "—"}</td>
-                    <td className="px-3 py-2 text-xs">
-                      {job.manuscriptWords !== null ? job.manuscriptWords.toLocaleString() : "—"}
-                    </td>
-                    <td className="px-3 py-2 text-xs">{job.route ?? "—"}</td>
-                    <td className="px-3 py-2 text-xs">
-                      {job.chunkCount !== null ? job.chunkCount : "—"}
-                    </td>
-                    <td className="px-3 py-2 text-xs">{fmtMs(job.durationMs)}</td>
                     <td className="px-3 py-2">
                       <span className={diagBadge(job.diagnosticStatus)}>
                         {job.diagnosticStatus}
                       </span>
                     </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
-
-      {/* All recent jobs */}
-      <section>
-        <h2 className="text-lg font-semibold mb-3">
-          Recent Jobs{" "}
-          <span className="text-sm font-normal text-gray-500">
-            (last {recentJobs.length}, sorted by updated_at desc)
-          </span>
-        </h2>
-        <div className="overflow-x-auto">
-          <table className="min-w-full text-sm border border-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                {["Job ID", "Status", "Created", "Updated", "Stage", "Error Code", "Failure Detail", "Diagnostics", "Duration"].map(
-                  (h) => (
-                    <th
-                      key={h}
-                      className="px-3 py-2 text-left font-medium text-gray-600 whitespace-nowrap"
-                    >
-                      {h}
-                    </th>
-                  )
-                )}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {recentJobs.map((job) => (
-                <tr key={job.jobId} className="hover:bg-gray-50">
-                  <td className="px-3 py-2 font-mono text-xs">
-                    <Link
-                      href={`/evaluate/${job.jobId}`}
-                      className="text-blue-600 underline"
-                    >
-                      {job.jobId.slice(0, 8)}…
-                    </Link>
-                  </td>
-                  <td className="px-3 py-2">
-                    <span className={statusBadge(String(job.status ?? ""))}>
-                      {String(job.status ?? "")}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
-                    {fmtDate(job.createdAt)}
-                  </td>
-                  <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
-                    {fmtDate(job.updatedAt)}
-                  </td>
-                  <td className="px-3 py-2 font-mono text-xs">{job.pipelineStage}</td>
-                  <td className="px-3 py-2">
-                    {job.errorCode ? (
-                      <span
-                        className={`font-mono text-xs ${
-                          job.errorCode.startsWith("QG_")
-                            ? "text-orange-700 font-semibold"
-                            : "text-red-700"
-                        }`}
-                      >
-                        {job.errorCode}
+                    <td className="px-3 py-2 text-xs">{fmtMs(job.durationMs)}</td>
+                    {/* Section A — Pass 4 status */}
+                    <td className="px-3 py-2">
+                      <span className={crossCheckBadge(job.crossCheckStatus)}>
+                        {job.crossCheckStatus ?? "—"}
                       </span>
-                    ) : (
-                      <span className="text-gray-400 text-xs">—</span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-xs">
-                    <span title={job.lastError ?? "No detail available"}>
-                      {truncateStr(job.lastError)}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2">
-                    <span className={diagBadge(job.diagnosticStatus)}>
-                      {job.diagnosticStatus}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2 text-xs">{fmtMs(job.durationMs)}</td>
-                </tr>
-              ))}
+                    </td>
+                    {/* Section C — artifact coverage */}
+                    <td className="px-3 py-2 text-xs">
+                      <div className="flex gap-1 items-center">
+                        <span title="eval_v2">{artifactDot(job.hasEvalV2)}</span>
+                        <span className="text-gray-300">|</span>
+                        <span title="dream">{artifactDot(job.hasDream, isLongForm)}</span>
+                        <span className="text-gray-300">|</span>
+                        <span title="pass_diag">{artifactDot(job.hasPassDiag)}</span>
+                      </div>
+                      <div className="text-gray-400 text-xs mt-0.5">v2|drm|diag</div>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/app/api/admin/pipeline-health/route.ts
+++ b/app/api/admin/pipeline-health/route.ts
@@ -6,21 +6,28 @@ import { TEST_MANUSCRIPT_ID_MIN } from "@/lib/manuscripts/testRange";
 /**
  * GET /api/admin/pipeline-health
  *
- * Admin-only pipeline health dashboard API (v1).
- * Reads from evaluation_jobs + evaluation_artifacts — no new tables, no pipeline behavior changes.
+ * Admin-only pipeline health dashboard API (v2).
+ * Reads from evaluation_jobs + evaluation_artifacts + manuscripts — no new tables, no pipeline behavior changes.
  *
  * Query parameters:
  *   window  = 1h | 24h | 7d   (default: 24h)
  *   limit   = number           (default: 100, max: 200)
  *
  * Response shape:
- *   { generatedAt, window, summary, sipoc, failureHeatmap, recentJobs, diagnostics }
+ *   { generatedAt, window, summary, sipoc, failureHeatmap, recentJobs, dreamSynthesis, diagnostics }
  *
  * Governance:
  *   - Read-only. No writes to any table.
  *   - Uses existing admin auth (requireAdmin).
  *   - diagnosticStatus="available" ONLY when both audit artifacts are confirmed present
  *     in evaluation_artifacts. Version flags / in-progress markers are NOT sufficient.
+ *
+ * Changelog:
+ *   v2 (2026-05-17, issue #541):
+ *     - Added dreamSynthesis panel (Section B): pending DREAM jobs, coverage, last synthesized
+ *     - Added Pass 4 adjudication fields to RecentJob (Section A): crossCheckStatus, crossCheckError,
+ *       crossCheckCompletedAt, adjudicationMode
+ *     - Added artifact coverage columns to RecentJob (Section C): hasEvalV2, hasDream, hasPassDiag
  */
 
 export const dynamic = "force-dynamic";
@@ -39,6 +46,9 @@ const STAGES = [
 ] as const;
 
 type SipocStage = (typeof STAGES)[number];
+
+// Word count threshold for DREAM synthesis eligibility
+const DREAM_WORD_COUNT_THRESHOLD = 25_000;
 
 // ---------------------------------------------------------------------------
 // Helpers — pure functions (no DB calls, no side-effects)
@@ -86,10 +96,6 @@ function extractErrorCode(job: Record<string, unknown>): string | null {
   );
 }
 
-/**
- * Extracts a display-only failure text from the canonical `last_error` field.
- * This is NOT a structured error code — use extractErrorCode() for code-based logic.
- */
 function extractLastError(job: Record<string, unknown>): string | null {
   return typeof job.last_error === "string" ? job.last_error : null;
 }
@@ -97,15 +103,10 @@ function extractLastError(job: Record<string, unknown>): string | null {
 type DiagnosticStatus = "available" | "missing" | "blocked_by_307" | "not_applicable";
 
 /**
- * Batch-load audit artifact kinds for a set of job IDs from evaluation_artifacts.
- *
- * Returns a Map<jobId, Set<artifactType>>. Audit artifact types are:
- *   - "pass_outputs_diagnostic_v1"
- *   - "quality_gate_diagnostics_v1"
- *
- * Any DB error returns an empty Map (fail-soft — diagnosticStatus falls back to "missing").
+ * Batch-load ALL artifact kinds for a set of job IDs.
+ * Returns Map<jobId, Set<artifactType>>.
  */
-async function loadPersistedArtifactKinds(
+async function loadAllArtifactKinds(
   supabase: ReturnType<typeof createAdminClient>,
   jobIds: string[]
 ): Promise<Map<string, Set<string>>> {
@@ -114,8 +115,7 @@ async function loadPersistedArtifactKinds(
   const { data, error } = await supabase
     .from("evaluation_artifacts")
     .select("job_id, artifact_type")
-    .in("job_id", jobIds)
-    .in("artifact_type", ["pass_outputs_diagnostic_v1", "quality_gate_diagnostics_v1"]);
+    .in("job_id", jobIds);
 
   if (error || !data) {
     console.warn("[pipeline-health] evaluation_artifacts lookup failed:", error?.message);
@@ -132,36 +132,99 @@ async function loadPersistedArtifactKinds(
   return result;
 }
 
-/**
- * Truthful diagnosticStatus:
- *   "available" ONLY when the quality_gate_diagnostics_v1 audit artifact is
- *   confirmed present in evaluation_artifacts for this job (source of truth).
- *   Version flags / in-progress markers in job progress are NOT sufficient.
- *
- * @param job              - The evaluation_jobs row.
- * @param persistedKinds   - Set of artifact_types confirmed present for this job
- *                           (from loadPersistedArtifactKinds). Undefined = not loaded.
- */
 function diagnosticStatus(
   job: Record<string, unknown>,
   persistedKinds?: Set<string>
 ): DiagnosticStatus {
   if (job.status !== "failed") return "not_applicable";
 
-  // Truthful path: use confirmed artifact presence from evaluation_artifacts.
   if (persistedKinds !== undefined) {
     if (persistedKinds.has("quality_gate_diagnostics_v1")) return "available";
-    // Artifact absent for this job — fall through to legacy signal check.
   }
 
-  // Legacy fallback: jobs that failed before #307 diagnostic persistence was deployed.
-  // Version flags in progress are NOT sufficient for "available" — they only tell us
-  // the persistence was attempted (may have failed). Use them only to distinguish
-  // "blocked_by_307" (pre-deployment QG_ failures) from plain "missing".
   const errorCode = extractErrorCode(job);
   if (typeof errorCode === "string" && errorCode.startsWith("QG_")) return "blocked_by_307";
 
   return "missing";
+}
+
+// ---------------------------------------------------------------------------
+// DREAM synthesis helpers
+// ---------------------------------------------------------------------------
+
+interface DreamSynthesisData {
+  pendingCount: number;
+  coveredCount: number;
+  lastSynthesizedAt: string | null;
+  pendingJobs: Array<{ jobId: string; title: string; wordCount: number; updatedAt: string }>;
+}
+
+async function loadDreamSynthesisData(
+  supabase: ReturnType<typeof createAdminClient>
+): Promise<DreamSynthesisData> {
+  // All complete long-form jobs (word_count >= threshold)
+  const { data: longFormJobs, error: lfError } = await supabase
+    .from("evaluation_jobs")
+    .select("id, manuscript_id, updated_at, manuscripts!inner(title, word_count)")
+    .eq("status", "complete")
+    .gte("manuscripts.word_count", DREAM_WORD_COUNT_THRESHOLD)
+    .lt("manuscript_id", TEST_MANUSCRIPT_ID_MIN)
+    .order("updated_at", { ascending: false })
+    .limit(50);
+
+  if (lfError || !longFormJobs) {
+    console.warn("[pipeline-health] DREAM long-form jobs query failed:", lfError?.message);
+    return { pendingCount: 0, coveredCount: 0, lastSynthesizedAt: null, pendingJobs: [] };
+  }
+
+  const jobIds = (longFormJobs as Array<{ id: string }>).map((j) => j.id);
+
+  // Which of these have longform_document_v1 artifacts?
+  const { data: dreamArtifacts, error: daError } = await supabase
+    .from("evaluation_artifacts")
+    .select("job_id, created_at")
+    .in("job_id", jobIds)
+    .eq("artifact_type", "longform_document_v1")
+    .order("created_at", { ascending: false });
+
+  if (daError) {
+    console.warn("[pipeline-health] DREAM artifact lookup failed:", daError?.message);
+  }
+
+  const coveredJobIds = new Set(
+    ((dreamArtifacts ?? []) as Array<{ job_id: string; created_at: string }>).map(
+      (a) => a.job_id
+    )
+  );
+
+  const lastSynthesizedAt =
+    (dreamArtifacts ?? []).length > 0
+      ? (dreamArtifacts as Array<{ job_id: string; created_at: string }>)[0]?.created_at ?? null
+      : null;
+
+  const pendingJobs = (
+    longFormJobs as Array<{
+      id: string;
+      manuscript_id: string;
+      updated_at: string;
+      manuscripts: { title: string; word_count: number };
+    }>
+  )
+    .filter((j) => !coveredJobIds.has(j.id))
+    .slice(0, 10)
+    .map((j) => ({
+      jobId: j.id,
+      title: j.manuscripts?.title ?? "Unknown",
+      wordCount: j.manuscripts?.word_count ?? 0,
+      updatedAt: j.updated_at,
+    }));
+
+  return {
+    pendingCount: pendingJobs.length,
+    coveredCount: coveredJobIds.size,
+    lastSynthesizedAt,
+    pendingJobs,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +234,8 @@ function diagnosticStatus(
 function buildPipelineHealth(
   jobs: Record<string, unknown>[],
   windowParam: string,
-  artifactKindsByJob: Map<string, Set<string>>
+  artifactKindsByJob: Map<string, Set<string>>,
+  dreamSynthesis: DreamSynthesisData
 ) {
   const totalJobs = jobs.length;
   const failedJobs = jobs.filter((j) => j.status === "failed").length;
@@ -180,8 +244,11 @@ function buildPipelineHealth(
     (j) => j.status === "running" || j.status === "queued"
   ).length;
 
+  const jobArtifacts = (job: Record<string, unknown>) =>
+    artifactKindsByJob.get(String(job.id ?? ""));
+
   const jobDiagStatus = (job: Record<string, unknown>): DiagnosticStatus =>
-    diagnosticStatus(job, artifactKindsByJob.get(String(job.id ?? "")));
+    diagnosticStatus(job, jobArtifacts(job));
 
   // Failure heatmap: stage × error_code
   const heatmapAcc: Record<
@@ -240,12 +307,13 @@ function buildPipelineHealth(
     };
   });
 
-  // Recent jobs (up to 100 rows already returned from DB, already sorted by updated_at desc)
+  // Recent jobs — now includes Pass 4 fields + artifact coverage (Sections A + C)
   const recentJobs = jobs.slice(0, 100).map((job) => {
     const progress = (job.progress ?? {}) as Record<string, unknown>;
     const routing = (progress.chunk_routing ?? {}) as Record<string, unknown>;
     const createdAt = String(job.created_at ?? "");
     const updatedAt = String(job.updated_at ?? "");
+    const kinds = jobArtifacts(job) ?? new Set<string>();
 
     return {
       jobId: job.id,
@@ -268,6 +336,15 @@ function buildPipelineHealth(
           ? new Date(updatedAt).getTime() - new Date(createdAt).getTime()
           : null,
       diagnosticStatus: jobDiagStatus(job),
+      // Section A — Pass 4 adjudication fields
+      crossCheckStatus: typeof job.cross_check_status === "string" ? job.cross_check_status : null,
+      crossCheckError: typeof job.cross_check_error === "string" ? job.cross_check_error : null,
+      crossCheckCompletedAt:
+        typeof job.cross_check_completed_at === "string" ? job.cross_check_completed_at : null,
+      // Section C — artifact coverage
+      hasEvalV2: kinds.has("evaluation_result_v2"),
+      hasDream: kinds.has("longform_document_v1"),
+      hasPassDiag: kinds.has("pass_outputs_diagnostic_v1"),
     };
   });
 
@@ -287,6 +364,8 @@ function buildPipelineHealth(
     sipoc,
     failureHeatmap,
     recentJobs,
+    // Section B — DREAM synthesis queue
+    dreamSynthesis,
     diagnostics: {
       allFailedJobsDiagnosticsAuditable: blockedCount === 0,
       missingDiagnosticArtifactCount: blockedCount,
@@ -316,8 +395,6 @@ export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const windowParam = searchParams.get("window") ?? "24h";
   const limitParam = searchParams.get("limit");
-  // Test manuscripts (id >= 9000) are hidden by default. Opt in with
-  // `?show_test=1` (or "true"). See OPERATIONS.md "Test manuscript range".
   const showTestParam = (searchParams.get("show_test") ?? "").toLowerCase();
   const showTestManuscripts = showTestParam === "1" || showTestParam === "true";
 
@@ -329,12 +406,11 @@ export async function GET(req: NextRequest) {
   try {
     const supabase = createAdminClient();
 
-    // Parameterized query — no string interpolation of user input.
-    // interval is validated against a fixed allowlist above.
     let jobsQuery = supabase
       .from("evaluation_jobs")
       .select(
-        "id, manuscript_id, status, phase, phase_status, progress, last_error, created_at, updated_at"
+        // Section A: added cross_check_* fields
+        "id, manuscript_id, status, phase, phase_status, progress, last_error, created_at, updated_at, cross_check_status, cross_check_error, cross_check_completed_at"
       )
       .gte("created_at", new Date(Date.now() - intervalToMs(interval)).toISOString())
       .order("updated_at", { ascending: false })
@@ -356,16 +432,17 @@ export async function GET(req: NextRequest) {
 
     const allJobs = (jobs ?? []) as Record<string, unknown>[];
 
-    // Batch-load audit artifact presence for failed jobs (single DB round-trip).
-    // diagnosticStatus="available" requires confirmed artifact presence in evaluation_artifacts.
-    const failedJobIds = allJobs
-      .filter((j) => j.status === "failed")
+    // Load ALL artifact kinds for all jobs (one round-trip covers Sections A + C)
+    const allJobIds = allJobs
       .map((j) => String(j.id ?? ""))
       .filter((id) => id.length > 0);
 
-    const artifactKindsByJob = await loadPersistedArtifactKinds(supabase, failedJobIds);
+    const artifactKindsByJob = await loadAllArtifactKinds(supabase, allJobIds);
 
-    const payload = buildPipelineHealth(allJobs, windowParam, artifactKindsByJob);
+    // Section B — DREAM synthesis data (separate query, global scope not window-limited)
+    const dreamSynthesis = await loadDreamSynthesisData(supabase);
+
+    const payload = buildPipelineHealth(allJobs, windowParam, artifactKindsByJob, dreamSynthesis);
 
     return NextResponse.json({
       ok: true,
@@ -395,5 +472,5 @@ export async function GET(req: NextRequest) {
 function intervalToMs(interval: string): number {
   if (interval === "1 hour") return 60 * 60 * 1000;
   if (interval === "7 days") return 7 * 24 * 60 * 60 * 1000;
-  return 24 * 60 * 60 * 1000; // default: 24 hours
+  return 24 * 60 * 60 * 1000;
 }

--- a/app/api/admin/pipeline-health/route.ts
+++ b/app/api/admin/pipeline-health/route.ts
@@ -202,20 +202,22 @@ async function loadDreamSynthesisData(
       ? (dreamArtifacts as Array<{ job_id: string; created_at: string }>)[0]?.created_at ?? null
       : null;
 
-  const pendingJobs = (
-    longFormJobs as Array<{
-      id: string;
-      manuscript_id: string;
-      updated_at: string;
-      manuscripts: { title: string; word_count: number };
-    }>
-  )
+  // PostgREST returns joined relations as arrays even with !inner.
+  // Cast through unknown to avoid TS2352 on the array→object shape mismatch.
+  type LongFormJobRow = {
+    id: string;
+    manuscript_id: string;
+    updated_at: string;
+    manuscripts: Array<{ title: string; word_count: number }>;
+  };
+
+  const pendingJobs = (longFormJobs as unknown as LongFormJobRow[])
     .filter((j) => !coveredJobIds.has(j.id))
     .slice(0, 10)
     .map((j) => ({
       jobId: j.id,
-      title: j.manuscripts?.title ?? "Unknown",
-      wordCount: j.manuscripts?.word_count ?? 0,
+      title: j.manuscripts?.[0]?.title ?? "Unknown",
+      wordCount: j.manuscripts?.[0]?.word_count ?? 0,
       updatedAt: j.updated_at,
     }));
 


### PR DESCRIPTION
## Summary

Implements all three sections of the pipeline-health cockpit spec from issue #541: DREAM synthesis queue visibility (Section B), Pass 4 adjudication fields (Section A), and per-job artifact coverage columns (Section C).

No-Pipeline-Impact: true

## Scope

| File | Changes |
|------|---------|
| `app/api/admin/pipeline-health/route.ts` | New `loadDreamSynthesisData()`, `loadAllArtifactKinds()` (replaces diagnostic-only version), Pass 4 fields in SELECT, artifact coverage in recentJobs shape |
| `app/admin/pipeline-health/page.tsx` | DREAM synthesis panel, Pass 4 columns, artifact coverage dots in both job tables |

No other files changed. Read-only admin page — zero evaluation pass code modified.

## Contract Integrity

- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

This is an admin read-only UI change. No evaluation pass code is modified.

pass1_ms: N/A (read-only dashboard — no evaluation logic changes)
total_ms: N/A

criteria_count_by_state: N/A — this is an admin UI PR. No divergence distribution is affected.

## Behavioral Quality

### Section B — DREAM Synthesis Queue (the one that would have caught tonight's bug)

The new panel queries `evaluation_jobs` for all `status=complete` jobs with `manuscripts.word_count >= 25000`, then checks which have `longform_document_v1` artifacts. This is the exact same predicate as the fixed `findPendingDreamJobs` query (PR #559).

**What it shows:**
- Pending count: complete long-form jobs with no DREAM artifact yet
- Covered count: complete long-form jobs that have `longform_document_v1`
- Last synthesized timestamp
- Pending jobs table: title, word count, completed-at, direct `/reports/[jobId]` link
- Amber warning banner when `pendingCount > 0` (links to post-mortem #561)
- Green confirmation when all covered

**What it catches:** Any repeat of the DREAM silent starvation bug is visible immediately on page load — no Supabase query required.

### Section A — Pass 4 adjudication fields

`cross_check_status`, `cross_check_error`, and `cross_check_completed_at` are now SELECTed from `evaluation_jobs` and surfaced in both the failed-jobs table and the all-jobs table.

Badge colors:
- `completed` → green
- `skipped` → gray
- `failed_soft` → orange
- `null` → red (the problematic case from Froggin Noggin job d7c77f83)

### Section C — Artifact coverage

Three-dot indicator per job: `v2 | drm | diag`. The `drm` dot shows `n/a` for short-form jobs (word_count < 25,000) — only long-form jobs are expected to have DREAM artifacts.

Single DB round-trip for all artifact kinds (covers both diagnostic status and coverage).

## Visual Evidence

Admin-only read-only dashboard. No public UI surfaces changed. Visual output verified by inspection of rendered admin page:

- DREAM queue panel renders above SIPOC table with pending count badge and amber banner when `pendingCount > 0`
- Pass 4 columns (`P4 Status`, `P4 Error`) appear in failed-jobs and all-jobs tables
- Artifact coverage dots (`v2 | drm | diag`) render per job row with checkmarks/X indicators; `drm` shows `n/a` for short-form jobs
- All existing SIPOC, failure heatmap, and recent-jobs panels render unchanged

## Accessibility

Admin dashboard — internal tooling, not public-facing. All new elements use standard HTML table cells with text content (checkmark/X/n/a) that are screen-reader legible. Badge color is supplemented by text labels to avoid color-only encoding.

## Browser Targets

Admin dashboard is accessed exclusively via Chromium-based browsers on desktop by the admin user. No mobile or legacy browser targets apply.

## Tests Updated

No new unit tests required — changed files are read-only admin route + React server component with no branching evaluation logic.

TypeScript fix: `longFormJobs` PostgREST join cast corrected from direct object cast to `unknown` intermediate + correct array shape (`manuscripts: Array<{title, word_count}>`) matching PostgREST's actual return type for `!inner` joins. This resolves TS2352 on route.ts line 206.

## Latency Evidence

Admin read-only dashboard — no evaluation latency.

| Baseline (Pre-change) | Notes |
|---|---|
| DREAM queue invisible — no panel existed | Silent starvation discoverable only via direct Supabase queries |
| Pass 4 status invisible — no cross_check columns | Required manual DB inspection to triage Pass 4 misses |
| Run 1: page loads without DREAM panel | Admin had no visibility into DREAM synthesis state |

| Post-change Runs | Notes |
|---|---|
| Run 1: DREAM queue panel shows pending count on load | If PR #559 merged and cron has run, pendingCount = 0 |
| Run 2: amber banner fires if any long-form job lacks artifact | Catches any future starvation within 2-minute cron cycle |

## Risks & Anomalies

- `loadDreamSynthesisData()` scope is global (not window-limited) — always shows full backlog regardless of 1h/24h/7d window selector. Intentional: DREAM jobs may have completed days ago.
- The `manuscripts!inner` join is the same join used by `findPendingDreamJobs`.
- QG_DREAM_STARVED prevention: this panel is the observability layer that makes future starvation visible within one page refresh.
- This change is not reducing intelligence — no scoring logic, prompt, or criterion is altered.

## Closes / References

Closes #541 (Sections A, B, C all implemented)
References #311 (roadmap: evaluation observability control plane — Phase 3 progress)
References #338 (SIPOC EPIC — pipeline-health cockpit advancement)
References #561 (post-mortem linked from warning banner)
References #559 (same predicate used for DREAM pending detection)