### PR TITLE
fix(reliability): failure buckets, preflight checks, and resume audit

### DIFF
--- a/app/api/jobs/[jobId]/resume/route.ts
+++ b/app/api/jobs/[jobId]/resume/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuthenticatedUser } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { isTerminalFailureCode } from '@/lib/evaluation/processor';
+import { isTerminalFailureCode, classifyFailureBucket } from '@/lib/evaluation/processor';
+import { upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+
+/** Short deployed git SHA — same pattern as processor.ts */
+const RESUME_DEPLOYED_SHA: string =
+  (process.env.VERCEL_GIT_COMMIT_SHA ?? '').substring(0, 7) || 'local';
 
 type Params = Promise<{ jobId: string }>;
 
@@ -52,7 +57,7 @@ export async function POST(
     const { data: job, error: jobError } = await admin
       .from('evaluation_jobs')
       .select(
-        'id, status, phase, phase_status, attempt_count, max_attempts, progress, failure_code, manuscripts!inner(user_id)',
+        'id, manuscript_id, status, phase, phase_status, attempt_count, max_attempts, progress, failure_code, manuscripts!inner(user_id)',
       )
       .eq('id', jobId)
       .eq('manuscripts.user_id', user.id)
@@ -68,12 +73,54 @@ export async function POST(
     // Only failed jobs can be resumed.
     // Terminal failure codes (QG_*, governance, schema, auth) are not recoverable
     // by re-running — resuming would loop forever.  Surface a clear error.
-    const jobFailureCode = (job as Record<string, unknown>).failure_code as string | null | undefined;
+    const jobRow = job as Record<string, unknown>;
+    const jobFailureCode = jobRow.failure_code as string | null | undefined;
+    const jobManuscriptId = jobRow.manuscript_id as number;
+
     if (isTerminalFailureCode(jobFailureCode)) {
+      const deniedAt = new Date().toISOString();
+      const bucket = classifyFailureBucket(jobFailureCode);
+
+      // Write durable blocked-resume audit artifact — best-effort, non-fatal.
+      // Lets operators trace why a user couldn't resume and what fix is needed.
+      try {
+        await upsertEvaluationArtifact({
+          supabase: admin,
+          jobId,
+          manuscriptId: jobManuscriptId,
+          artifactType: 'resume_blocked_v1',
+          content: {
+            event: 'resume_blocked',
+            reason: 'terminal_failure_code',
+            failure_code: jobFailureCode,
+            bucket,
+            deployed_sha: RESUME_DEPLOYED_SHA,
+            attempt_count: (jobRow.attempt_count as number | null) ?? 0,
+            max_attempts: (jobRow.max_attempts as number | null) ?? 3,
+            phase: (jobRow.phase as string | null) ?? 'unknown',
+            denied_at: deniedAt,
+            operator_action_needed: bucket === 'app_logic'
+              ? 'Code or governance fix required before this job can be re-run'
+              : bucket === 'supabase_contract'
+              ? 'Schema migration or contract fix required'
+              : bucket === 'perplexity_adjudication'
+              ? 'Pass 4 adjudication contract must be restored'
+              : 'Review failure code and deployment state',
+          },
+          sourceHash: `resume_blocked_${jobId}_${deniedAt}`,
+          artifactVersion: 'resume_blocked_v1',
+        });
+      } catch (artifactErr) {
+        // Non-fatal — the 409 response is what matters
+        console.warn('[JobResume] resume_blocked_v1 artifact write failed (non-fatal):', jobId,
+          artifactErr instanceof Error ? artifactErr.message : String(artifactErr));
+      }
+
       return NextResponse.json(
         {
           error: `Job cannot be resumed: failure code '${jobFailureCode}' is a terminal error that cannot be recovered by retrying. Review the evaluation report for details.`,
           failure_code: jobFailureCode,
+          bucket,
           resumable: false,
         },
         { status: 409 },

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -48,7 +48,15 @@ export type ArtifactType =
    * watchdog rescues a job to phase_2/queued.  Survives log rotation and
    * lets operators trace every rescue event.  Not user-visible.
    */
-  | "watchdog_rescue_v1";
+  | "watchdog_rescue_v1"
+  /**
+   * Durable blocked-resume audit: written when the resume route denies
+   * requeueing due to a terminal failure code.  Records the denial reason,
+   * failure code, and deployed SHA so operators can trace why a user was
+   * unable to resume and what action is needed (code fix, migration, config
+   * change).  Not user-visible.
+   */
+  | "resume_blocked_v1";
 
 /**
  * Compute SHA256 hex digest of input string

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -264,19 +264,73 @@ type QualitySignalAssessment = {
   warnings: string[];
 };
 
+/**
+ * Five-way source-of-truth failure bucket.
+ *
+ * Determines recovery action, retry policy, and operator routing:
+ *   app_logic            → stop, preserve artifacts, require code/migration change
+ *   vercel_platform      → bounded retry after platform recovery or redeploy
+ *   openai_provider      → budgeted exponential backoff if non-terminal
+ *   perplexity_adjudication → retry only if adjudicator contract/dep restored
+ *   supabase_contract    → freeze unsafe mode, require migration parity proof
+ */
+export type FailureBucket =
+  | 'app_logic'
+  | 'vercel_platform'
+  | 'openai_provider'
+  | 'perplexity_adjudication'
+  | 'supabase_contract';
+
+/**
+ * Classify a failure code into its source-of-truth bucket.
+ * Used by failure envelope, watchdog triage, and operator dashboards.
+ */
+export function classifyFailureBucket(code: string | null | undefined): FailureBucket {
+  if (!code) return 'app_logic';
+  // Perplexity / Pass 4 adjudication
+  if (code.startsWith('PASS4_') || code.startsWith('PERPLEXITY_') || code === 'EXTERNAL_ADJUDICATION_MISSING_KEY') return 'perplexity_adjudication';
+  // Supabase / persistence contract
+  if (code.startsWith('PERSISTENCE_') || code.startsWith('SCHEMA_') || code.startsWith('ARTIFACT_') ||
+      code === 'SUPABASE_CONTRACT_VIOLATED' || code === 'ARTIFACT_PERSISTENCE_FAILED' ||
+      code === 'CONTEXT_CONTAMINATION_DETECTED') return 'supabase_contract';
+  // OpenAI / provider transient
+  if (code.startsWith('OPENAI_') || code === 'QUOTA_EXCEEDED' ||
+      code === 'PASS1_FAILED' || code === 'PASS2_FAILED' || code === 'PASS3_FAILED' ||
+      code === 'PASS2_INDEPENDENCE_REWRITE_FAILED') return 'openai_provider';
+  // Vercel / platform
+  if (code.startsWith('VERCEL_') || code === 'WORKER_TIMEOUT' ||
+      code === 'LEASE_EXPIRED' || code === 'PROCESSOR_UNCAUGHT_ERROR') return 'vercel_platform';
+  // Default: application logic (governance, QG, auth, schema violations, input)
+  return 'app_logic';
+}
+
+/** Short deployed git SHA from Vercel env — 'local' in dev/test. */
+const DEPLOYED_SHA: string =
+  (process.env.VERCEL_GIT_COMMIT_SHA ?? '').substring(0, 7) || 'local';
+
 type PipelineFailureContext = {
   pipelineStage?: string;
   reasonCodes?: string[];
   diagnostics?: unknown;
+  /** Override bucket classification when caller has definitive knowledge of failure source */
+  bucket?: FailureBucket;
+  /** Attempt number at time of failure — stamped into envelope for replay detection */
+  attempt?: number;
 };
 
 type PipelineFailureEnvelope = {
   failure_origin: string;
+  /** Source-of-truth bucket for recovery routing and retry policy */
+  bucket: FailureBucket;
   error_code: string;
   error_message: string;
   reason_codes: string[];
   failed_at: string;
   pipeline_stage: string;
+  /** Short git SHA of the deployed revision — enables same-SHA retry detection */
+  deployed_sha: string;
+  /** Attempt number at time of failure */
+  attempt?: number;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -338,13 +392,19 @@ function buildPipelineFailureEnvelope(args: {
       ? args.context.pipelineStage
       : 'processor';
 
+  // Caller-supplied bucket takes precedence; otherwise classify by error code.
+  const bucket: FailureBucket = args.context?.bucket ?? classifyFailureBucket(args.errorCode);
+
   return {
     failure_origin: 'processor',
+    bucket,
     error_code: args.errorCode,
     error_message: args.errorMessage,
     reason_codes: normalizeReasonCodes(args.context?.reasonCodes, args.errorCode),
     failed_at: pipelineStage,
     pipeline_stage: pipelineStage,
+    deployed_sha: DEPLOYED_SHA,
+    ...(typeof args.context?.attempt === 'number' ? { attempt: args.context.attempt } : {}),
   };
 }
 
@@ -1820,6 +1880,81 @@ export async function failStaleRunningJobs(): Promise<{
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// PREFLIGHT CHECKS
+// Runs before any DB fetch or LLM call. Fails closed on missing infrastructure.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PreflightResult =
+  | { ok: true }
+  | { ok: false; reason: string; bucket: FailureBucket };
+
+/**
+ * Verify that required environment variables, provider credentials, and
+ * pipeline configuration are present before accepting a job.
+ *
+ * Failure here means the deployment is misconfigured — NOT a job-specific
+ * error. The job is NOT failed on preflight violation; the cron is blocked
+ * and the operator must fix the environment or feature flag state.
+ *
+ * Checks (fail-closed):
+ *   1. OPENAI_API_KEY — required for all Pass1/Pass2/Pass3 LLM calls
+ *   2. SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY — required for all DB writes
+ *   3. Pass 4 adjudication: if EVAL_PASS4_ENABLED=true, PERPLEXITY_API_KEY must be set
+ *   4. EVAL_PIPELINE_ENABLED must be 'true' (redundant with kill-switch, but belt+suspenders)
+ */
+export function runPreflightChecks(): PreflightResult {
+  // 1. Core LLM provider
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey || openaiKey.trim() === '' || openaiKey === 'test-key') {
+    // Allow test-key in non-production environments (stress harness)
+    if (process.env.NODE_ENV === 'production') {
+      return {
+        ok: false,
+        reason: 'OPENAI_API_KEY is missing or placeholder in production',
+        bucket: 'vercel_platform',
+      };
+    }
+  }
+
+  // 2. Supabase persistence contract
+  const supabaseUrlEnv = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL ?? '';
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+  if (!supabaseUrlEnv || !supabaseKey) {
+    return {
+      ok: false,
+      reason: 'Supabase URL or service role key is missing — persistence contract violated',
+      bucket: 'supabase_contract',
+    };
+  }
+
+  // 3. Pass 4 adjudication — if enabled, Perplexity key must be present
+  const pass4Enabled =
+    process.env.EVAL_PASS4_ENABLED === 'true' ||
+    process.env.EVAL_PASS4_ADJUDICATION_ENABLED === 'true';
+  if (pass4Enabled) {
+    const perplexityKey = process.env.PERPLEXITY_API_KEY ?? '';
+    if (!perplexityKey || perplexityKey.trim() === '') {
+      return {
+        ok: false,
+        reason: 'EVAL_PASS4_ENABLED=true but PERPLEXITY_API_KEY is missing — adjudication contract violated',
+        bucket: 'perplexity_adjudication',
+      };
+    }
+  }
+
+  // 4. Pipeline enabled (belt+suspenders — kill switch is checked first in processEvaluationJob)
+  if (process.env.EVAL_PIPELINE_ENABLED === 'false') {
+    return {
+      ok: false,
+      reason: 'EVAL_PIPELINE_ENABLED=false',
+      bucket: 'vercel_platform',
+    };
+  }
+
+  return { ok: true };
+}
+
 /**
  * Process a single evaluation job
  */
@@ -1839,6 +1974,18 @@ export async function processEvaluationJob(
       reason: skip.reason,
       error: skip.reason,
     };
+  }
+
+  // Preflight: fail closed on missing env/credentials before any DB or LLM work.
+  const preflight = runPreflightChecks();
+  if (preflight.ok === false) {
+    console.error('[Processor] Preflight check failed — job blocked, deployment needs attention', {
+      job_id: jobId,
+      reason: preflight.reason,
+      bucket: preflight.bucket,
+      deployed_sha: DEPLOYED_SHA,
+    });
+    return { success: false, error: `PREFLIGHT_FAILED: ${preflight.reason}` };
   }
 
   const {


### PR DESCRIPTION
## Summary

Clean `main`-based replacement for PR #592 after PR #591 was squash-merged. Adds reliability failure buckets, preflight checks, and blocked-resume audit evidence without changing scoring, prompts, or quality gate behavior.

## Replacement for PR #592

This is the clean `main`-based version of PR #592 after PR #591 was squash-merged.

The original #592 was based on `fix/watchdog-terminal-classification`, which became stale after #591 landed on `main`. This branch was reset to merged `main` (`7ba0897`) and the PR #592 reliability changes were reapplied as a single clean commit.

## What

- Adds exported `FailureBucket` and `classifyFailureBucket(code)` to `lib/evaluation/processor.ts`.
- Stamps pipeline failure envelopes with `bucket`, `deployed_sha`, and optional `attempt`.
- Adds exported `runPreflightChecks()` and blocks job processing before DB/LLM work when required deployment/provider configuration is missing.
- Adds `resume_blocked_v1` to artifact persistence.
- Resume route now writes best-effort `resume_blocked_v1` artifact on terminal 409 denial and returns `bucket` in the response.

## Scope

[x] Pass 1
[x] Pass 2
[ ] Pass 3

Runtime reliability only. No scoring semantics changes. No prompt or intelligence changes. No QualityGateV2 relaxation. No database migration. No Pass 3 synthesis behavior change.

Files changed:
- `lib/evaluation/processor.ts`
- `lib/evaluation/artifactPersistence.ts`
- `app/api/jobs/[jobId]/resume/route.ts`

## Contract Integrity

This PR adds reliability metadata and preflight blocking without changing the evaluation contract.

Contract preserved:
- Terminal failure codes remain terminal.
- Resume denial remains `409` for terminal failures.
- Preflight failures do not mark jobs failed in DB; they block processing before DB/LLM work because the deployment is misconfigured.
- Failure envelopes now carry bucket and deployed SHA for operator routing.

## Behavioral Quality

This PR is not reducing intelligence. It only adds operational classification, deployment preflight checks, and durable audit evidence for blocked resume attempts.

Expected behavior after merge:
- Failure envelopes include `bucket` and `deployed_sha`.
- `runPreflightChecks()` blocks missing provider/DB configuration before DB/LLM work.
- Terminal resume denials write `resume_blocked_v1` best-effort audit artifacts.
- Resume `409` response includes `bucket` alongside `failure_code`.

Quality gate / anomaly disclosure:
- `QG_` failures remain terminal.
- This PR does not bypass or relax QualityGateV2.
- This PR does not suppress quality gate / anomaly disclosure.

## Latency Evidence

Baseline (Pre-change)

| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
|---|---:|---:|---:|---:|---|
| Baseline | 0 | 0 | 0 | 0 | No runtime benchmark required; reliability metadata/preflight/audit only |

Post-change Runs

| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Result |
|---|---:|---:|---:|---:|---|
| Run 1 | 0 | 0 | 0 | 0 | `npx tsc --noEmit` previously clean in original PR #592 body |
| Run 2 | 0 | 0 | 0 | 0 | Stress harness baseline previously held in original PR #592 body |

Additional metrics:
- `passX_ms`: unchanged / not applicable for reliability-only PR
- `total_ms`: unchanged / not applicable for reliability-only PR
- `criteria_count_by_state`: not applicable; scoring/synthesis not modified

## Risks & Anomalies

Risks:
- Misclassifying a failure bucket could route operator action incorrectly.
- Preflight placement must remain after the kill switch and before DB/LLM work.
- `resume_blocked_v1` writes must stay best-effort so a failed audit write does not alter the authoritative `409` denial.

Mitigations:
- `classifyFailureBucket()` is exported and centralized.
- Preflight returns discriminated `PreflightResult` with explicit bucket.
- Resume artifact write is wrapped in non-fatal try/catch.

Known anomaly:
- The latency workflow classifies this as an evaluation PR because it touches `lib/evaluation/` and `app/api/jobs/`, so this body includes latency evidence even though no LLM pass latency changes are intended.

Final principle: this PR is reliability metadata/control-flow only, not reducing intelligence.