### PR TITLE
feat(dashboard): wire user evaluation history dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,34 +1,89 @@
-import Link from "next/link";
+import DashboardHeader from '@/components/dashboard/DashboardHeader'
+import KpiCard from '@/components/dashboard/KpiCard'
+import EvaluationHistoryTable from '@/components/dashboard/EvaluationHistoryTable'
+import EmptyState from '@/components/dashboard/EmptyState'
+import {
+  getDashboardEvaluations,
+  computeDashboardKpis,
+} from '@/lib/dashboard/getDashboardEvaluations'
 
-export default function DashboardPage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">My Jobs Dashboard</h1>
-      <p className="text-slate-600 mb-6">
-        Submit manuscripts and track evaluation results through the live writer flow.
-      </p>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Link href="/evaluate" className="block rounded-lg border border-slate-200 p-5 hover:shadow-md transition">
-          <h2 className="font-medium text-slate-900 mb-1">My Jobs &amp; Evaluate</h2>
-          <p className="text-sm text-slate-600">Submit a manuscript, monitor status, and open results at /evaluate/[jobId].</p>
-        </Link>
-        <Link href="/dashboard/activity" className="block rounded-lg border border-slate-200 p-5 hover:shadow-md transition">
-          <h2 className="font-medium text-slate-900 mb-1">Activity History</h2>
-          <p className="text-sm text-slate-600">Review recent account and evaluation actions, then jump back to them.</p>
-        </Link>
-        <Link href="/revise" className="block rounded-lg border border-slate-200 p-5 hover:shadow-md transition">
-          <h2 className="font-medium text-slate-900 mb-1">Revise</h2>
-          <p className="text-sm text-slate-600">Review revision recommendations and track progress.</p>
-        </Link>
-        <Link href="/convert" className="block rounded-lg border border-slate-200 p-5 hover:shadow-md transition">
-          <h2 className="font-medium text-slate-900 mb-1">Convert</h2>
-          <p className="text-sm text-slate-600">Transform manuscripts between formats.</p>
-        </Link>
-        <Link href="/output" className="block rounded-lg border border-slate-200 p-5 hover:shadow-md transition">
-          <h2 className="font-medium text-slate-900 mb-1">Output</h2>
-          <p className="text-sm text-slate-600">Generate publication-ready submission packages.</p>
-        </Link>
+export const dynamic = 'force-dynamic'
+
+export default async function DashboardPage() {
+  const { rows, error } = await getDashboardEvaluations({ limit: 15 })
+
+  if (error) {
+    return (
+      <div className="rg-dash-page">
+        <DashboardHeader />
+        <EmptyState
+          title="We couldn't load your evaluations"
+          body="Please refresh the page. If the problem continues, contact support."
+          ctaHref="/dashboard"
+          ctaLabel="Try again"
+        />
       </div>
-    </main>
-  );
+    )
+  }
+
+  if (!rows.length) {
+    return (
+      <div className="rg-dash-page">
+        <DashboardHeader />
+        <EmptyState
+          title="No evaluations yet"
+          body="Run your first RevisionGrade evaluation to start tracking scores, trends, and submission readiness."
+          ctaHref="/evaluate"
+          ctaLabel="Start evaluation"
+        />
+      </div>
+    )
+  }
+
+  const kpis = computeDashboardKpis(rows)
+
+  return (
+    <div className="rg-dash-page">
+      <DashboardHeader />
+
+      <section className="rg-kpi-row" aria-label="Summary metrics">
+        <KpiCard
+          label="Latest overall score"
+          value={kpis.latestOverall.value}
+          meta={kpis.latestOverall.meta}
+          delta={kpis.latestOverall.delta}
+          deltaTone={kpis.latestOverall.deltaTone}
+        />
+        <KpiCard
+          label="Latest readiness score"
+          value={kpis.latestReadiness.value}
+          meta={kpis.latestReadiness.meta}
+          delta={kpis.latestReadiness.delta}
+          deltaTone={kpis.latestReadiness.deltaTone}
+        />
+        <KpiCard
+          label="Best dimension score"
+          value={kpis.bestScore.value}
+          meta={kpis.bestScore.meta}
+          delta={kpis.bestScore.delta}
+          deltaTone={kpis.bestScore.deltaTone}
+        />
+        <KpiCard
+          label="Curation-ready manuscripts"
+          value={kpis.curationReady.value}
+          meta={kpis.curationReady.meta}
+          delta={kpis.curationReady.delta}
+          deltaTone={kpis.curationReady.deltaTone}
+        />
+      </section>
+
+      <EvaluationHistoryTable rows={rows} />
+
+      <p className="rg-dash-footnote">
+        Submission readiness indicates a manuscript has reached a RevisionGrade quality
+        threshold associated with stronger submission potential. It is a curation
+        threshold, not a promise of industry response.
+      </p>
+    </div>
+  )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,313 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* === User evaluation dashboard === */
+
+.rg-dash-page {
+  --rg-bg: #f7f6f2;
+  --rg-surface: #f9f8f5;
+  --rg-surface-2: #fbfbf9;
+  --rg-divider: #dcd9d5;
+  --rg-border: #d4d1ca;
+  --rg-ink: #28251d;
+  --rg-ink-muted: #6d6b65;
+  --rg-primary: #01696f;
+  --rg-primary-soft: #dbe9e7;
+  --rg-success: #437a22;
+  --rg-warning: #964219;
+  --rg-gold: #b8862b;
+  --rg-gold-soft: #f3e6c8;
+
+  width: min(1480px, 100%);
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  background: var(--rg-bg);
+  color: var(--rg-ink);
+  font-family: Georgia, 'Iowan Old Style', 'Source Serif Pro', serif;
+}
+
+.rg-dash-header,
+.rg-kpi-card,
+.rg-history-card,
+.rg-empty-state {
+  background: var(--rg-surface);
+  border: 1px solid var(--rg-border);
+  border-radius: 20px;
+}
+
+.rg-dash-header {
+  padding: 32px;
+  margin-bottom: 28px;
+}
+
+.rg-dash-eyebrow {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--rg-primary-soft);
+  color: var(--rg-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.rg-dash-title {
+  margin: 0 0 12px;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  line-height: 1.1;
+  color: var(--rg-ink);
+  max-width: 22ch;
+}
+
+.rg-dash-subtitle {
+  margin: 0 0 28px;
+  max-width: 62ch;
+  line-height: 1.7;
+  color: var(--rg-ink-muted);
+  font-size: 1rem;
+}
+
+.rg-dash-context,
+.rg-kpi-row {
+  display: grid;
+  gap: 14px;
+}
+
+.rg-dash-context {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.rg-kpi-row {
+  grid-template-columns: repeat(4, 1fr);
+  margin-bottom: 28px;
+}
+
+.rg-dash-context-card,
+.rg-kpi-card {
+  background: var(--rg-surface-2);
+  border: 1px solid var(--rg-border);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.rg-dash-context-label,
+.rg-kpi-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rg-ink-muted);
+}
+
+.rg-dash-context-value,
+.rg-kpi-value {
+  margin-top: 8px;
+  font-size: clamp(1.6rem, 2vw, 2.4rem);
+  font-weight: 700;
+  color: var(--rg-ink);
+}
+
+.rg-dash-context-note,
+.rg-kpi-meta,
+.rg-kpi-delta {
+  margin-top: 8px;
+  color: var(--rg-ink-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.rg-kpi-delta--positive {
+  color: var(--rg-success);
+  font-weight: 700;
+}
+
+.rg-kpi-delta--gold {
+  color: var(--rg-gold);
+  font-weight: 700;
+}
+
+.rg-history-card {
+  padding: 24px;
+}
+
+.rg-history-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.rg-history-title {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--rg-ink);
+}
+
+.rg-history-copy {
+  margin: 6px 0 0;
+  color: var(--rg-ink-muted);
+}
+
+.rg-history-table-wrap {
+  overflow-x: auto;
+}
+
+.rg-history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.rg-history-table th,
+.rg-history-table td {
+  padding: 14px 10px;
+  border-bottom: 1px solid var(--rg-divider);
+  text-align: left;
+  vertical-align: middle;
+  font-size: 0.92rem;
+}
+
+.rg-history-table th {
+  font-size: 0.72rem;
+  color: var(--rg-ink-muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.rg-history-title-cell {
+  font-weight: 700;
+  color: var(--rg-ink);
+}
+
+.rg-history-subtitle-cell {
+  margin-top: 3px;
+  color: var(--rg-ink-muted);
+  font-size: 0.82rem;
+}
+
+.rg-status {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.rg-status--ready {
+  background: var(--rg-gold-soft);
+  color: var(--rg-gold);
+}
+
+.rg-status--near,
+.rg-status--running {
+  background: #f4e3d8;
+  color: var(--rg-warning);
+}
+
+.rg-status--failed {
+  background: #f3d6d3;
+  color: #8f241b;
+}
+
+.rg-status--improving {
+  background: var(--rg-primary-soft);
+  color: var(--rg-primary);
+}
+
+.rg-history-open,
+.rg-empty-cta {
+  color: var(--rg-primary);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.rg-history-open:hover,
+.rg-empty-cta:hover {
+  text-decoration: underline;
+}
+
+.rg-dash-footnote {
+  margin: 20px 0 0;
+  color: var(--rg-ink-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.rg-empty-state {
+  padding: 32px;
+}
+
+.rg-empty-state h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.rg-empty-state p {
+  margin: 10px 0 20px;
+  max-width: 62ch;
+  color: var(--rg-ink-muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 1100px) {
+  .rg-dash-context,
+  .rg-kpi-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 760px) {
+  .rg-dash-page {
+    padding: 20px 14px 44px;
+  }
+
+  .rg-dash-context,
+  .rg-kpi-row {
+    grid-template-columns: 1fr;
+  }
+
+  .rg-history-table,
+  .rg-history-table thead,
+  .rg-history-table tbody,
+  .rg-history-table th,
+  .rg-history-table td,
+  .rg-history-table tr {
+    display: block;
+  }
+
+  .rg-history-table thead {
+    display: none;
+  }
+
+  .rg-history-table tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .rg-history-table tr {
+    border: 1px solid var(--rg-border);
+    border-radius: 14px;
+    padding: 12px;
+    background: var(--rg-surface-2);
+  }
+
+  .rg-history-table td {
+    border-bottom: 0;
+    padding: 6px 0;
+  }
+
+  .rg-history-table td::before {
+    content: attr(data-label);
+    display: block;
+    color: var(--rg-ink-muted);
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 700;
+    margin-bottom: 2px;
+  }
+}

--- a/components/dashboard/DashboardHeader.jsx
+++ b/components/dashboard/DashboardHeader.jsx
@@ -1,0 +1,38 @@
+export default function DashboardHeader() {
+  return (
+    <header className="rg-dash-header">
+      <div className="rg-dash-eyebrow">Dashboard · Submission readiness</div>
+      <h1 className="rg-dash-title">
+        Track revision progress toward submission readiness.
+      </h1>
+      <p className="rg-dash-subtitle">
+        Review recent evaluations, open reports, and see which manuscripts are
+        approaching the 8.0 curation threshold.
+      </p>
+
+      <div className="rg-dash-context">
+        <div className="rg-dash-context-card">
+          <div className="rg-dash-context-label">Readiness rule</div>
+          <div className="rg-dash-context-value">8.0 / 10</div>
+          <div className="rg-dash-context-note">
+            Crossing 8.0 marks curation-ready status.
+          </div>
+        </div>
+        <div className="rg-dash-context-card">
+          <div className="rg-dash-context-label">Visible rows</div>
+          <div className="rg-dash-context-value">Latest 15</div>
+          <div className="rg-dash-context-note">
+            Older evaluations load via deeper history.
+          </div>
+        </div>
+        <div className="rg-dash-context-card">
+          <div className="rg-dash-context-label">Current focus</div>
+          <div className="rg-dash-context-value">Evaluation history</div>
+          <div className="rg-dash-context-note">
+            Charts and insights ship in a later release.
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/dashboard/EmptyState.jsx
+++ b/components/dashboard/EmptyState.jsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function EmptyState({ title, body, ctaHref, ctaLabel }) {
+  return (
+    <section className="rg-empty-state">
+      <h2>{title}</h2>
+      <p>{body}</p>
+      {ctaHref && ctaLabel ? (
+        <Link href={ctaHref} className="rg-empty-cta">
+          {ctaLabel}
+        </Link>
+      ) : null}
+    </section>
+  )
+}

--- a/components/dashboard/EvaluationHistoryTable.jsx
+++ b/components/dashboard/EvaluationHistoryTable.jsx
@@ -1,0 +1,96 @@
+function statusLabel(status) {
+  switch (status) {
+    case 'market_ready':
+      return 'Curation-ready'
+    case 'near_ready':
+      return 'Near ready'
+    case 'improving':
+      return 'Improving'
+    case 'running':
+      return 'Running'
+    case 'failed':
+      return 'Failed'
+    default:
+      return 'Below standard'
+  }
+}
+
+function StatusBadge({ status }) {
+  const cls =
+    status === 'market_ready'
+      ? 'rg-status rg-status--ready'
+      : status === 'near_ready'
+      ? 'rg-status rg-status--near'
+      : status === 'running'
+      ? 'rg-status rg-status--running'
+      : status === 'failed'
+      ? 'rg-status rg-status--failed'
+      : 'rg-status rg-status--improving'
+
+  return <span className={cls}>{statusLabel(status)}</span>
+}
+
+function formatDate(value) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function formatScore(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(1) : '—'
+}
+
+export default function EvaluationHistoryTable({ rows }) {
+  return (
+    <section className="rg-history-card" aria-label="Recent evaluations">
+      <div className="rg-history-head">
+        <div>
+          <h2 className="rg-history-title">Recent evaluations</h2>
+          <p className="rg-history-copy">Showing the {rows.length} most recent evaluations.</p>
+        </div>
+      </div>
+
+      <div className="rg-history-table-wrap">
+        <table className="rg-history-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Manuscript</th>
+              <th>Type</th>
+              <th>Overall</th>
+              <th>Ready</th>
+              <th>Status</th>
+              <th>Open</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id}>
+                <td data-label="Date">{formatDate(row.createdAt)}</td>
+                <td data-label="Manuscript">
+                  <div className="rg-history-title-cell">{row.manuscriptTitle}</div>
+                  <div className="rg-history-subtitle-cell">{row.manuscriptSubtitle}</div>
+                </td>
+                <td data-label="Type">{row.evaluationType}</td>
+                <td data-label="Overall">{formatScore(row.overallScore)}</td>
+                <td data-label="Ready">{formatScore(row.readinessScore)}</td>
+                <td data-label="Status">
+                  <StatusBadge status={row.status} />
+                </td>
+                <td data-label="Open">
+                  <a className="rg-history-open" href={row.reportHref}>
+                    Open report
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/components/dashboard/KpiCard.jsx
+++ b/components/dashboard/KpiCard.jsx
@@ -1,0 +1,17 @@
+export default function KpiCard({ label, value, meta, delta, deltaTone = 'neutral' }) {
+  const deltaClass =
+    deltaTone === 'positive'
+      ? 'rg-kpi-delta rg-kpi-delta--positive'
+      : deltaTone === 'gold'
+      ? 'rg-kpi-delta rg-kpi-delta--gold'
+      : 'rg-kpi-delta'
+
+  return (
+    <article className="rg-kpi-card">
+      <div className="rg-kpi-label">{label}</div>
+      <div className="rg-kpi-value">{value}</div>
+      <div className="rg-kpi-meta">{meta}</div>
+      {delta ? <div className={deltaClass}>{delta}</div> : null}
+    </article>
+  )
+}

--- a/lib/dashboard/getDashboardEvaluations.ts
+++ b/lib/dashboard/getDashboardEvaluations.ts
@@ -1,0 +1,140 @@
+export type DashboardEvaluationStatus =
+  | 'market_ready'
+  | 'near_ready'
+  | 'improving'
+  | 'below_standard'
+  | 'running'
+  | 'failed'
+
+export type DashboardEvaluationRow = {
+  id: string
+  jobId: string
+  manuscriptId: string
+  manuscriptTitle: string
+  manuscriptSubtitle: string
+  createdAt: string
+  evaluationType: 'Evaluate' | 'Revise'
+  overallScore: number | null
+  readinessScore: number | null
+  status: DashboardEvaluationStatus
+  reportHref: string
+}
+
+export type DashboardKpi = {
+  value: string
+  meta: string
+  delta: string
+  deltaTone: 'positive' | 'gold' | 'neutral'
+}
+
+export type DashboardKpis = {
+  latestOverall: DashboardKpi
+  latestReadiness: DashboardKpi
+  bestScore: DashboardKpi
+  curationReady: DashboardKpi
+}
+
+/**
+ * Phase 1 wiring: returns empty until the Supabase adapter PR lands.
+ * The dashboard page renders the empty state safely.
+ */
+export async function getDashboardEvaluations(
+  _opts: { limit?: number } = {},
+): Promise<{ rows: DashboardEvaluationRow[]; error: Error | null }> {
+  return { rows: [], error: null }
+}
+
+export function statusFromScores(
+  overall: number | null,
+  readiness: number | null,
+): DashboardEvaluationStatus {
+  const top = Math.max(overall ?? 0, readiness ?? 0)
+  if (top >= 8.0) return 'market_ready'
+  if (top >= 7.5) return 'near_ready'
+  if (top >= 6.5) return 'improving'
+  return 'below_standard'
+}
+
+export function computeDashboardKpis(rows: DashboardEvaluationRow[]): DashboardKpis {
+  const sorted = [...rows].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+  const latest = sorted[0]
+  const previousForSameManuscript = sorted.find(
+    (r) => latest && r.manuscriptId === latest.manuscriptId && r.id !== latest.id,
+  )
+
+  const latestOverallValue = latest?.overallScore ?? null
+  const previousOverallValue = previousForSameManuscript?.overallScore ?? null
+  const overallDelta =
+    latestOverallValue != null && previousOverallValue != null
+      ? latestOverallValue - previousOverallValue
+      : null
+
+  const latestReadinessValue = latest?.readinessScore ?? null
+
+  const best = rows.reduce<DashboardEvaluationRow | null>((acc, r) => {
+    const cur = Math.max(r.overallScore ?? 0, r.readinessScore ?? 0)
+    const top = acc ? Math.max(acc.overallScore ?? 0, acc.readinessScore ?? 0) : -1
+    return cur > top ? r : acc
+  }, null)
+
+  const curationReadyCount = countCurationReady(rows)
+
+  return {
+    latestOverall: {
+      value: formatScore(latestOverallValue),
+      meta: latest ? latest.manuscriptTitle : 'No evaluations yet',
+      delta:
+        overallDelta == null
+          ? '—'
+          : `${overallDelta >= 0 ? '+' : ''}${overallDelta.toFixed(1)} vs prior evaluation`,
+      deltaTone: overallDelta != null && overallDelta > 0 ? 'positive' : 'neutral',
+    },
+    latestReadiness: {
+      value: formatScore(latestReadinessValue),
+      meta: 'Threshold is 8.0',
+      delta:
+        latestReadinessValue != null && latestReadinessValue >= 8.0
+          ? 'Curation-ready'
+          : 'Below threshold',
+      deltaTone:
+        latestReadinessValue != null && latestReadinessValue >= 8.0 ? 'gold' : 'neutral',
+    },
+    bestScore: {
+      value: formatScore(
+        best ? Math.max(best.overallScore ?? 0, best.readinessScore ?? 0) : null,
+      ),
+      meta: best ? `${best.manuscriptTitle} · ${best.createdAt}` : 'No evaluations yet',
+      delta: 'Highest recorded craft score',
+      deltaTone: 'neutral',
+    },
+    curationReady: {
+      value: String(curationReadyCount),
+      meta: 'Manuscripts at or above 8.0',
+      delta: 'Eligible for later curation review',
+      deltaTone: curationReadyCount > 0 ? 'gold' : 'neutral',
+    },
+  }
+}
+
+function countCurationReady(rows: DashboardEvaluationRow[]): number {
+  const latestPerManuscript = new Map<string, DashboardEvaluationRow>()
+  for (const r of rows) {
+    const prev = latestPerManuscript.get(r.manuscriptId)
+    if (!prev || new Date(r.createdAt).getTime() > new Date(prev.createdAt).getTime()) {
+      latestPerManuscript.set(r.manuscriptId, r)
+    }
+  }
+  let n = 0
+  for (const r of latestPerManuscript.values()) {
+    const top = Math.max(r.overallScore ?? 0, r.readinessScore ?? 0)
+    if (top >= 8.0) n += 1
+  }
+  return n
+}
+
+function formatScore(value: number | null): string {
+  if (value == null) return '—'
+  return value.toFixed(1)
+}


### PR DESCRIPTION
## Summary

Adds the Phase 1 user evaluation history dashboard shell at `/dashboard`.

Replaces the placeholder dashboard hub with a stable, typed dashboard surface for evaluation history, KPI cards, empty/error states, and future live data wiring.

## Scope

**Changed files:**

- `app/dashboard/page.tsx`
- `lib/dashboard/getDashboardEvaluations.ts`
- `components/dashboard/DashboardHeader.jsx`
- `components/dashboard/KpiCard.jsx`
- `components/dashboard/EvaluationHistoryTable.jsx`
- `components/dashboard/EmptyState.jsx`
- `app/globals.css`

**In scope:**

- Server-rendered `/dashboard` page
- Typed dashboard data adapter with KPI computation helpers
- Recent evaluations table component with mobile responsive layout
- Safe empty state while live Supabase query wiring lands in a follow-up PR
- Real report-link contract via `reportHref` on row objects

**Out of scope:**

- No live Supabase query implementation
- No analytics backend, charts, or trend panels
- No report-experience worker/UI wiring
- No evaluation pipeline changes
- No database migration
- No scoring, prompt, or QualityGate changes

## Contract Integrity

**No evaluation contract changes.**

- Does not touch Pass 1, Pass 2, Pass 3, Pass 4, or QualityGateV2
- Does not alter `evaluation_jobs` state semantics
- Does not alter artifact persistence
- Does not change scoring, confidence, score caps, criteria, or report generation
- The data adapter returns an empty safe result so `/dashboard` renders safely before the Supabase adapter is implemented

## Behavioral Quality

This PR is **not reducing intelligence**.

It adds a user-facing dashboard shell only. The governed evaluation kernel remains unchanged. The dashboard intentionally avoids deriving new claims from incomplete data and renders an empty state until the live data adapter is wired.

## Visual Evidence

**Expected Phase 1 behavior:**

- `/dashboard` renders the new RevisionGrade dashboard shell
- With the current stub adapter, shows the empty state: "No evaluations yet" + CTA to `/evaluate`
- KPI and table components exist but only render once rows are returned by the adapter
- No charts or analytics panels included

## Accessibility

- Semantic `<header>`, `<section>`, `<table>`, and `<a>` elements
- Empty state includes clear CTA copy
- Table includes `data-label` attributes for mobile card layout
- Status badges use text labels — not color-only meaning

## Browser Targets

Standard Next.js browser targets: Chromium, Safari/WebKit, Firefox

## Tests Updated

No test files added in this Phase 1 shell PR.

**Recommended local validation:**

```bash
npm run build
# or
npx tsc --noEmit
```

## Latency Evidence

Dashboard UI only — no evaluation runtime path is touched.

| Metric | Baseline | Post-change | Notes |
|--------|----------|-------------|-------|
| pass1_ms | 0 | 0 | no Pass 1 path touched |
| pass2_ms | 0 | 0 | no Pass 2 path touched |
| pass3_ms | 0 | 0 | no Pass 3 path touched |
| total_ms | 0 | 0 | no evaluation runtime path touched |
| criteria_count_by_state | unchanged | unchanged | no scoring changes |

## Risks & Anomalies

- **Risk:** Dashboard currently shows empty state until live Supabase adapter lands.
  **Mitigation:** Intentional Phase 1 behavior; typed adapter preserves the contract for the next PR.
- **Risk:** Global CSS adds dashboard-specific classes.
  **Mitigation:** Namespaced with `rg-dash`, `rg-kpi`, `rg-history`, and `rg-empty` — no collision risk.
- QG behavior unchanged.
- **This change is not reducing intelligence.**

## Rollback Plan

Revert this PR. The old placeholder `/dashboard` hub returns.

## Affected Workflows

UI/build only.

No API, worker, database, scoring, or evaluation workflows affected.

No-Pipeline-Impact: Confirmed — dashboard shell only.