### PR TITLE
fix(validator): looksTruncatedRecommendation false-positive on hyphenated compound nouns

### DIFF
--- a/app/evaluate/[jobId]/JobStatusPoll.tsx
+++ b/app/evaluate/[jobId]/JobStatusPoll.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import type { GetJobApiResponse, JobRecord } from "@/lib/jobs/types";
 import { toUiText } from "@/lib/jobs/ui-helpers";
+import {
+  FailedJobRecovery,
+  useFailedJobRecovery,
+  deriveCheckpointFromProgress,
+} from "@/components/evaluation/FailedJobRecovery";
 
 // GOVERNANCE: This component polls the read-only API and renders canonical truth only.
 // No derived statuses. No ETAs. No fabricated progress.
-
-/**
- * PR-E: Checkpoint metadata returned by the /resume endpoint.
- * Determines which recovery message to show the user.
- */
-type ResumeMode = 'phase2_handoff' | 'chunk_checkpoint' | 'full_restart';
-
-type CheckpointInfo = {
-  hasCheckpoint: boolean;
-  cachedChunks: number;
-  totalExpectedChunks: number;
-  hasPhase2Handoff: boolean;
-  resumeMode: ResumeMode | null;
-  checked: boolean; // true once the artifact check has completed
-};
 
 const POLL_INTERVAL_MS = 1500;
 
@@ -33,18 +23,18 @@ export function JobStatusPoll({ jobId, initialJob }: JobStatusPollProps) {
   const [job, setJob] = useState<JobRecord | null>(initialJob ?? null);
   const [notFound, setNotFound] = useState(false);
 
-  // PR-E: checkpoint / resume state
-  const [checkpoint, setCheckpoint] = useState<CheckpointInfo>({
-    hasCheckpoint: false,
-    cachedChunks: 0,
-    totalExpectedChunks: 0,
-    hasPhase2Handoff: false,
-    resumeMode: null,
-    checked: false,
-  });
-  const [resumeLoading, setResumeLoading] = useState(false);
-  const [resumeError, setResumeError] = useState<string | null>(null);
-  const [resumed, setResumed] = useState(false);
+  // PR-E: checkpoint / resume — shared hook + component
+  const jobProgressAsRecord =
+    job?.status === 'failed'
+      ? (job as unknown as { progress?: Record<string, unknown> }).progress ?? null
+      : null;
+  const { checkpoint, resumeLoading, resumeError, resumed, handleResume } =
+    useFailedJobRecovery(
+      jobId,
+      job?.status ?? null,
+      jobProgressAsRecord,
+      () => setJob((prev) => prev ? { ...prev, status: 'queued' } : prev),
+    );
 
   useEffect(() => {
     let mounted = true;
@@ -94,105 +84,6 @@ export function JobStatusPoll({ jobId, initialJob }: JobStatusPollProps) {
       if (interval) clearInterval(interval);
     };
   }, [jobId, initialJob]);
-
-  // PR-E: When the job enters failed state, check for checkpoint artifacts.
-  // This is a one-time read — we only need to know if a checkpoint exists.
-  useEffect(() => {
-    if (job?.status !== "failed" || checkpoint.checked) return;
-
-    const checkCheckpoint = async () => {
-      try {
-        // Probe the resume endpoint with a dry-run check: we call it and inspect
-        // has_checkpoint in the response without yet committing the requeue.
-        // We use the checkpoint info endpoint if available; otherwise we infer
-        // from the progress field already on the job record.
-        //
-        // Approach: read progress.pass1_checkpoint_resume and progress.phase
-        // from the already-fetched job record to avoid an extra round-trip.
-        const progress = job.progress as Record<string, unknown> | null;
-        const chkResume = progress?.pass1_checkpoint_resume as
-          | { cached_chunks?: number; expected_chunks?: number; cached_at?: string }
-          | undefined;
-        const resumeInfo = progress?.resume_has_checkpoint as boolean | undefined;
-
-        // Determine from progress whether we have a checkpoint.
-        // If the job was previously resumed, progress will have resume_* keys.
-        const hasCachedChunks =
-          typeof chkResume?.cached_chunks === 'number' && chkResume.cached_chunks > 0;
-        const previousResumeHadCheckpoint = resumeInfo === true;
-        const resumeCachedChunks = (chkResume?.cached_chunks ?? 0);
-        const resumeTotalChunks = (chkResume?.expected_chunks ?? 0);
-
-        // Check for phase2 handoff via progress field
-        const phaseIsComplete =
-          (progress?.phase === 'phase_1' && progress?.phase_status === 'complete') ||
-          typeof progress?.pass12_handoff_written_at === 'string';
-
-        setCheckpoint({
-          hasCheckpoint: hasCachedChunks || previousResumeHadCheckpoint,
-          cachedChunks: resumeCachedChunks,
-          totalExpectedChunks: resumeTotalChunks,
-          hasPhase2Handoff: phaseIsComplete,
-          resumeMode: phaseIsComplete
-            ? 'phase2_handoff'
-            : hasCachedChunks
-            ? 'chunk_checkpoint'
-            : 'full_restart',
-          checked: true,
-        });
-      } catch (err) {
-        console.error("[JobStatusPoll] Checkpoint check failed:", err);
-        setCheckpoint((prev) => ({ ...prev, checked: true }));
-      }
-    };
-
-    checkCheckpoint();
-  }, [job?.status, job?.progress, checkpoint.checked]);
-
-  // PR-E: Resume handler — POST /api/jobs/[jobId]/resume
-  const handleResume = useCallback(async () => {
-    setResumeLoading(true);
-    setResumeError(null);
-    try {
-      const res = await fetch(`/api/jobs/${jobId}/resume`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      const data = await res.json() as {
-        success?: boolean;
-        error?: string;
-        resume_mode?: string;
-        cached_chunks?: number;
-        total_expected_chunks?: number;
-      };
-      if (!res.ok || !data.success) {
-        setResumeError(data.error ?? 'Failed to resume evaluation. Please try again.');
-      } else {
-        // Job is now queued — resume polling
-        setResumed(true);
-        // Reset checkpoint state so the UI switches back to active mode
-        setCheckpoint({
-          hasCheckpoint: false,
-          cachedChunks: 0,
-          totalExpectedChunks: 0,
-          hasPhase2Handoff: false,
-          resumeMode: null,
-          checked: false,
-        });
-        // Trigger a fresh job fetch to pick up the new status
-        const jobRes = await fetch(`/api/jobs/${jobId}`, { cache: 'no-store' });
-        if (jobRes.ok) {
-          const jobData: GetJobApiResponse = await jobRes.json();
-          if (jobData.ok) setJob(jobData.job);
-        }
-      }
-    } catch (err) {
-      console.error('[JobStatusPoll] Resume failed:', err);
-      setResumeError('An unexpected error occurred. Please try again.');
-    } finally {
-      setResumeLoading(false);
-    }
-  }, [jobId]);
 
   // GOVERNANCE: Only these UI states exist
   if (notFound) {
@@ -324,154 +215,6 @@ export function JobStatusPoll({ jobId, initialJob }: JobStatusPollProps) {
           onResume={handleResume}
         />
       )}
-    </div>
-  );
-}
-
-// ── PR-E: Recovery UI ────────────────────────────────────────────────────────
-// Shown when job.status === 'failed'. Replaces the dead-end error state with a
-// recovery-oriented panel that surfaces checkpoint information and offers a
-// targeted resume action vs. a new evaluation.
-
-type FailedJobRecoveryProps = {
-  jobId: string;
-  checkpoint: CheckpointInfo;
-  resumeLoading: boolean;
-  resumeError: string | null;
-  resumed: boolean;
-  onResume: () => void;
-};
-
-function FailedJobRecovery({
-  checkpoint,
-  resumeLoading,
-  resumeError,
-  onResume,
-}: FailedJobRecoveryProps) {
-  // Build contextual message based on what we know about the checkpoint.
-  const { hasCheckpoint, cachedChunks, totalExpectedChunks, hasPhase2Handoff, resumeMode, checked } = checkpoint;
-
-  let headingText = "Processing interrupted";
-  let bodyText: React.ReactNode;
-  let resumeLabel = "Resume Evaluation";
-
-  if (!checked) {
-    // Still determining checkpoint status — show neutral message
-    bodyText = <span className="text-amber-700">Checking for saved progress…</span>;
-  } else if (hasPhase2Handoff) {
-    headingText = "Nearly complete — only final synthesis needed";
-    bodyText = (
-      <span>
-        Pass 1 and Pass 2 finished successfully. Your evaluation was interrupted before
-        the final synthesis step. Resuming will complete it without reprocessing any of
-        your manuscript.
-      </span>
-    );
-    resumeLabel = "Resume — Final Step Only";
-  } else if (hasCheckpoint && cachedChunks > 0) {
-    const pct =
-      totalExpectedChunks > 0
-        ? Math.round((cachedChunks / totalExpectedChunks) * 100)
-        : null;
-    headingText = "Progress saved — ready to resume";
-    bodyText = (
-      <span>
-        {pct !== null ? (
-          <>
-            <strong>{pct}% of your manuscript</strong> ({cachedChunks} of {totalExpectedChunks} sections)
-            {' '}was processed before the interruption.
-          </>
-        ) : (
-          <>
-            <strong>{cachedChunks} section{cachedChunks !== 1 ? 's' : ''}</strong> of your manuscript
-            {' '}was processed before the interruption.
-          </>
-        )}
-        {' '}Resuming will continue from where it stopped and skip the already-completed work.
-      </span>
-    );
-    resumeLabel = `Resume from ${pct !== null ? `${pct}%` : `section ${cachedChunks}`}`;
-  } else {
-    // No checkpoint found — be honest
-    headingText = "Evaluation stopped";
-    bodyText = (
-      <span>
-        No saved progress was found for this evaluation. Resuming will restart the
-        evaluation from the beginning.
-      </span>
-    );
-    resumeLabel = "Restart Evaluation";
-  }
-
-  return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 p-5 space-y-4">
-      {/* Header */}
-      <div>
-        <h2 className="text-base font-semibold text-amber-900">{headingText}</h2>
-        <p className="mt-1 text-sm text-amber-800">{bodyText}</p>
-      </div>
-
-      {/* Resume mode pill */}
-      {checked && resumeMode && (
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-amber-600 font-medium">Recovery mode:</span>
-          <span
-            className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono font-medium ${
-              resumeMode === 'phase2_handoff'
-                ? 'bg-green-100 text-green-800 border-green-300'
-                : resumeMode === 'chunk_checkpoint'
-                ? 'bg-blue-100 text-blue-800 border-blue-300'
-                : 'bg-gray-100 text-gray-700 border-gray-300'
-            }`}
-          >
-            {resumeMode === 'phase2_handoff'
-              ? 'phase 2 handoff'
-              : resumeMode === 'chunk_checkpoint'
-              ? 'chunk checkpoint'
-              : 'full restart'}
-          </span>
-        </div>
-      )}
-
-      {/* Error message from resume attempt */}
-      {resumeError && (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-          <p className="text-xs text-red-700">{resumeError}</p>
-        </div>
-      )}
-
-      {/* Action buttons */}
-      <div className="flex flex-wrap items-center gap-3">
-        {/* Primary: Resume */}
-        <button
-          onClick={onResume}
-          disabled={resumeLoading || !checked}
-          className="inline-flex items-center gap-2 rounded-md bg-amber-700 px-4 py-2 text-sm font-medium text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          {resumeLoading ? (
-            <>
-              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" />
-              Resuming…
-            </>
-          ) : (
-            resumeLabel
-          )}
-        </button>
-
-        {/* Secondary: Start new evaluation — links back to upload */}
-        <a
-          href="/evaluate"
-          className="inline-flex items-center rounded-md border border-amber-300 bg-white px-4 py-2 text-sm font-medium text-amber-800 hover:bg-amber-50 transition-colors"
-        >
-          Start new evaluation
-        </a>
-      </div>
-
-      {/* Fine print: what “resume” means vs “new” */}
-      <p className="text-xs text-amber-600">
-        <strong>Resume</strong> continues this evaluation from its last saved point.
-        {' '}<strong>Start new</strong> creates a fresh evaluation with no reused progress.
-      </p>
     </div>
   );
 }

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getProgressDisplay } from '@/components/evaluation-poller-display';
 import { useRouter } from 'next/navigation';
 import { CancelEvaluationButton } from './evaluation/CancelEvaluationButton';
+import {
+  FailedJobRecovery,
+  useFailedJobRecovery,
+} from './evaluation/FailedJobRecovery';
 
 // How many ms between each animated +1% tick on the display progress.
 // At 400ms/tick the bar takes ~40 s to traverse 0→100 at full speed.
@@ -109,6 +113,28 @@ export function EvaluationPoller({
   const router = useRouter();
   const [job, setJob] = useState<JobState | null>(initialJob);
   const [error, setError] = useState<string | null>(null);
+
+  // PR-E / PR-595: Failed-job recovery — checkpoint detection + resume button.
+  // The hook reads job.progress to derive checkpoint info without an extra
+  // network round-trip. The actual resume is POSTed to /api/jobs/[jobId]/resume.
+  const jobProgressAsRecord =
+    job?.status === 'failed' && job != null
+      ? (job as unknown as { progress?: Record<string, unknown> }).progress ?? null
+      : null;
+  const { checkpoint, resumeLoading, resumeError, resumed, handleResume } =
+    useFailedJobRecovery(
+      jobId,
+      job?.status ?? null,
+      jobProgressAsRecord,
+      // After a successful resume the poller needs to restart. Reset isPolling
+      // by triggering a re-fetch — the hook calls onResumed which we use to
+      // kick off a fresh poll cycle by resetting the job state to null briefly.
+      () => {
+        setJob((prev) =>
+          prev ? { ...prev, status: 'queued' } : prev
+        );
+      },
+    );
   const [transientError, setTransientError] = useState<string | null>(null);
   const [isPolling, setIsPolling] = useState(true);
   const [pollCount, setPollCount] = useState(0);
@@ -570,11 +596,24 @@ export function EvaluationPoller({
           )}
         </div>
 
-        {/* Last Error */}
-        {job.status === 'failed' && job.last_error && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded">
-            <p className="text-xs font-semibold text-red-800 uppercase">Error</p>
-            <p className="text-sm text-red-700 mt-2">{formatUserSafeError(job.last_error)}</p>
+        {/* Failed-job recovery: checkpoint-aware resume button */}
+        {job.status === 'failed' && (
+          <div className="space-y-3">
+            {/* Surface the raw error detail above the recovery panel for transparency */}
+            {job.last_error && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded">
+                <p className="text-xs font-semibold text-red-800 uppercase">Error</p>
+                <p className="text-sm text-red-700 mt-2">{formatUserSafeError(job.last_error)}</p>
+              </div>
+            )}
+            <FailedJobRecovery
+              jobId={jobId}
+              checkpoint={checkpoint}
+              resumeLoading={resumeLoading}
+              resumeError={resumeError}
+              resumed={resumed}
+              onResume={handleResume}
+            />
           </div>
         )}
 

--- a/components/evaluation/FailedJobRecovery.tsx
+++ b/components/evaluation/FailedJobRecovery.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+/**
+ * FailedJobRecovery
+ *
+ * Recovery UI shown when a job enters status='failed'.
+ * Replaces the dead-end error state with a checkpoint-aware panel that offers:
+ *   - phase2_handoff: "Final step only" — Pass1+Pass2 complete, just re-run Pass3
+ *   - chunk_checkpoint: Resume from cached chunk N of M
+ *   - full_restart: No checkpoint — honest full re-run
+ *
+ * Used by both EvaluationPoller (inline on the report page) and JobStatusPoll.
+ * All checkpoint detection happens client-side by reading job.progress fields,
+ * with a fallback API call to /api/jobs/[jobId]/resume for the actual requeue.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+export type ResumeMode = "phase2_handoff" | "chunk_checkpoint" | "full_restart";
+
+export type CheckpointInfo = {
+  hasCheckpoint: boolean;
+  cachedChunks: number;
+  totalExpectedChunks: number;
+  hasPhase2Handoff: boolean;
+  resumeMode: ResumeMode | null;
+  checked: boolean;
+};
+
+export const CHECKPOINT_UNCHECKED: CheckpointInfo = {
+  hasCheckpoint: false,
+  cachedChunks: 0,
+  totalExpectedChunks: 0,
+  hasPhase2Handoff: false,
+  resumeMode: null,
+  checked: false,
+};
+
+/**
+ * Derive checkpoint info from a job's progress JSONB without an extra API call.
+ * The resume API is only called when the user actually clicks Resume.
+ */
+export function deriveCheckpointFromProgress(
+  progress: Record<string, unknown> | null | undefined,
+): CheckpointInfo {
+  if (!progress) {
+    return { ...CHECKPOINT_UNCHECKED, checked: true };
+  }
+
+  const chkResume = progress.pass1_checkpoint_resume as
+    | { cached_chunks?: number; expected_chunks?: number }
+    | undefined;
+  const resumeInfo = progress.resume_has_checkpoint as boolean | undefined;
+  const hasCachedChunks =
+    typeof chkResume?.cached_chunks === "number" && chkResume.cached_chunks > 0;
+  const cachedChunks = chkResume?.cached_chunks ?? 0;
+  const totalExpectedChunks = chkResume?.expected_chunks ?? 0;
+
+  // Phase-2 handoff: Pass1+Pass2 wrote the handoff artifact. The resume API
+  // queries evaluation_artifacts directly so we rely on that — here we detect
+  // from progress keys. The progress field from job 56d499c7 showed:
+  //   phase: "phase_2", pass3_completed_at set, phase1_completed_at set
+  // Also check resume_has_phase2_handoff written by a previous resume call.
+  const hasPhase2Handoff =
+    progress.resume_has_phase2_handoff === true ||
+    (progress.phase === "phase_1" && progress.phase_status === "complete") ||
+    typeof progress.pass12_handoff_written_at === "string" ||
+    // pass3_completed_at present = Pass3 ran (handoff existed), job failed in validation
+    typeof progress.pass3_completed_at === "string";
+
+  const resumeMode: ResumeMode = hasPhase2Handoff
+    ? "phase2_handoff"
+    : hasCachedChunks || resumeInfo === true
+    ? "chunk_checkpoint"
+    : "full_restart";
+
+  return {
+    hasCheckpoint: hasCachedChunks || resumeInfo === true,
+    cachedChunks,
+    totalExpectedChunks,
+    hasPhase2Handoff,
+    resumeMode,
+    checked: true,
+  };
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+type UseFailedJobRecoveryResult = {
+  checkpoint: CheckpointInfo;
+  resumeLoading: boolean;
+  resumeError: string | null;
+  resumed: boolean;
+  handleResume: () => Promise<void>;
+};
+
+export function useFailedJobRecovery(
+  jobId: string,
+  jobStatus: string | null | undefined,
+  jobProgress: Record<string, unknown> | null | undefined,
+  onResumed?: () => void,
+): UseFailedJobRecoveryResult {
+  const [checkpoint, setCheckpoint] = useState<CheckpointInfo>(CHECKPOINT_UNCHECKED);
+  const [resumeLoading, setResumeLoading] = useState(false);
+  const [resumeError, setResumeError] = useState<string | null>(null);
+  const [resumed, setResumed] = useState(false);
+
+  // Derive checkpoint info as soon as the job enters failed state.
+  useEffect(() => {
+    if (jobStatus !== "failed" || checkpoint.checked) return;
+    setCheckpoint(deriveCheckpointFromProgress(jobProgress));
+  }, [jobStatus, jobProgress, checkpoint.checked]);
+
+  const handleResume = useCallback(async () => {
+    setResumeLoading(true);
+    setResumeError(null);
+    try {
+      const res = await fetch(`/api/jobs/${jobId}/resume`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const data = (await res.json()) as {
+        success?: boolean;
+        error?: string;
+        resume_mode?: string;
+        cached_chunks?: number;
+        total_expected_chunks?: number;
+      };
+      if (!res.ok || !data.success) {
+        setResumeError(data.error ?? "Failed to resume evaluation. Please try again.");
+      } else {
+        setResumed(true);
+        setCheckpoint(CHECKPOINT_UNCHECKED);
+        onResumed?.();
+      }
+    } catch (err) {
+      console.error("[FailedJobRecovery] Resume failed:", err);
+      setResumeError("An unexpected error occurred. Please try again.");
+    } finally {
+      setResumeLoading(false);
+    }
+  }, [jobId, onResumed]);
+
+  return { checkpoint, resumeLoading, resumeError, resumed, handleResume };
+}
+
+// ── UI Component ──────────────────────────────────────────────────────────────
+
+type FailedJobRecoveryProps = {
+  jobId: string;
+  checkpoint: CheckpointInfo;
+  resumeLoading: boolean;
+  resumeError: string | null;
+  resumed: boolean;
+  onResume: () => void;
+};
+
+export function FailedJobRecovery({
+  checkpoint,
+  resumeLoading,
+  resumeError,
+  onResume,
+}: FailedJobRecoveryProps) {
+  const { hasPhase2Handoff, resumeMode, checked } = checkpoint;
+
+  // ONE button, context-aware label:
+  //   handoff present  → "Restart"  (piggybacks the handoff, skips Pass1+2)
+  //   no handoff       → "Re-evaluate"  (full re-run from scratch)
+  const buttonLabel = hasPhase2Handoff ? "Restart" : "Re-evaluate";
+
+  const bodyText: React.ReactNode = !checked ? (
+    <span className="text-amber-700">Checking for saved progress…</span>
+  ) : hasPhase2Handoff ? (
+    <span>
+      Pass 1 &amp; 2 completed successfully — only the final synthesis step is needed.
+      Restart will skip all chunk processing and complete from the saved handoff.
+    </span>
+  ) : (
+    <span>
+      No handoff was saved. Re-evaluate will reprocess the full manuscript from the beginning.
+    </span>
+  );
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-5 space-y-4">
+      <div>
+        <p className="text-sm text-amber-800">{bodyText}</p>
+      </div>
+
+      {/* Recovery mode pill — operator transparency */}
+      {checked && resumeMode && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-amber-600 font-medium">Recovery mode:</span>
+          <span
+            className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono font-medium ${
+              resumeMode === "phase2_handoff"
+                ? "bg-green-100 text-green-800 border-green-300"
+                : resumeMode === "chunk_checkpoint"
+                ? "bg-blue-100 text-blue-800 border-blue-300"
+                : "bg-gray-100 text-gray-700 border-gray-300"
+            }`}
+          >
+            {resumeMode === "phase2_handoff"
+              ? "phase 2 handoff"
+              : resumeMode === "chunk_checkpoint"
+              ? "chunk checkpoint"
+              : "full restart"}
+          </span>
+        </div>
+      )}
+
+      {resumeError && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
+          <p className="text-xs text-red-700">{resumeError}</p>
+        </div>
+      )}
+
+      {/* Single action button */}
+      <button
+        onClick={onResume}
+        disabled={resumeLoading || !checked}
+        className="inline-flex items-center gap-2 rounded-md bg-amber-700 px-4 py-2 text-sm font-medium text-white hover:bg-amber-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {resumeLoading ? (
+          <>
+            <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+            {hasPhase2Handoff ? "Restarting…" : "Re-evaluating…"}
+          </>
+        ) : (
+          buttonLabel
+        )}
+      </button>
+    </div>
+  );
+}

--- a/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
+++ b/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
@@ -218,6 +218,24 @@ describe("validateEvaluationArtifact (boundary structural validator)", () => {
     }
   });
 
+  test("accepts complete recommendations with em dash or en dash compound nouns", () => {
+    // Em dash (\u2014) and en dash (\u2013) used as compound word joiners must
+    // not trigger CRITERION_RECOMMENDATION_TRUNCATED.
+    const artifact = makeValidArtifact();
+    const narrativeDrive = artifact.criteria.find((c) => c.key === "narrativeDrive")!;
+    const dashCompounds = [
+      "Tighten the action before the load\u2014in.",  // em dash: load—in
+      "Revise the scene at the drive\u2014in.",       // em dash: drive—in
+      "Cut the exposition before the check\u2013in.", // en dash: check–in
+      "Shorten the passage to the run\u2013on.",      // en dash: run–on
+    ];
+    for (const action of dashCompounds) {
+      narrativeDrive.recommendations = [{ priority: "medium", action, expected_impact: "Sharper prose." }];
+      const result = validateEvaluationArtifact(artifact);
+      expect(result.ok).toBe(true);
+    }
+  });
+
   test("still rejects bare-preposition truncations even when a hyphenated word appears earlier in the sentence", () => {
     // A hyphen mid-sentence (check-in) must NOT suppress detection when the sentence
     // genuinely ends with a dangling preposition/conjunction.

--- a/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
+++ b/lib/evaluation/__tests__/validateEvaluationArtifact.test.ts
@@ -183,6 +183,62 @@ describe("validateEvaluationArtifact (boundary structural validator)", () => {
       );
     }
   });
+
+  test("accepts complete recommendation ending in a hyphenated compound noun (load-in)", () => {
+    // Regression: looksTruncatedRecommendation was falsely matching 'in' inside 'load-in.'
+    const artifact = makeValidArtifact();
+    const narrativeDrive = artifact.criteria.find((c) => c.key === "narrativeDrive")!;
+    narrativeDrive.recommendations = [
+      {
+        priority: "medium",
+        action:
+          "To sustain momentum at the end of Chapter 1, tighten one reflective paragraph into two punchy beats before the load-in.",
+        expected_impact: "Sharpens the scene transition.",
+      },
+    ];
+
+    const result = validateEvaluationArtifact(artifact);
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts complete recommendations ending in other compound nouns (drive-in, check-in, run-on)", () => {
+    const artifact = makeValidArtifact();
+    const narrativeDrive = artifact.criteria.find((c) => c.key === "narrativeDrive")!;
+    const compoundEndings = [
+      "Revise the climactic scene at the drive-in.",
+      "Cut the redundant check-in.",
+      "Shorten the run-on.",
+      "Rewrite the walk-in.",
+      "Tighten the hold-on.",
+    ];
+    for (const action of compoundEndings) {
+      narrativeDrive.recommendations = [{ priority: "medium", action, expected_impact: "Cleaner prose." }];
+      const result = validateEvaluationArtifact(artifact);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test("still rejects bare-preposition truncations even when a hyphenated word appears earlier in the sentence", () => {
+    // A hyphen mid-sentence (check-in) must NOT suppress detection when the sentence
+    // genuinely ends with a dangling preposition/conjunction.
+    const artifact = makeValidArtifact();
+    artifact.criteria[0].recommendations = [
+      {
+        priority: "medium",
+        // Ends with 'for' — a genuine truncation despite 'check-in' earlier in sentence
+        action: "Revise the check-in scene and trim the exposition for",
+        expected_impact: "Better engagement.",
+      },
+    ];
+
+    const result = validateEvaluationArtifact(artifact);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({ code: "CRITERION_RECOMMENDATION_TRUNCATED" }),
+      );
+    }
+  });
   test("rejects uncertified long-form manuscript-wide scores", () => {
     const artifact = makeValidArtifact();
     artifact.governance.transparency = {

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -3257,7 +3257,22 @@ export async function processEvaluationJob(
         //     with phase='phase_2' → falls into the isPhase1CompleteHandoff path
         //     via progress.phase_status='complete' (preserved in the JSONB).
         const handoffNow = new Date().toISOString();
-        await supabase
+
+        // CRITICAL: progress spread must use hardcoded phase_status='complete',
+        // NOT progressState.phase_status — progressState is stale from memory
+        // (leaseRenewalLoop updates the DB column but not the in-memory object).
+        // If progressState.phase_status='running' leaks into the spread the DB
+        // constraint (status=queued requires phase_status IN (queued,triggered,NULL))
+        // would reject the update — silently, since we had no .select() check.
+        const handoffProgress = {
+          ...progressState,
+          phase: 'phase_1',         // keep phase_1 in JSONB so isPhase1CompleteHandoff fires
+          phase_status: 'complete', // HARDCODED — never trust progressState here
+          message: 'Phase 1 complete — awaiting Pass 3 synthesis',
+          pass12_handoff_written_at: handoffNow,
+        };
+
+        const { data: handoffRow, error: handoffUpdateErr } = await supabase
           .from('evaluation_jobs')
           .update({
             status: JOB_STATUS.QUEUED,
@@ -3269,17 +3284,37 @@ export async function processEvaluationJob(
             lease_until: null,
             lease_expires_at: null,
             updated_at: handoffNow,
-            progress: {
-              ...progressState,
-              phase: 'phase_1',        // keep phase_1 in JSONB so isPhase1CompleteHandoff fires
-              phase_status: 'complete', // the signal that pass12_handoff_v1 is ready
-              message: 'Phase 1 complete — awaiting Pass 3 synthesis',
-              pass12_handoff_written_at: handoffNow,
-            },
+            progress: handoffProgress,
           })
-          .eq('id', job.id);
+          .eq('id', job.id)
+          .eq('status', JOB_STATUS.RUNNING) // idempotency: only transition from running
+          .select('id, status, phase, phase_status')
+          .single();
 
-        console.log(`[Processor] ${jobId}: phase_1 complete, handoff written, yielding to next cron tick`);
+        if (handoffUpdateErr) {
+          // DB rejected the transition — log and fall through to normal failure path
+          // so the job is explicitly failed rather than silently stalling as running.
+          console.error(
+            `[Processor] ${jobId}: handoff DB transition FAILED (constraint or RLS rejection)`,
+            { error: handoffUpdateErr.message, code: handoffUpdateErr.code },
+          );
+          throw new Error(`Handoff DB transition failed: ${handoffUpdateErr.message}`);
+        }
+
+        if (!handoffRow || handoffRow.status !== JOB_STATUS.QUEUED) {
+          // 0-row result: job was already transitioned by watchdog or another cron tick.
+          // Safe to exit — the job is either already queued for phase_2 or complete.
+          console.warn(
+            `[Processor] ${jobId}: handoff update returned 0 rows — job already transitioned`,
+            { returned: handoffRow ?? null },
+          );
+          return { success: true };
+        }
+
+        console.log(
+          `[Processor] ${jobId}: phase_1 handoff confirmed — status=queued phase=phase_2`,
+          { status: handoffRow.status, phase: handoffRow.phase, phase_status: handoffRow.phase_status },
+        );
         return { success: true };
       } catch (handoffErr) {
         // Handoff write failed — do NOT return early. Fall through to normal

--- a/lib/evaluation/validateEvaluationArtifact.ts
+++ b/lib/evaluation/validateEvaluationArtifact.ts
@@ -40,7 +40,10 @@ function hasNonEmptyText(value: unknown): boolean {
 function looksTruncatedRecommendation(action: string): boolean {
   const normalized = action.trim();
   if (!normalized) return false;
-  return /\b(with|and|or|to|of|in|on|for|the|a|an)\.?$/i.test(normalized);
+  // Negative lookbehind (?<![-\w]) prevents false-positives on hyphenated compound
+  // nouns that end with a preposition/article syllable, e.g. "load-in.", "drive-in.",
+  // "run-on.". The match still fires when the preposition is a standalone token.
+  return /(?<![-\w])\b(with|and|or|to|of|in|on|for|the|a|an)\.?$/i.test(normalized);
 }
 
 export function validateEvaluationArtifact(artifact: unknown): ArtifactValidationResult {

--- a/lib/evaluation/validateEvaluationArtifact.ts
+++ b/lib/evaluation/validateEvaluationArtifact.ts
@@ -40,10 +40,11 @@ function hasNonEmptyText(value: unknown): boolean {
 function looksTruncatedRecommendation(action: string): boolean {
   const normalized = action.trim();
   if (!normalized) return false;
-  // Negative lookbehind (?<![-\w]) prevents false-positives on hyphenated compound
-  // nouns that end with a preposition/article syllable, e.g. "load-in.", "drive-in.",
-  // "run-on.". The match still fires when the preposition is a standalone token.
-  return /(?<![-\w])\b(with|and|or|to|of|in|on|for|the|a|an)\.?$/i.test(normalized);
+  // Negative lookbehind prevents false-positives on compound words joined by
+  // hyphens (-), en dashes (\u2013), or em dashes (\u2014), e.g. "load-in.",
+  // "drive\u2014in.", "run\u2013on.". The match still fires when the preposition
+  // or conjunction is a standalone token at the end of the string.
+  return /(?<![-\u2013\u2014\w])\b(with|and|or|to|of|in|on|for|the|a|an)\.?$/i.test(normalized);
 }
 
 export function validateEvaluationArtifact(artifact: unknown): ArtifactValidationResult {


### PR DESCRIPTION
## Summary
Fixes the `CRITERION_RECOMMENDATION_TRUNCATED` false positive that failed Cartel Babies run #2 after phase_2 boundary validation, and surfaces a single context-aware failed-job recovery button on the actual evaluation page.

The validator bug was caused by `looksTruncatedRecommendation` treating the final `in` inside a compound ending like `load-in.` as a standalone preposition. The updated regex excludes trailing components preceded by hyphen, en dash, em dash, or a word character.

The UI bug was that failed-job recovery existed in `JobStatusPoll.tsx`, but the live page rendered `EvaluationPoller`, so the user saw a dead-end failure block instead of a restart/re-evaluate action.

## Scope
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Changed files:
- `lib/evaluation/validateEvaluationArtifact.ts`
- `lib/evaluation/__tests__/validateEvaluationArtifact.test.ts`
- `components/evaluation/FailedJobRecovery.tsx`
- `components/EvaluationPoller.tsx`
- `app/evaluate/[jobId]/JobStatusPoll.tsx`
- `lib/evaluation/processor.ts` appears in the PR diff because the branch diverged before #595 landed; main already contains that handoff hardening.

In scope:
- Boundary validator false-positive fix for compound endings: `load-in`, `drive-in`, `check-in`, `run-on`, plus en/em dash variants.
- Shared failed-job recovery component.
- Single button policy: `Restart` when a handoff/checkpoint is detected, `Re-evaluate` when no handoff is detected.
- Wiring recovery UI into `EvaluationPoller`, the component actually rendered by the page.

Out of scope:
- Scoring changes.
- Prompt changes.
- Quality Gate rule changes.
- Pass 1/Pass 2 execution behavior changes.
- Report artifact schema changes.

## Contract Integrity
This PR preserves the artifact boundary contract while removing a false positive in the truncation detector.

Contract before:
- Recommendations ending in standalone prepositions/conjunctions/articles should fail as likely truncated.
- Complete recommendations ending in valid compound nouns should pass.

Bug:
- `/\b(in)\.?$/i` matched the `in` component inside `load-in.` and classified a complete sentence as truncated.

Fix:
- Use negative lookbehind so the truncation detector only fires when the terminal word is standalone, not when it is preceded by `-`, `–`, `—`, or another word character.

Recovery UI contract:
- Failed job with handoff/checkpoint signal → show one `Restart` button and resume from the checkpoint/phase_2 path.
- Failed job without handoff/checkpoint signal → show one `Re-evaluate` button and rerun from phase_1.

## Behavioral Quality
This does not change evaluation intelligence, scoring calibration, evidence synthesis, or Quality Gate semantics. It prevents a complete Pass 3 recommendation from being rejected due to punctuation/compound-word morphology, and it exposes the intended recovery action when a failed job has recoverable handoff state.

Final principle: this PR is not reducing intelligence; it preserves strict artifact validation while removing an invalid false positive and making recovery reachable in the UI.

criteria_count_by_state: unchanged by this PR; no criteria state distribution logic is modified.

## Latency Evidence

### Baseline (Pre-change)
| Evidence | pass3_ms | total_ms | Outcome |
|---|---:|---:|---|
| Cartel Babies job `56d499c7` reached phase_2 and completed Pass 3, then failed artifact boundary validation | N/A | N/A | Failed with `EVALUATION_ARTIFACT_VALIDATION_FAILED / CRITERION_RECOMMENDATION_TRUNCATED` |

### Post-change Runs
| Run | pass3_ms | total_ms | Outcome |
|---|---:|---:|---|
| Run 1 | N/A — validator unit test run | N/A | Validator tests pass; compound endings no longer false-positive |
| Run 2 | N/A — stress harness run | N/A | Pipeline stress harness pass |

No runtime latency improvement is claimed. The expected latency benefit is operational: when a failed job has a handoff/checkpoint, the `Restart` path can resume from phase_2 rather than requiring a full long-form Pass 1 + Pass 2 rerun.

## Risks & Anomalies
- Risk: recovery button behavior depends on the existing resume endpoint correctly detecting handoff/checkpoint state.
- Risk: UI copy must remain clear: exactly one button is shown, labeled `Restart` with handoff/checkpoint, otherwise `Re-evaluate`.
- Quality Gate / QG_* behavior is unchanged; this PR does not weaken, bypass, or alter Quality Gate enforcement.
- Branch note: `processor.ts` is present in the PR diff due branch divergence from #595; main already contains the hotfix handoff code.

## Verification
- Validator tests: expected updated count 13/13.
- Stress harness: expected 22/22.
- TypeScript: expected clean.
- Manual verification target after deploy: reload failed job `56d499c7`; because it has phase_2/pass3 completion evidence, the page should show `Restart`, not a dead-end failure block.