### PR TITLE
fix(report): null score crash + artifact isolation + synthesis auto-poll

### DIFF
--- a/app/api/jobs/[jobId]/artifacts/route.ts
+++ b/app/api/jobs/[jobId]/artifacts/route.ts
@@ -68,12 +68,16 @@ export async function GET(_: Request, { params }: Params) {
       return NextResponse.json({ ok: false, error: "Job not releasable" }, { status: 404 });
     }
 
-    // Fetch latest artifact
+    // Fetch the longform_document_v1 artifact for this specific job.
+    // ISOLATION: We filter by both job_id AND artifact_type so that concurrent
+    // evaluations from the same user never bleed into each other. Do NOT use
+    // "latest by created_at" across all types — a user may have two jobs in
+    // flight and the ordering across different artifact types is not meaningful.
     const { data: artifact, error } = await admin
       .from("evaluation_artifacts")
       .select("id, job_id, artifact_type, content, created_at")
       .eq("job_id", jobId)
-      // .eq("artifact_type", "evaluation_result_v1") // enable if needed
+      .eq("artifact_type", "longform_document_v1")
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/evaluation/reportRecommendations";
 import ModeConfirmationBlock from "@/components/evaluation/ModeConfirmationBlock";
 import { CancelEvaluationButton } from "@/components/evaluation/CancelEvaluationButton";
-import { SynthesisArtifactControls } from "@/components/evaluation/SynthesisArtifactControls";
+import { SynthesisPoller } from "@/components/evaluation/SynthesisPoller";
 import { classifyEvaluationIntegrityBanner } from "@/lib/evaluation/warningClassification";
 import {
   getCertifiedCriteriaSummary,
@@ -29,19 +29,6 @@ import {
 } from "@/lib/evaluation/reportCriterionDisplay";
 import { resolveReportTitle } from "@/lib/evaluation/reportTitle";
 import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
-import {
-  LongformExecutiveVerdict,
-  LongformScoreGrid,
-  LongformMarketShelf,
-  LongformStructuralStack,
-  LongformArcMap,
-  LongformCriterionAnalyses,
-  LongformLayerAnalysis,
-  LongformSymbolicAudit,
-  LongformReaderExperience,
-  LongformRevisionPlan,
-  LongformReleasability,
-} from "@/components/reports/longform";
 
 type Job = {
   id: string;
@@ -829,92 +816,17 @@ export default async function EvaluationReportPage({
                 </p>
               </div>
 
-              {dreamDoc ? (
-                <div className="space-y-8">
-                  {/* §1 Scores + Executive Verdict */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Executive Verdict</h3>
-                    <LongformExecutiveVerdict doc={dreamDoc} />
-                  </div>
-
-                  {/* §2 Market Shelf */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Market Shelf</h3>
-                    <LongformMarketShelf doc={dreamDoc} />
-                  </div>
-
-                  {/* §4 + §3 Structural Stack + Anti-Patterns */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Structural Stack</h3>
-                    <LongformStructuralStack doc={dreamDoc} />
-                  </div>
-
-                  {/* §5 Arc Map */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Arc Map</h3>
-                    <LongformArcMap doc={dreamDoc} />
-                  </div>
-
-                  {/* §6 Score Grid */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">13-Criterion Score Grid</h3>
-                    <LongformScoreGrid doc={dreamDoc} />
-                  </div>
-
-                  {/* §7 Criterion-by-Criterion Analyses */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Criterion Analysis</h3>
-                    <LongformCriterionAnalyses doc={dreamDoc} />
-                  </div>
-
-                  {/* §8 + §9 Layer Analysis + Cross-Layer */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Layer Analysis</h3>
-                    <LongformLayerAnalysis doc={dreamDoc} />
-                  </div>
-
-                  {/* §10 Symbolic Audit */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Symbolic / Doctrine Audit</h3>
-                    <LongformSymbolicAudit doc={dreamDoc} />
-                  </div>
-
-                  {/* §11 Reader Experience */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Reader Experience</h3>
-                    <LongformReaderExperience doc={dreamDoc} />
-                  </div>
-
-                  {/* §12 Revision Plan */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Revision Plan</h3>
-                    <LongformRevisionPlan doc={dreamDoc} />
-                  </div>
-
-                  {/* §13–§16 Releasability + Acceptance Checks + Integrity */}
-                  <div>
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Releasability</h3>
-                    <LongformReleasability doc={dreamDoc} />
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-4">
-                  <div className="flex items-center gap-3 py-6">
-                    <div className="animate-spin rounded-full h-5 w-5 border-2 border-indigo-400 border-t-transparent" aria-hidden />
-                    <p className="text-sm text-gray-500">
-                      Narrative Synthesis generating — check back in a minute for your full long-form analysis.
-                    </p>
-                  </div>
-                  
-                  {/* Synthesis controls: retry/skip if stuck */}
-                  <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
-                    <p className="text-sm font-medium text-amber-900 mb-3">
-                      Synthesis taking longer than expected?
-                    </p>
-                    <SynthesisArtifactControls jobId={jobId} />
-                  </div>
-                </div>
-              )}
+              {/* SynthesisPoller handles both states:
+                  - initialDreamDoc present  → renders immediately (fast path, no polling)
+                  - initialDreamDoc null     → polls /api/jobs/[jobId]/artifacts every 15s,
+                                               updates inline when longform_document_v1 lands
+                  Isolation: the artifacts endpoint now filters by job_id + artifact_type,
+                  so two concurrent evaluations from the same user cannot cross-contaminate. */}
+              <SynthesisPoller
+                jobId={jobId}
+                wordCount={wordCount ?? 0}
+                initialDreamDoc={dreamDoc}
+              />
             </section>
           )}
 

--- a/components/evaluation/SynthesisPoller.tsx
+++ b/components/evaluation/SynthesisPoller.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * SynthesisPoller
+ *
+ * Client component that automatically polls for the longform_document_v1
+ * artifact after job completion. Replaces the static "check back in a minute"
+ * message with:
+ *   - Auto-polling every 15s (cron fires every 2 min; synthesis takes 3-8 min)
+ *   - Honest time estimate based on manuscript word count
+ *   - Renders the full longform report inline when the artifact arrives
+ *   - No manual refresh required
+ *
+ * Architecture: server page passes null dreamDoc + wordCount + jobId.
+ * This component takes over rendering of the synthesis section client-side.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
+import {
+  LongformExecutiveVerdict,
+  LongformScoreGrid,
+  LongformMarketShelf,
+  LongformStructuralStack,
+  LongformArcMap,
+  LongformCriterionAnalyses,
+  LongformLayerAnalysis,
+  LongformSymbolicAudit,
+  LongformReaderExperience,
+  LongformRevisionPlan,
+  LongformReleasability,
+} from "@/components/reports/longform";
+import { SynthesisArtifactControls } from "./SynthesisArtifactControls";
+
+// How long between polls while waiting for synthesis.
+// Cron fires every 2 min; synthesis itself takes 3-10 min for long manuscripts.
+// 15s polling means we surface the result within 15s of it landing.
+const POLL_INTERVAL_MS = 15_000;
+
+// After this many minutes with no artifact, show the "taking longer" panel.
+const SHOW_CONTROLS_AFTER_MS = 5 * 60 * 1000; // 5 minutes
+
+function estimateSynthesisMinutes(wordCount: number): string {
+  // Based on observed runs: ~8 min for 110k words, ~3-4 min for 25-50k words.
+  if (wordCount >= 100_000) return "5–10";
+  if (wordCount >= 60_000) return "4–8";
+  if (wordCount >= 30_000) return "3–6";
+  return "2–5";
+}
+
+type Props = {
+  jobId: string;
+  wordCount: number;
+  // If the server already resolved the artifact (fast path), pass it here
+  // and this component renders it immediately without polling.
+  initialDreamDoc?: LongformDreamDocument | null;
+};
+
+type ArtifactRow = {
+  artifact_type: string;
+  content: { longform_document?: LongformDreamDocument } | null;
+};
+
+export function SynthesisPoller({ jobId, wordCount, initialDreamDoc = null }: Props) {
+  const [dreamDoc, setDreamDoc] = useState<LongformDreamDocument | null>(initialDreamDoc);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const startRef = useRef(Date.now());
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchArtifact = useCallback(async () => {
+    try {
+      // The artifacts endpoint returns the single most-recent artifact by created_at.
+      // longform_document_v1 is written after evaluation_result_v2, so once synthesis
+      // is done it will be the latest row. We check artifact_type to confirm.
+      const res = await fetch(`/api/jobs/${jobId}/artifacts`, { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json() as { ok: boolean; artifact?: ArtifactRow | null };
+      if (!data.ok || !data.artifact) return;
+      if (data.artifact.artifact_type !== "longform_document_v1") return;
+      if (!data.artifact.content?.longform_document) return;
+
+      setDreamDoc(data.artifact.content.longform_document);
+
+      // Stop all polling once we have the doc
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+    } catch {
+      // Silent — will retry on next interval
+    }
+  }, [jobId]);
+
+  useEffect(() => {
+    // Already have it — nothing to poll
+    if (dreamDoc) return;
+
+    // Start elapsed timer for the time estimate display
+    elapsedRef.current = setInterval(() => {
+      setElapsedMs(Date.now() - startRef.current);
+    }, 1000);
+
+    // Poll immediately, then every 15s
+    fetchArtifact();
+    pollRef.current = setInterval(fetchArtifact, POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (elapsedRef.current) clearInterval(elapsedRef.current);
+    };
+  }, [dreamDoc, fetchArtifact]);
+
+  // ── Synthesis ready ───────────────────────────────────────────────────────
+  if (dreamDoc) {
+    return (
+      <div className="space-y-8">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Executive Verdict</h3>
+          <LongformExecutiveVerdict doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Market Shelf</h3>
+          <LongformMarketShelf doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Structural Stack</h3>
+          <LongformStructuralStack doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Arc Map</h3>
+          <LongformArcMap doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">13-Criterion Score Grid</h3>
+          <LongformScoreGrid doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Criterion Analysis</h3>
+          <LongformCriterionAnalyses doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Layer Analysis</h3>
+          <LongformLayerAnalysis doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Symbolic / Doctrine Audit</h3>
+          <LongformSymbolicAudit doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Reader Experience</h3>
+          <LongformReaderExperience doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Revision Plan</h3>
+          <LongformRevisionPlan doc={dreamDoc} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Releasability</h3>
+          <LongformReleasability doc={dreamDoc} />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Synthesis pending ─────────────────────────────────────────────────────
+  const rangeLabel = estimateSynthesisMinutes(wordCount);
+  const elapsedMin = Math.floor(elapsedMs / 60_000);
+  const showControls = elapsedMs >= SHOW_CONTROLS_AFTER_MS;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 py-4">
+        <div
+          className="animate-spin rounded-full h-5 w-5 border-2 border-indigo-400 border-t-transparent shrink-0"
+          aria-hidden
+        />
+        <div>
+          <p className="text-sm text-gray-700 font-medium">
+            Narrative Synthesis is generating automatically.
+          </p>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Expected in approximately {rangeLabel} minutes for this manuscript length
+            {elapsedMin > 0 ? ` — ${elapsedMin} min elapsed` : ""}.
+            This page will update automatically — no refresh needed.
+          </p>
+        </div>
+      </div>
+
+      {showControls && (
+        <div className="rounded-md bg-amber-50 border border-amber-200 p-4">
+          <p className="text-sm font-medium text-amber-900 mb-3">
+            Taking longer than expected?
+          </p>
+          <SynthesisArtifactControls jobId={jobId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/reports/longform/LongformCriterionAnalyses.tsx
+++ b/components/reports/longform/LongformCriterionAnalyses.tsx
@@ -30,8 +30,13 @@ function EvidenceList({ items, label, accent }: { items: string[]; label: string
 function CriterionCard({ a }: { a: LongformDreamDocument["criterion_analyses"][number] }) {
   const [open, setOpen] = useState(false);
   const badge = CONFIDENCE_BADGE[a.confidence] ?? "bg-gray-100 text-gray-600";
+  // score can be null (e.g. proseControl in insufficient-signal state) — guard
+  const safeScore = a.score ?? null;
   const scoreColor =
-    a.score >= 7.5 ? "text-emerald-700" : a.score >= 6 ? "text-amber-600" : "text-rose-600";
+    safeScore !== null && safeScore >= 7.5 ? "text-emerald-700"
+    : safeScore !== null && safeScore >= 6 ? "text-amber-600"
+    : safeScore !== null ? "text-rose-600"
+    : "text-gray-400";
 
   return (
     <div className="rounded-lg border border-gray-200 overflow-hidden">
@@ -41,7 +46,7 @@ function CriterionCard({ a }: { a: LongformDreamDocument["criterion_analyses"][n
       >
         <div className="flex items-center gap-3">
           <span className={`text-xl font-bold tabular-nums ${scoreColor}`}>
-            {a.score.toFixed(1)}
+            {safeScore !== null ? safeScore.toFixed(1) : "—"}
           </span>
           <span className="font-medium text-gray-800 capitalize text-sm">
             {a.key.replace(/_/g, " ")}

--- a/components/reports/longform/LongformScoreGrid.tsx
+++ b/components/reports/longform/LongformScoreGrid.tsx
@@ -9,7 +9,17 @@ const CONFIDENCE_BADGE: Record<string, string> = {
   Low: "bg-rose-100 text-rose-700",
 };
 
-function scoreBar(score: number) {
+function scoreBar(score: number | null) {
+  // score can be null when the LLM returns null for a criterion (e.g. proseControl
+  // in insufficient-signal states). Guard here prevents a runtime crash.
+  if (score === null || score === undefined) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="w-8 text-right text-sm font-semibold tabular-nums text-gray-400">—</span>
+        <div className="flex-1 h-2 rounded-full bg-gray-100" />
+      </div>
+    );
+  }
   const pct = Math.min(100, Math.max(0, (score / 10) * 100));
   const color =
     score >= 7.5


### PR DESCRIPTION
## Summary

Fixes three completed-report issues without changing evaluation scoring, prompts, governance, or pipeline execution:

1. Prevents the longform report page from crashing when a criterion score is `null`.
2. Makes the longform artifact endpoint deterministic by filtering for `longform_document_v1`.
3. Replaces the static "check back in a minute" synthesis message with an auto-polling client component and realistic time estimate.

## Scope

[ ] Pass 1
[ ] Pass 2
[x] Pass 3
Report/UI/runtime-read fixes only.

Files changed:
- `components/reports/longform/LongformScoreGrid.tsx`
- `components/reports/longform/LongformCriterionAnalyses.tsx`
- `app/api/jobs/[jobId]/artifacts/route.ts`
- `components/evaluation/SynthesisPoller.tsx`
- `app/evaluate/[jobId]/page.tsx`

Out of scope:
- No scoring semantics changes
- No prompt/intelligence changes
- No QualityGateV2 relaxation
- No database migration
- No worker/processor lifecycle changes
- No artifact schema change

## Fix 1 — Page crash

Symptom: `/evaluate/370fbe1d` threw an Application error on refresh.

Cause: one longform criterion, `proseControl`, had `score: null` in an insufficient-signal state. Two render components called `.toFixed()` on the score without null checks.

Fix:
- `LongformScoreGrid` now accepts `number | null` and renders `—` for null.
- `LongformCriterionAnalyses` guards `safeScore` before calling `.toFixed()`.

## Fix 2 — Artifact endpoint determinism

The artifacts endpoint now filters by both:

- `job_id`
- `artifact_type = longform_document_v1`

This prevents same-job artifact-type ambiguity and ensures the synthesis poller reads the intended longform artifact.

## Fix 3 — Synthesis auto-poll

Replaces the static synthesis pending block with `SynthesisPoller`:

- polls every 15s while waiting for `longform_document_v1`
- renders inline when the artifact arrives
- does not require manual refresh
- shows realistic estimates by manuscript length, including `5–10` minutes for 100k+ words
- shows Retry / Skip controls after 5 minutes

## Contract Integrity

No evaluation contract changes.

- `QG_` failures remain terminal and unchanged.
- This PR does not bypass or relax QualityGateV2.
- This PR does not suppress quality gate / anomaly disclosure.
- This PR does not alter criteria, confidence, score caps, score ledger, Pass 1, Pass 2, Pass 3, worker claiming, handoff, or persistence semantics.

## Behavioral Quality

This PR is not reducing intelligence.

It only hardens report rendering and artifact display behavior after the evaluation has already completed or while the longform synthesis artifact is pending.

User-facing improvements:
- null criterion scores no longer crash the page
- pending synthesis no longer requires manual refresh
- the page gives a realistic time estimate instead of "check back in a minute"
- concurrent or overlapping job activity cannot cause the poller to read the wrong artifact type for this job

## Latency Evidence

Baseline (Pre-change)

| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Notes |
|---|---:|---:|---:|---:|---|
| Baseline | 0 | 0 | 0 | 0 | Report rendering / polling only; no LLM pass runtime benchmark required |

Post-change Runs

| Run | pass1_ms | pass2_ms | pass3_ms | total_ms | Result |
|---|---:|---:|---:|---:|---|
| Run 1 | 0 | 0 | 0 | 0 | `npx tsc --noEmit --skipLibCheck` clean per PR notes |
| Run 2 | 0 | 0 | 0 | 0 | Stress harness `22/22` per PR notes |

Additional metrics:
- `passX_ms`: unchanged / not applicable for report-only PR
- `total_ms`: unchanged / not applicable for report-only PR
- `criteria_count_by_state`: unchanged; scoring and synthesis semantics are not modified

## Risks & Anomalies

Risks:
- Client polling could continue longer than necessary if artifact write is delayed.
- The artifact endpoint now returns only `longform_document_v1`; callers expecting latest artifact of any type would need a separate endpoint.
- UI copy must not imply a guarantee; estimates are approximate.

Mitigations:
- Polling stops once the longform document is loaded.
- The endpoint is specifically for the report synthesis poller and now matches that use case.
- Copy says "Expected in approximately" and provides a range.

Known anomaly:
- The latency workflow classifies this as an evaluation PR because it touches report/evaluation routes, so this body includes latency evidence even though no LLM pass latency changes are intended.

Final principle: this PR is report display hardening only, not reducing intelligence.