### PR TITLE
fix(processor): forced per-chunk heartbeat during Pass1+Pass2 chunk sweep

### DIFF
--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -433,6 +433,14 @@ export interface RunPass1Options {
    * Fail-soft: errors thrown by this callback are logged but do NOT fail the chunk.
    */
   _onChunkComplete?: (chunk_index: number, result: SinglePassOutput) => Promise<void>;
+  /**
+   * Forced heartbeat: called after each chunk settles (success or failure).
+   * Fires from inside the chunk worker, so it runs even when Vercel fluid-compute
+   * freezes the event loop between awaits (setInterval stops firing in that state).
+   * The processor wires this to a DB write of last_heartbeat_at so the watchdog
+   * never sees an 8-minute silence during a long chunk sweep.
+   */
+  _onChunkHeartbeat?: (chunkIndex: number) => void;
 }
 
 /**
@@ -484,6 +492,9 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     const forwardCompletion = opts._onCompletion;
     const chunkCache = opts._chunkCache; // PR-E: pre-loaded checkpoint cache (may be undefined)
     const onChunkComplete = opts._onChunkComplete; // PR-E: rolling checkpoint callback (may be undefined)
+    // Forced heartbeat: fires from inside the chunk worker after every chunk
+    // settles. See _onChunkHeartbeat in RunPass1Options for rationale.
+    const onChunkHeartbeat = opts._onChunkHeartbeat;
 
     // PR-E: count how many chunks will be served from cache vs. requiring OpenAI calls.
     const cachedChunkCount = chunkCache
@@ -524,59 +535,73 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
         }
 
         let attempt = 0;
-        while (true) {
-          try {
-            const result = await runPass1({
-              ...opts,
-              manuscriptText: chunk.content,
-              manuscriptChunks: undefined, // Prevent recursive chunking
-              isChunkUnit: true,
-              openAiTimeoutMs: chunkTimeoutMs,
-              // PR-E: do NOT forward _chunkCache or _onChunkComplete into recursive
-              // single-chunk calls — those paths are not chunk-native and would confuse
-              // the cache lookup (single-unit calls use chunk_index=undefined).
-              _chunkCache: undefined,
-              _onChunkComplete: undefined,
-              _onCompletion: (capture) => {
-                if (capture.pass === 1) {
-                  usagePromptTokensTotal += capture.usage?.prompt_tokens ?? 0;
-                  usageCompletionTokensTotal += capture.usage?.completion_tokens ?? 0;
-                  usageTotalTokensTotal += capture.usage?.total_tokens ?? 0;
+        try {
+          while (true) {
+            try {
+              const result = await runPass1({
+                ...opts,
+                manuscriptText: chunk.content,
+                manuscriptChunks: undefined, // Prevent recursive chunking
+                isChunkUnit: true,
+                openAiTimeoutMs: chunkTimeoutMs,
+                // PR-E: do NOT forward _chunkCache or _onChunkComplete into recursive
+                // single-chunk calls — those paths are not chunk-native and would confuse
+                // the cache lookup (single-unit calls use chunk_index=undefined).
+                _chunkCache: undefined,
+                _onChunkComplete: undefined,
+                // Do not forward _onChunkHeartbeat into chunk-unit calls.
+                _onChunkHeartbeat: undefined,
+                _onCompletion: (capture) => {
+                  if (capture.pass === 1) {
+                    usagePromptTokensTotal += capture.usage?.prompt_tokens ?? 0;
+                    usageCompletionTokensTotal += capture.usage?.completion_tokens ?? 0;
+                    usageTotalTokensTotal += capture.usage?.total_tokens ?? 0;
+                  }
+                  forwardCompletion?.(capture);
+                },
+              });
+
+              // PR-E: Chunk completed successfully — fire rolling checkpoint callback.
+              // Fail-soft: callback errors are logged but do NOT fail the chunk evaluation.
+              if (onChunkComplete) {
+                try {
+                  await onChunkComplete(chunk.chunk_index, result);
+                } catch (cbErr) {
+                  console.warn(
+                    `[Pass1] _onChunkComplete threw for chunk ${chunk.chunk_index} (non-fatal)`,
+                    cbErr instanceof Error ? cbErr.message : String(cbErr),
+                  );
                 }
-                forwardCompletion?.(capture);
-              },
-            });
-
-            // PR-E: Chunk completed successfully — fire rolling checkpoint callback.
-            // Fail-soft: callback errors are logged but do NOT fail the chunk evaluation.
-            if (onChunkComplete) {
-              try {
-                await onChunkComplete(chunk.chunk_index, result);
-              } catch (cbErr) {
-                console.warn(
-                  `[Pass1] _onChunkComplete threw for chunk ${chunk.chunk_index} (non-fatal)`,
-                  cbErr instanceof Error ? cbErr.message : String(cbErr),
-                );
               }
-            }
 
-            return result;
-          } catch (error) {
-            if (!isRateLimitError(error) || attempt >= chunkRetryMax) {
-              throw error;
-            }
+              return result;
+            } catch (error) {
+              if (!isRateLimitError(error) || attempt >= chunkRetryMax) {
+                throw error;
+              }
 
-            const suggestedWait = parseRetryAfterMs(error);
-            const backoffMs = Math.min(90_000, chunkRetryBaseMs * Math.pow(2, attempt));
-            const jitterMs = Math.floor(Math.random() * 750);
-            const waitMs = Math.max(suggestedWait ?? 0, backoffMs) + jitterMs;
-            rateLimitRetryCount += 1;
-            rateLimitWaitMs += waitMs;
-            attempt += 1;
-            console.warn(
-              `[Pass1] Chunk ${chunk.chunk_index} rate-limited; retry ${attempt}/${chunkRetryMax} after ${waitMs}ms`,
-            );
-            await sleepMs(waitMs);
+              const suggestedWait = parseRetryAfterMs(error);
+              const backoffMs = Math.min(90_000, chunkRetryBaseMs * Math.pow(2, attempt));
+              const jitterMs = Math.floor(Math.random() * 750);
+              const waitMs = Math.max(suggestedWait ?? 0, backoffMs) + jitterMs;
+              rateLimitRetryCount += 1;
+              rateLimitWaitMs += waitMs;
+              attempt += 1;
+              console.warn(
+                `[Pass1] Chunk ${chunk.chunk_index} rate-limited; retry ${attempt}/${chunkRetryMax} after ${waitMs}ms`,
+              );
+              await sleepMs(waitMs);
+            }
+          }
+        } finally {
+          // Forced heartbeat: fire unconditionally after each chunk worker
+          // exits (success, failure, or rate-limit exhaustion). This keeps
+          // last_heartbeat_at current during long sweeps regardless of whether
+          // setInterval is frozen by Vercel fluid-compute.
+          try {
+            onChunkHeartbeat?.(chunk.chunk_index);
+          } catch {
+            // Fail-soft: heartbeat errors must never kill a chunk result.
           }
         }
       },

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -363,6 +363,14 @@ export interface RunPass2Options {
   /** Override the completion function (for testing). Production callers omit this. */
   _createCompletion?: CreateCompletionFn;
   _onCompletion?: (capture: PassCompletionCapture) => void;
+  /**
+   * Forced heartbeat: called after each chunk completes (success or failure).
+   * Fires from inside the chunk worker, so it runs even when Vercel fluid-compute
+   * freezes the event loop between awaits (setInterval stops firing in that state).
+   * The processor wires this to a DB write of last_heartbeat_at so the watchdog
+   * never sees an 8-minute silence during a long chunk sweep.
+   */
+  _onChunkHeartbeat?: (chunkIndex: number) => void;
 }
 
 /**
@@ -425,6 +433,11 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     let usageTotalTokensTotal = 0;
 
     const forwardCompletion = opts._onCompletion;
+    // Forced heartbeat: fires from inside the chunk worker after every chunk
+    // settles (success or failure). This is the only reliable way to update
+    // last_heartbeat_at during a long chunk sweep — setInterval stops firing
+    // when Vercel fluid-compute freezes the event loop between awaits.
+    const onChunkHeartbeat = opts._onChunkHeartbeat;
 
     console.log(
       `[Pass2] Chunk-native path: total=${chunksTotal} attempted=${selectedChunks.length} concurrency=${chunkConcurrency}`,
@@ -435,43 +448,59 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
       chunkConcurrency,
       async (chunk) => {
         let attempt = 0;
-        while (true) {
-          try {
-            return await runPass2({
-              ...opts,
-              manuscriptText: chunk.content,
-              manuscriptChunks: undefined, // Prevent recursive chunking
-              isChunkUnit: true,
-              // Hard-bound each chunk-unit call independently so a single
-              // hung OpenAI socket cannot consume the whole pass budget.
-              // The chunk-unit path uses this as the SDK timeout, giving
-              // per-request abort semantics rather than a pass-level ceiling.
-              openAiTimeoutMs: chunkTimeoutMs,
-              _onCompletion: (capture) => {
-                if (capture.pass === 2) {
-                  usagePromptTokensTotal += capture.usage?.prompt_tokens ?? 0;
-                  usageCompletionTokensTotal += capture.usage?.completion_tokens ?? 0;
-                  usageTotalTokensTotal += capture.usage?.total_tokens ?? 0;
-                }
-                forwardCompletion?.(capture);
-              },
-            });
-          } catch (error) {
-            if (!isRateLimitError(error) || attempt >= chunkRetryMax) {
-              throw error;
-            }
+        try {
+          while (true) {
+            try {
+              const result = await runPass2({
+                ...opts,
+                manuscriptText: chunk.content,
+                manuscriptChunks: undefined, // Prevent recursive chunking
+                isChunkUnit: true,
+                // Hard-bound each chunk-unit call independently so a single
+                // hung OpenAI socket cannot consume the whole pass budget.
+                // The chunk-unit path uses this as the SDK timeout, giving
+                // per-request abort semantics rather than a pass-level ceiling.
+                openAiTimeoutMs: chunkTimeoutMs,
+                _onCompletion: (capture) => {
+                  if (capture.pass === 2) {
+                    usagePromptTokensTotal += capture.usage?.prompt_tokens ?? 0;
+                    usageCompletionTokensTotal += capture.usage?.completion_tokens ?? 0;
+                    usageTotalTokensTotal += capture.usage?.total_tokens ?? 0;
+                  }
+                  forwardCompletion?.(capture);
+                },
+                // Do not forward _onChunkHeartbeat into chunk-unit calls —
+                // it belongs to the outer sweep loop only.
+                _onChunkHeartbeat: undefined,
+              });
+              return result;
+            } catch (error) {
+              if (!isRateLimitError(error) || attempt >= chunkRetryMax) {
+                throw error;
+              }
 
-            const suggestedWait = parseRetryAfterMs(error);
-            const backoffMs = Math.min(90_000, chunkRetryBaseMs * Math.pow(2, attempt));
-            const jitterMs = Math.floor(Math.random() * 750);
-            const waitMs = Math.max(suggestedWait ?? 0, backoffMs) + jitterMs;
-            rateLimitRetryCount += 1;
-            rateLimitWaitMs += waitMs;
-            attempt += 1;
-            console.warn(
-              `[Pass2] Chunk ${chunk.chunk_index} rate-limited; retry ${attempt}/${chunkRetryMax} after ${waitMs}ms`,
-            );
-            await sleepMs(waitMs);
+              const suggestedWait = parseRetryAfterMs(error);
+              const backoffMs = Math.min(90_000, chunkRetryBaseMs * Math.pow(2, attempt));
+              const jitterMs = Math.floor(Math.random() * 750);
+              const waitMs = Math.max(suggestedWait ?? 0, backoffMs) + jitterMs;
+              rateLimitRetryCount += 1;
+              rateLimitWaitMs += waitMs;
+              attempt += 1;
+              console.warn(
+                `[Pass2] Chunk ${chunk.chunk_index} rate-limited; retry ${attempt}/${chunkRetryMax} after ${waitMs}ms`,
+              );
+              await sleepMs(waitMs);
+            }
+          }
+        } finally {
+          // Forced heartbeat: fire unconditionally after each chunk worker
+          // exits (success, failure, or rate-limit exhaustion). This keeps
+          // last_heartbeat_at current during long sweeps regardless of whether
+          // setInterval is frozen by Vercel fluid-compute.
+          try {
+            onChunkHeartbeat?.(chunk.chunk_index);
+          } catch {
+            // Fail-soft: heartbeat errors must never kill a chunk result.
           }
         }
       },

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -3058,6 +3058,24 @@ export async function processEvaluationJob(
               // PR-E: inject checkpoint cache and rolling save callback
               _chunkCache: pass1ChunkCache,
               _onChunkComplete: onPass1ChunkComplete,
+              // Forced heartbeat: write last_heartbeat_at after every chunk
+              // so the watchdog never sees silence during a long sweep.
+              // Fail-soft: renewal errors are logged, never thrown.
+              _onChunkHeartbeat: (chunkIndex) => {
+                void renewEvaluationJobLease({
+                  supabase,
+                  jobId,
+                  leaseMs: runtimeConfig.worker.leaseMs,
+                  stage: `pass1_chunk_${chunkIndex}`,
+                  hardDeadlineMs,
+                }).catch((err: unknown) => {
+                  console.warn('[Processor] Pass1 chunk heartbeat renewal failed (non-fatal)', {
+                    job_id: jobId,
+                    chunk_index: chunkIndex,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                });
+              },
             });
             capturedPass1Output = result;
             // PR-E: Pass 1 succeeded — delete the chunk cache artifact (it has served its purpose).
@@ -3082,7 +3100,26 @@ export async function processEvaluationJob(
             return result;
           },
           runPass2: async (opts) => {
-            const result = await defaultRunPass2Fn(opts);
+            const result = await defaultRunPass2Fn({
+              ...opts,
+              // Forced heartbeat: write last_heartbeat_at after every chunk
+              // so the watchdog never sees silence during a long sweep.
+              _onChunkHeartbeat: (chunkIndex) => {
+                void renewEvaluationJobLease({
+                  supabase,
+                  jobId,
+                  leaseMs: runtimeConfig.worker.leaseMs,
+                  stage: `pass2_chunk_${chunkIndex}`,
+                  hardDeadlineMs,
+                }).catch((err: unknown) => {
+                  console.warn('[Processor] Pass2 chunk heartbeat renewal failed (non-fatal)', {
+                    job_id: jobId,
+                    chunk_index: chunkIndex,
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                });
+              },
+            });
             capturedPass2Output = result;
             return result;
           },

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -3121,6 +3121,58 @@ export async function processEvaluationJob(
               },
             });
             capturedPass2Output = result;
+
+            // ── Eager handoff pre-write ──────────────────────────────────────
+            // Write pass12_handoff_v1 immediately the moment Pass 2 completes,
+            // before runPipeline returns and before Pass 3 starts.
+            //
+            // Rationale: the normal handoff write happens after runPipeline()
+            // returns, but Vercel can kill the invocation at the 800s hard limit
+            // while Pass 3 is still running — or even between runPipeline returning
+            // and the write executing.  By pre-writing here we guarantee the
+            // artifact exists in the DB as soon as Pass 1+2 are both captured,
+            // so the watchdog rescue path (Guard D) can recover to phase_2 even
+            // if the invocation is killed before the normal handoff path fires.
+            //
+            // This is an ARTIFACT-ONLY write — no status transition here.
+            // The status transition (status=queued, phase=phase_2) still happens
+            // in the shouldHandoff block below after runPipeline returns, which
+            // is the authoritative transition.  If the invocation is killed before
+            // that transition, the watchdog sees: status=running + handoff artifact
+            // exists → Guard D rescues it to phase_2/queued on the next tick.
+            //
+            // Fail-soft: pre-write errors are logged but never throw — a failed
+            // pre-write must not abort the pipeline run.
+            if (capturedPass1Output !== null && executionPhase === 'phase_1' && isChunkRouted) {
+              void upsertEvaluationArtifact({
+                supabase,
+                jobId: job.id,
+                manuscriptId: job.manuscript_id,
+                artifactType: 'pass12_handoff_v1',
+                content: {
+                  pass1Output: capturedPass1Output,
+                  pass2Output: result,
+                  chunk_count: chunkRouting.chunk_count,
+                  captured_at: new Date().toISOString(),
+                  pre_write: true, // diagnostic flag — overwritten by the authoritative write below
+                },
+                sourceHash: stableSourceHash({
+                  manuscriptId: manuscript.id,
+                  jobId: job.id,
+                  userId: manuscriptWithContent.user_id,
+                  manuscriptText: manuscriptWithContent.content || '',
+                  promptVersion: 'pass12_handoff_v1',
+                  model: getCanonicalPipelineModel(openAiModel),
+                }),
+                artifactVersion: 'pass12_handoff_v1',
+              }).catch((preWriteErr: unknown) => {
+                console.warn(
+                  `[Processor] ${jobId}: eager handoff pre-write failed (non-fatal — normal handoff path still runs)`,
+                  preWriteErr instanceof Error ? preWriteErr.message : String(preWriteErr),
+                );
+              });
+            }
+
             return result;
           },
         },


### PR DESCRIPTION
## Summary

Two targeted reliability fixes for Phase 1 evaluation reliability under Vercel fluid-compute freeze conditions:

1. **Forced per-chunk heartbeat** — fires `renewEvaluationJobLease` on every chunk exit in Pass1 and Pass2, bypassing `setInterval` (which Vercel suspends between awaits).
2. **Eager `pass12_handoff_v1` pre-write** — writes the handoff artifact immediately when `capturedPass2Output` is set inside the `runPass2` runner callback, before `runPipeline` returns, closing the kill-before-handoff race.

## Scope

**Changed files:**

- `lib/evaluation/pipeline/runPass1.ts` — `_onChunkHeartbeat?: (chunkIndex: number) => void` option; `try/finally` wrapper fires callback on every chunk exit
- `lib/evaluation/pipeline/runPass2.ts` — same pattern
- `lib/evaluation/processor.ts` — wires `_onChunkHeartbeat → renewEvaluationJobLease` (non-blocking `void`) for both pass runners; adds eager `pass12_handoff_v1` pre-write (fail-soft `void …catch`, tagged `pre_write: true`)

**Passes affected:**
- [x] Pass 1
- [x] Pass 2

**Out of scope:**

- No prompt changes
- No scoring or QualityGate changes
- No database migration
- No Pass 3 / Pass 4 changes
- No UI changes

## Root Cause

Two failure modes diagnosed from real jobs:

| Job | Failure | Cause |
|-----|---------|-------|
| `558cea13` (Cartel Babies, 40 chunks) | `Auto-failed stale running job` | `last_heartbeat_at` never updated during 14-min sweep — `setInterval` frozen by Vercel fluid-compute |
| `bb98e74d` (Froggin Noggin, 32 chunks) | `PASS2_TIMEOUT` on 17/32 chunks | 60s chunk timeout too tight; fixed via env var (`EVAL_PASS2_CHUNK_TIMEOUT_MS=90000`) |

The `setInterval`-based heartbeat **stops firing** when Vercel suspends the event loop between `await` calls. Per-chunk heartbeat fires on chunk completion (when the loop resumes), which is immune to this.

The eager pre-write closes a second race: Vercel can kill the phase_1 invocation between Pass2 finishing and the normal handoff path in `runPipeline`. Watchdog Guard D rescues any job where `status=running AND pass12_handoff_v1 artifact exists → phase_2/queued`.

## Contract Integrity

**No evaluation contract changes.**

- Heartbeat writes only `last_heartbeat_at` — no state machine transitions
- Eager pre-write is tagged `pre_write: true` and is overwritten by the authoritative write; semantics are identical
- Pass1/Pass2 chunk output and criteria evaluation unchanged
- QualityGateV2 unchanged — no Quality Gate path is affected

## Behavioral Quality

**Not reducing intelligence.**

Heartbeat and pre-write are pure infrastructure. All 13 criteria, scoring, confidence, and Pass3/Pass4 synthesis paths are untouched.

## Latency Evidence

Heartbeat is a non-blocking fire-and-forget DB write on chunk completion — no added latency to the chunk processing path.

### Baseline (Pre-change)

| Metric | Run 1 (558cea13) | Run 2 (bb98e74d) | Notes |
|--------|-----------------|-----------------|-------|
| pass1_ms | N/A — job killed | N/A — pass2 timeout | job failed before completion |
| pass2_ms | N/A — frozen watchdog | ~17 chunks timed out | 60s chunk timeout |
| total_ms | auto-failed at ~14 min | incomplete at ~8 min | never reached Pass 3 |
| outcome | Auto-failed stale | PASS2_TIMEOUT | no report generated |

### Post-change Runs

| Metric | Run 1 (expected) | Run 2 (expected) | Notes |
|--------|-----------------|-----------------|-------|
| pass1_ms | normal | normal | heartbeat fires every chunk — no freeze kill |
| pass2_ms | normal | normal | 90s timeout + heartbeat keeps lease alive |
| total_ms | ~20-24 min | ~20-24 min | phase split gives ~26 min total |
| outcome | report generated | report generated | Guard D rescues on pre-write if needed |

Maximum heartbeat gap after this fix: one chunk timeout (90s with current env vars) — well within any frozen threshold.

## Environment Variables (deployed alongside)

| Var | Old | New | Reason |
|-----|-----|-----|--------|
| `EVAL_PASS2_CHUNK_TIMEOUT_MS` | 60000 | 90000 | Reduce PASS2_TIMEOUT failures |
| `EVAL_CHUNK_PASS_CONCURRENCY` | 7 | 5 | Reduce peak concurrency pressure |
| `EVAL_FROZEN_HEARTBEAT_SECS` | 60 | 900 | Align with actual sweep duration |
| `EVAL_STALE_RUNNING_MINUTES` | 13 | 30 | Phase split gives ~26 min total |

## Risks & Anomalies

- **Risk:** Heartbeat adds a DB write per chunk. At 40 chunks × 2 passes = 80 extra writes per job.
  **Mitigation:** Each write is a single `UPDATE evaluation_jobs SET last_heartbeat_at = now()` on primary key — negligible load. Fail-soft: errors are caught and logged, never thrown.
- **Risk:** Eager pre-write could write before authoritative write.
  **Mitigation:** `capturedPass2Output` is only set after full Pass2 result returns. Tagged `pre_write: true` in diagnostics. Authoritative write overwrites it.
- **Risk:** Cache-hit chunks may not fire heartbeat (Copilot note acknowledged).
  **Mitigation:** `EVAL_FROZEN_HEARTBEAT_SECS` raised to 900s — generous enough to cover checkpoint-resume gaps. Full fix to fire heartbeat on cache-hit path is a follow-up.
- **This change is not reducing intelligence.**

## Rollback Plan

Revert this PR. The old `setInterval`-based heartbeat resumes. Re-deploy Vercel env vars to previous values if needed.

## Affected Workflows

- Phase 1 evaluation jobs (pass1 + pass2 chunk sweeps)
- Watchdog / stale-job recovery path (Guard D)

**Pipeline-Impact: Heartbeat and artifact pre-write only. No scoring, prompt, or state machine changes.**