### PR TITLE
feat(pipeline): dual-model evaluation — GPT + Perplexity parallel chunk sweep, retire Pass 4

### DIFF
--- a/__tests__/lib/evaluation/pass4-cross-check-invocation.test.ts
+++ b/__tests__/lib/evaluation/pass4-cross-check-invocation.test.ts
@@ -1,141 +1,39 @@
 /**
- * Pass 4 Cross-Check Invocation — Truth Enforcement Test
+ * Pass 4 Cross-Check Invocation — RETIRED
  *
- * Real validation that Perplexity cross-check doesn't silently skip.
- * Binary check: Is runPerplexityCrossCheck called when apiKey provided?
+ * ARCHIVED: Pass 4 retired in favor of dual-model parallel scoring
+ * (feat/dual-model-parallel-scoring). The runPerplexityCrossCheck call is no
+ * longer invoked by runPipeline; Perplexity now scores all chunks during
+ * Pass 1+2 alongside GPT and feeds the Pass 3 collator as an independent
+ * second packet.
+ *
+ * These tests previously enforced that the pipeline awaits a post-synthesis
+ * Perplexity cross-check. After retirement, the file is preserved as a
+ * marker so the test suite documents the contract change. The retained
+ * assertions verify that the retirement is in place (i.e. the legacy
+ * invocation path is no longer present).
  */
 
 import { describe, test, expect } from "@jest/globals";
 import * as fs from "fs/promises";
 import * as path from "path";
 
-describe("Pass 4 Cross-Check — Truth Enforcement", () => {
-  test("runPipeline conditionally invokes runPerplexityCrossCheck based on opts.perplexityApiKey", async () => {
-    // Read the actual runPipeline source
+describe("Pass 4 Cross-Check — Retired", () => {
+  test("runPipeline no longer awaits runPerplexityCrossCheck (Pass 4 retired)", async () => {
     const pipelineFile = path.join(
       process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
+      "lib/evaluation/pipeline/runPipeline.ts",
     );
     const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Verify the conditional is present: if (opts.perplexityApiKey)
-    expect(source).toMatch(/if\s*\(\s*opts\.perplexityApiKey\s*\)/);
-
-    // Verify runPerplexityCrossCheck is called inside that conditional
-    const conditionalBlock = source.match(
-      /if\s*\(\s*opts\.perplexityApiKey\s*\)\s*\{[\s\S]*?runPerplexityCrossCheck/
-    );
-    expect(conditionalBlock).toBeDefined();
+    expect(source).not.toMatch(/await\s+runPerplexityCrossCheck\s*\(/);
   });
 
-  test("runPerplexityCrossCheck is awaited (not fire-and-forget)", async () => {
+  test("runPipeline references the dual-model parallel scorer", async () => {
     const pipelineFile = path.join(
       process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
+      "lib/evaluation/pipeline/runPipeline.ts",
     );
     const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Verify it's awaited
-    expect(source).toMatch(/await\s+runPerplexityCrossCheck/);
-  });
-
-  test("Perplexity cross-check failures are logged, not silently ignored", async () => {
-    const pipelineFile = path.join(
-      process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
-    );
-    const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Verify catch block exists
-    expect(source).toMatch(/catch\s*\(\s*err\s*\)/);
-
-    // Verify error is logged
-    expect(source).toMatch(/console\.warn/);
-    expect(source).toMatch(/Perplexity\s+cross-check\s+failed/);
-  });
-
-  test("Cross-check result is attached to pipeline output", async () => {
-    const pipelineFile = path.join(
-      process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
-    );
-    const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Verify cross_check is added to the return object
-    expect(source).toMatch(/cross_check:\s*crossCheckResult/);
-  });
-
-  test("Pass 4 governance is evaluated and can block the pipeline", async () => {
-    const pipelineFile = path.join(
-      process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
-    );
-    const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Verify governance evaluation
-    expect(source).toMatch(/pass4Governance\s*=\s*evaluatePass4Governance/);
-
-    // Verify it can fail pipeline
-    expect(source).toMatch(
-      /if\s*\(\s*pass4Governance\s*&&\s*!pass4Governance\.ok\s*\)/
-    );
-
-    // Verify explicit error is returned
-    expect(source).toMatch(/failed_at:\s*["']pass4["']/);
-  });
-
-  test("Cross-check imports are in place", async () => {
-    const pipelineFile = path.join(
-      process.cwd(),
-      "lib/evaluation/pipeline/runPipeline.ts"
-    );
-    const source = await fs.readFile(pipelineFile, "utf-8");
-
-    // Top of file should import runPerplexityCrossCheck
-    const firstLines = source.split("\n").slice(0, 30).join("\n");
-    expect(firstLines).toMatch(/runPerplexityCrossCheck/);
-  });
-
-  test("documentation: expected Pass 4 behavior when apiKey present", () => {
-    const expectedBehavior = {
-      scenario: "perplexityApiKey option is provided (string)",
-      expected: [
-        "runPerplexityCrossCheck is called with manuscript and synthesis",
-        "CrossCheckOutput is attached to pipeline result",
-        "Pass 4 governance evaluates the cross-check",
-        "If governance rejects, pipeline fails with error_code PASS4_GOVERNANCE_FAILED",
-      ],
-    };
-
-    expect(expectedBehavior.expected.length).toBeGreaterThan(0);
-  });
-
-  test("documentation: expected Pass 4 behavior when apiKey absent", () => {
-    const expectedBehavior = {
-      scenario: "perplexityApiKey option is undefined",
-      expected: [
-        "runPerplexityCrossCheck is NOT called",
-        "Pipeline continues successfully",
-        "cross_check field is undefined in result",
-        "pass4_governance is undefined",
-      ],
-    };
-
-    expect(expectedBehavior.expected.length).toBeGreaterThan(0);
-  });
-
-  test("documentation: expected Pass 4 behavior on API error", () => {
-    const expectedBehavior = {
-      scenario: "runPerplexityCrossCheck throws (API error, timeout, etc)",
-      expected: [
-        "Error is caught in try-catch block",
-        "Error logged to console.warn with [Pass4] prefix",
-        "Pipeline continues (graceful failure in optional mode)",
-        "crossCheckResult remains undefined",
-        "pass4Governance is evaluated with undefined input",
-      ],
-    };
-
-    expect(expectedBehavior.expected.length).toBeGreaterThan(0);
+    expect(source).toMatch(/runPerplexityChunkScorer/);
   });
 });

--- a/__tests__/lib/evaluation/pass4-governance-severity-mode.test.ts
+++ b/__tests__/lib/evaluation/pass4-governance-severity-mode.test.ts
@@ -1,172 +1,30 @@
 /**
- * Pass 4 Governance — Severity + Mode Enforcement Test (PR-A invariant)
+ * Pass 4 Governance — Severity + Mode Enforcement — RETIRED
  *
- * Validates that the runPipeline consumer at lib/evaluation/pipeline/runPipeline.ts
- * honors BOTH the governance decision's `severity` field AND the runtime
- * `adjudicationMode` when deciding whether a governance !ok blocks the pipeline.
+ * ARCHIVED: Pass 4 retired in favor of dual-model parallel scoring
+ * (feat/dual-model-parallel-scoring). The runtime governance gate that this
+ * test enforced is no longer invoked by runPipeline; evaluatePass4Governance
+ * is preserved on disk for type/import back-compat but is not called.
  *
- * Source-text regex assertions (no runtime), consistent with the existing
- * pass4-cross-check-invocation.test.ts style. Verifies the structural shape
- * of the consumer gate so future edits cannot silently regress the fix.
- *
- * Background:
- *   - evaluatePass4Governance() emits severity="warning" for PASS4_DISPUTED_CRITERIA
- *     and severity="error" for PASS4_CANON_INVALID + PASS4_WEAK_AGREEMENT.
- *   - The CONSUMER previously failed the pipeline on ANY governance !ok,
- *     ignoring both severity and mode. This killed jobs in optional mode
- *     whenever a single criterion delta crossed the dispute threshold.
- *   - Post-fix: pipeline only fails when severity==="error" OR mode is strict
- *     ("required" | "veto"). Warning + optional mode → ship with warning.
+ * The previous assertions checked the consumer-side gate for severity + mode
+ * branching. After retirement, the file is preserved as a marker so the
+ * test suite documents the contract change. The retained assertion verifies
+ * that the legacy governance call is gone.
  */
 
 import { describe, test, expect } from "@jest/globals";
 import * as fs from "fs/promises";
 import * as path from "path";
 
-describe("Pass 4 Governance — Severity + Mode Invariants (PR-A)", () => {
-  const pipelinePath = path.join(
-    process.cwd(),
-    "lib/evaluation/pipeline/runPipeline.ts"
-  );
-
-  test("consumer reads pass4Governance.severity when gating", async () => {
-    const source = await fs.readFile(pipelinePath, "utf-8");
-    // The consumer must explicitly check severity === "error" to determine
-    // whether a governance decision is structurally blocking.
-    expect(source).toMatch(/pass4Governance\.severity\s*===\s*["']error["']/);
-  });
-
-  test("consumer reads adjudicationMode when gating (required | veto)", async () => {
-    const source = await fs.readFile(pipelinePath, "utf-8");
-    // The consumer must check adjudicationMode for strict modes so operators
-    // who opt into fail-closed semantics still get them regardless of severity.
-    expect(source).toMatch(/adjudicationMode\s*===\s*["']required["']/);
-    expect(source).toMatch(/adjudicationMode\s*===\s*["']veto["']/);
-  });
-
-  test("non-blocking warning path falls through (does not return ok:false)", async () => {
-    const source = await fs.readFile(pipelinePath, "utf-8");
-
-    // Locate the governance gate block.
-    const gateMatch = source.match(
-      /if\s*\(\s*pass4Governance\s*&&\s*!pass4Governance\.ok\s*\)\s*\{[\s\S]*?\n\s{2}\}/
-    );
-    expect(gateMatch).toBeDefined();
-    const gateBlock = gateMatch![0];
-
-    // Inside the gate, there must be an inner conditional that wraps the
-    // fail-closed `return { ok: false, ... }`. The bare `return { ok: false }`
-    // must NOT be unconditional.
-    expect(gateBlock).toMatch(/if\s*\(\s*blocking\s*\)/);
-
-    // The fail-closed return must live inside the inner conditional.
-    expect(gateBlock).toMatch(/if\s*\(\s*blocking\s*\)\s*\{[\s\S]*?ok:\s*false/);
-  });
-
-  test("non-blocking warning is logged with mode context", async () => {
-    const source = await fs.readFile(pipelinePath, "utf-8");
-    // When falling through with a warning, the pipeline must log it so the
-    // event is auditable. The log must reference the mode for diagnosability.
-    expect(source).toMatch(
-      /\[Pass4\]\s+Governance\s+warning[\s\S]*?adjudicationMode/
-    );
-  });
-
-  test("success return still surfaces pass4_governance for warning case", async () => {
-    const source = await fs.readFile(pipelinePath, "utf-8");
-    // The success return must include pass4_governance so the processor can
-    // persist the warning onto progress and the UI can render it.
-    const successReturn = source.match(
-      /return\s*\{\s*ok:\s*true[\s\S]*?pass4_governance:\s*pass4Governance[\s\S]*?\}/
-    );
-    expect(successReturn).toBeDefined();
-  });
-
-  test("only PASS4_CANON_INVALID is severity:error (PR-G: disagreement is advisory)", async () => {
-    const governancePath = path.join(
+describe("Pass 4 Governance — Retired", () => {
+  test("runPipeline no longer invokes evaluatePass4Governance", async () => {
+    const pipelinePath = path.join(
       process.cwd(),
-      "lib/evaluation/governance/evaluatePass4Governance.ts"
+      "lib/evaluation/pipeline/runPipeline.ts",
     );
-    const source = await fs.readFile(governancePath, "utf-8");
-
-    // PR-G design: structural canon invalidity is the ONLY hard fail.
-    // Score disagreement (weak overall or per-criterion disputed) is
-    // advisory — the report ships with PRIMARY and SECONDARY verdicts
-    // surfaced per criterion and a human-readable reason for each
-    // conflict. The user deconflicts, not the pipeline.
-    const canonInvalidBlock = source.match(
-      /blockCode:\s*["']PASS4_CANON_INVALID["'][\s\S]*?severity:\s*["']error["']/
-    );
-    expect(canonInvalidBlock).toBeDefined();
-
-    const weakAgreementBlock = source.match(
-      /blockCode:\s*["']PASS4_WEAK_AGREEMENT["'][\s\S]*?severity:\s*["']warning["']/
-    );
-    expect(weakAgreementBlock).toBeDefined();
-
-    const disputedBlock = source.match(
-      /blockCode:\s*["']PASS4_DISPUTED_CRITERIA["'][\s\S]*?severity:\s*["']warning["']/
-    );
-    expect(disputedBlock).toBeDefined();
-  });
-
-  test("every conflicting block attaches criterionConflicts with articulated reasons (PR-G)", async () => {
-    const governancePath = path.join(
-      process.cwd(),
-      "lib/evaluation/governance/evaluatePass4Governance.ts"
-    );
-    const source = await fs.readFile(governancePath, "utf-8");
-
-    // Every non-ok governance return must carry criterionConflicts so the
-    // user sees per-criterion PRIMARY vs SECONDARY scores, rationales, and
-    // a clear reason for each disagreement. No conflict ships as a bare
-    // criterion key.
-    expect(source).toMatch(/criterionConflicts:\s*invalidConflicts/);
-    expect(source).toMatch(/criterionConflicts:\s*conflicts/);
-
-    // The CriterionConflict shape must carry both verdicts and a reason.
-    expect(source).toContain("primaryScore");
-    expect(source).toContain("primaryRationale");
-    expect(source).toContain("secondaryScore");
-    expect(source).toContain("secondaryRationale");
-    expect(source).toContain("reason");
-
-    // The reason builder must articulate WHY a conflict exists, not just
-    // emit a criterion key — covering at minimum the score-divergence,
-    // missing-evidence, and structurally-invalid cases.
-    expect(source).toMatch(/Secondary scored "\$\{key\}"/);
-    expect(source).toMatch(/Secondary cross-check could not locate evidence/);
-    expect(source).toMatch(/structurally invalid response/);
-  });
-
-  test("documentation: PR-A invariant matrix (severity × mode → outcome)", () => {
-    // Documentation-only matrix. This is the contract enforced by the
-    // consumer-side gate at runPipeline.ts after the PR-A fix.
-    const matrix = [
-      { severity: "error", mode: "optional", outcome: "ok:false (block)" },
-      { severity: "error", mode: "required", outcome: "ok:false (block)" },
-      { severity: "error", mode: "veto", outcome: "ok:false (block)" },
-      { severity: "warning", mode: "optional", outcome: "ok:true + warning" },
-      { severity: "warning", mode: "required", outcome: "ok:false (block)" },
-      { severity: "warning", mode: "veto", outcome: "ok:false (block)" },
-    ];
-
-    // The only outcome that differs from the pre-PR-A behavior is
-    // (warning, optional) → previously ok:false, now ok:true + warning.
-    const changed = matrix.filter(
-      (row) => row.severity === "warning" && row.mode === "optional"
-    );
-    expect(changed).toHaveLength(1);
-    expect(changed[0].outcome).toBe("ok:true + warning");
-
-    // PR-G addendum: under this matrix, only PASS4_CANON_INVALID (the
-    // sole severity:error code) reaches the block outcomes. WEAK and
-    // DISPUTED are severity:warning, so under EVAL_EXTERNAL_ADJUDICATION_MODE
-    // = "optional" (production today) they ship with the report and
-    // surface per-criterion conflicts with articulated reasons.
-    const errorCodes = ["PASS4_CANON_INVALID"];
-    const warningCodes = ["PASS4_WEAK_AGREEMENT", "PASS4_DISPUTED_CRITERIA"];
-    expect(errorCodes).toHaveLength(1);
-    expect(warningCodes).toHaveLength(2);
+    const source = await fs.readFile(pipelinePath, "utf-8");
+    // The retired call site invoked evaluatePass4Governance(crossCheckResult).
+    // After retirement, only commentary about the retirement may reference it.
+    expect(source).not.toMatch(/^\s*pass4Governance\s*=\s*evaluatePass4Governance\s*\(/m);
   });
 });

--- a/lib/config/envContract.ts
+++ b/lib/config/envContract.ts
@@ -39,6 +39,12 @@ export interface EvalEnvContract {
   // --- Conditional requirement flag ---
   /** True when adjudicationMode is 'required' or 'veto': PERPLEXITY_API_KEY must be set. */
   requiresPerplexityApiKey: boolean;
+
+  // --- Dual-model parallel scoring (Perplexity chunk sweep alongside GPT) ---
+  /** Worker concurrency for the Perplexity chunk sweep. Default 8. */
+  pplxChunkConcurrency: number;
+  /** Per-request timeout (ms) for sonar-reasoning-pro chunk scoring. Default 120_000. */
+  pplxChunkTimeoutMs: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +79,13 @@ const SYNTHESIS_REF_CHAR_BUDGET_MAX = 600_000;
 const SYNTHESIS_REF_CHAR_BUDGET_DEFAULT = 400_000;
 
 const OPENAI_MODEL_DEFAULT = 'gpt-5.1';
+
+const PPLX_CHUNK_CONCURRENCY_DEFAULT = 8;
+const PPLX_CHUNK_CONCURRENCY_MIN = 1;
+const PPLX_CHUNK_CONCURRENCY_MAX = 20;
+const PPLX_CHUNK_TIMEOUT_MS_DEFAULT = 120_000;
+const PPLX_CHUNK_TIMEOUT_MS_MIN = 30_000;
+const PPLX_CHUNK_TIMEOUT_MS_MAX = 600_000;
 
 /**
  * Parse a strict positive integer from an env string.
@@ -215,6 +228,22 @@ export function resolveEvalEnvContract(
   const requiresPerplexityApiKey =
     adjudicationMode === 'required' || adjudicationMode === 'veto';
 
+  const pplxChunkConcurrency = parseStrictPositiveInt(
+    'EVAL_PPLX_CHUNK_CONCURRENCY',
+    env.EVAL_PPLX_CHUNK_CONCURRENCY,
+    PPLX_CHUNK_CONCURRENCY_DEFAULT,
+    PPLX_CHUNK_CONCURRENCY_MIN,
+    PPLX_CHUNK_CONCURRENCY_MAX,
+  );
+
+  const pplxChunkTimeoutMs = parseStrictPositiveInt(
+    'EVAL_PPLX_CHUNK_TIMEOUT_MS',
+    env.EVAL_PPLX_CHUNK_TIMEOUT_MS,
+    PPLX_CHUNK_TIMEOUT_MS_DEFAULT,
+    PPLX_CHUNK_TIMEOUT_MS_MIN,
+    PPLX_CHUNK_TIMEOUT_MS_MAX,
+  );
+
   return {
     inputCharBudget,
     synthesisRefCharBudget,
@@ -224,6 +253,8 @@ export function resolveEvalEnvContract(
     nodeEnv,
     isEvidenceMode,
     requiresPerplexityApiKey,
+    pplxChunkConcurrency,
+    pplxChunkTimeoutMs,
   };
 }
 

--- a/lib/config/evaluationRuntimeConfig.ts
+++ b/lib/config/evaluationRuntimeConfig.ts
@@ -52,6 +52,11 @@ export interface EvaluationRuntimeConfig {
     inputCharBudget: number;
     synthesisRefCharBudget: number;
   };
+  /** Dual-model parallel scoring (Perplexity chunk sweep alongside GPT). */
+  pplxChunk: {
+    concurrency: number;
+    timeoutMs: number;
+  };
   worker: {
     batchSize: number;
     leaseMs: number;
@@ -362,6 +367,10 @@ export function resolveEvaluationRuntimeConfig(
       pass3PromptMaxChars,
       inputCharBudget,
       synthesisRefCharBudget,
+    },
+    pplxChunk: {
+      concurrency: envContract.pplxChunkConcurrency,
+      timeoutMs: envContract.pplxChunkTimeoutMs,
     },
     worker: {
       batchSize,

--- a/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
+++ b/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import { runPerplexityChunkScorer } from "../perplexityChunkScorer";
+import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+
+function buildPerplexityChunkResponseJson(): string {
+  const criteria = Object.fromEntries(
+    CRITERIA_KEYS.map((key, i) => [
+      key,
+      {
+        score: ((i % 9) + 1),
+        rationale: `${key} demonstrates ${i % 2 === 0 ? "competent" : "uneven"} craft in this window.`,
+        evidence: `representative line for ${key}.`,
+      },
+    ]),
+  );
+  return JSON.stringify({ criteria });
+}
+
+function buildFetchMock(opts: { jsonBody?: unknown; status?: number; text?: string } = {}) {
+  const body = opts.jsonBody ?? {
+    choices: [
+      {
+        message: { content: buildPerplexityChunkResponseJson() },
+        finish_reason: "stop",
+      },
+    ],
+  };
+  const status = opts.status ?? 200;
+  const text = opts.text ?? "";
+  return async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      async json() {
+        return body;
+      },
+      async text() {
+        return text;
+      },
+    }) as unknown as Response;
+}
+
+describe("runPerplexityChunkScorer", () => {
+  const ORIGINAL_KEY = process.env.PERPLEXITY_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.PERPLEXITY_API_KEY;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY !== undefined) {
+      process.env.PERPLEXITY_API_KEY = ORIGINAL_KEY;
+    } else {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+  });
+
+  test("returns null when PERPLEXITY_API_KEY is missing (graceful degradation)", async () => {
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "Short manuscript text.",
+      manuscriptChunks: [{ chunk_index: 0, content: "Short manuscript text." }],
+      workType: "novel",
+      title: "Test",
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns a SinglePassOutput shape covering all 13 criteria when API responds successfully", async () => {
+    const fetchMock = buildFetchMock();
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "Test manuscript content sufficient for one chunk.",
+      manuscriptChunks: [
+        { chunk_index: 0, content: "Test manuscript content sufficient for one chunk." },
+      ],
+      workType: "novel",
+      title: "Test",
+      perplexityApiKey: "test-key",
+      _fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.pass).toBe(1);
+    expect(result?.axis).toBe("craft_execution");
+    expect(result?.model).toBe("sonar-reasoning-pro");
+    expect(result?.temperature).toBe(0.1);
+    expect(Array.isArray(result?.criteria)).toBe(true);
+    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
+
+    const keys = new Set(result?.criteria.map((c) => c.key));
+    for (const key of CRITERIA_KEYS) {
+      expect(keys.has(key)).toBe(true);
+    }
+
+    for (const c of result!.criteria) {
+      expect(c.score_0_10).toBeGreaterThanOrEqual(1);
+      expect(c.score_0_10).toBeLessThanOrEqual(10);
+      expect(typeof c.rationale).toBe("string");
+      expect(c.rationale.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("calls Perplexity API once per chunk with sonar-reasoning-pro and disable_search", async () => {
+    const captured: Array<{ url: string; body: unknown }> = [];
+    const fetchSpy: typeof fetch = (async (url: string, init: RequestInit) => {
+      const parsed = JSON.parse((init.body as string) ?? "{}");
+      captured.push({ url, body: parsed });
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            choices: [
+              {
+                message: { content: buildPerplexityChunkResponseJson() },
+                finish_reason: "stop",
+              },
+            ],
+          };
+        },
+        async text() {
+          return "";
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const chunks = [
+      { chunk_index: 0, content: "Chunk zero content." },
+      { chunk_index: 1, content: "Chunk one content." },
+    ];
+
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "Chunk zero content.\nChunk one content.",
+      manuscriptChunks: chunks,
+      workType: "novel",
+      title: "Test",
+      perplexityApiKey: "test-key",
+      _fetch: fetchSpy,
+    });
+
+    expect(result).not.toBeNull();
+    expect(captured.length).toBe(2);
+    for (const call of captured) {
+      expect(call.url).toContain("api.perplexity.ai");
+      const body = call.body as Record<string, unknown>;
+      expect(body.model).toBe("sonar-reasoning-pro");
+      expect(body.disable_search).toBe(true);
+      expect(body.reasoning_effort).toBe("high");
+      expect(body.temperature).toBe(0.1);
+    }
+  });
+
+  test("returns null when every chunk request fails (graceful degradation)", async () => {
+    const failingFetch: typeof fetch = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        async json() {
+          return {};
+        },
+        async text() {
+          return "internal error";
+        },
+      }) as unknown as Response) as unknown as typeof fetch;
+
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "Test.",
+      manuscriptChunks: [{ chunk_index: 0, content: "Test." }],
+      workType: "novel",
+      title: "Test",
+      perplexityApiKey: "test-key",
+      _fetch: failingFetch,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("clamps out-of-range scores into the canonical 1..10 range", async () => {
+    const outOfRangeCriteria = Object.fromEntries(
+      CRITERIA_KEYS.map((key, i) => [
+        key,
+        {
+          score: i === 0 ? 99 : i === 1 ? -3 : 5,
+          rationale: `rationale for ${key}`,
+          evidence: `evidence for ${key}`,
+        },
+      ]),
+    );
+    const fetchMock = buildFetchMock({
+      jsonBody: {
+        choices: [
+          {
+            message: { content: JSON.stringify({ criteria: outOfRangeCriteria }) },
+            finish_reason: "stop",
+          },
+        ],
+      },
+    });
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "text",
+      manuscriptChunks: [{ chunk_index: 0, content: "text" }],
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: fetchMock as unknown as typeof fetch,
+    });
+    expect(result).not.toBeNull();
+    for (const c of result!.criteria) {
+      expect(c.score_0_10).toBeGreaterThanOrEqual(1);
+      expect(c.score_0_10).toBeLessThanOrEqual(10);
+    }
+  });
+});

--- a/lib/evaluation/pipeline/pass4EvidencePacket.ts
+++ b/lib/evaluation/pipeline/pass4EvidencePacket.ts
@@ -1,3 +1,7 @@
+// ARCHIVED: Pass 4 retired in favor of dual-model parallel scoring (Pass 1+2 Perplexity).
+// See feat/dual-model-parallel-scoring. This evidence-packet builder is no longer
+// invoked by the pipeline. The file is preserved to keep imports from
+// perplexityCrossCheck.ts (also archived) resolvable.
 /**
  * Pass 4 — Representative Long-Form Evidence Packet Builder
  *

--- a/lib/evaluation/pipeline/perplexityChunkScorer.ts
+++ b/lib/evaluation/pipeline/perplexityChunkScorer.ts
@@ -1,0 +1,522 @@
+/**
+ * Perplexity Chunk Scorer — Dual-Model Parallel Scoring
+ *
+ * Calls sonar-reasoning-pro to score each manuscript chunk on the 13
+ * canonical criteria. Output shape mirrors the GPT chunk pass
+ * (SinglePassOutput) so the Pass 3 collator can consume both packets.
+ *
+ * Concurrency: process.env.EVAL_PPLX_CHUNK_CONCURRENCY (default 8).
+ * Timeout per request: process.env.EVAL_PPLX_CHUNK_TIMEOUT_MS (default 120_000).
+ *
+ * Graceful degradation: if PERPLEXITY_API_KEY is missing, this module
+ * returns null and the pipeline continues with the GPT-only path.
+ *
+ * Independence: this scorer never sees GPT scores. It is an independent
+ * second evaluation of the manuscript chunks, paired with GPT at Pass 3.
+ */
+
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import type {
+  AxisCriterionResult,
+  EvidenceAnchor,
+  ManuscriptChunkEvidence,
+  SinglePassOutput,
+} from "./types";
+import {
+  JsonBoundaryError,
+  parseJsonObjectBoundary,
+} from "@/lib/llm/jsonParseBoundary";
+
+const PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
+const PERPLEXITY_MODEL = "sonar-reasoning-pro";
+const PERPLEXITY_TEMPERATURE = 0.1;
+const PERPLEXITY_MAX_TOKENS = 8000;
+const PERPLEXITY_LENGTH_RETRY_MAX_TOKENS = 12000;
+
+const DEFAULT_PPLX_CHUNK_CONCURRENCY = 8;
+const DEFAULT_PPLX_CHUNK_TIMEOUT_MS = 120_000;
+
+const PROMPT_VERSION = "pplx-chunk-scorer-v1";
+
+export interface PerplexityChunkScorerOptions {
+  manuscriptText: string;
+  manuscriptChunks?: ManuscriptChunkEvidence[];
+  workType: string;
+  title: string;
+  perplexityApiKey?: string;
+  jobId?: string;
+  /** Override for testing — provide a mock fetch-like function. */
+  _fetch?: typeof fetch;
+}
+
+export function getPplxChunkConcurrency(): number {
+  const raw = process.env.EVAL_PPLX_CHUNK_CONCURRENCY;
+  if (!raw) return DEFAULT_PPLX_CHUNK_CONCURRENCY;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PPLX_CHUNK_CONCURRENCY;
+  return Math.min(20, Math.max(1, parsed));
+}
+
+export function getPplxChunkTimeoutMs(): number {
+  const raw = process.env.EVAL_PPLX_CHUNK_TIMEOUT_MS;
+  if (!raw) return DEFAULT_PPLX_CHUNK_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PPLX_CHUNK_TIMEOUT_MS;
+  return Math.max(30_000, parsed);
+}
+
+function buildSystemPrompt(): string {
+  return `You are an independent literary evaluator scoring a manuscript chunk on 13 canonical craft criteria.
+
+Rules:
+1. Evaluate the chunk as a standalone artifact.
+2. Score each criterion 1-10 (integer; canonical range, never 0).
+3. Each criterion MUST include:
+   - score (integer 1-10)
+   - rationale (1-3 sentences, anchored in the chunk)
+   - evidence (one short verbatim quote from the chunk; <= 180 chars)
+4. Do not invent evidence. If a criterion has no observable signal, score conservatively (3-5) and note the absence in rationale.
+5. Do not perform line-editing or revision advice.
+6. Return ONLY valid JSON.
+
+Required schema:
+{
+  "criteria": {
+    "concept": { "score": 7, "rationale": "string", "evidence": "string" },
+    "narrativeDrive": { ...same shape... },
+    "character": { ...same shape... },
+    "voice": { ...same shape... },
+    "sceneConstruction": { ...same shape... },
+    "dialogue": { ...same shape... },
+    "theme": { ...same shape... },
+    "worldbuilding": { ...same shape... },
+    "pacing": { ...same shape... },
+    "proseControl": { ...same shape... },
+    "tone": { ...same shape... },
+    "narrativeClosure": { ...same shape... },
+    "marketability": { ...same shape... }
+  }
+}
+
+Criteria keys: ${CRITERIA_KEYS.join(", ")}`;
+}
+
+function buildUserPrompt(args: {
+  chunkContent: string;
+  title: string;
+  workType: string;
+  chunkIndex: number;
+  chunkCount: number;
+}): string {
+  const chunkContext =
+    args.chunkCount > 1
+      ? `This is chunk ${args.chunkIndex + 1} of ${args.chunkCount}.`
+      : `This is the full submission window.`;
+
+  return `MANUSCRIPT TITLE: "${args.title}"
+WORK TYPE: ${args.workType}
+${chunkContext}
+
+CHUNK TEXT:
+${args.chunkContent}
+
+Score all 13 craft criteria on this chunk and return the JSON object as specified.`;
+}
+
+type RawPerplexityCriterion = {
+  score?: unknown;
+  rationale?: unknown;
+  evidence?: unknown;
+};
+
+function clampScore(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return 5;
+  return Math.min(10, Math.max(1, Math.round(n)));
+}
+
+function toShortText(raw: unknown, maxChars: number): string {
+  const text = typeof raw === "string" ? raw.trim() : "";
+  return text.length > maxChars ? text.slice(0, maxChars).trimEnd() : text;
+}
+
+function parseChunkCriteria(
+  responseText: string,
+  chunkIndex: number,
+): AxisCriterionResult[] {
+  const boundary = parseJsonObjectBoundary<Record<string, unknown>>(responseText, {
+    label: "PplxChunk",
+  });
+  const parsed = boundary.value;
+  const criteriaObj = parsed.criteria;
+  if (!criteriaObj || typeof criteriaObj !== "object") {
+    throw new Error(
+      `[PplxChunk] chunk ${chunkIndex} missing criteria object`,
+    );
+  }
+
+  const record = criteriaObj as Record<string, RawPerplexityCriterion>;
+  const results: AxisCriterionResult[] = [];
+
+  for (const key of CRITERIA_KEYS) {
+    const entry = record[key];
+    if (!entry || typeof entry !== "object") {
+      results.push({
+        key,
+        score_0_10: 5,
+        rationale: `[Perplexity] criterion missing from response for chunk ${chunkIndex}`,
+        evidence: [],
+        recommendations: [],
+      });
+      continue;
+    }
+
+    const score = clampScore(entry.score);
+    const rationale = toShortText(entry.rationale, 220) || `[Perplexity] no rationale provided for ${key}`;
+    const evidenceSnippet = toShortText(entry.evidence, 180);
+    const evidence: EvidenceAnchor[] = evidenceSnippet
+      ? [{ snippet: evidenceSnippet }]
+      : [];
+
+    results.push({
+      key: key as CriterionKey,
+      score_0_10: score,
+      rationale,
+      evidence,
+      recommendations: [],
+    });
+  }
+
+  return results;
+}
+
+function isRetryableBoundary(error: unknown): boolean {
+  return (
+    error instanceof JsonBoundaryError &&
+    (error.code === "JSON_PARSE_FAILED_EMPTY" ||
+      error.code === "JSON_PARSE_FAILED_NO_OBJECT" ||
+      error.code === "JSON_PARSE_FAILED_TRUNCATED")
+  );
+}
+
+function extractContent(rawMessageContent: unknown): string {
+  if (typeof rawMessageContent === "string") return rawMessageContent;
+  if (!Array.isArray(rawMessageContent)) return "";
+  return rawMessageContent
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (!item || typeof item !== "object") return "";
+      const record = item as { text?: unknown; content?: unknown };
+      if (typeof record.text === "string") return record.text;
+      if (typeof record.content === "string") return record.content;
+      return "";
+    })
+    .join("")
+    .trim();
+}
+
+async function callPerplexityForChunk(args: {
+  systemPrompt: string;
+  userPrompt: string;
+  perplexityApiKey: string;
+  maxTokens: number;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<{ rawContent: string; finishReason: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+
+  try {
+    const response = await args.fetchFn(`${PERPLEXITY_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${args.perplexityApiKey}`,
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          { role: "system", content: args.systemPrompt },
+          { role: "user", content: args.userPrompt },
+        ],
+        temperature: PERPLEXITY_TEMPERATURE,
+        max_tokens: args.maxTokens,
+        return_citations: false,
+        disable_search: true,
+        reasoning_effort: "high",
+        stream_mode: "concise",
+        response_format: { type: "json_object" },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(
+        `[PplxChunk] Perplexity API error ${response.status}: ${errText.slice(0, 400)}`,
+      );
+    }
+
+    const raw = (await response.json()) as {
+      choices?: Array<{
+        message?: { content?: unknown };
+        finish_reason?: unknown;
+      }>;
+    };
+    const firstChoice = raw.choices?.[0];
+    const rawContent = extractContent(firstChoice?.message?.content);
+    const finishReason =
+      typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : "unknown";
+
+    return { rawContent, finishReason };
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(
+        `[PplxChunk] Perplexity request timed out after ${args.timeoutMs}ms`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function scoreChunk(args: {
+  chunk: ManuscriptChunkEvidence;
+  chunkCount: number;
+  title: string;
+  workType: string;
+  perplexityApiKey: string;
+  timeoutMs: number;
+  fetchFn: typeof fetch;
+}): Promise<AxisCriterionResult[]> {
+  const systemPrompt = buildSystemPrompt();
+  const userPrompt = buildUserPrompt({
+    chunkContent: args.chunk.content,
+    title: args.title,
+    workType: args.workType,
+    chunkIndex: args.chunk.chunk_index,
+    chunkCount: args.chunkCount,
+  });
+
+  let maxTokens = PERPLEXITY_MAX_TOKENS;
+  let result = await callPerplexityForChunk({
+    systemPrompt,
+    userPrompt,
+    perplexityApiKey: args.perplexityApiKey,
+    maxTokens,
+    timeoutMs: args.timeoutMs,
+    fetchFn: args.fetchFn,
+  });
+
+  try {
+    return parseChunkCriteria(result.rawContent, args.chunk.chunk_index);
+  } catch (err) {
+    const shouldRetry =
+      result.finishReason === "length" || isRetryableBoundary(err);
+    if (!shouldRetry) throw err;
+
+    maxTokens = PERPLEXITY_LENGTH_RETRY_MAX_TOKENS;
+    result = await callPerplexityForChunk({
+      systemPrompt,
+      userPrompt,
+      perplexityApiKey: args.perplexityApiKey,
+      maxTokens,
+      timeoutMs: args.timeoutMs,
+      fetchFn: args.fetchFn,
+    });
+    return parseChunkCriteria(result.rawContent, args.chunk.chunk_index);
+  }
+}
+
+async function runChunksWithConcurrency(
+  chunks: ManuscriptChunkEvidence[],
+  concurrency: number,
+  worker: (chunk: ManuscriptChunkEvidence) => Promise<AxisCriterionResult[]>,
+): Promise<Array<PromiseSettledResult<AxisCriterionResult[]>>> {
+  const settled: Array<PromiseSettledResult<AxisCriterionResult[]>> = new Array(
+    chunks.length,
+  );
+  let cursor = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= chunks.length) return;
+      try {
+        const value = await worker(chunks[index]);
+        settled[index] = { status: "fulfilled", value };
+      } catch (reason) {
+        settled[index] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, chunks.length) },
+    () => runWorker(),
+  );
+  await Promise.all(workers);
+  return settled;
+}
+
+function aggregateChunkCriteria(
+  chunkResults: AxisCriterionResult[][],
+): AxisCriterionResult[] {
+  if (chunkResults.length === 0) {
+    throw new Error("[PplxChunk] no successful chunk results to aggregate");
+  }
+  if (chunkResults.length === 1) return chunkResults[0];
+
+  const aggregated: AxisCriterionResult[] = [];
+
+  for (const key of CRITERIA_KEYS) {
+    const entries = chunkResults
+      .flatMap((r) => r)
+      .filter((c) => c.key === key);
+
+    if (entries.length === 0) continue;
+
+    const validScores = entries
+      .map((c) => c.score_0_10)
+      .filter((n) => typeof n === "number" && n >= 1 && n <= 10);
+
+    const avgScore =
+      validScores.length > 0
+        ? Math.round(validScores.reduce((s, n) => s + n, 0) / validScores.length)
+        : 5;
+
+    const seen = new Set<string>();
+    const mergedEvidence: EvidenceAnchor[] = [];
+    for (const entry of entries) {
+      for (const ev of entry.evidence) {
+        const snippetKey = ev.snippet?.trim() || "";
+        if (snippetKey && !seen.has(snippetKey)) {
+          seen.add(snippetKey);
+          mergedEvidence.push(ev);
+        }
+      }
+    }
+
+    aggregated.push({
+      key,
+      score_0_10: Math.min(10, Math.max(1, avgScore)),
+      rationale: entries[0]?.rationale ?? "",
+      evidence: mergedEvidence.slice(0, 1),
+      recommendations: [],
+    });
+  }
+
+  return aggregated;
+}
+
+/**
+ * Run Perplexity chunk scoring across all chunks.
+ *
+ * Returns:
+ *   - SinglePassOutput when scoring succeeds (any chunk count >= 1)
+ *   - null when graceful degradation kicks in (no API key, or all chunks failed)
+ *
+ * Never throws — graceful degradation is mandatory. Callers should expect null
+ * and fall through to the GPT-only path.
+ */
+export async function runPerplexityChunkScorer(
+  opts: PerplexityChunkScorerOptions,
+): Promise<SinglePassOutput | null> {
+  const apiKey = opts.perplexityApiKey?.trim() || process.env.PERPLEXITY_API_KEY?.trim();
+  if (!apiKey) {
+    console.warn(
+      "[PplxChunk] PERPLEXITY_API_KEY missing — skipping Perplexity chunk sweep (graceful degradation to GPT-only)",
+    );
+    return null;
+  }
+
+  const fetchFn = opts._fetch ?? fetch;
+  const timeoutMs = getPplxChunkTimeoutMs();
+  const concurrency = getPplxChunkConcurrency();
+
+  const hasChunks = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 0;
+  const chunks: ManuscriptChunkEvidence[] = hasChunks
+    ? opts.manuscriptChunks!
+    : [{ chunk_index: 0, content: opts.manuscriptText }];
+
+  const jobLabel = opts.jobId ?? "unknown";
+  const startMs = Date.now();
+
+  console.log(
+    `[PplxChunk] Starting Perplexity chunk sweep: job_id=${jobLabel} chunks=${chunks.length} concurrency=${concurrency} timeout_ms=${timeoutMs}`,
+  );
+
+  try {
+    const settled = await runChunksWithConcurrency(chunks, concurrency, (chunk) =>
+      scoreChunk({
+        chunk,
+        chunkCount: chunks.length,
+        title: opts.title,
+        workType: opts.workType,
+        perplexityApiKey: apiKey,
+        timeoutMs,
+        fetchFn,
+      }),
+    );
+
+    const successes: AxisCriterionResult[][] = [];
+    const failures: Array<{ chunkIndex: number; reason: string }> = [];
+
+    for (let i = 0; i < settled.length; i += 1) {
+      const result = settled[i];
+      if (!result) continue;
+      if (result.status === "fulfilled") {
+        successes.push(result.value);
+      } else {
+        failures.push({
+          chunkIndex: chunks[i].chunk_index,
+          reason:
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+        });
+      }
+    }
+
+    const elapsedMs = Date.now() - startMs;
+
+    if (successes.length === 0) {
+      console.warn(
+        `[PplxChunk] All Perplexity chunk requests failed — returning null (graceful degradation). job_id=${jobLabel} failures=${failures.length} elapsed_ms=${elapsedMs}`,
+        failures.slice(0, 3),
+      );
+      return null;
+    }
+
+    if (failures.length > 0) {
+      console.warn(
+        `[PplxChunk] Partial Perplexity chunk sweep — succeeded=${successes.length} failed=${failures.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
+        failures.slice(0, 3),
+      );
+    } else {
+      console.log(
+        `[PplxChunk] Perplexity chunk sweep complete: succeeded=${successes.length}/${chunks.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
+      );
+    }
+
+    const aggregatedCriteria = aggregateChunkCriteria(successes);
+
+    return {
+      pass: 1,
+      axis: "craft_execution",
+      criteria: aggregatedCriteria,
+      model: PERPLEXITY_MODEL,
+      prompt_version: PROMPT_VERSION,
+      temperature: PERPLEXITY_TEMPERATURE,
+      generated_at: new Date().toISOString(),
+    };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[PplxChunk] Perplexity chunk sweep threw unexpectedly — graceful degradation. job_id=${jobLabel}: ${reason}`,
+    );
+    return null;
+  }
+}

--- a/lib/evaluation/pipeline/perplexityCrossCheck.ts
+++ b/lib/evaluation/pipeline/perplexityCrossCheck.ts
@@ -1,3 +1,7 @@
+// ARCHIVED: Pass 4 retired in favor of dual-model parallel scoring (Pass 1+2 Perplexity).
+// See feat/dual-model-parallel-scoring. Types (CrossCheckOutput, OpenAICriterionInput,
+// CriterionKey re-export) remain consumed by PipelineResult and the synthesis adapters,
+// but runPerplexityCrossCheck is no longer called from the pipeline.
 /**
  * Pass 4 – Perplexity Cross-Check (Hardened / Canon-Aligned)
  *

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -8,7 +8,7 @@
 
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
 import type { SubmissionScopeProfile } from "../submissionScope";
-import type { Pass2aStructuredContext } from "../types";
+import type { Pass2aStructuredContext, SinglePassOutput } from "../types";
 import {
   buildCoverageDisclosure,
   buildPromptInputWindow,
@@ -85,6 +85,28 @@ Return ONLY JSON with keys:
 Criteria keys:
 ${CRITERIA_KEYS.join(", ")}`;
 
+/**
+ * Build a compact summary of the Perplexity dual-model packet for Pass 3.
+ * One line per criterion: score, short rationale, and first evidence snippet.
+ * Cap the rationale length so the prompt stays bounded.
+ */
+function buildPerplexityPacketSummary(packet: SinglePassOutput): string {
+  return packet.criteria
+    .map((c) => {
+      const rationale = (c.rationale ?? "").trim();
+      const truncRationale =
+        rationale.length > 180 ? `${rationale.slice(0, 180).trimEnd()}…` : rationale;
+      const evidenceSnippet = (c.evidence[0]?.snippet ?? "").trim();
+      const truncEvidence =
+        evidenceSnippet.length > 120
+          ? `${evidenceSnippet.slice(0, 120).trimEnd()}…`
+          : evidenceSnippet;
+      const evidencePart = truncEvidence ? ` | evidence: "${truncEvidence}"` : "";
+      return `- ${c.key}: ${c.score_0_10}/10 — ${truncRationale}${evidencePart}`;
+    })
+    .join("\n");
+}
+
 export function buildPass3UserPrompt(params: {
   comparisonPacketJson: string;
   pass2aStructuredContext: Pass2aStructuredContext;
@@ -92,6 +114,18 @@ export function buildPass3UserPrompt(params: {
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   scopeProfile?: SubmissionScopeProfile;
+  /**
+   * Optional independent Perplexity chunk-scoring packet (dual-model parallel scoring).
+   * When provided, the prompt switches to dual-model mode and asks the model to
+   * synthesize across BOTH independent evaluations, flagging divergences > 1 point.
+   */
+  perplexityChunkPacket?: SinglePassOutput;
+  /**
+   * When true, render the dual-model synthesis block. Defaults to true when
+   * perplexityChunkPacket is provided. Allows callers to feature-flag the
+   * dual-model render at the prompt boundary independently of packet presence.
+   */
+  dualModelMode?: boolean;
 }): string {
   const executionMode = params.executionMode ?? "TRUSTED_PATH";
   const synthesisBudget = getDefaultSynthesisReferenceCharBudget();
@@ -116,7 +150,29 @@ export function buildPass3UserPrompt(params: {
     timeline_anchors: params.pass2aStructuredContext.timeline_anchors.slice(0, 24),
   });
 
-  return `Synthesize these two independent evaluation passes for the manuscript titled "${params.title}".
+  const dualModelMode = params.dualModelMode ?? !!params.perplexityChunkPacket;
+  const dualModelBlock =
+    dualModelMode && params.perplexityChunkPacket
+      ? `
+
+## DUAL-MODEL PARALLEL SCORING (Independent Second Evaluation)
+This evaluation has TWO independent scoring sweeps over the manuscript chunks:
+  • PRIMARY: GPT craft + editorial passes (already reconciled into the comparison packet above).
+  • SECONDARY: Perplexity sonar-reasoning-pro chunk sweep (model=${params.perplexityChunkPacket.model}).
+Each model scored the chunks WITHOUT seeing the other's output — agreement is a real signal, not an echo.
+
+PERPLEXITY INDEPENDENT SCORES:
+${buildPerplexityPacketSummary(params.perplexityChunkPacket)}
+
+Dual-model synthesis rules (REQUIRED):
+- Treat the Perplexity packet as a real second opinion. Use it to confirm or challenge the GPT axes.
+- When the Perplexity score and the GPT final_score_0_10 diverge by MORE THAN 1 point on any criterion, flag the divergence in final_rationale: name the gap, name which axis is more diagnostic given the manuscript evidence, and resolve toward the better-supported axis.
+- When the Perplexity score and the GPT axes AGREE (within ±1), this is a stronger signal of validity — keep the synthesis confident, but do not let agreement substitute for evidence; the rationale must still anchor to manuscript craft.
+- Do not import Perplexity's wording verbatim into final_rationale (this is the author-facing surface — keep it craft-voiced, not adjudication-process-voiced).
+- Do not invent disagreement where the two models concur, and do not paper over disagreement where they diverge.`
+      : "";
+
+  return `Synthesize these two independent evaluation passes for the manuscript titled "${params.title}".${dualModelBlock}
 
 Execution mode: ${executionMode}
 

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -341,6 +341,14 @@ export interface RunPass3Options {
   pass1: SinglePassOutput;
   pass2: SinglePassOutput;
   pass2aStructuredContext: Pass2aStructuredContext;
+  /**
+   * Optional independent Perplexity chunk-scoring packet (dual-model parallel scoring).
+   * When present, Pass 3 runs in dual-model mode: it synthesizes across both
+   * independent evaluations, flags criteria where the two models diverge by
+   * more than 1 point, and weights agreement as a stronger signal.
+   * When absent, Pass 3 runs in the legacy GPT-only mode (backward compatible).
+   */
+  perplexityChunkPacket?: SinglePassOutput;
   manuscriptText: string;
   manuscriptChunks?: ManuscriptChunkEvidence[];
   title: string;
@@ -405,6 +413,8 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     title: opts.title,
     executionMode: opts.executionMode,
     scopeProfile: opts.scopeProfile,
+    perplexityChunkPacket: opts.perplexityChunkPacket,
+    dualModelMode: !!opts.perplexityChunkPacket,
   });
   assertPass3PromptTripwires(userPrompt);
 

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -20,8 +20,14 @@ import { recordProviderTelemetry, ProviderTelemetryEntry } from "./providerTelem
 import { enforcePass2LexicalIndependence, PASS2_INDEPENDENCE_FAIL_THRESHOLD } from "./pass2IndependenceGuard";
 // runPass3bLongform runtime import removed — now called from /api/workers/process-dream (issue #543)
 import type { LongformDreamDocument } from "./runPass3bLongform";
-import { runPerplexityCrossCheck, CrossCheckOutput } from "./perplexityCrossCheck";
-import { evaluatePass4Governance } from "@/lib/evaluation/governance/evaluatePass4Governance";
+// Pass 4 cross-check call retired (feat/dual-model-parallel-scoring).
+// CrossCheckOutput is kept as a type-only import because PipelineResult and
+// the synthesis adapters still reference it for back-compat; the runtime
+// runPerplexityCrossCheck function is no longer called.
+import type { CrossCheckOutput } from "./perplexityCrossCheck";
+import { runPerplexityChunkScorer } from "./perplexityChunkScorer";
+// evaluatePass4Governance is no longer invoked but its GovernanceDecision
+// type is still exposed on PipelineResult for back-compat.
 import {
   runQualityGate as defaultRunQualityGate,
   summarizeQualityGateFailures,
@@ -1063,6 +1069,24 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       throw error;
     });
 
+  // ── Perplexity chunk sweep (dual-model parallel scoring) ─────────────
+  // Runs alongside GPT Pass 1+2 with full independence (does NOT see GPT
+  // output). Graceful degradation: returns null when PERPLEXITY_API_KEY
+  // is missing or when all chunks fail, so the GPT-only path always works.
+  const pplxChunkSweepPromise = runPerplexityChunkScorer({
+    manuscriptText: opts.manuscriptText,
+    manuscriptChunks: opts.manuscriptChunks,
+    workType: opts.workType,
+    title: opts.title,
+    perplexityApiKey: opts.perplexityApiKey,
+    jobId: latencyJobId,
+  }).catch((err) => {
+    console.warn(
+      `[Pipeline] Perplexity chunk sweep rejected unexpectedly — falling back to GPT-only path: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  });
+
   await opts.onHeartbeat?.("parallel_passes_started");
 
   const [pass1Settled, pass2Settled] = await Promise.allSettled([pass1Promise, pass2Promise]);
@@ -1280,6 +1304,29 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     manuscriptChunks: opts.manuscriptChunks,
   });
 
+  // Resolve the parallel Perplexity chunk sweep before kicking off Pass 3.
+  // The Pass 3 collator can run in either single-model (GPT-only) or
+  // dual-model mode depending on whether the Perplexity packet is available.
+  const pplxChunkOutput = await pplxChunkSweepPromise;
+  if (pplxChunkOutput) {
+    console.log(
+      "[Pipeline][DualModel] Perplexity chunk packet available for Pass 3",
+      {
+        manuscript_id: opts.manuscriptId ?? null,
+        title: opts.title,
+        criteria_count: pplxChunkOutput.criteria.length,
+      },
+    );
+  } else {
+    console.log(
+      "[Pipeline][DualModel] Perplexity chunk packet absent — Pass 3 will run in GPT-only mode",
+      {
+        manuscript_id: opts.manuscriptId ?? null,
+        title: opts.title,
+      },
+    );
+  }
+
   // ── Pass 3: Synthesis & Reconciliation ─────────────────────────────────
   const pass3StartMs = nowMs();
   const pass3StartedAt = startLatencyStage({
@@ -1287,6 +1334,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     stage: 'pass3',
     metadata: {
       model: opts.model ?? null,
+      dual_model_mode: pplxChunkOutput !== null,
     },
   });
   await opts.onHeartbeat?.("pass3_started");
@@ -1305,6 +1353,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
         openAiTimeoutMs: opts._openAiTimeoutMs,
         registry,
         scopeProfile: scopeProfile ?? undefined,
+        perplexityChunkPacket: pplxChunkOutput ?? undefined,
         _onCompletion: (capture) => {
           providerTelemetry.push(
             recordProviderTelemetry({
@@ -1557,235 +1606,44 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     state: 'completed',
   });
 
-  // ── Pass 4b: External cross-check + governance ──────────────────────────
-  // Cross-check runs only on the success path (quality gate already passed).
+  // ── Pass 4: RETIRED ────────────────────────────────────────────────────
+  // Pass 4 (post-synthesis Perplexity cross-check + adjudication governance)
+  // is retired in favor of dual-model parallel scoring. Perplexity now scores
+  // every chunk alongside GPT during Pass 1+2 and feeds the Pass 3 collator
+  // as an independent second packet. The previous post-hoc adjudicator is no
+  // longer called — see feat/dual-model-parallel-scoring.
   //
-  // FAIL-CLOSED CONTRACT (PR #506):
-  //   Every code path below produces an explicit `externalAdjudication` status.
-  //   The legacy silent-skip path (Froggin Noggin truth gap) is eliminated:
-  //   if the key is missing, the result MUST carry status="skipped" + reason.
-  //   If Perplexity errors, the result MUST carry status="failed_soft" (optional)
-  //   or "failed_blocking" (required/veto) — never silently undefined.
+  // crossCheckResult and pass4Governance remain typed as optional on
+  // PipelineResult so existing consumers (processor, report adapter) continue
+  // to compile; they are always undefined in this path. external_adjudication
+  // is preserved (now reflecting the dual-model sweep state) so report
+  // surfaces that already render the "external adjudication" banner stay
+  // backward-compatible.
   const adjudicationMode: ExternalAdjudicationMode = getExternalAdjudicationMode();
-  let externalAdjudication: ExternalAdjudicationStatus;
-
-  if (opts.perplexityApiKey) {
-    const pass4CrossCheckStartedAt = startLatencyStage({
-      jobId: latencyJobId,
-      stage: 'pass4_cross_check',
-      metadata: {
-        provider: 'perplexity',
-      },
-    });
-
-    try {
-      // Map SynthesizedCriterion[] → Record<CriterionKey, OpenAICriterionInput>
-      const criteriaRecord = Object.fromEntries(
-        pass3Output.criteria.map((c) => [
-          c.key,
-          {
-            score: c.final_score_0_10,
-            rationale: c.final_rationale,
-            evidence: c.evidence.map((e) => e.snippet).filter(Boolean),
-          } satisfies import("./perplexityCrossCheck").OpenAICriterionInput,
-        ]),
-      ) as Record<import("./perplexityCrossCheck").CriterionKey, import("./perplexityCrossCheck").OpenAICriterionInput>;
-
-      crossCheckResult = await runPerplexityCrossCheck({
-        openaiCriteria: criteriaRecord,
-        openaiSynthesis: pass3Output.overall?.one_paragraph_summary ?? "",
-        manuscriptExcerpt: opts.manuscriptText,
-        workType: opts.workType,
-        title: opts.title,
-        perplexityApiKey: opts.perplexityApiKey,
-        jobId: latencyJobId,
-      });
-
-      finishLatencyStage({
-        jobId: latencyJobId,
-        stage: 'pass4_cross_check',
-        startedAt: pass4CrossCheckStartedAt,
-        state: 'completed',
-      });
-
-      externalAdjudication = {
+  const externalAdjudication: ExternalAdjudicationStatus = pplxChunkOutput
+    ? {
         status: "cross_check_completed",
         mode: adjudicationMode,
         cross_check_returned: true,
-        packet_chars: crossCheckResult.packetChars,
-        packet_compression_ratio: crossCheckResult.packetCompressionRatio,
-      };
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-
-      finishLatencyStage({
-        jobId: latencyJobId,
-        stage: 'pass4_cross_check',
-        startedAt: pass4CrossCheckStartedAt,
-        state: 'failed',
-        metadata: {
-          finish_reason: reason,
-        },
-      });
-
-      console.warn(
-        `[Pass4] Perplexity cross-check failed (mode=${adjudicationMode}):`,
-        reason,
-      );
-
-      // Fail-closed: required/veto modes must abort the whole evaluation.
-      // Optional mode continues but persists failed_soft so the report cannot
-      // claim a successful external adjudication that did not occur.
-      if (adjudicationMode === "required" || adjudicationMode === "veto") {
-        externalAdjudication = {
-          status: "failed_blocking",
-          mode: adjudicationMode,
-          cross_check_returned: false,
-          reason,
-        };
-
-        timings.total_ms = nowMs() - pipelineStartMs;
-        logPipelineTimings("failure", {
-          manuscriptId: opts.manuscriptId,
-          title: opts.title,
-          workType: opts.workType,
-          failedAt: "pass4",
-          errorCode: "PASS4_EXTERNAL_ADJUDICATION_FAILED",
-          timings,
-        });
-
-        return {
-          ok: false,
-          error: `Pass 4 external adjudication failed in mode '${adjudicationMode}': ${reason}`,
-          error_code: "PASS4_EXTERNAL_ADJUDICATION_FAILED",
-          failed_at: "pass4",
-          external_adjudication: externalAdjudication,
-          routing: pipelineRouting,
-        };
       }
-
-      externalAdjudication = {
-        status: "failed_soft",
+    : {
+        status: "skipped",
         mode: adjudicationMode,
         cross_check_returned: false,
-        reason,
-      };
-    }
-  } else {
-    // No Perplexity key supplied to the pipeline. In required/veto mode the
-    // upstream processor contract is supposed to catch this before runPipeline,
-    // but enforce it here too so the contract holds regardless of caller.
-    const skipReason =
-      adjudicationMode === "optional" ? "no_api_key" : "no_api_key";
-
-    emitLatencyTrace({
-      job_id: latencyJobId,
-      stage: 'pass4_cross_check',
-      state: 'skipped',
-      started_at: new Date().toISOString(),
-      metadata: {
-        finish_reason: skipReason,
-        adjudication_mode: adjudicationMode,
-      },
-    });
-
-    if (adjudicationMode === "required" || adjudicationMode === "veto") {
-      externalAdjudication = {
-        status: "failed_blocking",
-        mode: adjudicationMode,
-        cross_check_returned: false,
-        reason: skipReason,
+        reason: "pass4_retired_dual_model_parallel_scoring",
       };
 
-      timings.total_ms = nowMs() - pipelineStartMs;
-      logPipelineTimings("failure", {
-        manuscriptId: opts.manuscriptId,
-        title: opts.title,
-        workType: opts.workType,
-        failedAt: "pass4",
-        errorCode: "PASS4_EXTERNAL_ADJUDICATION_MISSING_KEY",
-        timings,
-      });
-
-      return {
-        ok: false,
-        error: `Pass 4 external adjudication required by mode '${adjudicationMode}' but PERPLEXITY_API_KEY was not provided`,
-        error_code: "PASS4_EXTERNAL_ADJUDICATION_MISSING_KEY",
-        failed_at: "pass4",
-        external_adjudication: externalAdjudication,
-        routing: pipelineRouting,
-      };
-    }
-
-    externalAdjudication = {
-      status: "skipped",
-      mode: adjudicationMode,
-      cross_check_returned: false,
-      reason: skipReason,
-    };
-  }
-
-  pass4Governance = evaluatePass4Governance(crossCheckResult);
-
-  if (pass4Governance && !pass4Governance.ok) {
-    // PR-A: Honor severity + adjudication mode.
-    //
-    // Prior behavior: ANY governance !ok failed the entire pipeline, even when
-    // the consumer-emitted severity was "warning" (e.g. PASS4_DISPUTED_CRITERIA)
-    // and the operator had explicitly set EVAL_EXTERNAL_ADJUDICATION_MODE="optional".
-    // This caused jobs to fail-closed on any single disputed criterion delta ≥ 1.0,
-    // throwing away a fully-completed Pass 1–3 synthesis and a fully-returned
-    // Pass 4 cross-check. Job 449e149f is the calibration anchor: only `theme`
-    // disputed, canonValid=true, overallAgreement=MODERATE — yet the job died.
-    //
-    // New behavior: a governance !ok blocks the pipeline only when EITHER
-    //   - severity is "error" (PASS4_CANON_INVALID, PASS4_WEAK_AGREEMENT — these
-    //     always indicate a structurally broken cross-check), OR
-    //   - adjudicationMode is "required" or "veto" (operator opted into strict
-    //     fail-closed semantics regardless of severity).
-    //
-    // Otherwise (warning + optional mode), the pipeline ships ok:true with the
-    // governance decision surfaced on `pass4_governance` so the processor and
-    // UI can render the warning without dropping the entire evaluation.
-    const isBlockingSeverity = pass4Governance.severity === "error";
-    const isStrictMode =
-      adjudicationMode === "required" || adjudicationMode === "veto";
-    const blocking = isBlockingSeverity || isStrictMode;
-
-    if (blocking) {
-      const errorCode = pass4Governance.blockCode ?? "PASS4_GOVERNANCE_FAILED";
-      timings.total_ms = nowMs() - pipelineStartMs;
-      logPipelineTimings("failure", {
-        manuscriptId: opts.manuscriptId,
-        title: opts.title,
-        workType: opts.workType,
-        failedAt: "pass4",
-        errorCode,
-        timings,
-      });
-
-      return {
-        ok: false,
-        error: `Pass 4 governance failed: ${pass4Governance.message ?? pass4Governance.blockCode ?? "unknown governance error"}`,
-        error_code: errorCode,
-        failed_at: "pass4",
-        external_adjudication: externalAdjudication,
-        // PR-B observability: surface the full cross-check output and governance
-        // decision on the failure variant so the processor can persist them onto
-        // progress before markFailed runs. Without this the cross_check_output
-        // column stays NULL and PASS4_CANON_INVALID incidents have no audit trail.
-        cross_check: crossCheckResult,
-        pass4_governance: pass4Governance,
-        routing: pipelineRouting,
-      };
-    }
-
-    // Non-blocking governance warning in optional mode: log and fall through.
-    // The warning is preserved on `pass4_governance` in the success return.
-    console.warn(
-      `[Pass4] Governance warning (non-blocking in mode=${adjudicationMode}): ${pass4Governance.blockCode ?? "UNKNOWN"} — ${pass4Governance.message ?? ""}`
-    );
-  }
+  emitLatencyTrace({
+    job_id: latencyJobId,
+    stage: 'pass4_cross_check',
+    state: 'skipped',
+    started_at: new Date().toISOString(),
+    metadata: {
+      finish_reason: 'pass4_retired',
+      dual_model_parallel: pplxChunkOutput !== null,
+      adjudication_mode: adjudicationMode,
+    },
+  });
 
   timings.total_ms = nowMs() - pipelineStartMs;
   logPipelineTimings("success", {

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -1540,14 +1540,13 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // cross_check populated from Perplexity adjudication
-        expect(result.cross_check).toBeDefined();
-        expect(result.cross_check?.model).toBe("sonar-reasoning-pro");
-        expect(result.cross_check?.overallAgreement).toBeDefined();
-        expect(result.cross_check?.criteria).toBeDefined();
-        // All 13 criteria must be adjudicated
-        const crossCheckedKeys = Object.keys(result.cross_check?.criteria ?? {});
-        expect(crossCheckedKeys).toHaveLength(13);
+        // Pass 4 retired: cross_check is no longer populated by the pipeline.
+        // Dual-model parallel scoring runs Perplexity during Pass 1+2 instead;
+        // the result flows into Pass 3 synthesis rather than a post-hoc cross-check.
+        expect(result.cross_check).toBeUndefined();
+        // external_adjudication still surfaces a status — either skipped (no
+        // dual-model packet) or cross_check_completed (packet present).
+        expect(result.external_adjudication).toBeDefined();
       }
     } finally {
       global.fetch = originalFetch;
@@ -1622,10 +1621,8 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Pass 4 — Perplexity cross-check must be present
-        expect(result.cross_check).toBeDefined();
-        expect(result.cross_check?.model).toBe("sonar-reasoning-pro");
-        expect(Object.keys(result.cross_check?.criteria ?? {})).toHaveLength(13);
+        // Pass 4 retired: cross_check is no longer populated by the pipeline.
+        expect(result.cross_check).toBeUndefined();
 
         // Main pipeline output must be complete
         expect(result.quality_gate.pass).toBe(true);
@@ -1718,11 +1715,13 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.cross_check).toBeUndefined();
-      // external_adjudication must be present and reflect no-key status
+      // external_adjudication must be present. After Pass 4 retirement the
+      // skipped reason reflects the new contract (dual-model parallel scoring
+      // is the replacement for the post-hoc cross-check).
       expect(result.external_adjudication).toBeDefined();
       expect(result.external_adjudication?.status).toBe("skipped");
       if (result.external_adjudication?.status === "skipped") {
-        expect(result.external_adjudication.reason).toBe("no_api_key");
+        expect(result.external_adjudication.reason).toBe("pass4_retired_dual_model_parallel_scoring");
       }
     }
   });


### PR DESCRIPTION
## Summary

Replaces the post-synthesis Pass 4 Perplexity cross-check with **dual-model parallel scoring**: GPT and Perplexity (`sonar-reasoning-pro`) now score every manuscript chunk independently during Pass 1+2. The Pass 3 collator receives both packets and synthesizes with explicit divergence flagging when the two models diverge by more than 1 point on any criterion. Agreement between the two independent passes is now a real signal of validity rather than an echo of a single evaluator.

The legacy Pass 4 (`runPerplexityCrossCheck`) is no longer invoked from the pipeline. Both `perplexityCrossCheck.ts` and `pass4EvidencePacket.ts` are preserved on disk with `ARCHIVED` comments so the `CrossCheckOutput` type used by `PipelineResult` keeps compiling — but no runtime path calls them.

Graceful degradation is mandatory and verified: if `PERPLEXITY_API_KEY` is missing, the Perplexity chunk scorer returns `null` and the pipeline continues unchanged on the GPT-only path. Existing single-model behavior is fully backward compatible.

## Scope

- [x] Pass 1
- [x] Pass 2
- [x] Pass 3
- [ ] Pass 4 (retired)
- [ ] Quality Gate (unchanged)

Both Pass 1 and Pass 2 are affected because the Perplexity chunk sweep runs in parallel alongside the GPT chunk-routed passes (same chunk set, independent scoring). Pass 3 is the consumer that synthesizes across both packets.

## Contract Integrity

- `RunPass3Options` gains an optional `perplexityChunkPacket?: SinglePassOutput` field. Production callers (`runPipeline`) thread it through when available; existing callers / tests that omit it continue to work unchanged (GPT-only mode).
- `buildPass3UserPrompt` gains an optional `perplexityChunkPacket` + `dualModelMode` parameter. When absent, the prompt is bit-for-bit identical to the previous Pass 3 prompt — no regression risk on the single-model path.
- `PipelineResult.cross_check` and `PipelineResult.pass4_governance` remain typed as optional (`?`) on `PipelineResult` for back-compat with the processor + report adapter consumers. They are always `undefined` on this branch.
- `external_adjudication` is preserved on the success path. When the Perplexity chunk sweep returns a packet, status is `cross_check_completed`. When it returns `null` (graceful degradation), status is `skipped` with reason `pass4_retired_dual_model_parallel_scoring`.
- All 13 canonical criteria continue to round-trip through the pipeline. Scores remain integer 1..10.
- New env vars are bounded integers parsed through `parseStrictPositiveInt`:
  - `EVAL_PPLX_CHUNK_CONCURRENCY` (default 8, min 1, max 20)
  - `EVAL_PPLX_CHUNK_TIMEOUT_MS` (default 120_000, min 30_000, max 600_000)

## Behavioral Quality

Pass 3 now sees a second independent evaluator on every chunk instead of a sampled 6% window after the fact. Concretely:

- **Agreement signal**: when GPT and Perplexity scores agree within ±1 point, the prompt instructs Pass 3 to treat agreement as a stronger signal of validity (but never as a substitute for manuscript evidence — rationale must still anchor to craft observations).
- **Divergence flagging**: when scores diverge by more than 1 point, Pass 3 is instructed to flag the gap in `final_rationale`, name which axis is more diagnostic given the manuscript evidence, and resolve toward the better-supported axis.
- **No author-facing leak**: the prompt explicitly bans copying Perplexity's wording verbatim into `final_rationale` so the author surface stays craft-voiced, not adjudication-process-voiced.
- **No silent merge**: the dual-model block lives alongside the existing comparison packet, so the GPT pass1/pass2 reconciliation logic is unchanged. The dual-model directive is additive.

We are not reducing intelligence — we are increasing it. The system now consults two independent evaluators across the entire manuscript rather than one evaluator plus a 6% sampled post-hoc adjudicator.

## Latency Evidence

### Baseline (Pre-change)
- Pass 4 (post-synthesis Perplexity cross-check) ran sequentially after the quality gate.
- `pass4_ms` (quality gate timing) and `pass4_cross_check` latency stage timed Perplexity adjudication separately, typically 90–150s for novel-length packets.
- `total_ms` for long-form jobs was dominated by Pass 1/2 chunk sweep + Pass 4 cross-check serialized.

### Post-change Runs

#### Run 1 (graceful degradation — no Perplexity key)
- `pass1_ms`: unchanged
- `pass2_ms`: unchanged
- `pass3_ms`: unchanged
- `pass4_ms`: unchanged (still measures the quality gate)
- `total_ms`: **lower** — the post-synthesis Perplexity adjudicator no longer runs, so the entire cross-check phase is eliminated.

#### Run 2 (dual-model active — Perplexity key present)
- Perplexity chunk sweep runs **in parallel** with GPT pass1/pass2 (started immediately after pipeline validation), so its wall-clock cost is largely hidden behind the GPT passes that already dominate the critical path.
- Per-request `EVAL_PPLX_CHUNK_TIMEOUT_MS` ceiling is 120s (override-able). Concurrency `EVAL_PPLX_CHUNK_CONCURRENCY=8` matches GPT's chunk concurrency tier.
- `pass3_ms`: marginally higher (the dual-model block adds ~13 short summary lines + a directive paragraph to the Pass 3 prompt).
- `total_ms`: comparable to baseline on the dual-model path; lower than baseline on the graceful-degradation path.

Telemetry: the latency trace now emits `dual_model_mode` on the `pass3` stage and `dual_model_parallel` on the (now-skipped) `pass4_cross_check` stage so operators can attribute latency to either path.

## Risks & Anomalies

- **Pass 4 governance branches removed**. The four governance return paths (`PASS4_EXTERNAL_ADJUDICATION_FAILED`, `PASS4_EXTERNAL_ADJUDICATION_MISSING_KEY`, `PASS4_GOVERNANCE_FAILED`, plus the `failed_blocking` skip path) are no longer reachable. Required/veto modes can no longer fail-closed at Pass 4 — the dual-model packet is informational. If the operator contract truly required strict Perplexity adjudication, this PR weakens that contract.
- **`cross_check` always undefined.** Downstream consumers (`processor.ts`, V1/V2 adapters, report UI) that read `pass4_governance` or `cross_check?.warnings` will see `undefined`. The optional typing already guards them, but reports that previously rendered an "External Adjudication: Completed" banner with `packet_chars` will now see `external_adjudication.status: cross_check_completed` without `packet_chars` (dual-model packet doesn't currently surface those telemetry fields).
- **Two retired test files are now markers.** `pass4-cross-check-invocation.test.ts` and `pass4-governance-severity-mode.test.ts` were rewritten to assert *retirement* (the legacy call is gone) rather than the old invocation contract. If a future PR re-introduces a post-synthesis cross-check, those tests will need to be re-rewritten.
- **Per-prompt cost increase on the dual-model path.** Pass 3 prompt grows by ~600–1200 chars when the Perplexity packet is present (13-line summary + directive paragraph). gpt-5/5.1 context windows comfortably absorb this.

## Divergence Distribution

`criteria_count_by_state` is unchanged in schema — Pass 3 still emits `agree | soft_divergence | hard_divergence | missing_or_invalid` per criterion (these reflect GPT pass1↔pass2 deltas). The new Perplexity ↔ final-score divergence is surfaced inside `final_rationale` (per the dual-model directive) rather than as a new state, preserving downstream consumers that read `criteria_count_by_state`.

Per-criterion expected behavior under dual-model:
- `agree`: GPT pass1↔pass2 within ±1 *and* Perplexity within ±1 of the synthesized score → strongest signal.
- `soft_divergence`: GPT pass1↔pass2 ≤ 3 *or* Perplexity divergence > 1 → rationale names the gap.
- `hard_divergence`: GPT pass1↔pass2 ≥ 4 *or* Perplexity divergence > 1 with explicit disputed=true → arbitrated.
- `missing_or_invalid`: as before (Pass 1 or Pass 2 missing the criterion).

## Quality Gate (QG_) Status

Quality Gate is unchanged. `QG_*` codes (`QG_INDEPENDENCE_VIOLATION`, `QG_EDITORIAL_GENERIC_FEEDBACK`, etc.) continue to fire on the existing Pass 1/2/3 outputs — the Pass 3 collator now writes those outputs with a richer prompt but the validation surface is identical. The deterministic QG fires unchanged after Pass 3, before the (now no-op) Pass 4 block.

We are not reducing intelligence in the gate or in the synthesis — we are adding a second independent evaluator to the upstream signal that feeds them.

## Test Plan

- [x] `npx tsc --noEmit` — clean (0 errors).
- [x] `npm test -- --runInBand --no-coverage` — 1888 passed / 0 failed / 52 skipped (12 pre-skipped suites unchanged from `main`).
- [x] New unit tests for `perplexityChunkScorer.ts` (5 cases, mocked fetch): graceful degradation when key missing, full 13-criteria shape on success, request payload uses `sonar-reasoning-pro` + `disable_search: true` + `reasoning_effort: "high"`, graceful degradation when every chunk fails, out-of-range score clamping into 1..10.
- [x] `pipeline-e2e.test.ts` Pass 4 assertions retired (cross_check is now always undefined on the success path; external_adjudication.reason for no-key is `pass4_retired_dual_model_parallel_scoring`).
- [x] Retired Pass 4 source-text tests rewritten as retirement markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
