### PR TITLE
test(dual-model): stress-test audit — partial-failure, empty-chunks, missing-criteria, Pass 3 dual-packet branches

### DIFF
--- a/lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts
+++ b/lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Pass 3 dual-model synthesis prompt — packet-present vs packet-absent branches.
+ *
+ * Verifies that buildPass3UserPrompt:
+ *   1. Injects the DUAL-MODEL block when perplexityChunkPacket is provided.
+ *   2. Omits the DUAL-MODEL block when perplexityChunkPacket is undefined
+ *      (graceful fallback to GPT-only).
+ *   3. Renders per-criterion Perplexity scores in the summary.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import { buildPass3UserPrompt } from "../prompts/pass3-synthesis";
+import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+import type { Pass2aStructuredContext, SinglePassOutput } from "../types";
+
+const emptyContext: Pass2aStructuredContext = {
+  character_ledger: [],
+  scene_index: [],
+  timeline_anchors: [],
+};
+
+function buildPerplexityPacket(): SinglePassOutput {
+  return {
+    pass: 1,
+    axis: "craft_execution",
+    model: "sonar-reasoning-pro",
+    prompt_version: "pplx-chunk-scorer-v1",
+    temperature: 0.1,
+    generated_at: new Date().toISOString(),
+    criteria: CRITERIA_KEYS.map((key, i) => ({
+      key,
+      score_0_10: ((i % 9) + 1),
+      rationale: `Independent observation for ${key}.`,
+      evidence: [{ snippet: `quote-${key}` }],
+      recommendations: [],
+    })),
+  };
+}
+
+describe("buildPass3UserPrompt — dual-model behavior", () => {
+  test("omits DUAL-MODEL block when perplexityChunkPacket is undefined (GPT-only fallback)", () => {
+    const prompt = buildPass3UserPrompt({
+      comparisonPacketJson: "{}",
+      pass2aStructuredContext: emptyContext,
+      manuscriptText: "minimal manuscript text",
+      title: "Test",
+    });
+
+    expect(prompt).not.toContain("DUAL-MODEL PARALLEL SCORING");
+    expect(prompt).not.toContain("PERPLEXITY INDEPENDENT SCORES");
+    expect(prompt).not.toContain("sonar-reasoning-pro");
+  });
+
+  test("injects DUAL-MODEL block when perplexityChunkPacket is provided", () => {
+    const packet = buildPerplexityPacket();
+    const prompt = buildPass3UserPrompt({
+      comparisonPacketJson: "{}",
+      pass2aStructuredContext: emptyContext,
+      manuscriptText: "minimal manuscript text",
+      title: "Test",
+      perplexityChunkPacket: packet,
+    });
+
+    expect(prompt).toContain("DUAL-MODEL PARALLEL SCORING");
+    expect(prompt).toContain("PERPLEXITY INDEPENDENT SCORES");
+    expect(prompt).toContain("sonar-reasoning-pro");
+    // Divergence rule (>1 point) is the contract — must appear verbatim.
+    expect(prompt).toContain("diverge by MORE THAN 1 point");
+  });
+
+  test("renders one summary line per criterion in the DUAL-MODEL block", () => {
+    const packet = buildPerplexityPacket();
+    const prompt = buildPass3UserPrompt({
+      comparisonPacketJson: "{}",
+      pass2aStructuredContext: emptyContext,
+      manuscriptText: "minimal manuscript text",
+      title: "Test",
+      perplexityChunkPacket: packet,
+    });
+    for (const key of CRITERIA_KEYS) {
+      expect(prompt).toContain(`- ${key}:`);
+    }
+  });
+
+  test("dualModelMode=false suppresses the block even when packet is present", () => {
+    const packet = buildPerplexityPacket();
+    const prompt = buildPass3UserPrompt({
+      comparisonPacketJson: "{}",
+      pass2aStructuredContext: emptyContext,
+      manuscriptText: "minimal manuscript text",
+      title: "Test",
+      perplexityChunkPacket: packet,
+      dualModelMode: false,
+    });
+    expect(prompt).not.toContain("DUAL-MODEL PARALLEL SCORING");
+  });
+});

--- a/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
+++ b/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
@@ -174,6 +174,124 @@ describe("runPerplexityChunkScorer", () => {
     expect(result).toBeNull();
   });
 
+  test("partial failure: keeps successful chunks and proceeds when only some chunks fail", async () => {
+    let callIndex = 0;
+    const partialFetch: typeof fetch = (async () => {
+      const i = callIndex;
+      callIndex += 1;
+      if (i === 1) {
+        return {
+          ok: false,
+          status: 500,
+          async json() {
+            return {};
+          },
+          async text() {
+            return "transient error";
+          },
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            choices: [
+              {
+                message: { content: buildPerplexityChunkResponseJson() },
+                finish_reason: "stop",
+              },
+            ],
+          };
+        },
+        async text() {
+          return "";
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "a b c",
+      manuscriptChunks: [
+        { chunk_index: 0, content: "chunk zero" },
+        { chunk_index: 1, content: "chunk one" },
+        { chunk_index: 2, content: "chunk two" },
+      ],
+      workType: "novel",
+      title: "Test",
+      perplexityApiKey: "test-key",
+      _fetch: partialFetch,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
+  });
+
+  test("returns null gracefully when manuscriptChunks is an empty array", async () => {
+    // Empty chunks array → scorer falls back to a single chunk wrapping manuscriptText
+    // (a 0-chunk job would be silently degraded). Verify the fallback path works.
+    const fetchMock = buildFetchMock();
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "minimal text",
+      manuscriptChunks: [],
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: fetchMock as unknown as typeof fetch,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
+  });
+
+  test("missing criteria in response are backfilled with placeholder score 5", async () => {
+    // Perplexity returns only 3 of 13 criteria. The remaining 10 should be
+    // backfilled with a conservative placeholder rather than throw.
+    const partialCriteria = {
+      concept: { score: 7, rationale: "ok", evidence: "snippet" },
+      voice: { score: 4, rationale: "weak", evidence: "snippet" },
+      pacing: { score: 6, rationale: "ok", evidence: "snippet" },
+    };
+    const fetchMock = buildFetchMock({
+      jsonBody: {
+        choices: [
+          {
+            message: { content: JSON.stringify({ criteria: partialCriteria }) },
+            finish_reason: "stop",
+          },
+        ],
+      },
+    });
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "x",
+      manuscriptChunks: [{ chunk_index: 0, content: "x" }],
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: fetchMock as unknown as typeof fetch,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
+    const placeholderCount = result!.criteria.filter((c) =>
+      c.rationale.includes("criterion missing from response"),
+    ).length;
+    expect(placeholderCount).toBe(CRITERIA_KEYS.length - 3);
+  });
+
+  test("returns null (does not throw) when fetch itself rejects unexpectedly", async () => {
+    const throwingFetch: typeof fetch = (async () => {
+      throw new Error("network unreachable");
+    }) as unknown as typeof fetch;
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "x",
+      manuscriptChunks: [{ chunk_index: 0, content: "x" }],
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: throwingFetch,
+    });
+    expect(result).toBeNull();
+  });
+
   test("clamps out-of-range scores into the canonical 1..10 range", async () => {
     const outOfRangeCriteria = Object.fromEntries(
       CRITERIA_KEYS.map((key, i) => [


### PR DESCRIPTION
## Summary

Stress-test audit of PR #606 (dual-model parallel scoring: GPT + Perplexity sonar-reasoning-pro running in parallel on all chunks, Pass 4 retired). Audited 10 risk dimensions across the new chunk scorer, the pipeline wiring, and the Pass 3 dual-packet synthesis prompt. Implementation is solid — no critical defects found. The only gaps were in **test coverage** of the degradation/edge-case branches; this PR closes those gaps.

### Audit verdict (no code fixes needed)

| Area | Verdict |
|---|---|
| Graceful degradation (missing key / all-fail / partial-fail) | ✅ correct — scorer never throws; returns `null`; Pass 3 falls back to GPT-only via `dualModelMode = !!packet` |
| Parallelism | ✅ pass1/pass2/pplx promises all created at lines 970/1020/1076 before any `await` at 1092 — truly parallel, no shared mutable state |
| Pass 3 dual-packet | ✅ divergence logic is prompt-side only (no TS divergence calc → no KeyError risk); `model` field always populated; evidence/rationale guarded against null |
| Token/context budget | ✅ `pass3PromptMaxChars` default = 500k (raised in #604), Perplexity summary is per-criterion compact lines (rationale ≤180c, evidence ≤120c) — adds ~5KB max |
| Type safety | ✅ `npx tsc --noEmit` clean (0 errors) |
| API correctness | ✅ `model=sonar-reasoning-pro`, `disable_search=true`, `reasoning_effort=high`, `temperature=0.1`, env reads via `EVAL_PPLX_CHUNK_*` |
| Edge cases | ✅ out-of-range scores clamped 1..10; missing criteria backfilled with score 5; empty chunks → single-chunk fallback; 0 successes → null |
| Logging | ✅ start/complete/partial/failure logs; Pass 3 logs `criteria_count` and dual_model_mode (packet-size in bytes not logged — minor obs gap, non-blocking) |
| Pass 4 retirement | ✅ `runPerplexityCrossCheck` is a type-only import; never called; `crossCheckResult`/`pass4Governance` always `undefined` in success path |

### Test gaps closed in this PR

**lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts** (+4 tests):
- Partial failure path: 1 of 3 chunks 500s → remaining 2 succeed → aggregated packet returned (NOT discarded)
- Empty `manuscriptChunks: []` → fallback path wraps `manuscriptText` as a single chunk
- Missing criteria in response (3 of 13 returned) → 10 backfilled with placeholder score 5 + diagnostic rationale
- `fetch()` itself rejects with a JS error (not HTTP error) → outer `try/catch` swallows, returns `null` (no throw escapes the scorer)

**lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts** (new file, 4 tests):
- `perplexityChunkPacket: undefined` → DUAL-MODEL block omitted (GPT-only legacy prompt shape)
- `perplexityChunkPacket: present` → DUAL-MODEL block + `"diverge by MORE THAN 1 point"` rule rendered
- Per-criterion summary line rendered for each of 13 canonical criteria keys
- `dualModelMode: false` explicitly suppresses the block even when packet is present (feature-flag safety)

## Testing

- `npx tsc --noEmit` → 0 errors
- `npx jest lib/evaluation/pipeline --runInBand --no-coverage` → **32 suites / 233 tests pass** (was 31/225 before — +1 suite, +8 tests)
- `npx jest lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts` → 13/13 pass

## Test plan

- [x] tsc clean
- [x] all pipeline tests pass
- [x] new tests exercise the four degradation/edge branches
- [x] new tests exercise both Pass 3 prompt branches (packet present + absent)
- [ ] Live evaluation run on a real manuscript (after merge) to confirm graceful degradation behaves as expected when `PERPLEXITY_API_KEY` is unset in preview environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope

- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Test coverage additions for the dual-model chunk scorer and Pass 3 dual-packet synthesis prompt. No pipeline logic changes — tests only.

## Latency Evidence

### Baseline (Pre-change)

| Metric | Run 1 | Run 2 |
|--------|-------|-------|
| pass3_ms | Tests only — no pipeline latency change | Tests only — no pipeline latency change |
| total_ms | Tests only — no pipeline latency change | Tests only — no pipeline latency change |

### Post-change Runs

| Metric | Run 1 | Run 2 |
|--------|-------|-------|
| pass3_ms | N/A — test coverage PR, zero runtime impact | N/A — test coverage PR, zero runtime impact |
| total_ms | N/A — test coverage PR, zero runtime impact | N/A — test coverage PR, zero runtime impact |

## Risks & Anomalies

No production code changed. All additions are test files only. Zero risk of regression.

Quality Gate: test coverage gaps in perplexityChunkScorer.ts and pass3 dual-packet prompt path are now closed.

## Divergence Distribution

criteria_count_by_state: N/A — this is a test-coverage PR. No scoring logic was modified. The dual-model divergence detection is prompt-side only and has no TS divergence calculation.

**Principle acknowledgment:** This PR adds tests for existing behavior — it is **not reducing intelligence** of the evaluation pipeline. All rubric definitions, scoring thresholds, and synthesis prompts are unchanged.

## Contract Integrity

- [x] tsc --noEmit clean (0 errors)
- [x] No production code changes — test files only
- [x] No env contract changes
- [x] No DB schema or migration changes
- [x] Quality Gate thresholds and rubric definitions unchanged
- [x] Backward compatible — existing tests unmodified

## Behavioral Quality

Test-only PR. No changes to scoring logic, synthesis prompts, or pipeline orchestration. All new tests validate pre-existing behavior introduced in PR #606. Pass scope: [x] Pass 1 [x] Pass 2 [x] Pass 3