### PR TITLE
fix(eval): rename stage and harden evaluation contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,34 @@
 @tailwind components;
 @tailwind utilities;
 
+/* === Evaluation/readability contrast guard ===
+ *
+ * Evaluation report/status/form surfaces use white cards on a light gray page.
+ * Small Tailwind gray-400/500 helper text is too faint in that context, so the
+ * evaluation shell promotes muted copy to AA-friendly dark grays without
+ * changing layout, pipeline behavior, scoring, or report content.
+ */
+.min-h-screen.bg-gray-50 .text-gray-400,
+.min-h-screen.bg-gray-50 .text-gray-500 {
+  color: #374151;
+}
+
+.min-h-screen.bg-gray-50 .text-gray-600 {
+  color: #1f2937;
+}
+
+.min-h-screen.bg-gray-50 .text-xs.text-gray-400,
+.min-h-screen.bg-gray-50 .text-xs.text-gray-500,
+.min-h-screen.bg-gray-50 .text-sm.text-gray-500 {
+  font-weight: 500;
+}
+
+.min-h-screen.bg-gray-50 input::placeholder,
+.min-h-screen.bg-gray-50 textarea::placeholder {
+  color: #4b5563;
+  opacity: 1;
+}
+
 /* === User evaluation dashboard === */
 
 .rg-dash-page {

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -9,7 +9,7 @@ export type ProgressDisplay = {
 } | null;
 
 const STAGE_ROADMAP =
-  "Stages: Preparing manuscript → Reading manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report.";
+  "Stages: Preparing manuscript → Analyzing manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report.";
 
 /**
  * Truthful, stage-weighted progress model.
@@ -18,7 +18,7 @@ const STAGE_ROADMAP =
  * proportional to the median time each stage takes in real pipeline runs:
  *
  *   Preparing manuscript  | 0 →  2%   (phase_1 / queued)
- *   Reading manuscript    | 2 → 64%   (phase_1 / running — heaviest stage)
+ *   Analyzing manuscript  | 2 → 64%   (phase_1 / running — heaviest stage)
  *   Building diagnosis    | 64 → 65%  (phase_1 / complete — transient handoff)
  *   Reconciling passes    | 65 → 83%  (phase_2 / running)
  *   Final QA checks       | 83 → 97%  (phase_2 / complete  +  cross_check running)
@@ -39,7 +39,7 @@ const STAGE_ROADMAP =
 
 type StageId =
   | "preparing_manuscript"
-  | "reading_manuscript"
+  | "analyzing_manuscript"
   | "building_diagnosis"
   | "reconciling_passes"
   | "final_qa_checks"
@@ -68,8 +68,8 @@ const STAGE_BUDGETS: readonly StageBudget[] = [
     medianSeconds: 8,
   },
   {
-    id: "reading_manuscript",
-    label: "Reading manuscript",
+    id: "analyzing_manuscript",
+    label: "Analyzing manuscript",
     start: 2,
     end: 64,
     medianSeconds: 420, // ~7 min on a 127k-word, 37-chunk run
@@ -138,7 +138,7 @@ function resolveStageId(inputs: StageInputs): StageId | null {
 
   if (inputs.phase === "phase_1") {
     if (inputs.phase_status === "queued") return "preparing_manuscript";
-    if (inputs.phase_status === "running") return "reading_manuscript";
+    if (inputs.phase_status === "running") return "analyzing_manuscript";
     if (inputs.phase_status === "complete") return "building_diagnosis";
     return null;
   }
@@ -165,7 +165,7 @@ function getStageStartedAt(
     case "preparing_manuscript":
       // Use job created_at as the start of the queued/preparing stage.
       return job.created_at ?? null;
-    case "reading_manuscript":
+    case "analyzing_manuscript":
       return job.phase1_started_at ?? job.created_at ?? null;
     case "building_diagnosis":
       return job.phase1_completed_at ?? job.phase2_started_at ?? null;

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -42,10 +42,10 @@ describe("resolveStageId: backend state -> stage", () => {
     ).toBe("preparing_manuscript");
   });
 
-  test("running in phase_1 -> reading_manuscript (heaviest stage)", () => {
+  test("running in phase_1 -> analyzing_manuscript (heaviest stage)", () => {
     expect(
       resolveStageId({ phase: "phase_1", phase_status: "running" }),
-    ).toBe("reading_manuscript");
+    ).toBe("analyzing_manuscript");
   });
 
   test("complete in phase_1 -> building_diagnosis (handoff)", () => {
@@ -87,7 +87,7 @@ describe("resolveStageId: backend state -> stage", () => {
 
 describe("interpolateWithinStage: never exceeds stage_end - 1%", () => {
   test("clamps to ceiling even when elapsed >> median", () => {
-    const stage = STAGE_BY_ID.reading_manuscript; // 2..64, median 420s
+    const stage = STAGE_BY_ID.analyzing_manuscript; // 2..64, median 420s
     const startedAt = T0;
     const farFuture = Date.parse(T0) + 1_000_000 * 1000; // way past median
     const pct = interpolateWithinStage(stage, startedAt, farFuture);
@@ -96,7 +96,7 @@ describe("interpolateWithinStage: never exceeds stage_end - 1%", () => {
   });
 
   test("starts at stage.start when elapsed=0", () => {
-    const stage = STAGE_BY_ID.reading_manuscript;
+    const stage = STAGE_BY_ID.analyzing_manuscript;
     const pct = interpolateWithinStage(stage, T0, Date.parse(T0));
     expect(pct).toBe(stage.start);
   });
@@ -114,7 +114,7 @@ describe("interpolateWithinStage: never exceeds stage_end - 1%", () => {
   });
 
   test("interpolates linearly inside the slice for elapsed < median", () => {
-    const stage = STAGE_BY_ID.reading_manuscript; // start 2, end 64, median 420
+    const stage = STAGE_BY_ID.analyzing_manuscript; // start 2, end 64, median 420
     // Half of median should put us ~halfway through the slice (clamped to end-1)
     const pct = interpolateWithinStage(
       stage,
@@ -163,8 +163,8 @@ describe("getProgressDisplay: end-to-end behavior", () => {
       },
       now,
     );
-    expect(pd!.label).toBe("Reading manuscript");
-    expect(pd!.percentage).toBe(2); // reading_manuscript.start
+    expect(pd!.label).toBe("Analyzing manuscript");
+    expect(pd!.percentage).toBe(2); // analyzing_manuscript.start
     expect(pd!.indeterminate).toBe(false);
   });
 
@@ -174,14 +174,14 @@ describe("getProgressDisplay: end-to-end behavior", () => {
       phase: "phase_1",
       phase_status: "running",
     });
-    expect(pd!.label).toBe("Reading manuscript");
+    expect(pd!.label).toBe("Analyzing manuscript");
     expect(pd!.indeterminate).toBe(true);
     expect(pd!.percentage).toBe(2);
   });
 
   test("never returns >= stage_end while still in same stage", () => {
-    // Sample many points within reading_manuscript stage (median 420s).
-    const stage = STAGE_BY_ID.reading_manuscript;
+    // Sample many points within analyzing_manuscript stage (median 420s).
+    const stage = STAGE_BY_ID.analyzing_manuscript;
     for (const sec of [1, 30, 100, 250, 420, 600, 1200, 10000]) {
       const pd = getProgressDisplay(
         {
@@ -344,7 +344,7 @@ describe("monotonicity across stage transitions", () => {
 describe("getStageLabelFromPhase: standalone label resolver", () => {
   test("matches getProgressDisplay's label for the same inputs", () => {
     const label = getStageLabelFromPhase("phase_1", "running", null);
-    expect(label).toBe("Reading manuscript");
+    expect(label).toBe("Analyzing manuscript");
   });
 
   test("returns null for queued / unknown so caller can render its own copy", () => {


### PR DESCRIPTION
## Summary

Renames the seven-stage evaluation progress nomenclature from **Reading manuscript** to **Analyzing manuscript** and hardens evaluation/report readability so light gray helper text is legible against white report cards.

## Scope

- Updates the stage roadmap copy shown in the evaluation progress helper.
- Renames the internal progress stage id from `reading_manuscript` to `analyzing_manuscript` so tests and implementation use the same nomenclature.
- Updates the progress display unit tests to assert the new stage label and stage id.
- Adds an evaluation/readability contrast guard in `app/globals.css` for evaluation surfaces using the light gray page shell.
- Promotes faint `text-gray-400` / `text-gray-500` / `text-gray-600` copy to darker grays on evaluation report/status/form surfaces.
- Strengthens small helper text and placeholders without changing layout.

## Contract Integrity

- [x] Pass 1 UI/status nomenclature only; no pass execution behavior changed.
- `phase_1` + `phase_status=running` now resolves to `analyzing_manuscript`.
- The visible label renders as **Analyzing manuscript**.
- The seven-stage roadmap renders: `Preparing manuscript → Analyzing manuscript → Building diagnosis → Reconciling passes → Final QA checks → Preparing report → Finalizing report`.
- Stage percentage boundaries and weights are unchanged.
- Contrast-only CSS affects visual readability only; no scoring, prompt, artifact, worker, database, timeout, or QG behavior changed.

## Behavioral Quality

- This is copy/nomenclature + readability alignment only.
- No scoring, prompt, model, criteria, Quality Gate, worker, database, timeout, or report-generation behavior changed.
- This change is not reducing intelligence; it preserves the existing evaluation behavior while making the user-facing status and report text more accurate and legible.

## Latency Evidence

### Baseline (Pre-change)

| Run | pass1_ms | total_ms | Notes |
| --- | ---: | ---: | --- |
| Run 1 | 0 | 0 | Not applicable — no runtime path changed |
| Run 2 | 0 | 0 | Not applicable — no runtime path changed |

### Post-change Runs

| Run | pass1_ms | total_ms | Notes |
| --- | ---: | ---: | --- |
| Run 1 | 0 | 0 | Not applicable — UI/status/CSS only |
| Run 2 | 0 | 0 | Not applicable — UI/status/CSS only |

Latency impact: expected 0ms. The diff changes static progress-display copy, a stage id, matching unit-test assertions, and CSS contrast rules only.

## Risks & Anomalies

- Quality Gate / QG impact: none. No QG_ behavior is touched.
- Main risk is stale nomenclature in archived Base44 exports or unrelated historical docs; production UI source and tests are updated.
- Contrast guard is intentionally scoped to `.min-h-screen.bg-gray-50` evaluation-style shells to avoid a whole-site typography change.
- Search evidence before PR creation found the active `reading_manuscript` implementation/test hits in `components/evaluation-poller-display.ts` and `tests/evaluation-poller-display.test.ts`; both are changed here.

## Verification

- Changed files: `app/globals.css`, `components/evaluation-poller-display.ts`, `tests/evaluation-poller-display.test.ts`.
- Code diff limited to progress-stage nomenclature, matching tests, and evaluation-surface contrast CSS.
- No scoring, pipeline, worker, database, timeout, or QualityGate behavior changed.