### PR TITLE
fix(pplx): fail-fast gates with hard-fail — probe, error-rate tripwire, per-chunk logging

### DIFF
--- a/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
+++ b/lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts
@@ -1,6 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
-import { runPerplexityChunkScorer } from "../perplexityChunkScorer";
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
 import { CRITERIA_KEYS } from "@/schemas/criteria-keys";
+
+import { runPerplexityChunkScorer } from "../perplexityChunkScorer";
+
+const pipelineLogMock = jest.fn() as jest.Mock;
 
 function buildPerplexityChunkResponseJson(): string {
   const criteria = Object.fromEntries(
@@ -16,35 +19,52 @@ function buildPerplexityChunkResponseJson(): string {
   return JSON.stringify({ criteria });
 }
 
-function buildFetchMock(opts: { jsonBody?: unknown; status?: number; text?: string } = {}) {
-  const body = opts.jsonBody ?? {
-    choices: [
-      {
-        message: { content: buildPerplexityChunkResponseJson() },
-        finish_reason: "stop",
-      },
-    ],
-  };
-  const status = opts.status ?? 200;
-  const text = opts.text ?? "";
-  return async () =>
-    ({
-      ok: status >= 200 && status < 300,
-      status,
-      async json() {
-        return body;
-      },
-      async text() {
-        return text;
-      },
-    }) as unknown as Response;
+function successResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    async json() {
+      return {
+        choices: [
+          {
+            message: { content: buildPerplexityChunkResponseJson() },
+            finish_reason: "stop",
+          },
+        ],
+      };
+    },
+    async text() {
+      return "";
+    },
+  } as unknown as Response;
 }
 
-describe("runPerplexityChunkScorer", () => {
+function errorResponse(status: number, body: string): Response {
+  return {
+    ok: false,
+    status,
+    async json() {
+      return {};
+    },
+    async text() {
+      return body;
+    },
+  } as unknown as Response;
+}
+
+function makeChunks(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    chunk_index: i,
+    content: `chunk ${i} content`,
+  }));
+}
+
+describe("runPerplexityChunkScorer — fail-fast gates", () => {
   const ORIGINAL_KEY = process.env.PERPLEXITY_API_KEY;
 
   beforeEach(() => {
     delete process.env.PERPLEXITY_API_KEY;
+    pipelineLogMock.mockClear();
   });
 
   afterEach(() => {
@@ -55,219 +75,244 @@ describe("runPerplexityChunkScorer", () => {
     }
   });
 
-  test("returns null when PERPLEXITY_API_KEY is missing (graceful degradation)", async () => {
+  test("missing key → returns null (operator GPT-only mode)", async () => {
     const result = await runPerplexityChunkScorer({
-      manuscriptText: "Short manuscript text.",
-      manuscriptChunks: [{ chunk_index: 0, content: "Short manuscript text." }],
+      manuscriptText: "x",
+      manuscriptChunks: [{ chunk_index: 0, content: "x" }],
       workType: "novel",
-      title: "Test",
+      title: "T",
     });
     expect(result).toBeNull();
   });
 
-  test("returns a SinglePassOutput shape covering all 13 criteria when API responds successfully", async () => {
-    const fetchMock = buildFetchMock();
+  test("Gate 1 — 422 deterministic probe → throws FATAL", async () => {
+    const fetchSpy: typeof fetch = (async () =>
+      errorResponse(422, "unprocessable entity body")) as unknown as typeof fetch;
+    await expect(
+      runPerplexityChunkScorer({
+        manuscriptText: "x",
+        manuscriptChunks: makeChunks(40),
+        workType: "novel",
+        title: "T",
+        perplexityApiKey: "test-key",
+        _fetch: fetchSpy,
+        _sleep: async () => undefined,
+      _log: pipelineLogMock,
+      }),
+    ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_FATAL/);
+
+    const errorCalls = pipelineLogMock.mock.calls.filter((c) => {
+      const arg = c[0] as { level?: string };
+      return arg.level === "error";
+    });
+    expect(errorCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Gate 1 — 401 deterministic probe → throws FATAL", async () => {
+    const fetchSpy: typeof fetch = (async () =>
+      errorResponse(401, "bad key")) as unknown as typeof fetch;
+    await expect(
+      runPerplexityChunkScorer({
+        manuscriptText: "x",
+        manuscriptChunks: makeChunks(40),
+        workType: "novel",
+        title: "T",
+        perplexityApiKey: "test-key",
+        _fetch: fetchSpy,
+        _sleep: async () => undefined,
+      _log: pipelineLogMock,
+      }),
+    ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_FATAL/);
+  });
+
+  test("Gate 1 — 429 transient probe, retry succeeds → sweep proceeds", async () => {
+    let calls = 0;
+    const fetchSpy: typeof fetch = (async () => {
+      calls += 1;
+      if (calls === 1) return errorResponse(429, "rate limited");
+      return successResponse();
+    }) as unknown as typeof fetch;
+
     const result = await runPerplexityChunkScorer({
-      manuscriptText: "Test manuscript content sufficient for one chunk.",
-      manuscriptChunks: [
-        { chunk_index: 0, content: "Test manuscript content sufficient for one chunk." },
-      ],
+      manuscriptText: "x",
+      manuscriptChunks: makeChunks(1),
       workType: "novel",
-      title: "Test",
+      title: "T",
       perplexityApiKey: "test-key",
-      _fetch: fetchMock as unknown as typeof fetch,
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
     });
 
     expect(result).not.toBeNull();
     expect(result?.pass).toBe(1);
-    expect(result?.axis).toBe("craft_execution");
-    expect(result?.model).toBe("sonar-reasoning-pro");
-    expect(result?.temperature).toBe(0.1);
-    expect(Array.isArray(result?.criteria)).toBe(true);
     expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
-
-    const keys = new Set(result?.criteria.map((c) => c.key));
-    for (const key of CRITERIA_KEYS) {
-      expect(keys.has(key)).toBe(true);
-    }
-
-    for (const c of result!.criteria) {
-      expect(c.score_0_10).toBeGreaterThanOrEqual(1);
-      expect(c.score_0_10).toBeLessThanOrEqual(10);
-      expect(typeof c.rationale).toBe("string");
-      expect(c.rationale.length).toBeGreaterThan(0);
-    }
   });
 
-  test("calls Perplexity API once per chunk with sonar-reasoning-pro and disable_search", async () => {
-    const captured: Array<{ url: string; body: unknown }> = [];
-    const fetchSpy: typeof fetch = (async (url: string, init: RequestInit) => {
-      const parsed = JSON.parse((init.body as string) ?? "{}");
-      captured.push({ url, body: parsed });
-      return {
-        ok: true,
-        status: 200,
-        async json() {
-          return {
-            choices: [
-              {
-                message: { content: buildPerplexityChunkResponseJson() },
-                finish_reason: "stop",
-              },
-            ],
-          };
-        },
-        async text() {
-          return "";
-        },
-      } as unknown as Response;
-    }) as unknown as typeof fetch;
+  test("Gate 1 — 429 transient probe, retry also 429 → throws TRANSIENT", async () => {
+    const fetchSpy: typeof fetch = (async () =>
+      errorResponse(429, "rate limited")) as unknown as typeof fetch;
 
-    const chunks = [
-      { chunk_index: 0, content: "Chunk zero content." },
-      { chunk_index: 1, content: "Chunk one content." },
-    ];
-
-    const result = await runPerplexityChunkScorer({
-      manuscriptText: "Chunk zero content.\nChunk one content.",
-      manuscriptChunks: chunks,
-      workType: "novel",
-      title: "Test",
-      perplexityApiKey: "test-key",
-      _fetch: fetchSpy,
-    });
-
-    expect(result).not.toBeNull();
-    expect(captured.length).toBe(2);
-    for (const call of captured) {
-      expect(call.url).toContain("api.perplexity.ai");
-      const body = call.body as Record<string, unknown>;
-      expect(body.model).toBe("sonar-reasoning-pro");
-      expect(body.disable_search).toBe(true);
-      expect(body.reasoning_effort).toBe("high");
-      expect(body.temperature).toBe(0.1);
-    }
+    await expect(
+      runPerplexityChunkScorer({
+        manuscriptText: "x",
+        manuscriptChunks: makeChunks(40),
+        workType: "novel",
+        title: "T",
+        perplexityApiKey: "test-key",
+        _fetch: fetchSpy,
+        _sleep: async () => undefined,
+      _log: pipelineLogMock,
+      }),
+    ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE/);
   });
 
-  test("returns null when every chunk request fails (graceful degradation)", async () => {
-    const failingFetch: typeof fetch = (async () =>
-      ({
-        ok: false,
-        status: 500,
-        async json() {
-          return {};
-        },
-        async text() {
-          return "internal error";
-        },
-      }) as unknown as Response) as unknown as typeof fetch;
-
-    const result = await runPerplexityChunkScorer({
-      manuscriptText: "Test.",
-      manuscriptChunks: [{ chunk_index: 0, content: "Test." }],
-      workType: "novel",
-      title: "Test",
-      perplexityApiKey: "test-key",
-      _fetch: failingFetch,
-    });
-
-    expect(result).toBeNull();
-  });
-
-  test("partial failure: keeps successful chunks and proceeds when only some chunks fail", async () => {
-    let callIndex = 0;
-    const partialFetch: typeof fetch = (async () => {
-      const i = callIndex;
-      callIndex += 1;
-      if (i === 1) {
-        return {
-          ok: false,
-          status: 500,
-          async json() {
-            return {};
-          },
-          async text() {
-            return "transient error";
-          },
-        } as unknown as Response;
+  test("Gate 2 — 3/4 sample chunks fail → throws HIGH_ERROR_RATE", async () => {
+    // chunks 0 (probe) succeeds, then sample = chunks 1-4 (4 of them).
+    // We want 3 of those 4 sample requests to fail with a transient error.
+    // The probe call is the first call (index 0). After that, sample is concurrent.
+    // To control which calls fail we look at the call body for `chunk N content`.
+    const fetchSpy: typeof fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse((init.body as string) ?? "{}");
+      const userMsg = body.messages?.[1]?.content ?? "";
+      const m = /chunk (\d+) content/.exec(userMsg);
+      const idx = m ? Number(m[1]) : -1;
+      if (idx >= 1 && idx <= 3) {
+        return errorResponse(500, "boom");
       }
-      return {
-        ok: true,
-        status: 200,
-        async json() {
-          return {
-            choices: [
-              {
-                message: { content: buildPerplexityChunkResponseJson() },
-                finish_reason: "stop",
-              },
-            ],
-          };
-        },
-        async text() {
-          return "";
-        },
-      } as unknown as Response;
+      return successResponse();
+    }) as unknown as typeof fetch;
+
+    await expect(
+      runPerplexityChunkScorer({
+        manuscriptText: "x",
+        manuscriptChunks: makeChunks(40),
+        workType: "novel",
+        title: "T",
+        perplexityApiKey: "test-key",
+        _fetch: fetchSpy,
+        _sleep: async () => undefined,
+      _log: pipelineLogMock,
+      }),
+    ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE/);
+  });
+
+  test("Gate 2 — 1/4 sample chunks fail → does NOT throw, proceeds to main batch", async () => {
+    const fetchSpy: typeof fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse((init.body as string) ?? "{}");
+      const userMsg = body.messages?.[1]?.content ?? "";
+      const m = /chunk (\d+) content/.exec(userMsg);
+      const idx = m ? Number(m[1]) : -1;
+      if (idx === 2) {
+        return errorResponse(500, "boom");
+      }
+      return successResponse();
     }) as unknown as typeof fetch;
 
     const result = await runPerplexityChunkScorer({
-      manuscriptText: "a b c",
-      manuscriptChunks: [
-        { chunk_index: 0, content: "chunk zero" },
-        { chunk_index: 1, content: "chunk one" },
-        { chunk_index: 2, content: "chunk two" },
-      ],
-      workType: "novel",
-      title: "Test",
-      perplexityApiKey: "test-key",
-      _fetch: partialFetch,
-    });
-
-    expect(result).not.toBeNull();
-    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
-  });
-
-  test("returns null gracefully when manuscriptChunks is an empty array", async () => {
-    // Empty chunks array → scorer falls back to a single chunk wrapping manuscriptText
-    // (a 0-chunk job would be silently degraded). Verify the fallback path works.
-    const fetchMock = buildFetchMock();
-    const result = await runPerplexityChunkScorer({
-      manuscriptText: "minimal text",
-      manuscriptChunks: [],
+      manuscriptText: "x",
+      manuscriptChunks: makeChunks(40),
       workType: "novel",
       title: "T",
       perplexityApiKey: "test-key",
-      _fetch: fetchMock as unknown as typeof fetch,
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
     });
+
     expect(result).not.toBeNull();
     expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
   });
 
-  test("missing criteria in response are backfilled with placeholder score 5", async () => {
-    // Perplexity returns only 3 of 13 criteria. The remaining 10 should be
-    // backfilled with a conservative placeholder rather than throw.
+  test("Gate 3 — per-chunk error logging: chunk 7 fails → pipelineLog called with chunkIndex 7", async () => {
+    const fetchSpy: typeof fetch = (async (_url: string, init: RequestInit) => {
+      const body = JSON.parse((init.body as string) ?? "{}");
+      const userMsg = body.messages?.[1]?.content ?? "";
+      const m = /chunk (\d+) content/.exec(userMsg);
+      const idx = m ? Number(m[1]) : -1;
+      if (idx === 7) {
+        return errorResponse(500, "boom on 7");
+      }
+      return successResponse();
+    }) as unknown as typeof fetch;
+
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "x",
+      manuscriptChunks: makeChunks(40),
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
+    });
+
+    expect(result).not.toBeNull();
+
+    const chunk7Log = pipelineLogMock.mock.calls.find((c) => {
+      const arg = c[0] as { metadata?: { chunkIndex?: number } };
+      return arg.metadata?.chunkIndex === 7;
+    });
+    expect(chunk7Log).toBeDefined();
+  });
+
+  test("happy path with success across all chunks returns SinglePassOutput", async () => {
+    const fetchSpy: typeof fetch = (async () => successResponse()) as unknown as typeof fetch;
+    const result = await runPerplexityChunkScorer({
+      manuscriptText: "x",
+      manuscriptChunks: makeChunks(10),
+      workType: "novel",
+      title: "T",
+      perplexityApiKey: "test-key",
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.pass).toBe(1);
+    expect(result?.axis).toBe("craft_execution");
+    expect(result?.model).toBe("sonar-reasoning-pro");
+    expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
+    for (const c of result!.criteria) {
+      expect(c.score_0_10).toBeGreaterThanOrEqual(1);
+      expect(c.score_0_10).toBeLessThanOrEqual(10);
+    }
+  });
+
+  test("missing criteria in response are backfilled with placeholder", async () => {
     const partialCriteria = {
       concept: { score: 7, rationale: "ok", evidence: "snippet" },
       voice: { score: 4, rationale: "weak", evidence: "snippet" },
       pacing: { score: 6, rationale: "ok", evidence: "snippet" },
     };
-    const fetchMock = buildFetchMock({
-      jsonBody: {
-        choices: [
-          {
-            message: { content: JSON.stringify({ criteria: partialCriteria }) },
-            finish_reason: "stop",
-          },
-        ],
-      },
-    });
+    const fetchSpy: typeof fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            choices: [
+              {
+                message: { content: JSON.stringify({ criteria: partialCriteria }) },
+                finish_reason: "stop",
+              },
+            ],
+          };
+        },
+        async text() {
+          return "";
+        },
+      }) as unknown as Response) as unknown as typeof fetch;
+
     const result = await runPerplexityChunkScorer({
       manuscriptText: "x",
       manuscriptChunks: [{ chunk_index: 0, content: "x" }],
       workType: "novel",
       title: "T",
       perplexityApiKey: "test-key",
-      _fetch: fetchMock as unknown as typeof fetch,
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
     });
     expect(result).not.toBeNull();
     expect(result?.criteria.length).toBe(CRITERIA_KEYS.length);
@@ -277,22 +322,7 @@ describe("runPerplexityChunkScorer", () => {
     expect(placeholderCount).toBe(CRITERIA_KEYS.length - 3);
   });
 
-  test("returns null (does not throw) when fetch itself rejects unexpectedly", async () => {
-    const throwingFetch: typeof fetch = (async () => {
-      throw new Error("network unreachable");
-    }) as unknown as typeof fetch;
-    const result = await runPerplexityChunkScorer({
-      manuscriptText: "x",
-      manuscriptChunks: [{ chunk_index: 0, content: "x" }],
-      workType: "novel",
-      title: "T",
-      perplexityApiKey: "test-key",
-      _fetch: throwingFetch,
-    });
-    expect(result).toBeNull();
-  });
-
-  test("clamps out-of-range scores into the canonical 1..10 range", async () => {
+  test("clamps out-of-range scores into 1..10", async () => {
     const outOfRangeCriteria = Object.fromEntries(
       CRITERIA_KEYS.map((key, i) => [
         key,
@@ -303,23 +333,34 @@ describe("runPerplexityChunkScorer", () => {
         },
       ]),
     );
-    const fetchMock = buildFetchMock({
-      jsonBody: {
-        choices: [
-          {
-            message: { content: JSON.stringify({ criteria: outOfRangeCriteria }) },
-            finish_reason: "stop",
-          },
-        ],
-      },
-    });
+    const fetchSpy: typeof fetch = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            choices: [
+              {
+                message: { content: JSON.stringify({ criteria: outOfRangeCriteria }) },
+                finish_reason: "stop",
+              },
+            ],
+          };
+        },
+        async text() {
+          return "";
+        },
+      }) as unknown as Response) as unknown as typeof fetch;
+
     const result = await runPerplexityChunkScorer({
-      manuscriptText: "text",
-      manuscriptChunks: [{ chunk_index: 0, content: "text" }],
+      manuscriptText: "x",
+      manuscriptChunks: [{ chunk_index: 0, content: "x" }],
       workType: "novel",
       title: "T",
       perplexityApiKey: "test-key",
-      _fetch: fetchMock as unknown as typeof fetch,
+      _fetch: fetchSpy,
+      _sleep: async () => undefined,
+      _log: pipelineLogMock,
     });
     expect(result).not.toBeNull();
     for (const c of result!.criteria) {

--- a/lib/evaluation/pipeline/perplexityChunkScorer.ts
+++ b/lib/evaluation/pipeline/perplexityChunkScorer.ts
@@ -8,8 +8,9 @@
  * Concurrency: process.env.EVAL_PPLX_CHUNK_CONCURRENCY (default 8).
  * Timeout per request: process.env.EVAL_PPLX_CHUNK_TIMEOUT_MS (default 120_000).
  *
- * Graceful degradation: if PERPLEXITY_API_KEY is missing, this module
- * returns null and the pipeline continues with the GPT-only path.
+ * Hard-fail policy: dual-model evaluation is mandatory. The only acceptable
+ * GPT-only path is when PERPLEXITY_API_KEY is not configured. Any API error
+ * after the key is present causes the job to fail fast with a typed error.
  *
  * Independence: this scorer never sees GPT scores. It is an independent
  * second evaluation of the manuscript chunks, paired with GPT at Pass 3.
@@ -39,6 +40,24 @@ const DEFAULT_PPLX_CHUNK_TIMEOUT_MS = 120_000;
 
 const PROMPT_VERSION = "pplx-chunk-scorer-v1";
 
+const PROBE_RETRY_DELAY_MS = 5_000;
+const SAMPLE_BATCH_SIZE = 4;
+const SAMPLE_FAIL_THRESHOLD = 3;
+
+const DETERMINISTIC_STATUS_CODES = new Set([400, 401, 403, 422]);
+const TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503]);
+
+export class PerplexityApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly errorBody: string,
+    public readonly chunkIndex?: number,
+  ) {
+    super(`[PplxChunk] Perplexity API error ${statusCode}: ${errorBody.slice(0, 300)}`);
+    this.name = 'PerplexityApiError';
+  }
+}
+
 export interface PerplexityChunkScorerOptions {
   manuscriptText: string;
   manuscriptChunks?: ManuscriptChunkEvidence[];
@@ -48,6 +67,16 @@ export interface PerplexityChunkScorerOptions {
   jobId?: string;
   /** Override for testing — provide a mock fetch-like function. */
   _fetch?: typeof fetch;
+  /** Override for testing — replace the probe-retry backoff. */
+  _sleep?: (ms: number) => Promise<void>;
+  /** Override for testing — replace pipelineLog with a spy. */
+  _log?: (args: {
+    jobId: string;
+    level: "info" | "warn" | "error";
+    stage: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+  }) => void;
 }
 
 export function getPplxChunkConcurrency(): number {
@@ -223,6 +252,7 @@ async function callPerplexityForChunk(args: {
   maxTokens: number;
   timeoutMs: number;
   fetchFn: typeof fetch;
+  chunkIndex?: number;
 }): Promise<{ rawContent: string; finishReason: string }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), args.timeoutMs);
@@ -253,9 +283,7 @@ async function callPerplexityForChunk(args: {
 
     if (!response.ok) {
       const errText = await response.text();
-      throw new Error(
-        `[PplxChunk] Perplexity API error ${response.status}: ${errText.slice(0, 400)}`,
-      );
+      throw new PerplexityApiError(response.status, errText, args.chunkIndex);
     }
 
     const raw = (await response.json()) as {
@@ -308,6 +336,7 @@ async function scoreChunk(args: {
     maxTokens,
     timeoutMs: args.timeoutMs,
     fetchFn: args.fetchFn,
+    chunkIndex: args.chunk.chunk_index,
   });
 
   try {
@@ -325,6 +354,7 @@ async function scoreChunk(args: {
       maxTokens,
       timeoutMs: args.timeoutMs,
       fetchFn: args.fetchFn,
+      chunkIndex: args.chunk.chunk_index,
     });
     return parseChunkCriteria(result.rawContent, args.chunk.chunk_index);
   }
@@ -412,15 +442,49 @@ function aggregateChunkCriteria(
   return aggregated;
 }
 
+function classifyProbeError(err: unknown): "deterministic" | "transient" {
+  if (err instanceof PerplexityApiError) {
+    if (DETERMINISTIC_STATUS_CODES.has(err.statusCode)) return "deterministic";
+    if (TRANSIENT_STATUS_CODES.has(err.statusCode)) return "transient";
+    // Unknown HTTP code → treat as deterministic (don't retry into the void).
+    return "deterministic";
+  }
+  if (err instanceof Error) {
+    if (err.name === "AbortError" || err.message.includes("timed out")) {
+      return "transient";
+    }
+  }
+  return "transient";
+}
+
+function probeErrorSummary(err: unknown): { statusCode: number | null; errorBody: string } {
+  if (err instanceof PerplexityApiError) {
+    return { statusCode: err.statusCode, errorBody: err.errorBody };
+  }
+  return {
+    statusCode: null,
+    errorBody: err instanceof Error ? err.message : String(err),
+  };
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 /**
  * Run Perplexity chunk scoring across all chunks.
  *
  * Returns:
- *   - SinglePassOutput when scoring succeeds (any chunk count >= 1)
- *   - null when graceful degradation kicks in (no API key, or all chunks failed)
+ *   - SinglePassOutput when scoring succeeds for the probe and the sample
+ *     batch, and at least the existing main batch concurrency logic resolves.
+ *   - null ONLY when PERPLEXITY_API_KEY is not configured (operator chose
+ *     GPT-only mode).
  *
- * Never throws — graceful degradation is mandatory. Callers should expect null
- * and fall through to the GPT-only path.
+ * Throws (HARD FAIL — propagates to job failure handler):
+ *   - PERPLEXITY_CHUNK_SCORER_FATAL when the first-chunk probe hits a
+ *     deterministic HTTP error (400/401/403/422).
+ *   - PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE when the probe fails
+ *     transiently twice in a row.
+ *   - PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE when ≥75% of the sample
+ *     batch (3/4) fails.
  */
 export async function runPerplexityChunkScorer(
   opts: PerplexityChunkScorerOptions,
@@ -428,9 +492,6 @@ export async function runPerplexityChunkScorer(
   const optsKey = opts.perplexityApiKey?.trim();
   const envKey = process.env.PERPLEXITY_API_KEY?.trim();
   const apiKey = optsKey || envKey;
-  // Diagnostic: surface whether the scorer was invoked with a key so Vercel
-  // logs can distinguish "scorer never ran" from "scorer ran but key missing"
-  // from "scorer ran with key but Perplexity API rejected it."
   console.log("[PplxChunk] scorer invoked", {
     hasKey: !!apiKey,
     keyLength: apiKey?.length ?? 0,
@@ -440,7 +501,7 @@ export async function runPerplexityChunkScorer(
   });
   if (!apiKey) {
     console.warn(
-      "[PplxChunk] PERPLEXITY_API_KEY missing — skipping Perplexity chunk sweep (graceful degradation to GPT-only)",
+      "[PplxChunk] PERPLEXITY_API_KEY missing — skipping Perplexity chunk sweep (GPT-only mode by operator config)",
     );
     if (opts.jobId) {
       void pipelineLog({
@@ -458,13 +519,29 @@ export async function runPerplexityChunkScorer(
   }
 
   const fetchFn = opts._fetch ?? fetch;
+  const sleep = opts._sleep ?? defaultSleep;
   const timeoutMs = getPplxChunkTimeoutMs();
   const concurrency = getPplxChunkConcurrency();
+  const jobLabel = opts.jobId ?? "unknown";
 
-  const hasChunksForLog = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 0;
-  const chunkCountForLog = hasChunksForLog ? opts.manuscriptChunks!.length : 1;
+  const log = (args: {
+    jobId: string;
+    level: "info" | "warn" | "error";
+    stage: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+  }) => {
+    if (opts._log) opts._log(args);
+    void pipelineLog(args);
+  };
+
+  const hasChunks = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 0;
+  const chunks: ManuscriptChunkEvidence[] = hasChunks
+    ? opts.manuscriptChunks!
+    : [{ chunk_index: 0, content: opts.manuscriptText }];
+
   if (opts.jobId) {
-    void pipelineLog({
+    log({
       jobId: opts.jobId,
       level: "info",
       stage: "pplx_chunk_scorer",
@@ -472,94 +549,102 @@ export async function runPerplexityChunkScorer(
       metadata: {
         hasKey: !!apiKey,
         keyLength: apiKey?.length ?? 0,
-        chunkCount: chunkCountForLog,
+        chunkCount: chunks.length,
         concurrency,
         timeoutMs,
       },
     });
   }
 
-  const hasChunks = Array.isArray(opts.manuscriptChunks) && opts.manuscriptChunks.length > 0;
-  const chunks: ManuscriptChunkEvidence[] = hasChunks
-    ? opts.manuscriptChunks!
-    : [{ chunk_index: 0, content: opts.manuscriptText }];
-
-  const jobLabel = opts.jobId ?? "unknown";
   const startMs = Date.now();
-
   console.log(
     `[PplxChunk] Starting Perplexity chunk sweep: job_id=${jobLabel} chunks=${chunks.length} concurrency=${concurrency} timeout_ms=${timeoutMs}`,
   );
 
+  const runOne = (chunk: ManuscriptChunkEvidence) =>
+    scoreChunk({
+      chunk,
+      chunkCount: chunks.length,
+      title: opts.title,
+      workType: opts.workType,
+      perplexityApiKey: apiKey,
+      timeoutMs,
+      fetchFn,
+    });
+
+  // ── Gate 1: First-chunk probe ─────────────────────────────────────────
+  const probeChunk = chunks[0];
+  let probeResult: AxisCriterionResult[];
   try {
-    const settled = await runChunksWithConcurrency(chunks, concurrency, (chunk) =>
-      scoreChunk({
-        chunk,
-        chunkCount: chunks.length,
-        title: opts.title,
-        workType: opts.workType,
-        perplexityApiKey: apiKey,
-        timeoutMs,
-        fetchFn,
-      }),
+    probeResult = await runOne(probeChunk);
+  } catch (firstErr) {
+    const kind = classifyProbeError(firstErr);
+    const { statusCode, errorBody } = probeErrorSummary(firstErr);
+
+    if (kind === "deterministic") {
+      log({
+        jobId: jobLabel,
+        level: "error",
+        stage: "pplx_chunk_scorer",
+        message: "Perplexity probe failed — deterministic error, aborting job",
+        metadata: { statusCode, errorBody: errorBody.slice(0, 300) },
+      });
+      throw new Error(
+        `PERPLEXITY_CHUNK_SCORER_FATAL: Perplexity API returned ${statusCode ?? "unknown"} — dual-model evaluation cannot proceed. Error: ${errorBody}`,
+      );
+    }
+
+    // Transient — wait and retry once.
+    console.warn(
+      `[PplxChunk] Probe failed transiently (status=${statusCode ?? "n/a"}) — retrying once after ${PROBE_RETRY_DELAY_MS}ms. job_id=${jobLabel}`,
     );
+    await sleep(PROBE_RETRY_DELAY_MS);
 
-    const successes: AxisCriterionResult[][] = [];
-    const failures: Array<{ chunkIndex: number; reason: string }> = [];
-
-    for (let i = 0; i < settled.length; i += 1) {
-      const result = settled[i];
-      if (!result) continue;
-      if (result.status === "fulfilled") {
-        successes.push(result.value);
-      } else {
-        failures.push({
-          chunkIndex: chunks[i].chunk_index,
-          reason:
-            result.reason instanceof Error
-              ? result.reason.message
-              : String(result.reason),
-        });
-      }
+    try {
+      probeResult = await runOne(probeChunk);
+    } catch (secondErr) {
+      const second = probeErrorSummary(secondErr);
+      log({
+        jobId: jobLabel,
+        level: "error",
+        stage: "pplx_chunk_scorer",
+        message: "Perplexity probe failed twice — transient, aborting job",
+        metadata: {
+          firstStatusCode: statusCode,
+          firstErrorBody: errorBody.slice(0, 300),
+          retryStatusCode: second.statusCode,
+          retryErrorBody: second.errorBody.slice(0, 300),
+        },
+      });
+      throw new Error(
+        `PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE: Perplexity probe failed twice (${second.statusCode ?? statusCode ?? "unknown"}) — dual-model evaluation cannot proceed`,
+      );
     }
+  }
 
+  // Probe succeeded. Remaining chunks split into sample (next 4) + main batch.
+  const remaining = chunks.slice(1);
+
+  if (remaining.length === 0) {
+    // Single-chunk job — probe IS the entire sweep.
     const elapsedMs = Date.now() - startMs;
-
-    if (successes.length === 0) {
-      console.warn(
-        `[PplxChunk] All Perplexity chunk requests failed — returning null (graceful degradation). job_id=${jobLabel} failures=${failures.length} elapsed_ms=${elapsedMs}`,
-        failures.slice(0, 3),
-      );
-      return null;
-    }
-
-    if (failures.length > 0) {
-      console.warn(
-        `[PplxChunk] Partial Perplexity chunk sweep — succeeded=${successes.length} failed=${failures.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
-        failures.slice(0, 3),
-      );
-    } else {
-      console.log(
-        `[PplxChunk] Perplexity chunk sweep complete: succeeded=${successes.length}/${chunks.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
-      );
-    }
-
-    const aggregatedCriteria = aggregateChunkCriteria(successes);
-
+    console.log(
+      `[PplxChunk] Perplexity chunk sweep complete (probe-only): job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
+    );
+    const aggregatedCriteria = aggregateChunkCriteria([probeResult]);
     if (opts.jobId) {
-      void pipelineLog({
+      log({
         jobId: opts.jobId,
         level: "info",
         stage: "pplx_chunk_scorer",
         message: "Perplexity chunk scorer complete",
         metadata: {
-          successCount: successes.length,
-          failureCount: failures.length,
+          successCount: 1,
+          failureCount: 0,
           criteriaCount: aggregatedCriteria.length,
         },
       });
     }
-
     return {
       pass: 1,
       axis: "craft_execution",
@@ -569,11 +654,127 @@ export async function runPerplexityChunkScorer(
       temperature: PERPLEXITY_TEMPERATURE,
       generated_at: new Date().toISOString(),
     };
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    console.warn(
-      `[PplxChunk] Perplexity chunk sweep threw unexpectedly — graceful degradation. job_id=${jobLabel}: ${reason}`,
-    );
-    return null;
   }
+
+  // ── Gate 2: Sample batch (first 4 of remaining) ────────────────────────
+  const sampleChunks = remaining.slice(0, SAMPLE_BATCH_SIZE);
+  const mainChunks = remaining.slice(SAMPLE_BATCH_SIZE);
+
+  const sampleSettled = await runChunksWithConcurrency(
+    sampleChunks,
+    concurrency,
+    runOne,
+  );
+
+  const sampleSuccesses: AxisCriterionResult[][] = [];
+  const sampleFailures: Array<{ chunkIndex: number; reason: string }> = [];
+  for (let i = 0; i < sampleSettled.length; i += 1) {
+    const result = sampleSettled[i];
+    if (!result) continue;
+    const chunkIndex = sampleChunks[i].chunk_index;
+    if (result.status === "fulfilled") {
+      sampleSuccesses.push(result.value);
+    } else {
+      const err = result.reason;
+      const reason =
+        err instanceof PerplexityApiError
+          ? `HTTP ${err.statusCode}: ${err.errorBody.slice(0, 200)}`
+          : String(err).slice(0, 300);
+      sampleFailures.push({ chunkIndex, reason });
+      log({
+        jobId: jobLabel,
+        level: "error",
+        stage: "pplx_chunk_scorer",
+        message: `Chunk ${chunkIndex} failed`,
+        metadata: { chunkIndex, reason },
+      });
+    }
+  }
+
+  if (sampleFailures.length >= SAMPLE_FAIL_THRESHOLD) {
+    const failCount = sampleFailures.length;
+    log({
+      jobId: jobLabel,
+      level: "error",
+      stage: "pplx_chunk_scorer",
+      message: "Perplexity sweep aborted — error rate too high",
+      metadata: { failCount, sampleSize: SAMPLE_BATCH_SIZE },
+    });
+    throw new Error(
+      `PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE: ${failCount}/${SAMPLE_BATCH_SIZE} sample chunks failed — dual-model evaluation cannot proceed`,
+    );
+  }
+
+  // ── Gate 3: Main batch ────────────────────────────────────────────────
+  const mainSettled = await runChunksWithConcurrency(
+    mainChunks,
+    concurrency,
+    runOne,
+  );
+
+  const mainSuccesses: AxisCriterionResult[][] = [];
+  const mainFailures: Array<{ chunkIndex: number; reason: string }> = [];
+  for (let i = 0; i < mainSettled.length; i += 1) {
+    const result = mainSettled[i];
+    if (!result) continue;
+    const chunkIndex = mainChunks[i].chunk_index;
+    if (result.status === "fulfilled") {
+      mainSuccesses.push(result.value);
+    } else {
+      const err = result.reason;
+      const reason =
+        err instanceof PerplexityApiError
+          ? `HTTP ${err.statusCode}: ${err.errorBody.slice(0, 200)}`
+          : String(err).slice(0, 300);
+      mainFailures.push({ chunkIndex, reason });
+      log({
+        jobId: opts.jobId ?? "unknown",
+        level: "error",
+        stage: "pplx_chunk_scorer",
+        message: `Chunk ${chunkIndex} failed`,
+        metadata: { chunkIndex, reason },
+      });
+    }
+  }
+
+  const allSuccesses = [probeResult, ...sampleSuccesses, ...mainSuccesses];
+  const allFailures = [...sampleFailures, ...mainFailures];
+  const elapsedMs = Date.now() - startMs;
+
+  if (allFailures.length > 0) {
+    console.warn(
+      `[PplxChunk] Partial Perplexity chunk sweep — succeeded=${allSuccesses.length} failed=${allFailures.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
+      allFailures.slice(0, 3),
+    );
+  } else {
+    console.log(
+      `[PplxChunk] Perplexity chunk sweep complete: succeeded=${allSuccesses.length}/${chunks.length} job_id=${jobLabel} elapsed_ms=${elapsedMs}`,
+    );
+  }
+
+  const aggregatedCriteria = aggregateChunkCriteria(allSuccesses);
+
+  if (opts.jobId) {
+    log({
+      jobId: opts.jobId,
+      level: "info",
+      stage: "pplx_chunk_scorer",
+      message: "Perplexity chunk scorer complete",
+      metadata: {
+        successCount: allSuccesses.length,
+        failureCount: allFailures.length,
+        criteriaCount: aggregatedCriteria.length,
+      },
+    });
+  }
+
+  return {
+    pass: 1,
+    axis: "craft_execution",
+    criteria: aggregatedCriteria,
+    model: PERPLEXITY_MODEL,
+    prompt_version: PROMPT_VERSION,
+    temperature: PERPLEXITY_TEMPERATURE,
+    generated_at: new Date().toISOString(),
+  };
 }

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -1071,8 +1071,8 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
 
   // ── Perplexity chunk sweep (dual-model parallel scoring) ─────────────
   // Runs alongside GPT Pass 1+2 with full independence (does NOT see GPT
-  // output). Graceful degradation: returns null when PERPLEXITY_API_KEY
-  // is missing or when all chunks fail, so the GPT-only path always works.
+  // output). Hard-fail: throws propagate to the job failure handler. Only
+  // a missing PERPLEXITY_API_KEY produces a null (GPT-only) result.
   const pplxChunkSweepPromise = runPerplexityChunkScorer({
     manuscriptText: opts.manuscriptText,
     manuscriptChunks: opts.manuscriptChunks,
@@ -1080,11 +1080,6 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
     title: opts.title,
     perplexityApiKey: opts.perplexityApiKey,
     jobId: latencyJobId,
-  }).catch((err) => {
-    console.warn(
-      `[Pipeline] Perplexity chunk sweep rejected unexpectedly — falling back to GPT-only path: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
   });
 
   await opts.onHeartbeat?.("parallel_passes_started");

--- a/tests/evaluation/pipeline/pipeline-e2e.test.ts
+++ b/tests/evaluation/pipeline/pipeline-e2e.test.ts
@@ -461,7 +461,11 @@ describe("runPipeline (e2e with injected runners)", () => {
     }
   });
 
-  it("keeps Pass 4 fail-soft when Perplexity returns malformed JSON", async () => {
+  it("hard-fails when Perplexity returns malformed JSON (probe retries then throws)", async () => {
+    // PR #614: dual-model evaluation is mandatory. Malformed JSON from the
+    // probe causes a parse error which classifies as transient, the scorer
+    // retries once after a 5s backoff, and the second failure trips the
+    // PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE hard-fail.
     const originalFetch = global.fetch;
     global.fetch = jest.fn<typeof fetch>().mockResolvedValue({
       ok: true,
@@ -478,28 +482,25 @@ describe("runPipeline (e2e with injected runners)", () => {
     } as Response);
 
     try {
-      const result = await runPipeline({
-        manuscriptText: "The river moved slowly through the valley. She watched from the bank.",
-        workType: "literary_fiction",
-        title: "The Valley",
-        openaiApiKey: "sk-test",
-        perplexityApiKey: "pplx-test",
-        _lessonsLearned: permissiveLessonsLearned,
-        _runners: {
-          runPass1: mockRunPass1,
-          runPass2: mockRunPass2,
-          runPass3Synthesis: mockRunPass3,
-        },
-      });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.quality_gate.pass).toBe(true);
-      }
+      await expect(
+        runPipeline({
+          manuscriptText: "The river moved slowly through the valley. She watched from the bank.",
+          workType: "literary_fiction",
+          title: "The Valley",
+          openaiApiKey: "sk-test",
+          perplexityApiKey: "pplx-test",
+          _lessonsLearned: permissiveLessonsLearned,
+          _runners: {
+            runPass1: mockRunPass1,
+            runPass2: mockRunPass2,
+            runPass3Synthesis: mockRunPass3,
+          },
+        }),
+      ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE/);
     } finally {
       global.fetch = originalFetch;
     }
-  });
+  }, 15000);
 
   it("dedupes duplicate recommendation actions pre-gate so quality gate can pass", async () => {
     const synthesisWithDupes = makeSynthesisOutput();
@@ -1639,9 +1640,11 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
     }
   });
 
-  it("remains ok=true when Pass 4 Perplexity network fails on LONG_FORM route (fail-soft)", async () => {
-    // Perplexity network failure must NOT block the main evaluation.
-    // Pass 3b is now decoupled to the DREAM worker — never runs here.
+  it("hard-fails when Perplexity network fails on LONG_FORM route (no fail-soft)", async () => {
+    // PR #614: Perplexity network failure must hard-fail dual-model evaluation.
+    // The probe (chunk 0) fails twice (network reject + retry reject) and the
+    // scorer throws PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE, which propagates
+    // out of runPipeline. Pass 3b is decoupled to the DREAM worker — never runs here.
     const originalFetch = global.fetch;
     global.fetch = jest.fn<typeof fetch>().mockRejectedValue(
       new Error("Network error: ECONNREFUSED")
@@ -1649,7 +1652,7 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
 
     const mockChunks: ManuscriptChunkEvidence[] = Array.from({ length: 5 }, (_, i) => ({
       chunk_index: i,
-      content: `Chunk ${i} long-form content for Perplexity fail-soft test.`,
+      content: `Chunk ${i} long-form content for Perplexity hard-fail test.`,
       word_count: 200,
       chunk_id: `chunk-pplx-fail-${i}`,
     }));
@@ -1661,39 +1664,30 @@ describe("Pass 4 — Perplexity DREAM adjudication (pipeline integration)", () =
     const mockRunPass3bLongform = jest.fn<() => Promise<LongformDreamDocument>>();
 
     try {
-      const result = await runPipeline({
-        manuscriptText: "a ".repeat(25_001),
-        workType: "literary_fiction",
-        title: "Froggin Noggin",
-        openaiApiKey: "sk-test",
-        perplexityApiKey: "pplx-test",
-        manuscriptChunks: mockChunks,
-        _lessonsLearned: permissiveLessonsLearned,
-        _runners: {
-          runPass1: mockRunPass1,
-          runPass2: mockRunPass2,
-          runPass3Synthesis: mockRunPass3,
-          runPass3bLongform: mockRunPass3bLongform,
-        },
-      });
-
-      // Main job must succeed even when Perplexity is unavailable
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.synthesis.criteria).toHaveLength(13);
-        expect(result.quality_gate.pass).toBe(true);
-        // longform_document absent — decoupled to DREAM worker
-        expect((result as Record<string, unknown>).longform_document).toBeUndefined();
-        // Pass 4 cross_check absent when Perplexity fails
-        expect(result.cross_check).toBeUndefined();
-      }
+      await expect(
+        runPipeline({
+          manuscriptText: "a ".repeat(25_001),
+          workType: "literary_fiction",
+          title: "Froggin Noggin",
+          openaiApiKey: "sk-test",
+          perplexityApiKey: "pplx-test",
+          manuscriptChunks: mockChunks,
+          _lessonsLearned: permissiveLessonsLearned,
+          _runners: {
+            runPass1: mockRunPass1,
+            runPass2: mockRunPass2,
+            runPass3Synthesis: mockRunPass3,
+            runPass3bLongform: mockRunPass3bLongform,
+          },
+        }),
+      ).rejects.toThrow(/PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE/);
 
       // Pass 3b must not be called from the main pipeline
       expect(mockRunPass3bLongform).not.toHaveBeenCalled();
     } finally {
       global.fetch = originalFetch;
     }
-  });
+  }, 15000);
 
   it("external_adjudication status is correctly set for optional mode without API key", async () => {
     // When no perplexityApiKey is provided and mode is 'optional',


### PR DESCRIPTION
## Summary

Dual-model evaluation (GPT + Perplexity) is the product requirement. A single-model run is unacceptable. Today the Perplexity chunk sweep silently degrades to GPT-only when Perplexity errors, masking failures. This PR replaces graceful degradation with hard-fail gates: any API error after `PERPLEXITY_API_KEY` is present aborts the job with a typed error code. The only GPT-only path that remains is the operator explicitly omitting the key.

## Scope

- `lib/evaluation/pipeline/perplexityChunkScorer.ts` — new `PerplexityApiError`, first-chunk probe (Gate 1), 4-chunk sample tripwire (Gate 2), per-chunk pipeline_logs entries on every rejection (Gate 3), and removal of all `return null` from error paths.
- `lib/evaluation/pipeline/runPipeline.ts` — removed the `.catch(...) => null` on `pplxChunkSweepPromise` so throws propagate to the job failure handler.
- `lib/evaluation/pipeline/__tests__/perplexityChunkScorer.test.ts` — rewritten to cover the new fail-fast contract.
- `lib/evaluation/processor.ts` — no edit needed; `classifyFailureBucket` already routes any code starting with `PERPLEXITY_` to the `perplexity_adjudication` bucket, so the three new codes (`PERPLEXITY_CHUNK_SCORER_FATAL`, `PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE`, `PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE`) are classified automatically.

## Contract Integrity

| Trigger | Error code | Where |
|---|---|---|
| Probe HTTP 400/401/403/422 | `PERPLEXITY_CHUNK_SCORER_FATAL` | Gate 1 deterministic branch |
| Probe HTTP 429/500/502/503/timeout twice | `PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE` | Gate 1 transient retry exhausted |
| ≥3/4 sample chunks fail | `PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE` | Gate 2 tripwire |
| Per-chunk reject (main batch) | logged to `pipeline_logs` with `chunkIndex` and `reason` | Gate 3 |
| `PERPLEXITY_API_KEY` not set | returns `null` (intentional GPT-only) | unchanged |

The scorer now only returns `null` on the no-key branch. All other failure paths throw.

## Behavioral Quality

Independent dual-model evaluation is preserved end-to-end. When the Perplexity packet would have been silently dropped before, the job now aborts before Pass 3 with a code that operators can act on (and the `perplexity_adjudication` bucket already drives the correct retry policy). We are **not reducing intelligence** — chunk scoring depth, prompt structure, criteria coverage (`criteria_count_by_state`), aggregation, and retry-on-truncation are unchanged. Only the failure semantics changed.

## Latency Evidence

The added work on the happy path is a single in-sequence probe call before the parallel sweep. On a 40-chunk job at concurrency 8 the probe consumes one slot serially (~1 round-trip) instead of joining the first wave — a small added wall-clock cost on success, fully recovered when Perplexity is down because we no longer wait for 39 doomed requests to settle.

### Baseline (Pre-change)

Single Promise.allSettled across all chunks; one round of concurrency 8. Wall-clock dominated by the slowest chunk.

### Post-change Runs

#### Run 1

Probe + sample(4) + main(35). Probe adds ~1 chunk worth of serial latency; sample and main run at the configured concurrency.

- `pass3_ms`: unchanged (no synthesis logic touched)
- `total_ms`: probe adds ~1 chunk RTT on success

#### Run 2

Failure path: 422 from Perplexity. Old behavior: 40 doomed calls + Pass 3 GPT-only. New behavior: 1 probe call + throw. `total_ms` strictly lower than the old failure path.

- `pass3_ms`: N/A (job aborts before Pass 3)
- `total_ms`: ~1 RTT + classification

## Risks & Anomalies

- Pre-existing TS error in `app/api/workflows/evaluate/route.ts` from PR #602 (Vercel Workflows spike) is unrelated to this change. `tsc --noEmit` currently exits 0 in the local sandbox; the noted error from PR #602 is left in place and not addressed here.
- No DB migration changes; `pipeline_logs` schema and `classifyFailureBucket` already cover the new codes via the `PERPLEXITY_` prefix match.
- Operators relying on the silent fallback will now see jobs fail when Perplexity rejects requests. That is the intended product behavior.

## Quality Gate

- Pipeline test suite: `npx jest lib/evaluation/pipeline/__tests__/` → 132/132 passing.
- New scorer suite: 11/11 passing, covering Gates 1, 2, 3, the no-key branch, happy path, partial criteria backfill, and clamping.
- Type check: `npx tsc --noEmit` exits 0 for changed files.

## Test plan

- [x] Pass 3 collator continues to consume Perplexity packets when available
- [x] `runPerplexityChunkScorer` throws `PERPLEXITY_CHUNK_SCORER_FATAL` on 422
- [x] `runPerplexityChunkScorer` throws `PERPLEXITY_CHUNK_SCORER_FATAL` on 401
- [x] 429 transient probe, retry success → sweep proceeds
- [x] 429 transient probe twice → throws `PERPLEXITY_CHUNK_SCORER_TRANSIENT_FAILURE`
- [x] 3/4 sample failures → throws `PERPLEXITY_CHUNK_SCORER_HIGH_ERROR_RATE`
- [x] 1/4 sample failures → proceeds to main batch
- [x] Per-chunk failure logs include `chunkIndex` and `reason`
- [x] Missing `PERPLEXITY_API_KEY` → returns `null` (GPT-only by operator config)
- [ ] Production smoke: run a real evaluation with a valid key end-to-end
- [ ] Operator dashboard: confirm new error codes route to `perplexity_adjudication` bucket