### PR TITLE
fix(config): revert withWorkflow wrapper — breaks runtime worker route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,4 +22,5 @@ const nextConfig = {
   },
 };
 
+// Keep Next config unwrapped until Vercel Workflows is fully production-wired.
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,3 @@
-// Vercel Workflows SDK integration (spike: feat/vercel-workflows-spike)
-// withWorkflow() enables 'use workflow' and 'use step' directive transforms.
-// Safe to add now — has no effect until WORKFLOW_EVALUATION_ENABLED=true.
-import { withWorkflow } from 'workflow/next';
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -27,4 +22,4 @@ const nextConfig = {
   },
 };
 
-export default withWorkflow(nextConfig);
+export default nextConfig;


### PR DESCRIPTION
## Summary
Reverts `withWorkflow()` wrapper from `next.config.mjs` introduced by PR #602 (Vercel Workflows RFC). The wrapper is causing the evaluation worker route to crash at runtime before executing any code — jobs are being killed by the frozen-heartbeat guard after 60 seconds with no pipeline logs written and no preflight output.

Evidence: job `e9a02fd6` — created 20:21:35, killed 20:22:38 (63 seconds), zero pipeline_logs entries, `progress` still showing 'Job created'. Worker was claimed but crashed on startup.

## Scope
- `next.config.mjs` — remove `withWorkflow` import and wrapper, restore `export default nextConfig`
- No other files changed

## CI/Infra Scope
- Two-line revert of `next.config.mjs`
- Removes `withWorkflow` wrapper that was wrapping ALL routes at the module transform level
- `workflow` package remains in `package.json` — no dependency changes

## Rollback Plan
- Re-introduce `withWorkflow` wrapper if needed. The original PR #602 diff is preserved in git history.
- The `WORKFLOW_EVALUATION_ENABLED` env var guards the workflow trigger route independently.

## Affected Workflows
- Evaluation pipeline worker route (`app/api/workers/`) — restored to functional state
- All other routes: no change (the wrapper was removed, not added, so no new wrapping)
- No CI workflows affected

No-Pipeline-Impact: false — this RESTORES pipeline execution (worker was crashing on startup before this revert)

## Risks & Anomalies
- The Vercel Workflows spike (PR #602) should be revisited as a proper implementation with the `withWorkflow` wrapper only enabled when the workflow route is fully wired into `app/api/evaluate/route.ts`.
- Risk of regression is minimal — this is a two-line revert to a previously working config.