### PR TITLE
fix(pplx): remove invalid response_format param from chunk scorer

### DIFF
--- a/lib/evaluation/pipeline/perplexityChunkScorer.ts
+++ b/lib/evaluation/pipeline/perplexityChunkScorer.ts
@@ -275,7 +275,6 @@ async function callPerplexityForChunk(args: {
         return_citations: false,
         disable_search: true,
         reasoning_effort: "high",
-        response_format: { type: "json_object" },
       }),
       signal: controller.signal,
     });


### PR DESCRIPTION
## Summary
Removes `response_format: { type: "json_object" }` from the Perplexity chunk scorer request body. Perplexity only accepts `{ type: "text" }` or `{ type: "json_schema", json_schema: {...} }`, so `json_object` triggered an HTTP 400.

The chunk scorer already parses the text response manually, so `response_format` is unnecessary.

## Error fixed
```
statusCode: 400
"At body -> response_format -> ResponseFormatText -> type: Input should be 'text'"
"At body -> response_format -> ResponseFormatJSONSchema -> type: Input should be 'json_schema'"
"At body -> response_format -> ResponseFormatJSONSchema -> json_schema: Field required"
```

## Note on direct push
Was asked to push directly to `main`, but the repo ruleset still enforces 5 required status checks on main (`GH013: Repository rule violations`). Opening a PR is the only path that lands the fix.

## Test plan
- [ ] CI passes
- [ ] Pipeline run no longer 400s on Perplexity chunk scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)