### PR TITLE
fix(secrets): normalize Supabase secret names — remove _CI suffix variants

### DIFF
--- a/.github/pr-bodies/PR-624.md
+++ b/.github/pr-bodies/PR-624.md
@@ -1,0 +1,30 @@
+## What
+
+Removes the three legacy `_CI` Supabase secret variants that existed only in `ci.yml` and served no functional purpose beyond adding cognitive load and rotation surface.
+
+Also fixes a latent bug in `guards.ts` where checking `SUPABASE_URL && NEXT_PUBLIC_SUPABASE_URL` simultaneously could fire false-positive production guards if either name was populated but not the other.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | `SUPABASE_URL_CI` → `SUPABASE_URL`, `SUPABASE_ANON_KEY_CI` → `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY_CI` → `SUPABASE_SERVICE_ROLE_KEY` |
+| `lib/jobs/guards.ts` | Single guard on `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — removes dual-check anti-pattern |
+| `lib/supabase/admin.ts` | Error message: remove stale `_CI` secret names |
+| `lib/supabase/adminClient.js` | Same |
+| `docs/SECRET_REGISTRY.md` | Mark `_CI` variants deleted, document post-merge manual cleanup |
+
+## After merge (manual step required)
+
+Once CI is **green**, delete these 3 secrets from [GitHub repo settings → Secrets](https://github.com/Mmeraw/literary-ai-partner/settings/secrets/actions):
+- `SUPABASE_URL_CI`
+- `SUPABASE_ANON_KEY_CI`
+- `SUPABASE_SERVICE_ROLE_KEY_CI`
+
+**Do not delete before CI confirms green.** The canonical secrets (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) must already exist in repo settings — they do, they're used by `job-system-ci.yml` today.
+
+## What this does NOT do
+
+- Does not rename `PROD_SUPABASE_*` — the `PROD_` prefix is intentional isolation between CI and production
+- Does not rename `SUPABASE_STRESS_URL` — purpose-named, separate project
+- Does not collapse `SUPABASE_URL` / `SUPABASE_ANON_KEY` server aliases — `admin.ts` fallback is acceptable as-is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOBSYSTEM_ENV: ci
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL_CI }}
-      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_CI }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY_CI }}
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL_CI }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_CI }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
       USE_SUPABASE_JOBS: "true"
       TEST_MODE: "true"
     steps:

--- a/docs/SECRET_REGISTRY.md
+++ b/docs/SECRET_REGISTRY.md
@@ -14,17 +14,17 @@ Single source of truth for all environment/secret names used across workflows an
 |---|---|---|---|
 | `NEXT_PUBLIC_SUPABASE_URL` | ✅ canonical | `process-evaluations/route.ts`, `process-dream/route.ts`, Next.js client bundle | Required to have `NEXT_PUBLIC_` prefix for client bundle inclusion |
 | `SUPABASE_URL` | ⚠️ alias | `job-system-ci.yml`, `guards.ts`, CI scripts | Server-side alias for same value. Fallback chain: `NEXT_PUBLIC_SUPABASE_URL \|\| SUPABASE_URL` |
-| `SUPABASE_URL_CI` | ❌ legacy | `ci.yml` only | Same project URL, `_CI` suffix added historically — no functional difference. Normalize → `SUPABASE_URL` |
+| ~~`SUPABASE_URL_CI`~~ | ✅ deleted | was `ci.yml` only | Removed — `ci.yml` now reads `SUPABASE_URL` directly. Delete this secret from GitHub repo settings. |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✅ canonical | Next.js client bundle, `phase1-evidence.yml`, `phase2d-evidence.yml` | Safe for browser |
-| `SUPABASE_ANON_KEY` | ⚠️ alias | `phase1-evidence.yml`, `phase2d-evidence.yml`, `guards.ts` | Server-side alias. Normalize → always use `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
-| `SUPABASE_ANON_KEY_CI` | ❌ legacy | `ci.yml` only | Same value, `_CI` suffix. Normalize → `SUPABASE_ANON_KEY` |
+| `SUPABASE_ANON_KEY` | ⚠️ alias | `phase1-evidence.yml`, `phase2d-evidence.yml` | Server-side alias. Acceptable — no dual-check anti-pattern remaining. |
+| ~~`SUPABASE_ANON_KEY_CI`~~ | ✅ deleted | was `ci.yml` only | Removed — `ci.yml` now reads `SUPABASE_ANON_KEY` directly. Delete this secret from GitHub repo settings. |
 
 ## Supabase — Server-only secrets
 
 | Secret name | Canonical? | Where used | Notes |
 |---|---|---|---|
 | `SUPABASE_SERVICE_ROLE_KEY` | ✅ canonical | workers, guards, all CI jobs | Must never reach client bundle |
-| `SUPABASE_SERVICE_ROLE_KEY_CI` | ❌ legacy | `ci.yml` only | Same value. Normalize → `SUPABASE_SERVICE_ROLE_KEY` |
+| ~~`SUPABASE_SERVICE_ROLE_KEY_CI`~~ | ✅ deleted | was `ci.yml` only | Removed — `ci.yml` now reads `SUPABASE_SERVICE_ROLE_KEY` directly. Delete this secret from GitHub repo settings. |
 | `SUPABASE_ACCESS_TOKEN` | ✅ canonical | `prod-alignment-guard.yml`, `job-system-ci.yml` | Supabase management API token (not a DB credential) |
 | `SUPABASE_PROJECT_REF` | ✅ canonical | `job-system-ci.yml` | CI/shared project ref |
 | `SUPABASE_DB_URL` | ✅ canonical | `job-system-ci.yml` | postgres:// connection string for CI project |
@@ -54,14 +54,23 @@ Single source of truth for all environment/secret names used across workflows an
 
 ---
 
-## Normalization Backlog
+## Normalization Status
 
-When ready to normalize, do these atomically (one PR):
+✅ **Done (this PR):**
+1. Deleted `SUPABASE_URL_CI` from `ci.yml` → now reads `SUPABASE_URL`
+2. Deleted `SUPABASE_ANON_KEY_CI` from `ci.yml` → now reads `SUPABASE_ANON_KEY`
+3. Deleted `SUPABASE_SERVICE_ROLE_KEY_CI` from `ci.yml` → now reads `SUPABASE_SERVICE_ROLE_KEY`
+4. Fixed `guards.ts` dual-check anti-pattern → single guard on `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+5. Removed stale `_CI` secret references from error messages in `admin.ts` and `adminClient.js`
 
-1. **Delete `SUPABASE_URL_CI`** — replace with `SUPABASE_URL` in `ci.yml`
-2. **Delete `SUPABASE_ANON_KEY_CI`** — replace with `SUPABASE_ANON_KEY` in `ci.yml`
-3. **Delete `SUPABASE_SERVICE_ROLE_KEY_CI`** — replace with `SUPABASE_SERVICE_ROLE_KEY` in `ci.yml`
-4. **Consolidate `SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_URL`** — pick one canonical name at each usage site (server = `SUPABASE_URL`, client = `NEXT_PUBLIC_SUPABASE_URL`)
-5. **Fix `guards.ts:73-78`** — remove the dual-check; guard on `NEXT_PUBLIC_SUPABASE_URL` for client paths only, `SUPABASE_URL` for server
+⚠️ **Action required (manual — cannot be done in code):**
+Once this PR is merged and CI is green, delete these 3 secrets from GitHub repo settings:
+- `SUPABASE_URL_CI`
+- `SUPABASE_ANON_KEY_CI`
+- `SUPABASE_SERVICE_ROLE_KEY_CI`
 
-**Prerequisite:** All three `_CI` secrets must exist in GitHub repo settings until `ci.yml` is updated. Do not delete secrets before the workflow is updated.
+**Do not delete them before CI confirms green** — if something regresses mid-merge, you want the option to roll back.
+
+⏳ **Future (separate PR, not urgent):**
+- Consolidate `SUPABASE_URL` server-alias usage — `admin.ts` fallback chain `NEXT_PUBLIC_SUPABASE_URL || SUPABASE_URL` is acceptable for now
+- Collapse `SUPABASE_ANON_KEY` server alias if all consumer paths migrate to `NEXT_PUBLIC_SUPABASE_ANON_KEY`

--- a/lib/jobs/guards.ts
+++ b/lib/jobs/guards.ts
@@ -69,13 +69,20 @@ export function validateProductionConfig(): {
       errors.push("USE_SUPABASE_JOBS must be 'true' in production");
     }
     
-    // Critical: Supabase connection
-    if (!process.env.SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_URL) {
-      errors.push("SUPABASE_URL is required in production");
+    // Critical: Supabase connection.
+    // NEXT_PUBLIC_SUPABASE_URL is the canonical client-facing name (required by Next.js
+    // for browser bundle inclusion). SUPABASE_URL is the server-side alias — admin.ts
+    // reads whichever is present via `NEXT_PUBLIC_SUPABASE_URL || SUPABASE_URL`.
+    // Guard on NEXT_PUBLIC_SUPABASE_URL as the single source of truth here; if it's
+    // missing the client bundle is broken regardless of SUPABASE_URL.
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
+      errors.push("NEXT_PUBLIC_SUPABASE_URL is required in production");
     }
-    
-    if (!process.env.SUPABASE_ANON_KEY || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-      errors.push("SUPABASE_ANON_KEY is required in production");
+
+    // NEXT_PUBLIC_SUPABASE_ANON_KEY is the canonical client-facing name.
+    // SUPABASE_ANON_KEY is the server-side alias. Same reasoning as above.
+    if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+      errors.push("NEXT_PUBLIC_SUPABASE_ANON_KEY is required in production");
     }
     
     // Warning: Rate limiting works better with these

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -44,14 +44,14 @@ export function createAdminClient(
 
     if (!url) {
       throw new Error(
-        "Missing Supabase URL. Expected NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL. " +
-        "In CI, ensure SUPABASE_URL_CI secret is set and workflow overrides canonical names."
+        "Missing Supabase URL. Expected NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL as server-side alias). " +
+        "In CI, the workflow injects these from the canonical SUPABASE_URL / SUPABASE_ANON_KEY repository secrets."
       );
     }
 
     throw new Error(
       "Missing SUPABASE_SERVICE_ROLE_KEY. " +
-      "In CI, ensure SUPABASE_SERVICE_ROLE_KEY_CI secret is set and workflow overrides canonical names."
+      "In CI, the workflow injects this from the canonical SUPABASE_SERVICE_ROLE_KEY repository secret."
     );
   }
 

--- a/lib/supabase/adminClient.js
+++ b/lib/supabase/adminClient.js
@@ -16,14 +16,14 @@ export function createAdminClient(options = {}) {
 
     if (!url) {
       throw new Error(
-        "Missing Supabase URL. Expected NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL. " +
-          "In CI, ensure SUPABASE_URL_CI secret is set and workflow overrides canonical names."
+        "Missing Supabase URL. Expected NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL as server-side alias). " +
+          "In CI, the workflow injects these from the canonical SUPABASE_URL / SUPABASE_ANON_KEY repository secrets."
       );
     }
 
     throw new Error(
       "Missing SUPABASE_SERVICE_ROLE_KEY. " +
-        "In CI, ensure SUPABASE_SERVICE_ROLE_KEY_CI secret is set and workflow overrides canonical names."
+        "In CI, the workflow injects this from the canonical SUPABASE_SERVICE_ROLE_KEY repository secret."
     );
   }
 


### PR DESCRIPTION
## What

Removes the three legacy `_CI` Supabase secret variants that existed only in `ci.yml` and served no functional purpose beyond adding cognitive load and rotation surface.

Also fixes a latent bug in `guards.ts` where checking `SUPABASE_URL && NEXT_PUBLIC_SUPABASE_URL` simultaneously could fire false-positive production guards if either name was populated but not the other.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `SUPABASE_URL_CI` → `SUPABASE_URL`, `SUPABASE_ANON_KEY_CI` → `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY_CI` → `SUPABASE_SERVICE_ROLE_KEY` |
| `lib/jobs/guards.ts` | Single guard on `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — removes dual-check anti-pattern |
| `lib/supabase/admin.ts` | Error message: remove stale `_CI` secret names |
| `lib/supabase/adminClient.js` | Same |
| `docs/SECRET_REGISTRY.md` | Mark `_CI` variants deleted, document post-merge manual cleanup |

## After merge (manual step required)

Once CI is **green**, delete these 3 secrets from [GitHub repo settings → Secrets](https://github.com/Mmeraw/literary-ai-partner/settings/secrets/actions):
- `SUPABASE_URL_CI`
- `SUPABASE_ANON_KEY_CI`
- `SUPABASE_SERVICE_ROLE_KEY_CI`

**Do not delete before CI confirms green.** The canonical secrets (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) must already exist in repo settings — they do, they're used by `job-system-ci.yml` today.

## What this does NOT do

- Does not rename `PROD_SUPABASE_*` — the `PROD_` prefix is intentional isolation between CI and production
- Does not rename `SUPABASE_STRESS_URL` — purpose-named, separate project
- Does not collapse `SUPABASE_URL` / `SUPABASE_ANON_KEY` server aliases — `admin.ts` fallback is acceptable as-is