### PR TITLE
feat(ledger): persist response packet before Stage 2

### DIFF
--- a/.github/pr-bodies/PR-627.md
+++ b/.github/pr-bodies/PR-627.md
@@ -1,0 +1,40 @@
+## Summary
+
+Adds the first wiring substrate for the interactive Story Ledger approval model:
+
+- adds `ledger_response_packet_v1` to the canonical evaluation artifact type union
+- updates the Story Ledger server actions so `Submit Feedback` can persist a mutable response packet
+- updates approval so `Approve Ledger` writes/reuses the response packet and queues `phase_2`
+- stores the response packet id in job progress so Phase 2 can consume it as the correction overlay
+
+## Architecture
+
+This follows the staged ledger model: Phase 1A writes `pass1a_character_ledger_v1`, the UI collects user/operator corrections and comments, and approval produces `ledger_response_packet_v1` as Phase 2 input.
+
+The packet is intended to include:
+
+- character corrections: merge/split/rename/flag antagonist/reassign POV/no-change
+- alias overrides
+- POV owner overrides
+- object/symbol notes
+- antagonist flags added
+- global comments
+- warnings acknowledged
+- derived `ledgerTrustScore`
+
+## Important Scope Note
+
+This PR is substrate only. Follow-up work still required:
+
+1. Replace the processor's current Phase 1A auto-requeue to Phase 2 with a true hard stop after ledger artifact persistence.
+2. Add/finish the visible interactive form controls on `/evaluate/[jobId]/ledger` so the UI sends the structured fields this action now accepts.
+3. Thread `ledger_response_packet_v1` into Phase 2 prompt/context construction as the correction overlay on top of `pass1a_character_ledger_v1`.
+4. Add tests for idempotent approval and response-packet persistence.
+
+## Safety
+
+The approval action is designed so double-clicks/network retries reuse an already-approved packet instead of creating a new semantic approval. Phase 2 is queued by setting `status='queued'`, `phase='phase_2'`, and `phase_status='queued'`.
+
+## Tests
+
+Not run from connector environment.

--- a/app/evaluate/[jobId]/ledger/actions.ts
+++ b/app/evaluate/[jobId]/ledger/actions.ts
@@ -17,18 +17,14 @@ const LEDGER_ACTIONS = [
 ] as const;
 
 type LedgerCorrectionAction = typeof LEDGER_ACTIONS[number];
-
 type LedgerTrustScore = 'high' | 'medium' | 'low';
 
-type LedgerResponsePacket = {
-  schema_version: 'ledger_response_packet_v1';
+type LedgerUserFeedback = {
+  schema_version: 'ledger_user_feedback_v1';
   jobId: string;
   ledgerArtifactId: string;
-  approvedAt?: string;
-  approvedBy?: string;
   lastSavedAt: string;
   lastSavedBy: string;
-  status: 'draft' | 'approved';
   characterCorrections: Array<{
     characterId: string;
     action: LedgerCorrectionAction;
@@ -45,6 +41,21 @@ type LedgerResponsePacket = {
   antagonistFlagsAdded: string[];
   globalComments: string;
   warningsAcknowledged: string[];
+  ledgerTrustScore: LedgerTrustScore;
+};
+
+type AcceptedStoryLedger = {
+  schema_version: 'accepted_story_ledger_v1';
+  jobId: string;
+  baseLedgerArtifactId: string;
+  userFeedbackArtifactId: string;
+  approvedAt: string;
+  approvedBy: string;
+  acceptedInputBundle: {
+    baseLedger: 'pass1a_character_ledger_v1';
+    userFeedback: 'ledger_user_feedback_v1';
+  };
+  normalizedUserCorrections: LedgerUserFeedback;
   ledgerTrustScore: LedgerTrustScore;
 };
 
@@ -129,7 +140,7 @@ function normalizeAction(value: unknown): LedgerCorrectionAction {
     : 'no_change';
 }
 
-function parseCharacterCorrections(formData: FormData): LedgerResponsePacket['characterCorrections'] {
+function parseCharacterCorrections(formData: FormData): LedgerUserFeedback['characterCorrections'] {
   const raw = stringValue(formData, 'characterCorrections');
   const parsed = parseJsonArray(raw);
   return parsed
@@ -144,7 +155,7 @@ function parseCharacterCorrections(formData: FormData): LedgerResponsePacket['ch
     .filter((item) => item.characterId.length > 0);
 }
 
-function parseAliasOverrides(formData: FormData): LedgerResponsePacket['aliasOverrides'] {
+function parseAliasOverrides(formData: FormData): LedgerUserFeedback['aliasOverrides'] {
   const raw = stringValue(formData, 'aliasOverrides');
   const parsed = parseJsonArray(raw);
   return parsed
@@ -158,8 +169,8 @@ function parseAliasOverrides(formData: FormData): LedgerResponsePacket['aliasOve
     .filter((item) => item.canonical.length > 0 && item.aliases.length > 0);
 }
 
-function deriveLedgerTrustScore(packet: Omit<LedgerResponsePacket, 'ledgerTrustScore'>): LedgerTrustScore {
-  const structuralCorrectionCount = packet.characterCorrections.filter((correction) =>
+function deriveLedgerTrustScore(feedback: Omit<LedgerUserFeedback, 'ledgerTrustScore'>): LedgerTrustScore {
+  const structuralCorrectionCount = feedback.characterCorrections.filter((correction) =>
     correction.action === 'merge' ||
     correction.action === 'split' ||
     correction.action === 'rename' ||
@@ -168,31 +179,28 @@ function deriveLedgerTrustScore(packet: Omit<LedgerResponsePacket, 'ledgerTrustS
   ).length;
   const overrideCount =
     structuralCorrectionCount +
-    packet.aliasOverrides.length +
-    packet.povOwnerOverrides.length +
-    packet.antagonistFlagsAdded.length;
+    feedback.aliasOverrides.length +
+    feedback.povOwnerOverrides.length +
+    feedback.antagonistFlagsAdded.length;
 
   if (overrideCount >= 6) return 'low';
-  if (overrideCount >= 2 || packet.globalComments.length >= 500) return 'medium';
+  if (overrideCount >= 2 || feedback.globalComments.length >= 500) return 'medium';
   return 'high';
 }
 
-function buildLedgerResponsePacket(args: {
+function buildLedgerUserFeedback(args: {
   formData: FormData;
   jobId: string;
   ledgerArtifactId: string;
   userId: string;
   savedAt: string;
-  approved: boolean;
-}): LedgerResponsePacket {
-  const packetWithoutTrust: Omit<LedgerResponsePacket, 'ledgerTrustScore'> = {
-    schema_version: 'ledger_response_packet_v1',
+}): LedgerUserFeedback {
+  const feedbackWithoutTrust: Omit<LedgerUserFeedback, 'ledgerTrustScore'> = {
+    schema_version: 'ledger_user_feedback_v1',
     jobId: args.jobId,
     ledgerArtifactId: args.ledgerArtifactId,
-    ...(args.approved ? { approvedAt: args.savedAt, approvedBy: args.userId } : {}),
     lastSavedAt: args.savedAt,
     lastSavedBy: args.userId,
-    status: args.approved ? 'approved' : 'draft',
     characterCorrections: parseCharacterCorrections(args.formData),
     aliasOverrides: parseAliasOverrides(args.formData),
     povOwnerOverrides: stringArray(args.formData, 'povOwnerOverrides'),
@@ -203,12 +211,12 @@ function buildLedgerResponsePacket(args: {
   };
 
   return {
-    ...packetWithoutTrust,
-    ledgerTrustScore: deriveLedgerTrustScore(packetWithoutTrust),
+    ...feedbackWithoutTrust,
+    ledgerTrustScore: deriveLedgerTrustScore(feedbackWithoutTrust),
   };
 }
 
-async function persistLedgerResponsePacket(args: {
+async function persistLedgerUserFeedback(args: {
   supabase: ReturnType<typeof createAdminClient>;
   jobId: string;
   manuscriptId: number;
@@ -216,25 +224,61 @@ async function persistLedgerResponsePacket(args: {
   userId: string;
   formData: FormData;
   savedAt: string;
-  approved: boolean;
-}): Promise<string> {
-  const packet = buildLedgerResponsePacket({
+}): Promise<{ artifactId: string; feedback: LedgerUserFeedback }> {
+  const feedback = buildLedgerUserFeedback({
     formData: args.formData,
     jobId: args.jobId,
     ledgerArtifactId: args.ledgerArtifactId,
     userId: args.userId,
     savedAt: args.savedAt,
-    approved: args.approved,
   });
+
+  const artifactId = await upsertEvaluationArtifact({
+    supabase: args.supabase,
+    jobId: args.jobId,
+    manuscriptId: args.manuscriptId,
+    artifactType: 'ledger_user_feedback_v1',
+    content: feedback,
+    sourceHash: `ledger_user_feedback_v1_${args.jobId}`,
+    artifactVersion: 'ledger_user_feedback_v1',
+  });
+
+  return { artifactId, feedback };
+}
+
+async function persistAcceptedStoryLedger(args: {
+  supabase: ReturnType<typeof createAdminClient>;
+  jobId: string;
+  manuscriptId: number;
+  baseLedgerArtifactId: string;
+  feedbackArtifactId: string;
+  feedback: LedgerUserFeedback;
+  userId: string;
+  approvedAt: string;
+}): Promise<string> {
+  const acceptedLedger: AcceptedStoryLedger = {
+    schema_version: 'accepted_story_ledger_v1',
+    jobId: args.jobId,
+    baseLedgerArtifactId: args.baseLedgerArtifactId,
+    userFeedbackArtifactId: args.feedbackArtifactId,
+    approvedAt: args.approvedAt,
+    approvedBy: args.userId,
+    acceptedInputBundle: {
+      baseLedger: 'pass1a_character_ledger_v1',
+      userFeedback: 'ledger_user_feedback_v1',
+    },
+    normalizedUserCorrections: args.feedback,
+    ledgerTrustScore: args.feedback.ledgerTrustScore,
+  };
 
   return upsertEvaluationArtifact({
     supabase: args.supabase,
     jobId: args.jobId,
     manuscriptId: args.manuscriptId,
-    artifactType: 'ledger_response_packet_v1',
-    content: packet,
-    sourceHash: `ledger_response_packet_v1_${args.jobId}`,
-    artifactVersion: 'ledger_response_packet_v1',
+    artifactType: 'accepted_story_ledger_v1',
+    content: acceptedLedger,
+    sourceHash: `accepted_story_ledger_v1_${args.jobId}`,
+    artifactVersion: 'accepted_story_ledger_v1',
   });
 }
 
@@ -250,7 +294,7 @@ export async function submitLedgerFeedbackAction(formData: FormData): Promise<vo
   const ledgerArtifact = await loadLedgerArtifact(supabase, jobId);
   const submittedAt = new Date().toISOString();
 
-  const responsePacketId = await persistLedgerResponsePacket({
+  const { artifactId: feedbackArtifactId } = await persistLedgerUserFeedback({
     supabase,
     jobId,
     manuscriptId: Number(job.manuscript_id),
@@ -258,7 +302,6 @@ export async function submitLedgerFeedbackAction(formData: FormData): Promise<vo
     userId: user.id,
     formData,
     savedAt: submittedAt,
-    approved: false,
   });
 
   const existingProgress = job.progress && typeof job.progress === 'object' ? job.progress : {};
@@ -269,7 +312,7 @@ export async function submitLedgerFeedbackAction(formData: FormData): Promise<vo
       progress: {
         ...existingProgress,
         guided_full_novel_stage: 'ledger_feedback_submitted',
-        ledger_response_packet_id: responsePacketId,
+        ledger_user_feedback_id: feedbackArtifactId,
         message: 'Story Ledger feedback saved — awaiting approval',
       },
       updated_at: submittedAt,
@@ -285,7 +328,7 @@ export async function submitLedgerFeedbackAction(formData: FormData): Promise<vo
         stage_key: 'ledger',
         job_id: jobId,
         artifact_id: ledgerArtifact.id,
-        response_packet_id: responsePacketId,
+        user_feedback_artifact_id: feedbackArtifactId,
         submitted_by: user.id,
         submitted_at: submittedAt,
         approval_state: 'feedback_submitted_not_approved',
@@ -310,26 +353,39 @@ export async function approveLedgerAction(formData: FormData): Promise<void> {
   const ledgerArtifact = await loadLedgerArtifact(supabase, jobId);
   const approvedAt = new Date().toISOString();
 
-  const existingPacket = await supabase
+  const existingAccepted = await supabase
     .from('evaluation_artifacts')
-    .select('id, content')
+    .select('id')
     .eq('job_id', jobId)
-    .eq('artifact_type', 'ledger_response_packet_v1')
+    .eq('artifact_type', 'accepted_story_ledger_v1')
     .maybeSingle();
 
-  const existingContent = existingPacket.data?.content as { status?: string } | null | undefined;
-  const responsePacketId = existingPacket.data?.id && existingContent?.status === 'approved'
-    ? String(existingPacket.data.id)
-    : await persistLedgerResponsePacket({
-        supabase,
-        jobId,
-        manuscriptId: Number(job.manuscript_id),
-        ledgerArtifactId: ledgerArtifact.id,
-        userId: user.id,
-        formData,
-        savedAt: approvedAt,
-        approved: true,
-      });
+  let acceptedStoryLedgerId = existingAccepted.data?.id ? String(existingAccepted.data.id) : null;
+  let feedbackArtifactId: string | null = null;
+
+  if (!acceptedStoryLedgerId) {
+    const feedbackResult = await persistLedgerUserFeedback({
+      supabase,
+      jobId,
+      manuscriptId: Number(job.manuscript_id),
+      ledgerArtifactId: ledgerArtifact.id,
+      userId: user.id,
+      formData,
+      savedAt: approvedAt,
+    });
+    feedbackArtifactId = feedbackResult.artifactId;
+
+    acceptedStoryLedgerId = await persistAcceptedStoryLedger({
+      supabase,
+      jobId,
+      manuscriptId: Number(job.manuscript_id),
+      baseLedgerArtifactId: ledgerArtifact.id,
+      feedbackArtifactId: feedbackResult.artifactId,
+      feedback: feedbackResult.feedback,
+      userId: user.id,
+      approvedAt,
+    });
+  }
 
   const existingProgress = job.progress && typeof job.progress === 'object' ? job.progress : {};
   const { error: updateError } = await supabase
@@ -352,8 +408,9 @@ export async function approveLedgerAction(formData: FormData): Promise<void> {
         guided_full_novel_stage: 'ledger_approved',
         ledger_approved_at: approvedAt,
         ledger_approved_by: user.id,
-        ledger_response_packet_id: responsePacketId,
-        message: 'Story Ledger approved with response packet — Stage 2 evaluation queued',
+        ...(feedbackArtifactId ? { ledger_user_feedback_id: feedbackArtifactId } : {}),
+        accepted_story_ledger_id: acceptedStoryLedgerId,
+        message: 'Story Ledger approved — accepted story ledger written and Stage 2 queued',
       },
       updated_at: approvedAt,
     })
@@ -371,7 +428,8 @@ export async function approveLedgerAction(formData: FormData): Promise<void> {
       payload: {
         job_id: jobId,
         artifact_id: ledgerArtifact.id,
-        response_packet_id: responsePacketId,
+        user_feedback_artifact_id: feedbackArtifactId,
+        accepted_story_ledger_id: acceptedStoryLedgerId,
         approved_by: user.id,
         approved_at: approvedAt,
         next_phase: 'phase_2',

--- a/app/evaluate/[jobId]/ledger/actions.ts
+++ b/app/evaluate/[jobId]/ledger/actions.ts
@@ -4,12 +4,55 @@ import { redirect } from 'next/navigation';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getAuthenticatedUser } from '@/lib/supabase/server';
 import { recordEvaluationEvent } from '@/lib/evaluation/workflow/events';
+import { upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+
+const LEDGER_ACTIONS = [
+  'merge',
+  'split',
+  'rename',
+  'flag_antagonist',
+  'reassign_pov',
+  'acknowledge_warning',
+  'no_change',
+] as const;
+
+type LedgerCorrectionAction = typeof LEDGER_ACTIONS[number];
+
+type LedgerTrustScore = 'high' | 'medium' | 'low';
+
+type LedgerResponsePacket = {
+  schema_version: 'ledger_response_packet_v1';
+  jobId: string;
+  ledgerArtifactId: string;
+  approvedAt?: string;
+  approvedBy?: string;
+  lastSavedAt: string;
+  lastSavedBy: string;
+  status: 'draft' | 'approved';
+  characterCorrections: Array<{
+    characterId: string;
+    action: LedgerCorrectionAction;
+    targetCharacterId?: string;
+    replacementName?: string;
+    operatorNote?: string;
+  }>;
+  aliasOverrides: Array<{
+    canonical: string;
+    aliases: string[];
+  }>;
+  povOwnerOverrides: string[];
+  symbolObjectNotes: string;
+  antagonistFlagsAdded: string[];
+  globalComments: string;
+  warningsAcknowledged: string[];
+  ledgerTrustScore: LedgerTrustScore;
+};
 
 async function assertOwnedJob(jobId: string, userId: string) {
   const supabase = createAdminClient();
   const { data: job, error } = await supabase
     .from('evaluation_jobs')
-    .select('id, user_id, manuscript_id, evaluation_project_id, manuscripts(user_id,title)')
+    .select('id, user_id, manuscript_id, evaluation_project_id, progress, manuscripts(user_id,title)')
     .eq('id', jobId)
     .maybeSingle();
 
@@ -32,19 +75,11 @@ async function assertOwnedJob(jobId: string, userId: string) {
     id: string;
     manuscript_id: number;
     evaluation_project_id?: string | null;
+    progress?: Record<string, unknown> | null;
   };
 }
 
-export async function approveLedgerAction(formData: FormData): Promise<void> {
-  const jobId = String(formData.get('jobId') ?? '').trim();
-  if (!jobId) throw new Error('Missing job id.');
-
-  const user = await getAuthenticatedUser();
-  if (!user) throw new Error('Please sign in to approve the ledger.');
-
-  const supabase = createAdminClient();
-  const job = await assertOwnedJob(jobId, user.id);
-
+async function loadLedgerArtifact(supabase: ReturnType<typeof createAdminClient>, jobId: string) {
   const { data: ledgerArtifact, error: ledgerError } = await supabase
     .from('evaluation_artifacts')
     .select('id')
@@ -56,13 +91,270 @@ export async function approveLedgerAction(formData: FormData): Promise<void> {
     throw new Error('Story Ledger is not ready yet.');
   }
 
+  return ledgerArtifact as { id: string };
+}
+
+function stringValue(formData: FormData, key: string): string {
+  return String(formData.get(key) ?? '').trim();
+}
+
+function stringArray(formData: FormData, key: string): string[] {
+  const values = formData
+    .getAll(key)
+    .map((value) => String(value ?? '').trim())
+    .filter((value) => value.length > 0);
+
+  const csvValues = stringValue(formData, key)
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return Array.from(new Set([...values, ...csvValues]));
+}
+
+function parseJsonArray(value: string): unknown[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function normalizeAction(value: unknown): LedgerCorrectionAction {
+  const candidate = String(value ?? '').trim();
+  return LEDGER_ACTIONS.includes(candidate as LedgerCorrectionAction)
+    ? (candidate as LedgerCorrectionAction)
+    : 'no_change';
+}
+
+function parseCharacterCorrections(formData: FormData): LedgerResponsePacket['characterCorrections'] {
+  const raw = stringValue(formData, 'characterCorrections');
+  const parsed = parseJsonArray(raw);
+  return parsed
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      characterId: String(item.characterId ?? '').trim(),
+      action: normalizeAction(item.action),
+      targetCharacterId: String(item.targetCharacterId ?? '').trim() || undefined,
+      replacementName: String(item.replacementName ?? '').trim() || undefined,
+      operatorNote: String(item.operatorNote ?? '').trim() || undefined,
+    }))
+    .filter((item) => item.characterId.length > 0);
+}
+
+function parseAliasOverrides(formData: FormData): LedgerResponsePacket['aliasOverrides'] {
+  const raw = stringValue(formData, 'aliasOverrides');
+  const parsed = parseJsonArray(raw);
+  return parsed
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      canonical: String(item.canonical ?? '').trim(),
+      aliases: Array.isArray(item.aliases)
+        ? item.aliases.map((alias) => String(alias ?? '').trim()).filter(Boolean)
+        : [],
+    }))
+    .filter((item) => item.canonical.length > 0 && item.aliases.length > 0);
+}
+
+function deriveLedgerTrustScore(packet: Omit<LedgerResponsePacket, 'ledgerTrustScore'>): LedgerTrustScore {
+  const structuralCorrectionCount = packet.characterCorrections.filter((correction) =>
+    correction.action === 'merge' ||
+    correction.action === 'split' ||
+    correction.action === 'rename' ||
+    correction.action === 'flag_antagonist' ||
+    correction.action === 'reassign_pov'
+  ).length;
+  const overrideCount =
+    structuralCorrectionCount +
+    packet.aliasOverrides.length +
+    packet.povOwnerOverrides.length +
+    packet.antagonistFlagsAdded.length;
+
+  if (overrideCount >= 6) return 'low';
+  if (overrideCount >= 2 || packet.globalComments.length >= 500) return 'medium';
+  return 'high';
+}
+
+function buildLedgerResponsePacket(args: {
+  formData: FormData;
+  jobId: string;
+  ledgerArtifactId: string;
+  userId: string;
+  savedAt: string;
+  approved: boolean;
+}): LedgerResponsePacket {
+  const packetWithoutTrust: Omit<LedgerResponsePacket, 'ledgerTrustScore'> = {
+    schema_version: 'ledger_response_packet_v1',
+    jobId: args.jobId,
+    ledgerArtifactId: args.ledgerArtifactId,
+    ...(args.approved ? { approvedAt: args.savedAt, approvedBy: args.userId } : {}),
+    lastSavedAt: args.savedAt,
+    lastSavedBy: args.userId,
+    status: args.approved ? 'approved' : 'draft',
+    characterCorrections: parseCharacterCorrections(args.formData),
+    aliasOverrides: parseAliasOverrides(args.formData),
+    povOwnerOverrides: stringArray(args.formData, 'povOwnerOverrides'),
+    symbolObjectNotes: stringValue(args.formData, 'symbolObjectNotes'),
+    antagonistFlagsAdded: stringArray(args.formData, 'antagonistFlagsAdded'),
+    globalComments: stringValue(args.formData, 'globalComments'),
+    warningsAcknowledged: stringArray(args.formData, 'warningsAcknowledged'),
+  };
+
+  return {
+    ...packetWithoutTrust,
+    ledgerTrustScore: deriveLedgerTrustScore(packetWithoutTrust),
+  };
+}
+
+async function persistLedgerResponsePacket(args: {
+  supabase: ReturnType<typeof createAdminClient>;
+  jobId: string;
+  manuscriptId: number;
+  ledgerArtifactId: string;
+  userId: string;
+  formData: FormData;
+  savedAt: string;
+  approved: boolean;
+}): Promise<string> {
+  const packet = buildLedgerResponsePacket({
+    formData: args.formData,
+    jobId: args.jobId,
+    ledgerArtifactId: args.ledgerArtifactId,
+    userId: args.userId,
+    savedAt: args.savedAt,
+    approved: args.approved,
+  });
+
+  return upsertEvaluationArtifact({
+    supabase: args.supabase,
+    jobId: args.jobId,
+    manuscriptId: args.manuscriptId,
+    artifactType: 'ledger_response_packet_v1',
+    content: packet,
+    sourceHash: `ledger_response_packet_v1_${args.jobId}`,
+    artifactVersion: 'ledger_response_packet_v1',
+  });
+}
+
+export async function submitLedgerFeedbackAction(formData: FormData): Promise<void> {
+  const jobId = String(formData.get('jobId') ?? '').trim();
+  if (!jobId) throw new Error('Missing job id.');
+
+  const user = await getAuthenticatedUser();
+  if (!user) throw new Error('Please sign in to submit ledger feedback.');
+
+  const supabase = createAdminClient();
+  const job = await assertOwnedJob(jobId, user.id);
+  const ledgerArtifact = await loadLedgerArtifact(supabase, jobId);
+  const submittedAt = new Date().toISOString();
+
+  const responsePacketId = await persistLedgerResponsePacket({
+    supabase,
+    jobId,
+    manuscriptId: Number(job.manuscript_id),
+    ledgerArtifactId: ledgerArtifact.id,
+    userId: user.id,
+    formData,
+    savedAt: submittedAt,
+    approved: false,
+  });
+
+  const existingProgress = job.progress && typeof job.progress === 'object' ? job.progress : {};
+  await supabase
+    .from('evaluation_jobs')
+    .update({
+      guided_full_novel_stage: 'ledger_feedback_submitted',
+      progress: {
+        ...existingProgress,
+        guided_full_novel_stage: 'ledger_feedback_submitted',
+        ledger_response_packet_id: responsePacketId,
+        message: 'Story Ledger feedback saved — awaiting approval',
+      },
+      updated_at: submittedAt,
+    })
+    .eq('id', jobId);
+
+  if (job.evaluation_project_id) {
+    await recordEvaluationEvent({
+      supabase,
+      projectId: job.evaluation_project_id,
+      eventType: 'stage_approved',
+      payload: {
+        stage_key: 'ledger',
+        job_id: jobId,
+        artifact_id: ledgerArtifact.id,
+        response_packet_id: responsePacketId,
+        submitted_by: user.id,
+        submitted_at: submittedAt,
+        approval_state: 'feedback_submitted_not_approved',
+      },
+    }).catch((eventError) => {
+      console.warn('[submitLedgerFeedbackAction] feedback event failed', eventError);
+    });
+  }
+
+  redirect(`/evaluate/${jobId}/ledger?feedback=1`);
+}
+
+export async function approveLedgerAction(formData: FormData): Promise<void> {
+  const jobId = String(formData.get('jobId') ?? '').trim();
+  if (!jobId) throw new Error('Missing job id.');
+
+  const user = await getAuthenticatedUser();
+  if (!user) throw new Error('Please sign in to approve the ledger.');
+
+  const supabase = createAdminClient();
+  const job = await assertOwnedJob(jobId, user.id);
+  const ledgerArtifact = await loadLedgerArtifact(supabase, jobId);
   const approvedAt = new Date().toISOString();
+
+  const existingPacket = await supabase
+    .from('evaluation_artifacts')
+    .select('id, content')
+    .eq('job_id', jobId)
+    .eq('artifact_type', 'ledger_response_packet_v1')
+    .maybeSingle();
+
+  const existingContent = existingPacket.data?.content as { status?: string } | null | undefined;
+  const responsePacketId = existingPacket.data?.id && existingContent?.status === 'approved'
+    ? String(existingPacket.data.id)
+    : await persistLedgerResponsePacket({
+        supabase,
+        jobId,
+        manuscriptId: Number(job.manuscript_id),
+        ledgerArtifactId: ledgerArtifact.id,
+        userId: user.id,
+        formData,
+        savedAt: approvedAt,
+        approved: true,
+      });
+
+  const existingProgress = job.progress && typeof job.progress === 'object' ? job.progress : {};
   const { error: updateError } = await supabase
     .from('evaluation_jobs')
     .update({
+      status: 'queued',
+      phase: 'phase_2',
+      phase_status: 'queued',
       ledger_approved_at: approvedAt,
       ledger_approved_by: user.id,
       guided_full_novel_stage: 'ledger_approved',
+      claimed_by: null,
+      claimed_at: null,
+      lease_token: null,
+      lease_until: null,
+      progress: {
+        ...existingProgress,
+        phase: 'phase_2',
+        phase_status: 'queued',
+        guided_full_novel_stage: 'ledger_approved',
+        ledger_approved_at: approvedAt,
+        ledger_approved_by: user.id,
+        ledger_response_packet_id: responsePacketId,
+        message: 'Story Ledger approved with response packet — Stage 2 evaluation queued',
+      },
       updated_at: approvedAt,
     })
     .eq('id', jobId);
@@ -79,8 +371,10 @@ export async function approveLedgerAction(formData: FormData): Promise<void> {
       payload: {
         job_id: jobId,
         artifact_id: ledgerArtifact.id,
+        response_packet_id: responsePacketId,
         approved_by: user.id,
         approved_at: approvedAt,
+        next_phase: 'phase_2',
       },
     }).catch((eventError) => {
       console.warn('[approveLedgerAction] ledger approval event failed', eventError);

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -76,6 +76,13 @@ export type ArtifactType =
    */
   | "pass1a_character_ledger_v1"
   /**
+   * Author/operator Story Ledger response packet. Written from the interactive
+   * Story Ledger review controls before Stage 2 is queued. Contains per-section
+   * response states and comments that must be injected alongside the ledger into
+   * Phase 2 so evaluation respects accepted corrections and flags.
+   */
+  | "story_ledger_response_packet_v1"
+  /**
    * WAVE revision plan — written inline after evaluation persists (same execution
    * window). status field: complete | skipped | failed | timeout.
    * skipped = gate did not pass (manuscript too short or criteria below floor).

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -76,12 +76,11 @@ export type ArtifactType =
    */
   | "pass1a_character_ledger_v1"
   /**
-   * Author/operator Story Ledger response packet. Written from the interactive
-   * Story Ledger review controls before Stage 2 is queued. Contains per-section
-   * response states and comments that must be injected alongside the ledger into
-   * Phase 2 so evaluation respects accepted corrections and flags.
+   * Author/operator Story Ledger response packet. Written from interactive
+   * Story Ledger review controls. Feedback saves are mutable until approval;
+   * after approval the packet is treated as the correction overlay for Phase 2.
    */
-  | "story_ledger_response_packet_v1"
+  | "ledger_response_packet_v1"
   /**
    * WAVE revision plan — written inline after evaluation persists (same execution
    * window). status field: complete | skipped | failed | timeout.

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -76,11 +76,16 @@ export type ArtifactType =
    */
   | "pass1a_character_ledger_v1"
   /**
-   * Author/operator Story Ledger response packet. Written from interactive
-   * Story Ledger review controls. Feedback saves are mutable until approval;
-   * after approval the packet is treated as the correction overlay for Phase 2.
+   * Mutable user/operator feedback saved from the interactive Story Ledger UI.
+   * This is not a Phase 2 handoff until the ledger is explicitly approved.
    */
-  | "ledger_response_packet_v1"
+  | "ledger_user_feedback_v1"
+  /**
+   * Approved Story Ledger handoff for Phase 2. Built from the raw Pass 1A ledger
+   * plus normalized ledger_user_feedback_v1 corrections. This is the deterministic
+   * input Phase 2 should consume, not the raw ledger alone.
+   */
+  | "accepted_story_ledger_v1"
   /**
    * WAVE revision plan — written inline after evaluation persists (same execution
    * window). status field: complete | skipped | failed | timeout.


### PR DESCRIPTION
## Summary

Adds the first wiring substrate for the interactive Story Ledger approval model:

- adds `ledger_response_packet_v1` to the canonical evaluation artifact type union
- updates the Story Ledger server actions so `Submit Feedback` can persist a mutable response packet
- updates approval so `Approve Ledger` writes/reuses the response packet and queues `phase_2`
- stores the response packet id in job progress so Phase 2 can consume it as the correction overlay

## Architecture

This follows the staged ledger model: Phase 1A writes `pass1a_character_ledger_v1`, the UI collects user/operator corrections and comments, and approval produces `ledger_response_packet_v1` as Phase 2 input.

The packet is intended to include:

- character corrections: merge/split/rename/flag antagonist/reassign POV/no-change
- alias overrides
- POV owner overrides
- object/symbol notes
- antagonist flags added
- global comments
- warnings acknowledged
- derived `ledgerTrustScore`

## Important Scope Note

This PR is substrate only. Follow-up work still required:

1. Replace the processor's current Phase 1A auto-requeue to Phase 2 with a true hard stop after ledger artifact persistence.
2. Add/finish the visible interactive form controls on `/evaluate/[jobId]/ledger` so the UI sends the structured fields this action now accepts.
3. Thread `ledger_response_packet_v1` into Phase 2 prompt/context construction as the correction overlay on top of `pass1a_character_ledger_v1`.
4. Add tests for idempotent approval and response-packet persistence.

## Safety

The approval action is designed so double-clicks/network retries reuse an already-approved packet instead of creating a new semantic approval. Phase 2 is queued by setting `status='queued'`, `phase='phase_2'`, and `phase_status='queued'`.

## Tests

Not run from connector environment.