### PR TITLE
docs(canon): freeze Story Layer and support artifact contracts

### DIFF
--- a/.github/pr-bodies/PR-628.md
+++ b/.github/pr-bodies/PR-628.md
@@ -1,0 +1,130 @@
+## PR 1: Story Layer Contract Docs Only
+
+### Scope
+
+This PR is docs-only. It freezes the Story Layer and supporting-signal contracts as the spine for later schema, stage machine, pipeline, and UI work.
+
+No runtime or UI code changes.
+
+This is the contract foundation for the larger orchestration spine:
+
+Phase 0 → Story Layer → Story Evaluation → Final Report → WAVE Revision
+
+But this PR only freezes the Story Layer and supporting-signal doctrine.
+
+---
+
+## Files added
+
+### `docs/canon/STORY_LAYER_CONTRACT_V1.md`
+
+Canonical doctrine:
+
+- Phase 0 → Phase 1A → Review Gate → Approval Normalizer → Phase 2.
+- Phase 2 may consume `accepted_story_ledger_v1` as its only story-understanding authority.
+- Phase 2 may also consume `dream_calibration_packet_v1`, `manuscript_evidence_map`, and non-governing support artifacts.
+- `pass1a_story_layer_v1` = exactly 8 layers.
+- Governance is separate.
+- Support artifacts are separate.
+- There is no Layer 9.
+- `ledger_quality_report_v1` = gate verdict artifact.
+- `ledger_user_feedback_v1` = mandatory review artifact, even for `accepted_without_changes`.
+- `accepted_story_ledger_v1` = only approved story-understanding authority for Phase 2.
+- `story_shape_signal_map_v1` / `manuscript_signal_appendix_v1` = enrichment only; never Layer 9, never governing.
+
+Gate rule:
+
+- Approval Normalizer must never create `accepted_story_ledger_v1` from `pass1a_story_layer_v1` alone.
+- Every path must pass through Review Gate and write `ledger_user_feedback_v1`.
+
+Override rule:
+
+- `accepted_with_override` may only be written by admin/operator roles.
+- Unresolved warnings must be preserved in governance.
+
+Runtime envelope aligned with repo vocabulary:
+
+- `job_id`
+- `evaluation_project_id`
+- optional `stage_run_id`
+- `manuscript_id`
+- `manuscript_version_hash`
+- `artifact_id`
+- `artifact_type`
+- `artifact_version`
+- `source_hash`
+- `generated_at`
+
+Final Mermaid diagrams:
+
+- Artifact flow.
+- No Layer 9 model.
+- Phase 2 connects only to `accepted_story_ledger_v1`.
+- Support artifacts connect to Phase 2 as dotted “enrichment only” edges, not to `pass1a_story_layer_v1`.
+
+---
+
+### `docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md`
+
+Defines:
+
+- Story Layer = eight-layer approved story understanding.
+- Support artifacts = Phase 2 enrichment only.
+- `story_shape_signal_map_v1` = beat/arc/structure-over-time support artifact.
+- `manuscript_signal_appendix_v1` = surface/craft/market signal appendix.
+
+Dependency rule:
+
+- Support artifacts must store:
+  - `accepted_story_ledger_artifact_id`
+  - `accepted_story_ledger_source_hash`
+
+Staleness rule:
+
+- If the accepted ledger’s `source_hash` changes, support artifacts are stale.
+- Stale support artifacts must be regenerated or marked degraded before Phase 2 uses them.
+
+Consumption rule:
+
+- Support artifacts cannot override accepted story understanding.
+- Support artifacts cannot override approval state.
+- Support artifacts cannot override governance warnings.
+- Support artifacts do not create Layer 9.
+
+---
+
+## Out of scope
+
+Explicitly no changes to:
+
+- `evaluation_projects`
+- `evaluation_stage_runs`
+- `evaluation_events`
+- artifact persistence
+- runtime processor behavior
+- schemas
+- artifact registry
+- stage machine
+- UI
+- API routes
+
+This PR does not implement the pipeline. It freezes the contract the pipeline must obey.
+
+---
+
+## Intent for follow-up PRs
+
+- PR 2: artifact registry + shallow schemas.
+- PR 3: stage machine / hard-stop contract wired to Review Gate and Approval Normalizer.
+- PR 4: Phase 1A writers for `pass1a_story_layer_v1` + `ledger_quality_report_v1`.
+- PR 5: approval writer for `accepted_story_ledger_v1`.
+- PR 6: support artifact writers for `story_shape_signal_map_v1` + `manuscript_signal_appendix_v1`.
+- PR 7: UI shell.
+
+---
+
+## Reviewer note
+
+Please treat these docs as the canonical authority for Story Layer behavior going forward.
+
+Any later implementation that diverges from this contract should be treated as a bug, not a design choice.

--- a/docs/canon/STORY_LAYER_CONTRACT_V1.md
+++ b/docs/canon/STORY_LAYER_CONTRACT_V1.md
@@ -1,0 +1,119 @@
+# STORY_LAYER_CONTRACT_V1
+
+## Canonical doctrine
+
+The canonical flow is:
+
+```text
+Phase 0 → Phase 1A → Review Gate → Approval Normalizer → Phase 2
+```
+
+Phase 2 may consume `accepted_story_ledger_v1` as its only story-understanding authority. It may also consume `dream_calibration_packet_v1`, `manuscript_evidence_map`, and non-governing support artifacts.
+
+`pass1a_story_layer_v1` contains exactly eight story layers and nothing else. Governance remains separate. Support artifacts remain separate. There is no Layer 9.
+
+## Artifact flow
+
+```mermaid
+flowchart TD
+    A[Phase 0: DREAM Calibration / Warmup] --> B[Phase 1A: Story Layer Builder]
+    B --> C[pass1a_story_layer_v1]
+    B --> D[ledger_quality_report_v1]
+    C --> E[Review Gate Workspace]
+    D --> E
+    E --> F[ledger_user_feedback_v1]
+    F --> G[Approval Normalizer]
+    C --> G
+    D --> G
+    G --> H{All blockers resolved<br/>or admin/operator override approved?}
+    H -->|Yes| I[accepted_story_ledger_v1]
+    H -->|No| E
+    I --> J[Phase 2: Story Evaluation]
+    I -. accepted ledger id/hash dependency .-> K[story_shape_signal_map_v1]
+    I -. accepted ledger id/hash dependency .-> L[manuscript_signal_appendix_v1]
+    K -. enrichment only .-> J
+    L -. enrichment only .-> J
+```
+
+## Gate rule
+
+Every path must pass through the Review Gate and write `ledger_user_feedback_v1`, even when there are no hard fails and the disposition is `accepted_without_changes`.
+
+The Approval Normalizer must never create `accepted_story_ledger_v1` from `pass1a_story_layer_v1` alone.
+
+`accepted_with_override` may only be written by `admin` or `operator` roles and must preserve unresolved warnings in governance.
+
+## No Layer 9 model
+
+```mermaid
+flowchart TD
+    A[pass1a_story_layer_v1] --> A1[source_integrity_layer]
+    A --> A2[pov_structure_layer]
+    A --> A3[canonical_identity_layer]
+    A --> A4[cast_role_tier_layer]
+    A --> A5[relationship_network_layer]
+    A --> A6[object_symbol_layer]
+    A --> A7[location_timeline_worldstate_layer]
+    A --> A8[threat_antagonist_ending_layer]
+
+    B[governance_rail_v1] --> B1[warnings]
+    B --> B2[evidence_locations]
+    B --> B3[blocking_reasons]
+    B --> B4[approval_state]
+
+    A --> C[Review Gate]
+    B --> C
+    C --> D[ledger_user_feedback_v1]
+    D --> E[Approval Normalizer]
+    A --> E
+    B --> E
+    E --> F[accepted_story_ledger_v1]
+
+    F --> G[Phase 2: Story Evaluation]
+
+    H[story_shape_signal_map_v1]
+    I[manuscript_signal_appendix_v1]
+
+    F -. accepted ledger id/hash dependency .-> H
+    F -. accepted ledger id/hash dependency .-> I
+    H -. enrichment only .-> G
+    I -. enrichment only .-> G
+```
+
+## Runtime envelope
+
+Use the repo-aligned runtime envelope below for artifact content. `evaluation_project_id` should be the public artifact field name because the existing bridge vocabulary already uses that field on the legacy job path. `stage_run_id` is optional for artifacts written inside the staged runner.
+
+```ts
+export type RuntimeArtifactEnvelope = {
+  job_id: string;
+  evaluation_project_id: string | null;
+  stage_run_id?: string | null;
+  manuscript_id: number;
+  manuscript_version_hash: string;
+
+  artifact_id: string;
+  artifact_type: string;
+  artifact_version: string;
+  source_hash: string;
+  generated_at: string;
+};
+```
+
+## Supporting signal artifacts
+
+`story_shape_signal_map_v1` and `manuscript_signal_appendix_v1` enrich Phase 2 but do not alter, override, or replace `accepted_story_ledger_v1`. They are not Story Layer layers and do not create Layer 9.
+
+They must reference `accepted_story_ledger_v1.artifact_id` and `accepted_story_ledger_v1.source_hash`. If the accepted ledger changes, those support artifacts are stale and must be regenerated or marked degraded before use.
+
+## Implementation order
+
+1. PR 1: docs only — split and freeze contract authorities.
+2. PR 2: artifact registry + schemas.
+3. PR 3: stage machine / hard-stop contract.
+4. PR 4: Phase 1A writes `pass1a_story_layer_v1` + `ledger_quality_report_v1`.
+5. PR 5: approval writes `accepted_story_ledger_v1`.
+6. PR 6: support artifacts — `story_shape_signal_map_v1` + `manuscript_signal_appendix_v1`.
+7. PR 7: UI shell.
+
+Do not move runtime code yet. Do not build UI yet. The UI shell must reflect this contract and must not introduce alternate approval paths.

--- a/docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md
+++ b/docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md
@@ -1,0 +1,336 @@
+# SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1
+
+## Canonical rule
+
+Do **not** add Layer 9.
+
+Keep `pass1a_story_layer_v1` as an eight-layer story-understanding artifact only, with user feedback in `ledger_user_feedback_v1`, approval output in `accepted_story_ledger_v1`, and Phase 2 consuming only approved story understanding plus support artifacts.
+
+## Durable artifact set
+
+Core pipeline artifacts:
+
+1. `dream_calibration_packet_v1`
+2. `pass1a_story_layer_v1`
+3. `ledger_quality_report_v1`
+4. `ledger_user_feedback_v1`
+5. `accepted_story_ledger_v1`
+6. `story_shape_signal_map_v1`
+7. `manuscript_signal_appendix_v1`
+
+Later, if needed:
+
+8. `phase2_evaluation_packet_v1`
+9. `phase2_author_response_v1`
+10. `evaluation_result_v2`
+
+## Boundary doctrine
+
+Schema the contract; nest the rest.
+
+`story_shape_signal_map_v1` and `manuscript_signal_appendix_v1` are first-class only because they support Phase 2 interpretation and author-facing diagnostics without polluting the eight-layer Story Layer itself.
+
+Marlowe-style outputs such as arc graphs, beat spacing, dialogue ratios, readability, repetition scans, content warnings, and content/market indicators are useful confidence-builders, but they are not foundational story-system layers.
+
+## Phase placement
+
+### Phase 1A core
+
+- `pass1a_story_layer_v1`
+- `ledger_quality_report_v1`
+
+### Phase 1A / Phase 2 support
+
+- `story_shape_signal_map_v1`
+- `manuscript_signal_appendix_v1`
+
+### User review
+
+- `ledger_user_feedback_v1`
+
+### Approved handoff
+
+- `accepted_story_ledger_v1`
+
+### Phase 2 consumes
+
+- `accepted_story_ledger_v1`
+- `dream_calibration_packet_v1`
+- `manuscript_evidence_map`
+- `story_shape_signal_map_v1`
+- `manuscript_signal_appendix_v1`
+
+This preserves the core doctrine: evaluation must not proceed from raw or failed story understanding.
+
+## Dependency and staleness rule
+
+Support artifacts must store:
+
+```ts
+accepted_story_ledger_artifact_id: string;
+accepted_story_ledger_source_hash: string;
+```
+
+If `accepted_story_ledger_v1.source_hash` changes, existing support artifacts are stale. They must be regenerated or marked degraded before Phase 2 uses them.
+
+Support artifacts cannot override accepted story understanding, approval state, or governance warnings.
+
+## Support artifact 1: `story_shape_signal_map_v1`
+
+Purpose: structure-over-time support artifact for Phase 2; not a blocking Story Layer and not authority over `accepted_story_ledger_v1`.
+
+```ts
+type StoryShapeSignalMapV1 = RuntimeArtifactEnvelope & {
+  artifact_type: "story_shape_signal_map_v1";
+  accepted_story_ledger_artifact_id: string;
+  accepted_story_ledger_source_hash: string;
+  status: "complete" | "partial" | "degraded" | "failed";
+  warnings: string[];
+
+  authority: {
+    derived_from: [
+      "manuscript_evidence_map",
+      "accepted_story_ledger_v1",
+      "dream_calibration_packet_v1"
+    ];
+    blocking_story_layer: false;
+    phase2_support_artifact: true;
+  };
+
+  structural_beats: {
+    inciting_incident: BeatSignal | null;
+    first_plot_point: BeatSignal | null;
+    midpoint_shift: BeatSignal | null;
+    second_plot_point: BeatSignal | null;
+    climax: BeatSignal | null;
+    resolution: BeatSignal | null;
+  };
+
+  emotional_arc: {
+    overall_direction: "rising" | "falling" | "oscillating" | "flat" | "mixed";
+    tonal_band: "lighter" | "neutral" | "darker" | "extreme";
+    major_emotional_beats: EmotionalBeat[];
+  };
+
+  conflict_shape: {
+    conflict_intensity_curve: SignalPoint[];
+    dominant_conflict_axes: Array<
+      "internal" |
+      "interpersonal" |
+      "institutional" |
+      "environmental" |
+      "legal" |
+      "moral"
+    >;
+    escalation_pattern:
+      | "steady_escalation"
+      | "episodic_spikes"
+      | "midpoint_reversal"
+      | "late_surge"
+      | "diffuse";
+  };
+
+  pacing_shape: {
+    pacing_pressure_curve: SignalPoint[];
+    slowest_spans: EvidencePointer[];
+    fastest_spans: EvidencePointer[];
+    compression_expansion_notes: string[];
+  };
+
+  confidence: {
+    beat_location_confidence: "high" | "medium" | "low";
+    confidence_rationale: string;
+    missing_or_ambiguous_beats: string[];
+  };
+};
+
+type BeatSignal = {
+  label: string;
+  narrative_percent_estimate: number;
+  chapter_or_section: string;
+  evidence_anchors: EvidencePointer[];
+  why_this_beat_matters: string;
+  confidence: "high" | "medium" | "low";
+};
+
+type EmotionalBeat = {
+  label: string;
+  direction: "positive" | "negative" | "mixed";
+  intensity: 1 | 2 | 3 | 4 | 5;
+  affected_characters: string[];
+  affected_relationships: string[];
+  evidence_anchors: EvidencePointer[];
+};
+
+type SignalPoint = {
+  narrative_percent: number;
+  value: number;
+  evidence_anchor_id: string;
+  note: string;
+};
+
+type EvidencePointer = {
+  evidence_anchor_id: string;
+  chapter_or_section: string;
+  excerpt?: string;
+};
+```
+
+This artifact is where beat structure, emotional movement, conflict curves, and pacing curves live. It supports richer Phase 2 diagnosis similar to beat and arc graphs, but it does not redefine the accepted story map.
+
+## Support artifact 2: `manuscript_signal_appendix_v1`
+
+Purpose: surface/craft/market appendix for Phase 2 and author-facing diagnostics; not a blocking Story Layer.
+
+```ts
+type ManuscriptSignalAppendixV1 = RuntimeArtifactEnvelope & {
+  artifact_type: "manuscript_signal_appendix_v1";
+  accepted_story_ledger_artifact_id: string;
+  accepted_story_ledger_source_hash: string;
+  status: "complete" | "partial" | "degraded" | "failed";
+  warnings: string[];
+
+  authority: {
+    blocking_story_layer: false;
+    phase2_support_artifact: true;
+    author_facing_appendix: true;
+  };
+
+  dialogue_narrative_ratio: {
+    dialogue_percent: number;
+    narrative_percent: number;
+    by_pov_owner?: Record<string, {
+      dialogue_percent: number;
+      narrative_percent: number;
+    }>;
+    interpretation: string;
+  };
+
+  readability_stats: {
+    estimated_grade_level: number;
+    complexity_score?: number;
+    sentence_length_distribution: {
+      average_sentence_length: number;
+      median_sentence_length: number;
+      longest_sentences: EvidencePointer[];
+    };
+  };
+
+  repetition_scan: {
+    repeated_phrases: Array<{
+      phrase: string;
+      count: number;
+      per_100k_words?: number;
+      classification:
+        | "intentional_motif"
+        | "voice_signature"
+        | "trauma_rhythm"
+        | "lazy_repetition"
+        | "uncertain";
+      evidence_anchors: EvidencePointer[];
+    }>;
+  };
+
+  style_density: {
+    adverb_density?: number;
+    adjective_density?: number;
+    cliche_flags: Array<{
+      phrase: string;
+      count: number;
+      evidence_anchors: EvidencePointer[];
+    }>;
+  };
+
+  content_and_market_signals: {
+    genre_primary?: string;
+    genre_secondary?: string;
+    word_count_band:
+      | "short_for_genre"
+      | "within_range"
+      | "long_for_genre"
+      | "very_long";
+    tonal_band: "lighter" | "average" | "darker" | "extreme";
+    content_warnings: Array<{
+      type: string;
+      severity: "mild" | "moderate" | "strong" | "severe";
+      evidence_anchors: EvidencePointer[];
+      recommended_author_facing_phrase: string;
+    }>;
+  };
+};
+```
+
+This appendix holds dialogue ratio, readability, repetition, style density, content warnings, and market-facing signals. These categories align with the kinds of report packaging visible in Marlowe-style reports, but they remain non-governing support only.
+
+## Required layer additions
+
+The two support artifacts do not expand the Story Layer count, but they justify a few field additions to existing layers.
+
+### Layer 5 — Relationship Arc Network
+
+Add:
+
+```ts
+stakes_type: Array<
+  "emotional" |
+  "physical" |
+  "social" |
+  "economic" |
+  "existential" |
+  "moral" |
+  "legal"
+>;
+
+stakes_intensity_trajectory:
+  | "low_to_high"
+  | "high_to_higher"
+  | "rupture_to_repair"
+  | "rupture_to_loss"
+  | "stable_to_transformed"
+  | "unresolved";
+
+relationship_pressure_curve: Array<{
+  evidence_anchor_id: string;
+  pressure_level: 1 | 2 | 3 | 4 | 5;
+  note: string;
+}>;
+```
+
+### Layer 8 — Threat / Antagonist / Pressure + Ending Accountability
+
+Add:
+
+```ts
+conflict_axes: Array<
+  "internal" |
+  "interpersonal" |
+  "institutional" |
+  "environmental" |
+  "legal" |
+  "moral"
+>;
+
+stakes_resolution_status:
+  | "resolved"
+  | "transformed"
+  | "escalated"
+  | "intentionally_unresolved"
+  | "accidentally_abandoned";
+
+pressure_escalation_path: Array<{
+  evidence_anchor_id: string;
+  pressure_source: string;
+  target: string;
+  escalation_level: 1 | 2 | 3 | 4 | 5;
+  outcome: string;
+}>;
+```
+
+## Implementation instruction
+
+The next concrete schema work should create exactly these two new schema artifacts and no new Story Layer:
+
+1. `story_shape_signal_map_v1`
+2. `manuscript_signal_appendix_v1`
+
+Constraint: they remain support artifacts in the larger doctrine, not authority over `accepted_story_ledger_v1`, and not substitutes for Phase 1A story understanding.


### PR DESCRIPTION
## PR 1: Story Layer Contract Docs Only

### Scope

This PR is docs-only. It freezes the Story Layer and supporting-signal contracts as the spine for later schema, stage machine, pipeline, and UI work.

No runtime or UI code changes.

This is the contract foundation for the larger orchestration spine:

Phase 0 → Story Layer → Story Evaluation → Final Report → WAVE Revision

But this PR only freezes the Story Layer and supporting-signal doctrine.

---

## Files added

### `docs/canon/STORY_LAYER_CONTRACT_V1.md`

Canonical doctrine:

- Phase 0 → Phase 1A → Review Gate → Approval Normalizer → Phase 2.
- Phase 2 may consume `accepted_story_ledger_v1` as its only story-understanding authority.
- Phase 2 may also consume `dream_calibration_packet_v1`, `manuscript_evidence_map`, and non-governing support artifacts.
- `pass1a_story_layer_v1` = exactly 8 layers.
- Governance is separate.
- Support artifacts are separate.
- There is no Layer 9.
- `ledger_quality_report_v1` = gate verdict artifact.
- `ledger_user_feedback_v1` = mandatory review artifact, even for `accepted_without_changes`.
- `accepted_story_ledger_v1` = only approved story-understanding authority for Phase 2.
- `story_shape_signal_map_v1` / `manuscript_signal_appendix_v1` = enrichment only; never Layer 9, never governing.

Gate rule:

- Approval Normalizer must never create `accepted_story_ledger_v1` from `pass1a_story_layer_v1` alone.
- Every path must pass through Review Gate and write `ledger_user_feedback_v1`.

Override rule:

- `accepted_with_override` may only be written by admin/operator roles.
- Unresolved warnings must be preserved in governance.

Runtime envelope aligned with repo vocabulary:

- `job_id`
- `evaluation_project_id`
- optional `stage_run_id`
- `manuscript_id`
- `manuscript_version_hash`
- `artifact_id`
- `artifact_type`
- `artifact_version`
- `source_hash`
- `generated_at`

Final Mermaid diagrams:

- Artifact flow.
- No Layer 9 model.
- Phase 2 connects only to `accepted_story_ledger_v1`.
- Support artifacts connect to Phase 2 as dotted “enrichment only” edges, not to `pass1a_story_layer_v1`.

---

### `docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md`

Defines:

- Story Layer = eight-layer approved story understanding.
- Support artifacts = Phase 2 enrichment only.
- `story_shape_signal_map_v1` = beat/arc/structure-over-time support artifact.
- `manuscript_signal_appendix_v1` = surface/craft/market signal appendix.

Dependency rule:

- Support artifacts must store:
  - `accepted_story_ledger_artifact_id`
  - `accepted_story_ledger_source_hash`

Staleness rule:

- If the accepted ledger’s `source_hash` changes, support artifacts are stale.
- Stale support artifacts must be regenerated or marked degraded before Phase 2 uses them.

Consumption rule:

- Support artifacts cannot override accepted story understanding.
- Support artifacts cannot override approval state.
- Support artifacts cannot override governance warnings.
- Support artifacts do not create Layer 9.

---

## Out of scope

Explicitly no changes to:

- `evaluation_projects`
- `evaluation_stage_runs`
- `evaluation_events`
- artifact persistence
- runtime processor behavior
- schemas
- artifact registry
- stage machine
- UI
- API routes

This PR does not implement the pipeline. It freezes the contract the pipeline must obey.

---

## Intent for follow-up PRs

- PR 2: artifact registry + shallow schemas.
- PR 3: stage machine / hard-stop contract wired to Review Gate and Approval Normalizer.
- PR 4: Phase 1A writers for `pass1a_story_layer_v1` + `ledger_quality_report_v1`.
- PR 5: approval writer for `accepted_story_ledger_v1`.
- PR 6: support artifact writers for `story_shape_signal_map_v1` + `manuscript_signal_appendix_v1`.
- PR 7: UI shell.

---

## Reviewer note

Please treat these docs as the canonical authority for Story Layer behavior going forward.

Any later implementation that diverges from this contract should be treated as a bug, not a design choice.