### PR TITLE
feat(stage): add stage machine and hard-stop contract enforcement

### DIFF
--- a/__tests__/evaluation/stageMachine.hardStop.test.ts
+++ b/__tests__/evaluation/stageMachine.hardStop.test.ts
@@ -1,0 +1,89 @@
+import {
+  canonicalLayerKeys,
+  checkSupportArtifactFreshness,
+  forbidLayer9,
+  forbidPhase2WithoutAcceptedLedger,
+  requireAcceptedLedger,
+  requireOverrideRole,
+  requireQualityReport,
+  requireStoryLayer,
+  requireUserFeedback,
+  type ArtifactSet,
+} from '../../lib/evaluation/stage-machine/hardStopGuards';
+
+const artifact = (id: string) => ({ artifact_id: id, source_hash: `hash:${id}` });
+
+describe('stage machine hard-stop guards', () => {
+  it('requires story layer and quality report before review gate', () => {
+    expect(requireStoryLayer({ pass1a_story_layer_v1: artifact('pass1a') })).toEqual({ ok: true });
+    expect(requireStoryLayer({})).toMatchObject({ ok: false });
+
+    expect(requireQualityReport({ ledger_quality_report_v1: artifact('quality') })).toEqual({ ok: true });
+    expect(requireQualityReport({})).toMatchObject({ ok: false });
+  });
+
+  it('requires user feedback even when the review disposition is accepted_without_changes', () => {
+    expect(requireUserFeedback({ ledger_user_feedback_v1: artifact('feedback') })).toEqual({ ok: true });
+    expect(requireUserFeedback({})).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('accepted_without_changes'),
+    });
+  });
+
+  it('requires accepted ledger before Phase 2 and rejects raw ledger-only handoff', () => {
+    const rawOnly: ArtifactSet = {
+      pass1a_story_layer_v1: artifact('pass1a'),
+      ledger_user_feedback_v1: artifact('feedback'),
+    };
+
+    expect(requireAcceptedLedger({ accepted_story_ledger_v1: artifact('accepted') })).toEqual({ ok: true });
+    expect(requireAcceptedLedger(rawOnly)).toMatchObject({ ok: false });
+    expect(forbidPhase2WithoutAcceptedLedger(rawOnly)).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('raw pass1a_story_layer_v1'),
+    });
+  });
+
+  it('allows override only for admin or operator roles', () => {
+    expect(requireOverrideRole('admin')).toEqual({ ok: true });
+    expect(requireOverrideRole('operator')).toEqual({ ok: true });
+    expect(requireOverrideRole('author')).toMatchObject({ ok: false });
+  });
+
+  it('flags stale support artifacts relative to accepted_story_ledger_v1', () => {
+    expect(checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: artifact('accepted'),
+      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: 'hash:accepted' },
+      manuscript_signal_appendix_v1: { accepted_story_ledger_source_hash: 'hash:accepted' },
+    })).toEqual({ ok: true });
+
+    expect(checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: artifact('accepted'),
+      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: 'stale-hash' },
+    })).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('stale'),
+    });
+  });
+
+  it('rejects any ninth or non-canonical Story Layer key', () => {
+    expect(forbidLayer9(canonicalLayerKeys())).toEqual({ ok: true });
+
+    expect(forbidLayer9([
+      ...canonicalLayerKeys(),
+      'structural_beat_layer',
+    ])).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('non-canonical'),
+    });
+  });
+
+  it('rejects missing or duplicate canonical layer keys', () => {
+    expect(forbidLayer9(canonicalLayerKeys().slice(0, 7))).toMatchObject({ ok: false });
+
+    expect(forbidLayer9([
+      ...canonicalLayerKeys().slice(0, 7),
+      canonicalLayerKeys()[0],
+    ])).toMatchObject({ ok: false });
+  });
+});

--- a/__tests__/evaluation/stageMachine.transitions.test.ts
+++ b/__tests__/evaluation/stageMachine.transitions.test.ts
@@ -1,0 +1,110 @@
+import { evaluateStageTransition } from '../../lib/evaluation/stage-machine/stageMachine';
+import { isAllowedStageTransition, STAGE_TRANSITIONS } from '../../lib/evaluation/stage-machine/stageTransitions';
+import type { ArtifactSet } from '../../lib/evaluation/stage-machine/hardStopGuards';
+
+const artifact = (id: string) => ({ artifact_id: id, source_hash: `hash:${id}` });
+
+const completeArtifactSet: ArtifactSet = {
+  pass1a_story_layer_v1: artifact('pass1a'),
+  ledger_quality_report_v1: artifact('quality'),
+  ledger_user_feedback_v1: artifact('feedback'),
+  accepted_story_ledger_v1: artifact('accepted'),
+};
+
+describe('stage machine canonical transitions', () => {
+  it('declares only the four canonical forward transitions', () => {
+    expect(STAGE_TRANSITIONS.map((transition) => `${transition.from}->${transition.to}`)).toEqual([
+      'phase_0_calibration->phase_1a_story_layer_build',
+      'phase_1a_story_layer_build->review_gate',
+      'review_gate->approval_normalizer',
+      'approval_normalizer->phase_2_evaluation',
+    ]);
+  });
+
+  it('allows Phase 0 to Phase 1A without artifact guards', () => {
+    expect(evaluateStageTransition({
+      from: 'phase_0_calibration',
+      to: 'phase_1a_story_layer_build',
+      artifacts: {},
+    })).toEqual({
+      ok: true,
+      from: 'phase_0_calibration',
+      to: 'phase_1a_story_layer_build',
+    });
+  });
+
+  it('allows Phase 1A to Review Gate only after story layer and quality report exist', () => {
+    expect(evaluateStageTransition({
+      from: 'phase_1a_story_layer_build',
+      to: 'review_gate',
+      artifacts: {
+        pass1a_story_layer_v1: completeArtifactSet.pass1a_story_layer_v1,
+        ledger_quality_report_v1: completeArtifactSet.ledger_quality_report_v1,
+      },
+    }).ok).toBe(true);
+
+    expect(evaluateStageTransition({
+      from: 'phase_1a_story_layer_build',
+      to: 'review_gate',
+      artifacts: {
+        pass1a_story_layer_v1: completeArtifactSet.pass1a_story_layer_v1,
+      },
+    })).toMatchObject({ ok: false });
+  });
+
+  it('allows Review Gate to Approval Normalizer only after ledger_user_feedback_v1 exists', () => {
+    expect(evaluateStageTransition({
+      from: 'review_gate',
+      to: 'approval_normalizer',
+      artifacts: {
+        ledger_user_feedback_v1: completeArtifactSet.ledger_user_feedback_v1,
+      },
+    }).ok).toBe(true);
+
+    expect(evaluateStageTransition({
+      from: 'review_gate',
+      to: 'approval_normalizer',
+      artifacts: {},
+    })).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('ledger_user_feedback_v1'),
+    });
+  });
+
+  it('allows Approval Normalizer to Phase 2 only after accepted_story_ledger_v1 exists', () => {
+    expect(evaluateStageTransition({
+      from: 'approval_normalizer',
+      to: 'phase_2_evaluation',
+      artifacts: {
+        accepted_story_ledger_v1: completeArtifactSet.accepted_story_ledger_v1,
+      },
+    }).ok).toBe(true);
+
+    expect(evaluateStageTransition({
+      from: 'approval_normalizer',
+      to: 'phase_2_evaluation',
+      artifacts: {
+        pass1a_story_layer_v1: completeArtifactSet.pass1a_story_layer_v1,
+        ledger_user_feedback_v1: completeArtifactSet.ledger_user_feedback_v1,
+      },
+    })).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('accepted_story_ledger_v1'),
+    });
+  });
+
+  it('rejects forbidden shortcuts and arbitrary backward jumps', () => {
+    const forbiddenPairs = [
+      ['phase_1a_story_layer_build', 'approval_normalizer'],
+      ['phase_1a_story_layer_build', 'phase_2_evaluation'],
+      ['review_gate', 'phase_2_evaluation'],
+      ['phase_2_evaluation', 'approval_normalizer'],
+      ['review_gate', 'phase_0_calibration'],
+    ] as const;
+
+    for (const [from, to] of forbiddenPairs) {
+      expect(isAllowedStageTransition(from, to)).toBe(false);
+      expect(evaluateStageTransition({ from, to, artifacts: completeArtifactSet })).toMatchObject({ ok: false });
+    }
+  });
+});

--- a/lib/evaluation/stage-machine/hardStopGuards.ts
+++ b/lib/evaluation/stage-machine/hardStopGuards.ts
@@ -1,0 +1,123 @@
+import { STORY_LAYER_CORE_LAYER_KEYS, type StoryLayerCoreLayerKey } from '../artifacts/artifactTypes';
+
+export type GuardResult = { ok: true } | { ok: false; reason: string };
+
+export type ArtifactRef = {
+  artifact_id: string;
+  source_hash: string;
+};
+
+export type SupportArtifactRef = {
+  accepted_story_ledger_source_hash: string;
+};
+
+export type ArtifactSet = {
+  pass1a_story_layer_v1?: ArtifactRef;
+  ledger_quality_report_v1?: ArtifactRef;
+  ledger_user_feedback_v1?: ArtifactRef;
+  accepted_story_ledger_v1?: ArtifactRef;
+  story_shape_signal_map_v1?: SupportArtifactRef;
+  manuscript_signal_appendix_v1?: SupportArtifactRef;
+};
+
+export type ReviewerRole = 'author' | 'admin' | 'operator';
+
+function ok(): GuardResult {
+  return { ok: true };
+}
+
+function fail(reason: string): GuardResult {
+  return { ok: false, reason };
+}
+
+function hasArtifactRef(ref: ArtifactRef | undefined): ref is ArtifactRef {
+  return Boolean(ref?.artifact_id && ref?.source_hash);
+}
+
+export function requireStoryLayer(set: ArtifactSet): GuardResult {
+  return hasArtifactRef(set.pass1a_story_layer_v1)
+    ? ok()
+    : fail('pass1a_story_layer_v1 is required before leaving Phase 1A');
+}
+
+export function requireQualityReport(set: ArtifactSet): GuardResult {
+  return hasArtifactRef(set.ledger_quality_report_v1)
+    ? ok()
+    : fail('ledger_quality_report_v1 is required before entering Review Gate');
+}
+
+export function requireUserFeedback(set: ArtifactSet): GuardResult {
+  return hasArtifactRef(set.ledger_user_feedback_v1)
+    ? ok()
+    : fail('ledger_user_feedback_v1 is required before Approval Normalizer, even for accepted_without_changes');
+}
+
+export function requireAcceptedLedger(set: ArtifactSet): GuardResult {
+  return hasArtifactRef(set.accepted_story_ledger_v1)
+    ? ok()
+    : fail('accepted_story_ledger_v1 is required before Phase 2 evaluation');
+}
+
+export function forbidPhase2WithoutAcceptedLedger(set: ArtifactSet): GuardResult {
+  if (hasArtifactRef(set.accepted_story_ledger_v1)) {
+    return ok();
+  }
+
+  if (hasArtifactRef(set.pass1a_story_layer_v1)) {
+    return fail('Phase 2 cannot consume raw pass1a_story_layer_v1; accepted_story_ledger_v1 is required');
+  }
+
+  return fail('Phase 2 requires accepted_story_ledger_v1 as story-understanding authority');
+}
+
+export function requireOverrideRole(role: ReviewerRole): GuardResult {
+  return role === 'admin' || role === 'operator'
+    ? ok()
+    : fail('accepted_with_override may only be written by admin or operator roles');
+}
+
+export function checkSupportArtifactFreshness(set: ArtifactSet): GuardResult {
+  const acceptedHash = set.accepted_story_ledger_v1?.source_hash;
+  if (!acceptedHash) {
+    return fail('accepted_story_ledger_v1 is required to validate support artifact freshness');
+  }
+
+  const supportArtifacts: Array<[keyof ArtifactSet, SupportArtifactRef | undefined]> = [
+    ['story_shape_signal_map_v1', set.story_shape_signal_map_v1],
+    ['manuscript_signal_appendix_v1', set.manuscript_signal_appendix_v1],
+  ];
+
+  for (const [artifactType, supportArtifact] of supportArtifacts) {
+    if (!supportArtifact) continue;
+    if (supportArtifact.accepted_story_ledger_source_hash !== acceptedHash) {
+      return fail(`${artifactType} is stale relative to accepted_story_ledger_v1`);
+    }
+  }
+
+  return ok();
+}
+
+export function forbidLayer9(layerKeys: readonly string[]): GuardResult {
+  const allowed = new Set<string>(STORY_LAYER_CORE_LAYER_KEYS);
+  const unexpected = layerKeys.filter((key) => !allowed.has(key));
+
+  if (unexpected.length > 0) {
+    return fail(`Story Layer contains non-canonical layer key(s): ${unexpected.join(', ')}`);
+  }
+
+  const missing = STORY_LAYER_CORE_LAYER_KEYS.filter((key) => !layerKeys.includes(key));
+  if (missing.length > 0) {
+    return fail(`Story Layer is missing canonical layer key(s): ${missing.join(', ')}`);
+  }
+
+  const uniqueLayerCount = new Set(layerKeys).size;
+  if (uniqueLayerCount !== STORY_LAYER_CORE_LAYER_KEYS.length || layerKeys.length !== STORY_LAYER_CORE_LAYER_KEYS.length) {
+    return fail('Story Layer must contain exactly eight canonical layers');
+  }
+
+  return ok();
+}
+
+export function canonicalLayerKeys(): readonly StoryLayerCoreLayerKey[] {
+  return STORY_LAYER_CORE_LAYER_KEYS;
+}

--- a/lib/evaluation/stage-machine/stageMachine.ts
+++ b/lib/evaluation/stage-machine/stageMachine.ts
@@ -1,0 +1,57 @@
+import { findStageTransition } from './stageTransitions';
+import type { StageState } from './stageStates';
+import {
+  forbidPhase2WithoutAcceptedLedger,
+  requireAcceptedLedger,
+  requireQualityReport,
+  requireStoryLayer,
+  requireUserFeedback,
+  type ArtifactSet,
+  type GuardResult,
+} from './hardStopGuards';
+
+export type StageMachineResult =
+  | { ok: true; from: StageState; to: StageState }
+  | { ok: false; from: StageState; to: StageState; reason: string };
+
+type GuardName =
+  | 'requireStoryLayer'
+  | 'requireQualityReport'
+  | 'requireUserFeedback'
+  | 'requireAcceptedLedger'
+  | 'forbidPhase2WithoutAcceptedLedger';
+
+const GUARDS: Record<GuardName, (set: ArtifactSet) => GuardResult> = {
+  requireStoryLayer,
+  requireQualityReport,
+  requireUserFeedback,
+  requireAcceptedLedger,
+  forbidPhase2WithoutAcceptedLedger,
+};
+
+function fail(from: StageState, to: StageState, reason: string): StageMachineResult {
+  return { ok: false, from, to, reason };
+}
+
+export function evaluateStageTransition(params: {
+  from: StageState;
+  to: StageState;
+  artifacts: ArtifactSet;
+}): StageMachineResult {
+  const transition = findStageTransition(params.from, params.to);
+
+  if (!transition) {
+    return fail(params.from, params.to, `Forbidden stage transition: ${params.from} to ${params.to}`);
+  }
+
+  for (const guardName of transition.requiredGuards) {
+    const guard = GUARDS[guardName as GuardName];
+    const result = guard(params.artifacts);
+
+    if (result.ok === false) {
+      return fail(params.from, params.to, result.reason);
+    }
+  }
+
+  return { ok: true, from: params.from, to: params.to };
+}

--- a/lib/evaluation/stage-machine/stageStates.ts
+++ b/lib/evaluation/stage-machine/stageStates.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical pure stage states for the Story Layer hard-stop contract.
+ *
+ * Scope: PR 3 pure state-machine logic only.
+ * Do not import runtime processor, worker, route, OpenAI, Supabase, or writer modules here.
+ */
+
+export const STAGE_STATES = [
+  'phase_0_calibration',
+  'phase_1a_story_layer_build',
+  'review_gate',
+  'approval_normalizer',
+  'phase_2_evaluation',
+] as const;
+
+export type StageState = typeof STAGE_STATES[number];
+
+export function isStageState(value: string): value is StageState {
+  return (STAGE_STATES as readonly string[]).includes(value);
+}

--- a/lib/evaluation/stage-machine/stageTransitions.ts
+++ b/lib/evaluation/stage-machine/stageTransitions.ts
@@ -1,0 +1,38 @@
+import type { StageState } from './stageStates';
+
+export type StageTransition = {
+  from: StageState;
+  to: StageState;
+  requiredGuards: readonly string[];
+};
+
+export const STAGE_TRANSITIONS: readonly StageTransition[] = [
+  {
+    from: 'phase_0_calibration',
+    to: 'phase_1a_story_layer_build',
+    requiredGuards: [],
+  },
+  {
+    from: 'phase_1a_story_layer_build',
+    to: 'review_gate',
+    requiredGuards: ['requireStoryLayer', 'requireQualityReport'],
+  },
+  {
+    from: 'review_gate',
+    to: 'approval_normalizer',
+    requiredGuards: ['requireUserFeedback'],
+  },
+  {
+    from: 'approval_normalizer',
+    to: 'phase_2_evaluation',
+    requiredGuards: ['requireAcceptedLedger', 'forbidPhase2WithoutAcceptedLedger'],
+  },
+] as const;
+
+export function findStageTransition(from: StageState, to: StageState): StageTransition | null {
+  return STAGE_TRANSITIONS.find((transition) => transition.from === from && transition.to === to) ?? null;
+}
+
+export function isAllowedStageTransition(from: StageState, to: StageState): boolean {
+  return findStageTransition(from, to) !== null;
+}


### PR DESCRIPTION
## Summary

Adds a pure-logic Eval 2.0 stage machine and hard-stop guard layer for the Story Layer / Review Gate rollout.

This PR encodes the canonical stage transitions from `STORY_LAYER_CONTRACT_V1.md` and enforces the rule that Phase 2 cannot consume raw `pass1a_story_layer_v1`; it may only proceed from `accepted_story_ledger_v1`.

## Scope

Adds descriptor/logic-only stage-machine files and tests:

- `lib/evaluation/stage-machine/stageStates.ts`
- `lib/evaluation/stage-machine/stageTransitions.ts`
- `lib/evaluation/stage-machine/stageMachine.ts`
- `lib/evaluation/stage-machine/hardStopGuards.ts`
- `__tests__/evaluation/stageMachine.transitions.test.ts`
- `__tests__/evaluation/stageMachine.hardStop.test.ts`

Canonical transitions enforced:

- `phase_0_calibration` → `phase_1a_story_layer_build`
- `phase_1a_story_layer_build` → `review_gate`
- `review_gate` → `approval_normalizer` `[guard: requireUserFeedback]`
- `approval_normalizer` → `phase_2_evaluation` `[guard: requireAcceptedLedger]`

Hard-stop guards include:

- `requireStoryLayer`
- `requireQualityReport`
- `requireUserFeedback`
- `requireAcceptedLedger`
- `forbidPhase2WithoutAcceptedLedger`
- `requireOverrideRole`
- `checkSupportArtifactFreshness`
- `forbidLayer9`

## Tests Updated

Added tests for:

- Allows Phase 1A → Review Gate only when `pass1a_story_layer_v1` + `ledger_quality_report_v1` exist.
- Allows Review Gate → Approval Normalizer only when `ledger_user_feedback_v1` exists.
- Allows Approval Normalizer → Phase 2 only when `accepted_story_ledger_v1` exists.
- Rejects raw ledger-only Phase 2 handoff.
- Rejects forbidden shortcuts and arbitrary backward jumps.
- Rejects `accepted_with_override` for author role.
- Flags stale support artifacts.
- Rejects any 9th or non-canonical Story Layer key.

## Risks & Anomalies

Risk is intentionally low because this PR is pure logic and tests. It does not wire the stage machine into runtime processors, workers, routes, cron jobs, SQL, prompts, Supabase writes, or UI behavior.

The main anomaly is CI classification: changed files live under `lib/evaluation/` and `__tests__/evaluation/`, so latency enforcement initially classified the PR as an evaluation-runtime PR. This PR is now labeled `pr-type:code` because it is a descriptor/guard substrate with no live runtime or latency impact.

## Out of Scope

- Phase 1A writers / PR4
- Approval writer
- Support artifact writers
- UI shell
- Processor/runtime/queue behavior
- SQL migrations
- Supabase writes
- Route, worker, cron, prompt, or UI changes

## Reviewer Note

This PR must remain pure-logic. Reject any commit that writes to Supabase, imports pipeline runtime modules, starts worker behavior, adds SQL, or changes prompt/runtime execution.

No-Pipeline-Impact: pure stage-machine guard substrate only; no runtime evaluator, LLM call, worker, queue, SQL, prompt, or artifact persistence path is executed by this PR.