### PR TITLE
feat(revision): bind WAVE voice protection to canon registry

### DIFF
--- a/.github/pr-bodies/PR-647.md
+++ b/.github/pr-bodies/PR-647.md
@@ -1,0 +1,33 @@
+## Summary
+
+Installs the pre-rewrite voice/dialogue protection layer for WAVE revision modules before they become destructive text-rewrite surfaces.
+
+This PR keeps the scope intentionally narrow:
+
+- Adds `lib/revision/canon/vocabulary.ts` as the canonical dialogue attribution-tag registry.
+- Adds `lib/revision/canon/voiceProtection.ts` as the canonical voice-protection registry/helper surface.
+- Binds Wave 23 attribution analysis to the canonical dialogue-tag registry instead of local hardcoded tag regex.
+- Surfaces canon-bound voice-protection signals in Waves 19, 54, and 55.
+- Adds regression coverage proving protected dialect, panic repetition, ritual/chant repetition, and cadence signals are detected without rewriting prose.
+
+## Non-goals
+
+- No processor/runtime changes.
+- No lease/fatal-write changes; that remains a separate PR B.
+- No text rewriting behavior added.
+- No WAVE routing changes.
+- No Gate 15.1/15.2 implementation changes.
+- No canon document relocation.
+
+## Verification
+
+- Added `__tests__/lib/revision/canon/voice-protection.test.ts`.
+- Targeted test command for CI/local verification:
+
+```bash
+npm test -- --runInBand --runTestsByPath __tests__/lib/revision/canon/voice-protection.test.ts
+```
+
+## Why this matters
+
+This makes the revision engine governance-first before it becomes rewrite-capable. The modules still return `proposedText: text` and `changes: []`, but now they emit explicit canon-bound protection signals for voice, dialect, ritual repetition, chant/song cadence, panic cognition, and symbolic echo.

--- a/__tests__/lib/revision/canon/voice-protection.test.ts
+++ b/__tests__/lib/revision/canon/voice-protection.test.ts
@@ -1,0 +1,115 @@
+import {
+	CANON_DIALOGUE_TAGS,
+	countCanonDialogueTags,
+	hasCanonDialogueTag,
+} from "../../../../lib/revision/canon/vocabulary";
+import {
+	buildVoiceProtectionModifications,
+	classifyProtectedVoiceSpans,
+	isProtectedVoiceSpan,
+} from "../../../../lib/revision/canon/voiceProtection";
+import wave19CharacterIdiolectSignatures from "../../../../lib/wave-modules/wave-19-character-idiolect-signatures";
+import wave23AttributionFrictionReduction from "../../../../lib/wave-modules/wave-23-attribution-friction-reduction";
+import wave54RepetitionAndEchoCleanup from "../../../../lib/wave-modules/wave-54-repetition-and-echo-cleanup";
+import wave55RhythmAndCadencePolish from "../../../../lib/wave-modules/wave-55-rhythm-and-cadence-polish";
+
+const STANDARD_MODE = "standard" as const;
+
+describe("canon-bound revision voice protection", () => {
+	test("dialogue tag registry is the single source used by attribution utilities", () => {
+		expect(CANON_DIALOGUE_TAGS).toContain("said");
+		expect(CANON_DIALOGUE_TAGS).toContain("whispered");
+		expect(CANON_DIALOGUE_TAGS).toContain("rasped");
+
+		const text = '"No time," she rasped. "Move," he said.';
+
+		expect(hasCanonDialogueTag(text)).toBe(true);
+		expect(countCanonDialogueTags(text)).toBe(2);
+	});
+
+	test("protects panic phrase repetition instead of treating it as generic cleanup", () => {
+		const text = "No time. No time. He kept moving.";
+		const hits = classifyProtectedVoiceSpans(text);
+
+		expect(isProtectedVoiceSpan(text)).toBe(true);
+		expect(hits.map((hit) => hit.protection)).toContain("PANIC_COGNITION");
+		expect(buildVoiceProtectionModifications(text)).toContain(
+			"voice-protection:PANIC_COGNITION:panic-cognition-phrase-repeat",
+		);
+	});
+
+	test("protects dialect register as possible character voice", () => {
+		const text = '"Ya gotta be kidding," he said.';
+		const protections = classifyProtectedVoiceSpans(text).map((hit) => hit.protection);
+
+		expect(protections).toContain("VOICE_DIALECT");
+	});
+
+	test("Wave 23 is bound to canonical dialogue tags", async () => {
+		const result = await wave23AttributionFrictionReduction(
+			'"No time," she rasped. "Move," he said.',
+			[{ zone: "scene", issueType: "dialogue", recommendedWave: 23, priority: "medium" }],
+			STANDARD_MODE,
+		);
+
+		expect(result.proposedText).toBe('"No time," she rasped. "Move," he said.');
+		expect(result.changes).toEqual([]);
+		expect(result.modifications).toContain("canon-bound:dialogue-tags");
+		expect(result.modifications).toContain("attribution-chain-detected");
+		expect(result.modifications).not.toContain("directive-verify-speaker-cues-without-explicit-tags");
+	});
+
+	test("Wave 19 surfaces protected voice signals without rewriting", async () => {
+		const text = '"Ya gotta move," he said. "No time. No time."';
+		const result = await wave19CharacterIdiolectSignatures(
+			text,
+			[{ zone: "scene", issueType: "voice", recommendedWave: 19, priority: "medium" }],
+			"deep",
+		);
+
+		expect(result.proposedText).toBe(text);
+		expect(result.changes).toEqual([]);
+		expect(result.modifications).toContain("canon-bound:voice-protection");
+		expect(result.modifications).toContain(
+			"wave19-protect:VOICE_DIALECT:dialect-contraction-register",
+		);
+		expect(result.modifications).toContain(
+			"wave19-protect:PANIC_COGNITION:panic-cognition-phrase-repeat",
+		);
+	});
+
+	test("Wave 54 protects ritual repetition before cleanup", async () => {
+		const text = "The chant came again and again. No time. No time.";
+		const result = await wave54RepetitionAndEchoCleanup(
+			text,
+			[{ zone: "paragraph", issueType: "repetition", recommendedWave: 54, priority: "medium" }],
+			STANDARD_MODE,
+		);
+
+		expect(result.proposedText).toBe(text);
+		expect(result.changes).toEqual([]);
+		expect(result.modifications).toContain("canon-bound:voice-protection");
+		expect(result.modifications).toContain(
+			"wave54-protect:CHANT_OR_SONG:chant-or-song-marker",
+		);
+		expect(result.modifications).toContain(
+			"wave54-protect:PANIC_COGNITION:panic-cognition-phrase-repeat",
+		);
+	});
+
+	test("Wave 55 surfaces cadence protection without changing prose", async () => {
+		const text = "The refrain came soft, soft, soft, then hard. No time. No time.";
+		const result = await wave55RhythmAndCadencePolish(
+			text,
+			[{ zone: "paragraph", issueType: "cadence", recommendedWave: 55, priority: "medium" }],
+			STANDARD_MODE,
+		);
+
+		expect(result.proposedText).toBe(text);
+		expect(result.changes).toEqual([]);
+		expect(result.modifications).toContain("canon-bound:voice-protection");
+		expect(result.modifications).toContain(
+			"wave55-protect:RITUAL_REPETITION:ritual-repetition-marker",
+		);
+	});
+});

--- a/lib/revision/canon/vocabulary.ts
+++ b/lib/revision/canon/vocabulary.ts
@@ -1,0 +1,48 @@
+/**
+ * Canonical dialogue vocabulary registry.
+ *
+ * This file is runtime canon for dialogue-attribution detection. WAVE modules
+ * must import this registry instead of maintaining local tag regex lists.
+ */
+
+export const CANON_DIALOGUE_TAGS = [
+  "said",
+  "asked",
+  "replied",
+  "answered",
+  "responded",
+  "whispered",
+  "murmured",
+  "muttered",
+  "breathed",
+  "snapped",
+  "shouted",
+  "yelled",
+  "called",
+  "cried",
+  "growled",
+  "hissed",
+  "rasped",
+] as const;
+
+export type CanonDialogueTag = (typeof CANON_DIALOGUE_TAGS)[number];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export const CANON_DIALOGUE_TAG_PATTERN_SOURCE = CANON_DIALOGUE_TAGS
+  .map(escapeRegExp)
+  .join("|");
+
+export function buildCanonDialogueTagRegex(flags = "gi"): RegExp {
+  return new RegExp(`\\b(?:${CANON_DIALOGUE_TAG_PATTERN_SOURCE})\\b`, flags);
+}
+
+export function countCanonDialogueTags(text: string): number {
+  return text.match(buildCanonDialogueTagRegex("gi"))?.length ?? 0;
+}
+
+export function hasCanonDialogueTag(text: string): boolean {
+  return buildCanonDialogueTagRegex("i").test(text);
+}

--- a/lib/revision/canon/voiceProtection.ts
+++ b/lib/revision/canon/voiceProtection.ts
@@ -1,0 +1,118 @@
+/**
+ * Canonical voice-protection registry.
+ *
+ * This is the pre-rewrite firewall for WAVE modules that may otherwise flatten
+ * dialect, ritual repetition, chant/song cadence, crude humor, panic cognition,
+ * or intentional symbolic echo into generic prose.
+ */
+
+export const VOICE_PROTECTION_CLASSES = [
+  "VOICE_DIALECT",
+  "CHARACTER_IDIOLECT",
+  "RITUAL_REPETITION",
+  "CHANT_OR_SONG",
+  "CRUDE_HUMOR",
+  "PANIC_COGNITION",
+  "SYMBOLIC_ECHO",
+  "INTENTIONAL_CADENCE",
+] as const;
+
+export type VoiceProtectionClass = (typeof VOICE_PROTECTION_CLASSES)[number];
+
+export type VoiceProtectionRule = {
+  id: string;
+  protection: VoiceProtectionClass;
+  pattern: RegExp;
+  rationale: string;
+};
+
+export type VoiceProtectionHit = {
+  ruleId: string;
+  protection: VoiceProtectionClass;
+  rationale: string;
+  excerpt: string;
+};
+
+export const VOICE_PROTECTION_RULES: VoiceProtectionRule[] = [
+  {
+    id: "dialect-contraction-register",
+    protection: "VOICE_DIALECT",
+    pattern: /\b(?:ain't|gonna|wanna|ya|y'all|gotta|lemme|kinda|sorta)\b/i,
+    rationale: "Dialect/contraction register may be character voice, not prose error.",
+  },
+  {
+    id: "panic-cognition-word-repeat",
+    protection: "PANIC_COGNITION",
+    pattern: /\b([a-z][a-z'\-]{1,20})(?:[.!?,;:\s]+\1){1,}\b/i,
+    rationale: "Immediate word repetition may encode panic, pressure, ritual emphasis, or cognition under stress.",
+  },
+  {
+    id: "panic-cognition-phrase-repeat",
+    protection: "PANIC_COGNITION",
+    pattern: /\b([a-z][a-z'\-]{1,20}(?:\s+[a-z][a-z'\-]{1,20}){0,3})(?:[.!?,;:]\s+|\s+)\1\b/i,
+    rationale: "Immediate phrase repetition may encode panic, pressure, ritual emphasis, or cognition under stress.",
+  },
+  {
+    id: "chant-or-song-marker",
+    protection: "CHANT_OR_SONG",
+    pattern: /\b(?:chant|song|sang|sing|sung|refrain|chorus|hymn|lullaby)\b/i,
+    rationale: "Chant/song/refrain language requires cadence protection before repetition cleanup.",
+  },
+  {
+    id: "ritual-repetition-marker",
+    protection: "RITUAL_REPETITION",
+    pattern: /\b(?:ritual|refrain|again and again|over and over|echo|incantation|prayer)\b/i,
+    rationale: "Ritualized repetition can be structural meaning rather than redundancy.",
+  },
+  {
+    id: "symbolic-echo-marker",
+    protection: "SYMBOLIC_ECHO",
+    pattern: /\b(?:motif|symbol|echo|callback|talisman|totem)\b/i,
+    rationale: "Symbolic echo/callback should be protected before line-level cleanup.",
+  },
+  {
+    id: "crude-humor-register",
+    protection: "CRUDE_HUMOR",
+    pattern: /\b(?:ass|shit|damn|hell|piss|crap|fuck)\b/i,
+    rationale: "Crude humor or profanity may be intentional voice/register and must not be normalized by default.",
+  },
+];
+
+function excerptForMatch(text: string, matchIndex: number, matchLength: number): string {
+  const start = Math.max(0, matchIndex - 40);
+  const end = Math.min(text.length, matchIndex + matchLength + 40);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+export function classifyProtectedVoiceSpans(text: string): VoiceProtectionHit[] {
+  const hits: VoiceProtectionHit[] = [];
+
+  for (const rule of VOICE_PROTECTION_RULES) {
+    const match = rule.pattern.exec(text);
+    if (!match || match.index === undefined) {
+      continue;
+    }
+
+    hits.push({
+      ruleId: rule.id,
+      protection: rule.protection,
+      rationale: rule.rationale,
+      excerpt: excerptForMatch(text, match.index, match[0].length),
+    });
+  }
+
+  return hits;
+}
+
+export function isProtectedVoiceSpan(text: string): boolean {
+  return classifyProtectedVoiceSpans(text).length > 0;
+}
+
+export function buildVoiceProtectionModifications(
+  text: string,
+  prefix = "voice-protection",
+): string[] {
+  return classifyProtectedVoiceSpans(text).map(
+    (hit) => `${prefix}:${hit.protection}:${hit.ruleId}`,
+  );
+}

--- a/lib/wave-modules/wave-19-character-idiolect-signatures.ts
+++ b/lib/wave-modules/wave-19-character-idiolect-signatures.ts
@@ -4,6 +4,7 @@ import {
 	isAllowedScope,
 } from "../revision/surgicalEnforcement";
 import { type WaveEntry, WAVE_REGISTRY } from "../revision/waveRegistry";
+import { buildVoiceProtectionModifications } from "../revision/canon/voiceProtection";
 
 export type RevisionTarget = {
 	zone: string;
@@ -62,7 +63,9 @@ export default async function wave19CharacterIdiolectSignatures(
 		"meta:category:character",
 		"meta:scope:scene",
 		"meta:criteria:IDIOLECT_SIGNATURE|CHARACTER_DIFFERENTIATION",
-		"analysis:description:Builds distinct lexical and syntactic fingerprints for principal speakers.",
+		"analysis:description:Builds distinct lexical and syntactic speaker markers.",
+		"canon-bound:voice-protection",
+		...buildVoiceProtectionModifications(text, "wave19-protect"),
 	];
 
 	if (lines.length > 1) {
@@ -78,7 +81,7 @@ export default async function wave19CharacterIdiolectSignatures(
 			mods.push("flag-flat-dialogue-cadence-across-speakers");
 		}
 	}
-	mods.push("directive-strengthen-speaker-specific-lexical-and-rhythmic-fingerprints");
+	mods.push("directive-strengthen-speaker-specific-lexical-and-rhythmic-markers");
 
 	return {
 		waveNumber: WAVE_NUMBER,

--- a/lib/wave-modules/wave-23-attribution-friction-reduction.ts
+++ b/lib/wave-modules/wave-23-attribution-friction-reduction.ts
@@ -4,6 +4,11 @@ import {
 	isAllowedScope,
 } from "../revision/surgicalEnforcement";
 import { type WaveEntry, WAVE_REGISTRY } from "../revision/waveRegistry";
+import {
+	CANON_DIALOGUE_TAG_PATTERN_SOURCE,
+	countCanonDialogueTags,
+	hasCanonDialogueTag,
+} from "../revision/canon/vocabulary";
 
 export type RevisionTarget = {
 	zone: string;
@@ -31,6 +36,10 @@ export type WaveModuleResult = {
 
 const WAVE_NUMBER = 23;
 const CRITERIA_IDS = ["ATTRIBUTION_CLARITY", "DIALOGUE_FLOW"];
+const ATTRIBUTION_CHAIN_REGEX = new RegExp(
+	`"[^"]+"\\s*,\\s*[^\\n]{0,25}\\b(?:${CANON_DIALOGUE_TAG_PATTERN_SOURCE})\\b[\\s\\S]{0,60}"[^"]+"`,
+	"i",
+);
 
 function getWave(): WaveEntry | undefined {
 	return WAVE_REGISTRY.find((wave) => wave.id === WAVE_NUMBER);
@@ -56,14 +65,15 @@ export default async function wave23AttributionFrictionReduction(
 		`wave-meta:category:${wave?.category ?? "dialogue"}`,
 		`wave-meta:scope:${wave?.scope ?? "paragraph"}`,
 		...CRITERIA_IDS.map((id) => `criterion:${id}`),
+		"canon-bound:dialogue-tags",
 	];
 
-	const tagMatches = text.match(/\b(said|asked|replied|whispered|shouted|murmured|snapped)\b/gi) ?? [];
-	if (tagMatches.length > 6) modifications.push("flag-heavy-attribution-density");
-	if (/"[^"]+"\s*,\s*[^\n]{0,25}\b(said|asked|replied)\b[\s\S]{0,60}"[^"]+"/i.test(text)) {
+	const tagMatches = countCanonDialogueTags(text);
+	if (tagMatches > 6) modifications.push("flag-heavy-attribution-density");
+	if (ATTRIBUTION_CHAIN_REGEX.test(text)) {
 		modifications.push("attribution-chain-detected");
 	}
-	if (!/\b(said|asked|replied|whispered|shouted|murmured|snapped)\b/i.test(text)) {
+	if (!hasCanonDialogueTag(text)) {
 		modifications.push("directive-verify-speaker-cues-without-explicit-tags");
 	}
 

--- a/lib/wave-modules/wave-54-repetition-and-echo-cleanup.ts
+++ b/lib/wave-modules/wave-54-repetition-and-echo-cleanup.ts
@@ -4,6 +4,7 @@ import {
 	isAllowedScope,
 } from "../revision/surgicalEnforcement";
 import { type WaveEntry, WAVE_REGISTRY } from "../revision/waveRegistry";
+import { buildVoiceProtectionModifications } from "../revision/canon/voiceProtection";
 
 export type RevisionTarget = {
 	zone: string;
@@ -71,6 +72,8 @@ export default async function wave54RepetitionAndEchoCleanup(
 		`wave-meta:category:${wave?.category ?? "polish"}`,
 		`wave-meta:scope:${wave?.scope ?? "paragraph"}`,
 		...CRITERIA_IDS.map((id) => `criterion:${id}`),
+		"canon-bound:voice-protection",
+		...buildVoiceProtectionModifications(text, "wave54-protect"),
 	];
 
 	for (let i = 0; i < paragraphs.length; i += 1) {

--- a/lib/wave-modules/wave-55-rhythm-and-cadence-polish.ts
+++ b/lib/wave-modules/wave-55-rhythm-and-cadence-polish.ts
@@ -4,6 +4,7 @@ import {
 	isAllowedScope,
 } from "../revision/surgicalEnforcement";
 import { type WaveEntry, WAVE_REGISTRY } from "../revision/waveRegistry";
+import { buildVoiceProtectionModifications } from "../revision/canon/voiceProtection";
 
 export type RevisionTarget = {
 	zone: string;
@@ -65,6 +66,8 @@ export default async function wave55RhythmAndCadencePolish(
 		`wave-meta:category:${wave?.category ?? "polish"}`,
 		`wave-meta:scope:${wave?.scope ?? "paragraph"}`,
 		...CRITERIA_IDS.map((id) => `criterion:${id}`),
+		"canon-bound:voice-protection",
+		...buildVoiceProtectionModifications(text, "wave55-protect"),
 	];
 
 	for (let i = 0; i < paragraphs.length; i += 1) {


### PR DESCRIPTION
## Summary

Installs the pre-rewrite voice/dialogue protection layer for WAVE revision modules before they become destructive text-rewrite surfaces.

This PR keeps the scope intentionally narrow:

- Adds `lib/revision/canon/vocabulary.ts` as the canonical dialogue attribution-tag registry.
- Adds `lib/revision/canon/voiceProtection.ts` as the canonical voice-protection registry/helper surface.
- Binds Wave 23 attribution analysis to the canonical dialogue-tag registry instead of local hardcoded tag regex.
- Surfaces canon-bound voice-protection signals in Waves 19, 54, and 55.
- Adds regression coverage proving protected dialect, panic repetition, ritual/chant repetition, and cadence signals are detected without rewriting prose.

## Non-goals

- No processor/runtime changes.
- No lease/fatal-write changes; that remains a separate PR B.
- No text rewriting behavior added.
- No WAVE routing changes.
- No Gate 15.1/15.2 implementation changes.
- No canon document relocation.

## Verification

- Added `__tests__/lib/revision/canon/voice-protection.test.ts`.
- Targeted test command for CI/local verification:

```bash
npm test -- --runInBand --runTestsByPath __tests__/lib/revision/canon/voice-protection.test.ts
```

## Why this matters

This makes the revision engine governance-first before it becomes rewrite-capable. The modules still return `proposedText: text` and `changes: []`, but now they emit explicit canon-bound protection signals for voice, dialect, ritual repetition, chant/song cadence, panic cognition, and symbolic echo.