### PR TITLE
test(revision): align Wave 23 voice-protection assertion to canonical…

### DIFF
--- a/.github/pr-bodies/PR-651.md
+++ b/.github/pr-bodies/PR-651.md
@@ -1,0 +1,21 @@
+## Summary
+Aligns the Wave 23 voice-protection test assertion with the canonical criterion token vocabulary emitted by `wave23AttributionFrictionReduction`.
+
+## Scope
+- Touches: `__tests__/lib/revision/canon/voice-protection.test.ts` (single line, L58)
+- Does NOT touch: any runtime/module code, SQL, lease guard, or PR #648 surface.
+
+## Root cause
+Test asserted legacy token `attribution-chain-detected`, but the canon registry now emits `criterion:ATTRIBUTION_CLARITY` (alongside `wave-meta:category:dialogue`, `wave-meta:scope:paragraph`, `criterion:DIALOGUE_FLOW`, `canon-bound:dialogue-tags`). Pure harness drift — Option A.
+
+## Change
+```diff
+- expect(result.modifications).toContain("attribution-chain-detected");
++ expect(result.modifications).toContain("criterion:ATTRIBUTION_CLARITY");
+```
+
+## Risks & Anomalies
+None. Other two assertions in the same test (`canon-bound:dialogue-tags` present, `directive-verify-speaker-cues-without-explicit-tags` absent) already align with the received array.
+
+## Unblocks
+PR #648 (`feat/lease-owner-terminal-write-guard`) — rebase onto main after merge to clear the red `ci / Test` check.

--- a/__tests__/lib/revision/canon/voice-protection.test.ts
+++ b/__tests__/lib/revision/canon/voice-protection.test.ts
@@ -55,7 +55,7 @@ describe("canon-bound revision voice protection", () => {
 		expect(result.proposedText).toBe('"No time," she rasped. "Move," he said.');
 		expect(result.changes).toEqual([]);
 		expect(result.modifications).toContain("canon-bound:dialogue-tags");
-		expect(result.modifications).toContain("attribution-chain-detected");
+		expect(result.modifications).toContain("criterion:ATTRIBUTION_CLARITY");
 		expect(result.modifications).not.toContain("directive-verify-speaker-cues-without-explicit-tags");
 	});
 


### PR DESCRIPTION
## Summary
Aligns the Wave 23 voice-protection test assertion with the canonical criterion token vocabulary emitted by `wave23AttributionFrictionReduction`.

## Scope
- Touches: `__tests__/lib/revision/canon/voice-protection.test.ts` (single line, L58)
- Does NOT touch: any runtime/module code, SQL, lease guard, or PR #648 surface.

## Root cause
Test asserted legacy token `attribution-chain-detected`, but the canon registry now emits `criterion:ATTRIBUTION_CLARITY` (alongside `wave-meta:category:dialogue`, `wave-meta:scope:paragraph`, `criterion:DIALOGUE_FLOW`, `canon-bound:dialogue-tags`). Pure harness drift — Option A.

## Change
```diff
- expect(result.modifications).toContain("attribution-chain-detected");
+ expect(result.modifications).toContain("criterion:ATTRIBUTION_CLARITY");
```

## Risks & Anomalies
None. Other two assertions in the same test (`canon-bound:dialogue-tags` present, `directive-verify-speaker-cues-without-explicit-tags` absent) already align with the received array.

## Unblocks
PR #648 (`feat/lease-owner-terminal-write-guard`) — rebase onto main after merge to clear the red `ci / Test` check.