### PR TITLE
Archive legacy silo references and add parity audit certificate

### DIFF
--- a/.github/pr-bodies/PR-656.md
+++ b/.github/pr-bodies/PR-656.md
@@ -1,0 +1,67 @@
+## Summary
+
+Adds an archive-only decommissioning registry entry for the legacy static marketing/export silo after PR #654 moved canonical public routing into the Next.js `app/` router shell.
+
+This PR intentionally does **not** delete any legacy static files.
+
+## Why
+
+PR #654 established the App Router shell as canonical for the public RevisionGrade user journey. However, the remaining static assets under `public/marketing-export/` may still contain reference copy, interaction behavior, or Workbench/demo logic that has not been fully proven migrated.
+
+The governance-safe action is therefore:
+
+1. Mark the silo as non-canonical runtime material.
+2. Preserve it as reference-only material.
+3. Block purge until a parity audit proves no mission-critical behavior remains trapped in static HTML/JS/CSS.
+
+## What changed
+
+Adds:
+
+- `docs/governance/decommissioning-registry.md`
+
+The registry records:
+
+- PR #654 as the routing ownership trigger.
+- Current canonical `app/` route owners.
+- Evidence that `ChartEngine` and `useInlineEdit` were not found on `main` during parity checks.
+- Evidence that `app/dashboard/page.tsx` is routed and componentized.
+- Evidence that `app/workbench/page.tsx` is still local-state/static-opportunity driven.
+- A purge block for Workbench/dashboard parity risks.
+- Required grep/audit commands before any later deletion PR.
+
+## Scope boundaries
+
+This PR does **not** change:
+
+- Runtime routing
+- Public navigation
+- App Router pages
+- Evaluation pipeline logic
+- Scoring
+- Worker logic
+- Supabase schema/migrations
+- Any static assets under `public/marketing-export/`
+
+## Governance position
+
+Archive: allowed.
+
+Purge: blocked.
+
+Permanent deletion of the legacy silo requires a later PR with a parity report demonstrating that Workbench and dashboard behavior has either been migrated or explicitly waived.
+
+## Validation
+
+Docs-only change. No build/runtime behavior should change.
+
+Recommended local verification:
+
+```bash
+git grep -n "DECOMMISSIONING CERTIFICATE" docs/governance/decommissioning-registry.md
+git grep -n "Purge is blocked" docs/governance/decommissioning-registry.md
+```
+
+## No-Pipeline-Impact
+
+true

--- a/docs/governance/decommissioning-registry.md
+++ b/docs/governance/decommissioning-registry.md
@@ -1,0 +1,87 @@
+# Decommissioning Registry
+
+## DECOMMISSIONING CERTIFICATE: Silo Prototype Retirement — Phase 1 Archive Gate
+
+- **Date:** 2026-05-23
+- **Status:** Archive-only; purge is not authorized.
+- **Trigger:** PR #654 migrated public routing ownership from static `public/marketing-export` rewrites to the canonical Next.js `app/` router shell.
+- **Canonical Runtime Ownership:**
+  - `app/page.tsx`
+  - `app/revise/page.tsx`
+  - `app/resources/page.tsx`
+  - `app/reliability/page.tsx`
+  - `app/methodology/page.tsx`
+  - `app/dashboard/page.tsx`
+  - `app/workbench/page.tsx`
+
+### Runtime disposition
+
+The legacy static marketing-export assets are no longer canonical production route owners after PR #654. They remain reference material only until parity risk is closed.
+
+### Evidence snapshot
+
+- Repository search found no `ChartEngine` symbol on `main` during the parity check.
+- Repository search found no `useInlineEdit` symbol on `main` during the parity check.
+- `app/dashboard/page.tsx` is production-routed and componentized through `DashboardHeader`, `KpiCard`, `EvaluationHistoryTable`, `EmptyState`, `getDashboardEvaluations`, and `computeDashboardKpis`.
+- `app/workbench/page.tsx` is a client route with local `useState`, typed `Opportunity`, typed `Decision`, typed `SessionEntry`, static `OPPORTUNITIES`, and local decision stamping.
+- The legacy revise script still contains substantive queue/demo behavior and must remain available as parity reference until Workbench migration is complete.
+
+### Legacy assets currently treated as reference-only
+
+- `public/marketing-export/main/index.html`
+- `public/marketing-export/main/landing.js`
+- `public/marketing-export/revise/index.html`
+- `public/marketing-export/revise/script.js`
+- Associated CSS/assets under `public/marketing-export/`
+
+### Referenced artifacts not proven present on current `main`
+
+The following prototype-era filenames were referenced in planning material but were not proven present as root-level files during the parity check:
+
+- `dashboard.html`
+- `workbench.html`
+- `revise-workbench.html`
+- `update_css.py`
+- root-level `style.css`, `marketing.css`, `dashboard.css`, `report.css`
+
+If copies exist in another branch, local workspace, uploaded bundle, or archive directory, they remain subject to the same parity gate before purge.
+
+### Open parity risk
+
+Purge is blocked until the following Workbench behaviors are either verified in `app/` / `components/` / `lib/` or explicitly waived in a follow-up certificate:
+
+- Inline edit behavior
+- `onBlur` persistence
+- `Escape` / ESC rejection behavior
+- Keyboard event handling
+- `localStorage` or `sessionStorage` persistence
+- Accept / reject / keep / custom decision state-machine behavior
+- Revision diff or custom revision wrapping behavior
+- Any Chart.js or dashboard visualization behavior not represented by current dashboard components
+
+### Required audit command before purge
+
+```bash
+grep -RniE "Chart|new Chart|chart.js|addEventListener|onclick|localStorage|sessionStorage|contenteditable|onblur|blur|Escape|keydown|custom-wrap|accept|reject|defer|diff|revision" public/marketing-export docs archive . 2>/dev/null
+```
+
+Meaningful hits must be compared against:
+
+```bash
+app/dashboard
+components/dashboard
+lib/dashboard
+app/workbench
+components
+lib/hooks
+```
+
+### Purge authorization
+
+**Blocked.**
+
+A later PR may permanently delete the legacy silo only after the parity report demonstrates that no mission-critical dashboard/workbench interaction logic remains trapped in static HTML/JS/CSS assets.
+
+### Authorized next action
+
+Archive or retain legacy assets as reference-only material. Do not delete them as part of this certificate.


### PR DESCRIPTION
## Summary

Adds an archive-only decommissioning registry entry for the legacy static marketing/export silo after PR #654 moved canonical public routing into the Next.js `app/` router shell.

This PR intentionally does **not** delete any legacy static files.

## Why

PR #654 established the App Router shell as canonical for the public RevisionGrade user journey. However, the remaining static assets under `public/marketing-export/` may still contain reference copy, interaction behavior, or Workbench/demo logic that has not been fully proven migrated.

The governance-safe action is therefore:

1. Mark the silo as non-canonical runtime material.
2. Preserve it as reference-only material.
3. Block purge until a parity audit proves no mission-critical behavior remains trapped in static HTML/JS/CSS.

## What changed

Adds:

- `docs/governance/decommissioning-registry.md`

The registry records:

- PR #654 as the routing ownership trigger.
- Current canonical `app/` route owners.
- Evidence that `ChartEngine` and `useInlineEdit` were not found on `main` during parity checks.
- Evidence that `app/dashboard/page.tsx` is routed and componentized.
- Evidence that `app/workbench/page.tsx` is still local-state/static-opportunity driven.
- A purge block for Workbench/dashboard parity risks.
- Required grep/audit commands before any later deletion PR.

## Scope boundaries

This PR does **not** change:

- Runtime routing
- Public navigation
- App Router pages
- Evaluation pipeline logic
- Scoring
- Worker logic
- Supabase schema/migrations
- Any static assets under `public/marketing-export/`

## Governance position

Archive: allowed.

Purge: blocked.

Permanent deletion of the legacy silo requires a later PR with a parity report demonstrating that Workbench and dashboard behavior has either been migrated or explicitly waived.

## Validation

Docs-only change. No build/runtime behavior should change.

Recommended local verification:

```bash
git grep -n "DECOMMISSIONING CERTIFICATE" docs/governance/decommissioning-registry.md
git grep -n "Purge is blocked" docs/governance/decommissioning-registry.md
```

## No-Pipeline-Impact

true