### PR TITLE
Replace subscription pricing with readiness audit model

### DIFF
--- a/.github/pr-bodies/PR-658.md
+++ b/.github/pr-bodies/PR-658.md
@@ -1,0 +1,53 @@
+## Summary
+
+Replaces the legacy subscription-style pricing page with the RevisionGrade™ fixed-price audit / metered Editorial Actions pricing doctrine.
+
+This PR removes the old Free / Professional / Studio monthly pricing copy, including the misleading unlimited-evaluations model, and replaces it with the governed Editorial Audit ladder.
+
+## What changed
+
+- Refactors `app/pricing/page.tsx` into the new audit pricing page.
+- Adds `docs/brand/pricing-readiness.md` as the pricing doctrine source of truth.
+- Updates `docs/brand/black-box-readiness.md` with:
+  - Editorial Blind Date doctrine
+  - Golden Spine™ threshold
+  - WAVE Revision System™ threshold
+  - fixed-price audit / metered repair doctrine
+- Updates `docs/brand/README.md` to link the pricing doctrine.
+
+## Pricing doctrine
+
+- Fixed-price audit.
+- Metered repair.
+- No unlimited revision.
+- The audit reveals the condition of the manuscript.
+- Editorial Actions unlock and repair specific opportunities.
+
+## Scope boundaries
+
+This PR does **not** change:
+
+- Stripe or checkout logic
+- Database schema
+- Editorial Actions ledger enforcement
+- Opportunity unlock endpoints
+- Auth
+- Evaluation pipeline
+- Revise execution
+- Dashboard/workbench behavior
+- Runtime governance
+
+## Validation
+
+Recommended:
+
+```bash
+npm run build
+```
+
+## Changed files
+
+- `app/pricing/page.tsx`
+- `docs/brand/pricing-readiness.md`
+- `docs/brand/black-box-readiness.md`
+- `docs/brand/README.md`

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,44 +1,237 @@
 import Link from "next/link";
 
+export const metadata = {
+  title: "Pricing | RevisionGrade™",
+  description:
+    "Fixed-price editorial audits and metered Editorial Actions for governed manuscript readiness.",
+};
+
+const auditTiers = [
+  {
+    name: "Free Opening Diagnostic",
+    wordCount: "Up to 3,000 words",
+    price: "$0",
+    actionsIncluded: "0",
+    bestFor: "Testing hook, voice, and narrative pressure.",
+    features: ["Opening hook", "Voice signal", "Readiness preview", "No WAVE Revision System"],
+  },
+  {
+    name: "Short-Form Evaluation",
+    wordCount: "Up to 24,999 words",
+    price: "$49",
+    actionsIncluded: "5",
+    bestFor: "Novellas, short stories, and early concept tests.",
+    features: ["13 Story Criteria", "Readiness verdict", "Editorial path preview", "No WAVE Revision System"],
+  },
+  {
+    name: "Full Manuscript Readiness Audit",
+    wordCount: "25,000–120,000 words",
+    price: "$249",
+    actionsIncluded: "25",
+    bestFor: "The Professional Standard for novels and long-form manuscripts.",
+    features: ["13 Story Criteria", "WAVE Revision System™", "Readiness diagnosis", "Golden Spine™ long-form threshold"],
+    highlighted: true,
+  },
+  {
+    name: "Long Manuscript Readiness Audit",
+    wordCount: "120,001–180,000 words",
+    price: "$399",
+    actionsIncluded: "50",
+    bestFor: "Epic-scale manuscripts and longer novels.",
+    features: ["13 Story Criteria", "WAVE Revision System™", "Expanded long-form diagnostics", "Scale-aware opportunity summary"],
+  },
+  {
+    name: "Complex Narrative Audit",
+    wordCount: "180,001+ words",
+    price: "$499+",
+    actionsIncluded: "100",
+    bestFor: "Multi-layer, transmedia, or franchise-scale work.",
+    features: ["13 Story Criteria", "WAVE Revision System™", "Multi-POV architecture review", "Custom complexity handling"],
+  },
+];
+
+const actionPacks = [
+  { name: "Starter Pack", actions: "25 Editorial Actions", price: "$29" },
+  { name: "Professional Pack", actions: "100 Editorial Actions", price: "$89" },
+  { name: "Studio Pack", actions: "300 Editorial Actions", price: "$199" },
+];
+
+const faqs = [
+  {
+    question: "What is the difference between an audit and an Editorial Action?",
+    answer:
+      "An audit is the fixed-price diagnostic: it reveals the condition of the manuscript, including readiness risks, strengths, and the kind of editorial support the work may need next. Editorial Actions unlock and repair specific opportunities through granular opportunity cards and governed repair proposals.",
+  },
+  {
+    question: "Why does the WAVE Revision System™ start at 25,000 words?",
+    answer:
+      "We call 25,000 words the Golden Spine™ threshold. Below that point, most works can be evaluated through the 13 Story Criteria. At and above that threshold, long-range structure, pacing, character continuity, payoff, and cumulative reader experience require the WAVE Revision System™.",
+  },
+  {
+    question: "Can I see every granular opportunity after an audit?",
+    answer:
+      "Every paid audit includes a readiness diagnosis and opportunity summary. Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions included with your audit or available in packs.",
+  },
+  {
+    question: "Why not offer unlimited revisions?",
+    answer:
+      "Revision work is variable. A strong manuscript may need only a few targeted repairs, while a structurally weak manuscript may produce hundreds of opportunities. Fixed-price unlimited revision would force strong manuscripts to subsidize weak ones and would encourage low-value generation.",
+  },
+  {
+    question: "Is RevisionGrade replacing human editors?",
+    answer:
+      "No. RevisionGrade helps you understand what kind of editorial help your manuscript actually needs before you spend money on professional human intervention: developmental editing, line editing, copyediting, proofreading, market positioning, or deeper structural repair.",
+  },
+];
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">
+      {children}
+    </p>
+  );
+}
+
 export default function PricingPage() {
   return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Pricing</h1>
-      <p className="text-slate-600 mb-6">Choose the plan that fits your needs.</p>
-      <div className="grid gap-6 sm:grid-cols-3">
-        <div className="rounded-lg border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold">Essentials</h3>
-          <p className="text-2xl font-bold text-indigo-600 mt-2 mb-4">Free</p>
-          <ul className="space-y-2 text-sm text-slate-600">
-            <li>Single manuscript evaluation</li>
-            <li>Basic WAVE scoring</li>
-            <li>Summary feedback</li>
-          </ul>
-          <Link href="/evaluate" className="mt-6 block text-center rounded-lg bg-indigo-600 px-4 py-2 text-white text-sm font-medium hover:bg-indigo-700">Get Started</Link>
+    <div className="bg-rg-ink text-rg-cream">
+      <section className="mx-auto max-w-7xl px-6 py-20 lg:py-28">
+        <div className="max-w-4xl">
+          <SectionLabel>RevisionGrade™ Pricing</SectionLabel>
+          <h1 className="mt-6 font-rg-serif text-5xl leading-[0.98] tracking-tight text-rg-cream md:text-7xl">
+            Before you pay for polish, diagnose readiness.
+          </h1>
+          <p className="mt-8 max-w-3xl text-lg leading-8 text-rg-cream2/80">
+            RevisionGrade™ is priced as an editorial audit system: fixed-price diagnosis first, metered repair only when you unlock and act on specific story opportunities.
+          </p>
         </div>
-        <div className="rounded-lg border-2 border-indigo-600 p-6">
-          <h3 className="text-lg font-semibold">Professional</h3>
-          <p className="text-2xl font-bold text-indigo-600 mt-2 mb-4">$29/mo</p>
-          <ul className="space-y-2 text-sm text-slate-600">
-            <li>Unlimited evaluations</li>
-            <li>Full WAVE reports</li>
-            <li>Revision tracking</li>
-            <li>Content conversion</li>
-          </ul>
-          <Link href="/evaluate" className="mt-6 block text-center rounded-lg bg-indigo-600 px-4 py-2 text-white text-sm font-medium hover:bg-indigo-700">Get Started</Link>
+      </section>
+
+      <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
+        <div className="mx-auto max-w-7xl px-6 py-16">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <SectionLabel>Editorial Audit Pricing</SectionLabel>
+              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl">
+                Fixed-price readiness audits.
+              </h2>
+            </div>
+            <p className="max-w-xl text-sm leading-7 text-rg-cream2/70">
+              The Full Manuscript Readiness Audit is the professional standard for long-form authors preparing a serious manuscript for revision, editing, or submission.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-5 lg:grid-cols-5">
+            {auditTiers.map((tier) => (
+              <article
+                key={tier.name}
+                className={`relative border p-5 ${
+                  tier.highlighted
+                    ? "border-rg-gold bg-rg-cream text-rg-ink shadow-2xl shadow-black/30"
+                    : "border-rg-cream2/12 bg-rg-ink/70 text-rg-cream"
+                }`}
+              >
+                {tier.highlighted && (
+                  <div className="absolute -top-3 left-5 bg-rg-gold px-3 py-1 font-rg-mono text-[0.62rem] uppercase tracking-[0.16em] text-rg-ink">
+                    Professional Standard
+                  </div>
+                )}
+                <h3 className="font-rg-serif text-2xl leading-tight">{tier.name}</h3>
+                <p className={`mt-3 font-rg-mono text-[0.68rem] uppercase tracking-[0.14em] ${tier.highlighted ? "text-rg-ink/65" : "text-rg-gold"}`}>
+                  {tier.wordCount}
+                </p>
+                <p className="mt-5 font-rg-serif text-4xl">{tier.price}</p>
+                <p className={`mt-3 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/70" : "text-rg-cream2/75"}`}>
+                  {tier.bestFor}
+                </p>
+                <div className={`mt-5 border-t pt-4 ${tier.highlighted ? "border-rg-ink/15" : "border-rg-cream2/10"}`}>
+                  <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.14em]">
+                    {tier.actionsIncluded} Editorial Actions included
+                  </p>
+                  <ul className={`mt-4 space-y-2 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/75" : "text-rg-cream2/75"}`}>
+                    {tier.features.map((feature) => (
+                      <li key={feature}>• {feature}</li>
+                    ))}
+                  </ul>
+                </div>
+                <Link
+                  href="/evaluate"
+                  className={`mt-6 block border px-4 py-3 text-center font-rg-mono text-xs uppercase tracking-[0.16em] transition ${
+                    tier.highlighted
+                      ? "border-rg-ink bg-rg-ink text-rg-cream hover:bg-transparent hover:text-rg-ink"
+                      : "border-rg-gold text-rg-gold hover:bg-rg-gold hover:text-rg-ink"
+                  }`}
+                >
+                  Start Audit
+                </Link>
+              </article>
+            ))}
+          </div>
         </div>
-        <div className="rounded-lg border border-slate-200 p-6">
-          <h3 className="text-lg font-semibold">Studio</h3>
-          <p className="text-2xl font-bold text-indigo-600 mt-2 mb-4">$79/mo</p>
-          <ul className="space-y-2 text-sm text-slate-600">
-            <li>Everything in Professional</li>
-            <li>Storygate Studio access</li>
-            <li>Priority processing</li>
-            <li>Admin dashboard</li>
-          </ul>
-          <Link href="/evaluate" className="mt-6 block text-center rounded-lg bg-indigo-600 px-4 py-2 text-white text-sm font-medium hover:bg-indigo-700">Get Started</Link>
+      </section>
+
+      <section className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.85fr_1.15fr]">
+        <div>
+          <SectionLabel>Editorial Actions</SectionLabel>
+          <h2 className="mt-4 font-rg-serif text-4xl leading-tight text-rg-cream md:text-5xl">
+            Metered repair. No unlimited revision.
+          </h2>
+          <p className="mt-6 leading-8 text-rg-cream2/75">
+            Once your audit is complete, Editorial Actions unlock granular opportunity cards and generate governed, continuity-aware repair proposals for specific story opportunities.
+          </p>
         </div>
-      </div>
-    </main>
+        <div className="grid gap-4 md:grid-cols-3">
+          {actionPacks.map((pack) => (
+            <article key={pack.name} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6">
+              <h3 className="font-rg-serif text-2xl text-rg-cream">{pack.name}</h3>
+              <p className="mt-3 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-gold">{pack.actions}</p>
+              <p className="mt-5 font-rg-serif text-4xl text-rg-cream">{pack.price}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-rg-cream text-rg-ink">
+        <div className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.8fr_1.2fr]">
+          <div>
+            <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">A Note on Editorial Readiness</p>
+            <h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">
+              RevisionGrade™ is not a writing tool.
+            </h2>
+          </div>
+          <div className="space-y-5 text-lg leading-8 text-rg-ink/75">
+            <p>
+              It is an editorial audit system. Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is strong, where it is vulnerable, and what kind of editorial support it may need next.
+            </p>
+            <p>
+              Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions included with your audit or available in packs.
+            </p>
+            <p className="font-rg-serif text-3xl leading-tight text-rg-ink">
+              Before you pay for polish, diagnose readiness.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-20">
+        <SectionLabel>FAQ</SectionLabel>
+        <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl">
+          Fixed-price audit. Metered repair.
+        </h2>
+        <div className="mt-10 grid gap-4 md:grid-cols-2">
+          {faqs.map((item) => (
+            <article key={item.question} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6">
+              <h3 className="font-rg-serif text-2xl text-rg-cream">{item.question}</h3>
+              <p className="mt-4 leading-7 text-rg-cream2/75">{item.answer}</p>
+            </article>
+          ))}
+        </div>
+        <div className="mt-12 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]">
+          <Link href="/black-box-problem" className="text-rg-gold hover:text-rg-cream">Read the Black Box Problem →</Link>
+          <Link href="/resources" className="text-rg-gold hover:text-rg-cream">Resources →</Link>
+          <Link href="/evaluate" className="text-rg-gold hover:text-rg-cream">Start Evaluate →</Link>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -5,13 +5,20 @@ This directory contains canonical public-brand doctrine for RevisionGrade™.
 ## Canonical documents
 
 - `black-box-readiness.md` — defines the Black Box Problem, the RevisionGrade™ Readiness Standard, the tagline hierarchy, and the readiness-vs-generation roadmap filter.
+- `pricing-readiness.md` — defines the fixed-price audit / metered Editorial Actions pricing doctrine, the Golden Spine™ threshold, and the no-unlimited-revision rule.
 
 ## Governance use
 
-Brand doctrine in this directory should be used to evaluate public-route copy, product positioning, and feature proposals that affect the author-facing promise.
+Brand doctrine in this directory should be used to evaluate public-route copy, product positioning, pricing language, and feature proposals that affect the author-facing promise.
 
 A future feature should answer this question before implementation:
 
 > Does the feature help an author understand or improve manuscript readiness, or does it merely generate more text?
 
 If it only generates more text without diagnosis, traceability, author control, or voice preservation, it does not align with the Readiness Standard.
+
+A future pricing or Revise feature should also answer this question:
+
+> Does the feature preserve the distinction between fixed-price diagnosis and metered repair?
+
+If it implies unlimited revision, bulk extraction of the repair blueprint, token-based commodity pricing, or unchecked generation, it does not align with the Pricing Readiness Doctrine.

--- a/docs/brand/black-box-readiness.md
+++ b/docs/brand/black-box-readiness.md
@@ -32,6 +32,10 @@ RevisionGrade helps writers separate manuscript readiness from market rejection.
 
 RevisionGrade exists to make manuscript readiness visible before the publishing industry turns uncertainty into silence.
 
+### Pricing line
+
+Before you pay for polish, diagnose readiness.
+
 ## The Black Box
 
 I wrote four novels. Like many writers, I sent them into the publishing industry's black box. At best, I received a template rejection. More often, I received silence.
@@ -45,6 +49,18 @@ From the outside, all of those answers look the same: no diagnosis, no explanati
 Publishing gives writers verdicts, not diagnoses.
 
 Without a diagnosis, a writer cannot systematically improve the work. The result is a costly loop: revise blindly, query again, wait again, and still not know whether the manuscript is structurally failing or simply mismatched to that agent, list, or moment.
+
+## The Editorial Blind Date
+
+Many authors do not know whether they need a developmental editor, a line editor, a copy editor, a proofreader, or market-positioning support.
+
+That uncertainty creates the Editorial Blind Date: the author hires based on credentials, reputation, sample pages, and hope before knowing what kind of editorial intervention the manuscript actually needs.
+
+A manuscript with structural problems may not be ready for copyediting. A manuscript with point-of-view confusion may not need polish first. A manuscript with weak scene pressure may need developmental repair before line-level refinement.
+
+Human editors can be valuable. They are most valuable when the author knows what problem they are hiring them to solve.
+
+RevisionGrade helps diagnose manuscript readiness first, so writers can approach editing with evidence instead of guesswork.
 
 ## The separation principle
 
@@ -76,6 +92,28 @@ RevisionGrade evaluates manuscript readiness across thirteen core dimensions of 
 - Marketability
 
 The Readiness Standard does not exist to generate more words. It exists to diagnose structural friction first. Any revision assistance must remain evidence-bound, author-controlled, and voice-preserving.
+
+## Golden Spine™ and WAVE Revision System™
+
+The Golden Spine™ threshold begins at 25,000 words.
+
+Below 25,000 words, most works can be evaluated through the 13 Story Criteria.
+
+At 25,000 words and above, long-range structure, pacing, character continuity, payoff, and cumulative reader experience require the WAVE Revision System™.
+
+## Pricing doctrine
+
+RevisionGrade uses fixed-price audits and metered repair.
+
+> The audit reveals the condition of the manuscript. Editorial Actions unlock and repair specific opportunities.
+
+Fixed-price audits are used for bounded manuscript diagnosis.
+
+Editorial Actions are used for granular opportunity cards and governed repair proposals.
+
+Unlimited revision is not part of the RevisionGrade doctrine.
+
+The pricing source of truth is `docs/brand/pricing-readiness.md`.
 
 ## Built from systems discipline
 
@@ -113,6 +151,12 @@ Future features should be evaluated against this question:
 If a feature helps the author understand readiness, preserve voice, clarify structural friction, or revise from evidence, it may align with this doctrine.
 
 If a feature merely adds fluent text without diagnosis, traceability, or author control, it fails the Readiness Standard.
+
+Future pricing or Revise features should also answer this question:
+
+> Does the feature preserve the distinction between fixed-price diagnosis and metered repair?
+
+If it implies unlimited revision, bulk extraction of the repair blueprint, token-based commodity pricing, or unchecked generation, it fails the Pricing Readiness Doctrine.
 
 ## Public route ownership
 

--- a/docs/brand/pricing-readiness.md
+++ b/docs/brand/pricing-readiness.md
@@ -1,0 +1,152 @@
+# RevisionGrade™ Pricing Readiness Doctrine
+
+## Canonical pricing principle
+
+RevisionGrade uses a fixed-price audit and metered repair model.
+
+> The audit reveals the condition of the manuscript. Editorial Actions unlock and repair specific opportunities.
+
+This separates bounded diagnosis from variable-cost revision execution.
+
+## Pricing ladder
+
+| Audit Tier | Manuscript Word Count | Editorial Actions Included | Price | Best For |
+| --- | ---: | ---: | ---: | --- |
+| Free Opening Diagnostic | Up to 3,000 words | 0 | $0 | Testing hook, voice, and narrative pressure. |
+| Short-Form Evaluation | Up to 24,999 words | 5 | $49 | Novellas, short stories, and early concept tests. |
+| Full Manuscript Readiness Audit | 25,000–120,000 words | 25 | $249 | The Professional Standard; includes WAVE Revision System™. |
+| Long Manuscript Readiness Audit | 120,001–180,000 words | 50 | $399 | Epic-scale manuscripts and longer novels. |
+| Complex Narrative Audit | 180,001+ words | 100 | $499+ | Multi-layer, transmedia, or franchise-scale work. |
+
+## Editorial Action packs
+
+| Pack | Editorial Actions | Price |
+| --- | ---: | ---: |
+| Starter Pack | 25 | $29 |
+| Professional Pack | 100 | $89 |
+| Studio Pack | 300 | $199 |
+
+## Golden Spine™ threshold
+
+The Golden Spine™ threshold begins at 25,000 words.
+
+Below 25,000 words, a work is evaluated through the 13 Story Criteria.
+
+At 25,000 words and above, long-range structure, pacing, character continuity, payoff, and cumulative reader experience require the WAVE Revision System™.
+
+## Editorial Actions doctrine
+
+Editorial Actions are not tokens and should not be described as tokens.
+
+An Editorial Action unlocks and repairs a specific revision opportunity.
+
+At launch, one Editorial Action should represent:
+
+- unlock one Granular Opportunity Card
+- return the full evidence and diagnosis for that opportunity
+- generate one governed repair proposal or rewrite pathway
+
+The user should always receive a readiness diagnosis and opportunity summary from a paid audit. The full repair blueprint is not given away in bulk.
+
+## Audit versus repair
+
+The fixed-price audit includes:
+
+- readiness verdict
+- criteria or WAVE results as applicable
+- strengths and weaknesses
+- opportunity count
+- severity distribution
+- top systemic risks
+- recommended editorial path
+
+Editorial Actions unlock:
+
+- specific evidence
+- specific passage reference where applicable
+- cause
+- reader effect
+- fix direction
+- governed repair proposal
+- dialogue patch, scene repair, continuity-safe alternative, or validation pass where applicable
+
+## No unlimited revision
+
+Unlimited revision is not allowed in the RevisionGrade pricing doctrine.
+
+Revision is variable. A strong manuscript may need only a few targeted repairs. A structurally weak manuscript may produce hundreds of opportunities. Unlimited revision pricing would force strong manuscripts to subsidize weak ones and would encourage low-value generation.
+
+## Action lifecycle doctrine
+
+Included Editorial Actions are project-bound.
+
+Purchased Editorial Action packs are account-level.
+
+Recommended future implementation rule:
+
+- Included actions expire after 12 months.
+- Purchased actions expire after 24 months unless local law requires otherwise.
+- Used actions are not refundable when the generation succeeds and the user receives the unlocked opportunity or proposal.
+- Failed generations should be represented as ledger reversal/refund events, not as a user-callable refund endpoint.
+
+## Upgrade policy doctrine
+
+Free Opening Diagnostic purchases create no cash credit.
+
+Paid lower-tier audits may be credited toward a higher-tier audit for the same project/manuscript lineage within 30 days.
+
+Recommended examples:
+
+- Short-Form Evaluation to Full Manuscript Readiness Audit: $49 credit toward $249.
+- Full Manuscript Readiness Audit to Long Manuscript Readiness Audit: $249 credit toward $399 when the manuscript crosses the tier before or shortly after purchase.
+
+A substantially expanded manuscript should usually require a new audit or discounted re-audit rather than a simple upgrade.
+
+Major expansion indicators include:
+
+- more than 15–20% word-count growth
+- new POV architecture
+- new ending
+- new major subplot
+- new genre/category positioning
+
+## Future ledger implementation
+
+The pricing page is declarative only. It does not implement payments, ledger enforcement, or unlock behavior.
+
+Future backend enforcement should use a transactional unlock route:
+
+```txt
+POST /opportunities/:id/unlock
+```
+
+Read-only details should remain read-only:
+
+```txt
+GET /opportunity-details/:id
+```
+
+The unlock operation must be intentional, idempotent, auditable, and protected from accidental GET requests, browser prefetching, duplicate clicks, or bots.
+
+Recommended future records:
+
+- `editorial_action_ledger`
+- `opportunity_unlocks`
+- `audit_upgrades`
+
+Recommended invariant:
+
+- already unlocked opportunity returns existing details and does not debit again
+- not unlocked opportunity debits once, generates once, persists once
+
+## Public pricing copy
+
+A Note on Editorial Readiness:
+
+RevisionGrade™ is not a writing tool. It is an editorial audit system.
+
+Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is strong, where it is vulnerable, and what kind of editorial support it may need next.
+
+Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions included with your audit or available in packs.
+
+Before you pay for polish, diagnose readiness.


### PR DESCRIPTION
## Summary

Replaces the legacy subscription-style pricing page with the RevisionGrade™ fixed-price audit / metered Editorial Actions pricing doctrine.

This PR removes the old Free / Professional / Studio monthly pricing copy, including the misleading unlimited-evaluations model, and replaces it with the governed Editorial Audit ladder.

## What changed

- Refactors `app/pricing/page.tsx` into the new audit pricing page.
- Adds `docs/brand/pricing-readiness.md` as the pricing doctrine source of truth.
- Updates `docs/brand/black-box-readiness.md` with:
  - Editorial Blind Date doctrine
  - Golden Spine™ threshold
  - WAVE Revision System™ threshold
  - fixed-price audit / metered repair doctrine
- Updates `docs/brand/README.md` to link the pricing doctrine.

## Pricing doctrine

- Fixed-price audit.
- Metered repair.
- No unlimited revision.
- The audit reveals the condition of the manuscript.
- Editorial Actions unlock and repair specific opportunities.

## Scope boundaries

This PR does **not** change:

- Stripe or checkout logic
- Database schema
- Editorial Actions ledger enforcement
- Opportunity unlock endpoints
- Auth
- Evaluation pipeline
- Revise execution
- Dashboard/workbench behavior
- Runtime governance

## Validation

Recommended:

```bash
npm run build
```

## Changed files

- `app/pricing/page.tsx`
- `docs/brand/pricing-readiness.md`
- `docs/brand/black-box-readiness.md`
- `docs/brand/README.md`
