### PR TITLE
Polish pricing page mobile layout and readiness copy

### DIFF
--- a/.github/pr-bodies/PR-659.md
+++ b/.github/pr-bodies/PR-659.md
@@ -1,0 +1,51 @@
+## Summary
+
+Hotfixes the public pricing page to improve mobile/tablet readability and remove negative public-facing readiness language.
+
+## What changed
+
+- Changes pricing audit cards from a compressed 5-card desktop row to a premium responsive grid:
+  - mobile: 1 column
+  - tablet: 2 columns
+  - desktop: 3 columns / 3+2 flow
+- Enlarges card spacing and typography for a more white-glove presentation.
+- Replaces public language such as `weaknesses`, `vulnerable`, `structurally weak`, and `hundreds of opportunities` with safer readiness language:
+  - readiness profile
+  - priority signals
+  - where readiness can be improved
+  - targeted refinements
+  - deeper staged repair
+- Updates `docs/brand/pricing-readiness.md` to match the safer public-facing language.
+
+## Scope boundaries
+
+This PR does **not** change:
+
+- pricing amounts
+- Stripe or checkout logic
+- database schema
+- Editorial Actions ledger enforcement
+- opportunity unlock endpoints
+- auth
+- evaluation pipeline
+- Revise execution
+- dashboard/workbench behavior
+
+## Files changed
+
+- `app/pricing/page.tsx`
+- `docs/brand/pricing-readiness.md`
+
+## Validation
+
+Recommended:
+
+```bash
+npm run build
+```
+
+Visual smoke test:
+
+- `/pricing` desktop
+- `/pricing` tablet width
+- `/pricing` mobile width

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -60,7 +60,7 @@ const faqs = [
   {
     question: "What is the difference between an audit and an Editorial Action?",
     answer:
-      "An audit is the fixed-price diagnostic: it reveals the condition of the manuscript, including readiness risks, strengths, and the kind of editorial support the work may need next. Editorial Actions unlock and repair specific opportunities through granular opportunity cards and governed repair proposals.",
+      "An audit is the fixed-price diagnostic: it reveals the manuscript’s readiness profile, including strengths, priority signals, and the kind of editorial support the work may benefit from next. Editorial Actions unlock and repair specific opportunities through granular opportunity cards and governed repair proposals.",
   },
   {
     question: "Why does the WAVE Revision System™ start at 25,000 words?",
@@ -75,12 +75,12 @@ const faqs = [
   {
     question: "Why not offer unlimited revisions?",
     answer:
-      "Revision work is variable. A strong manuscript may need only a few targeted repairs, while a structurally weak manuscript may produce hundreds of opportunities. Fixed-price unlimited revision would force strong manuscripts to subsidize weak ones and would encourage low-value generation.",
+      "Revision work is variable. Some manuscripts need only a few targeted refinements, while others benefit from deeper staged repair. Fixed-price unlimited revision would dilute the audit standard and encourage low-value generation instead of focused, high-impact revision work.",
   },
   {
     question: "Is RevisionGrade replacing human editors?",
     answer:
-      "No. RevisionGrade helps you understand what kind of editorial help your manuscript actually needs before you spend money on professional human intervention: developmental editing, line editing, copyediting, proofreading, market positioning, or deeper structural repair.",
+      "No. RevisionGrade helps you understand what kind of editorial help your manuscript may benefit from before you spend money on professional human intervention: developmental editing, line editing, copyediting, proofreading, market positioning, or deeper structural repair.",
   },
 ];
 
@@ -95,24 +95,24 @@ function SectionLabel({ children }: { children: string }) {
 export default function PricingPage() {
   return (
     <div className="bg-rg-ink text-rg-cream">
-      <section className="mx-auto max-w-7xl px-6 py-20 lg:py-28">
-        <div className="max-w-4xl">
+      <section className="mx-auto max-w-7xl px-5 py-16 sm:px-6 md:py-20 lg:py-28">
+        <div className="max-w-5xl">
           <SectionLabel>RevisionGrade™ Pricing</SectionLabel>
-          <h1 className="mt-6 font-rg-serif text-5xl leading-[0.98] tracking-tight text-rg-cream md:text-7xl">
+          <h1 className="mt-6 font-rg-serif text-4xl leading-[1.02] tracking-tight text-rg-cream sm:text-5xl md:text-7xl">
             Before you pay for polish, diagnose readiness.
           </h1>
-          <p className="mt-8 max-w-3xl text-lg leading-8 text-rg-cream2/80">
+          <p className="mt-8 max-w-3xl text-base leading-8 text-rg-cream2/80 sm:text-lg">
             RevisionGrade™ is priced as an editorial audit system: fixed-price diagnosis first, metered repair only when you unlock and act on specific story opportunities.
           </p>
         </div>
       </section>
 
       <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
-        <div className="mx-auto max-w-7xl px-6 py-16">
+        <div className="mx-auto max-w-7xl px-5 py-14 sm:px-6 md:py-16">
           <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-            <div>
+            <div className="max-w-3xl">
               <SectionLabel>Editorial Audit Pricing</SectionLabel>
-              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl">
+              <h2 className="mt-4 font-rg-serif text-3xl leading-tight text-rg-cream sm:text-4xl md:text-5xl">
                 Fixed-price readiness audits.
               </h2>
             </div>
@@ -121,11 +121,11 @@ export default function PricingPage() {
             </p>
           </div>
 
-          <div className="mt-10 grid gap-5 lg:grid-cols-5">
+          <div className="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
             {auditTiers.map((tier) => (
               <article
                 key={tier.name}
-                className={`relative border p-5 ${
+                className={`relative flex min-h-full flex-col border p-6 md:p-7 ${
                   tier.highlighted
                     ? "border-rg-gold bg-rg-cream text-rg-ink shadow-2xl shadow-black/30"
                     : "border-rg-cream2/12 bg-rg-ink/70 text-rg-cream"
@@ -136,27 +136,29 @@ export default function PricingPage() {
                     Professional Standard
                   </div>
                 )}
-                <h3 className="font-rg-serif text-2xl leading-tight">{tier.name}</h3>
-                <p className={`mt-3 font-rg-mono text-[0.68rem] uppercase tracking-[0.14em] ${tier.highlighted ? "text-rg-ink/65" : "text-rg-gold"}`}>
-                  {tier.wordCount}
-                </p>
-                <p className="mt-5 font-rg-serif text-4xl">{tier.price}</p>
-                <p className={`mt-3 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/70" : "text-rg-cream2/75"}`}>
-                  {tier.bestFor}
-                </p>
-                <div className={`mt-5 border-t pt-4 ${tier.highlighted ? "border-rg-ink/15" : "border-rg-cream2/10"}`}>
-                  <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.14em]">
-                    {tier.actionsIncluded} Editorial Actions included
+                <div className="flex-1">
+                  <h3 className="font-rg-serif text-2xl leading-tight sm:text-3xl">{tier.name}</h3>
+                  <p className={`mt-3 font-rg-mono text-[0.68rem] uppercase tracking-[0.14em] ${tier.highlighted ? "text-rg-ink/65" : "text-rg-gold"}`}>
+                    {tier.wordCount}
                   </p>
-                  <ul className={`mt-4 space-y-2 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/75" : "text-rg-cream2/75"}`}>
-                    {tier.features.map((feature) => (
-                      <li key={feature}>• {feature}</li>
-                    ))}
-                  </ul>
+                  <p className="mt-5 font-rg-serif text-4xl sm:text-5xl">{tier.price}</p>
+                  <p className={`mt-4 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/70" : "text-rg-cream2/75"}`}>
+                    {tier.bestFor}
+                  </p>
+                  <div className={`mt-6 border-t pt-5 ${tier.highlighted ? "border-rg-ink/15" : "border-rg-cream2/10"}`}>
+                    <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.14em]">
+                      {tier.actionsIncluded} Editorial Actions included
+                    </p>
+                    <ul className={`mt-4 space-y-2 text-sm leading-6 ${tier.highlighted ? "text-rg-ink/75" : "text-rg-cream2/75"}`}>
+                      {tier.features.map((feature) => (
+                        <li key={feature}>• {feature}</li>
+                      ))}
+                    </ul>
+                  </div>
                 </div>
                 <Link
                   href="/evaluate"
-                  className={`mt-6 block border px-4 py-3 text-center font-rg-mono text-xs uppercase tracking-[0.16em] transition ${
+                  className={`mt-7 block border px-4 py-3 text-center font-rg-mono text-xs uppercase tracking-[0.16em] transition ${
                     tier.highlighted
                       ? "border-rg-ink bg-rg-ink text-rg-cream hover:bg-transparent hover:text-rg-ink"
                       : "border-rg-gold text-rg-gold hover:bg-rg-gold hover:text-rg-ink"
@@ -170,57 +172,57 @@ export default function PricingPage() {
         </div>
       </section>
 
-      <section className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.85fr_1.15fr]">
+      <section className="mx-auto grid max-w-7xl gap-10 px-5 py-16 sm:px-6 md:py-20 lg:grid-cols-[0.85fr_1.15fr]">
         <div>
           <SectionLabel>Editorial Actions</SectionLabel>
-          <h2 className="mt-4 font-rg-serif text-4xl leading-tight text-rg-cream md:text-5xl">
+          <h2 className="mt-4 font-rg-serif text-3xl leading-tight text-rg-cream sm:text-4xl md:text-5xl">
             Metered repair. No unlimited revision.
           </h2>
           <p className="mt-6 leading-8 text-rg-cream2/75">
             Once your audit is complete, Editorial Actions unlock granular opportunity cards and generate governed, continuity-aware repair proposals for specific story opportunities.
           </p>
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {actionPacks.map((pack) => (
-            <article key={pack.name} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6">
+            <article key={pack.name} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6 md:p-7">
               <h3 className="font-rg-serif text-2xl text-rg-cream">{pack.name}</h3>
               <p className="mt-3 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-gold">{pack.actions}</p>
-              <p className="mt-5 font-rg-serif text-4xl text-rg-cream">{pack.price}</p>
+              <p className="mt-5 font-rg-serif text-4xl text-rg-cream sm:text-5xl">{pack.price}</p>
             </article>
           ))}
         </div>
       </section>
 
       <section className="bg-rg-cream text-rg-ink">
-        <div className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.8fr_1.2fr]">
+        <div className="mx-auto grid max-w-7xl gap-10 px-5 py-16 sm:px-6 md:py-20 lg:grid-cols-[0.8fr_1.2fr]">
           <div>
             <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">A Note on Editorial Readiness</p>
-            <h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">
+            <h2 className="mt-4 font-rg-serif text-3xl leading-tight sm:text-4xl md:text-5xl">
               RevisionGrade™ is not a writing tool.
             </h2>
           </div>
-          <div className="space-y-5 text-lg leading-8 text-rg-ink/75">
+          <div className="space-y-5 text-base leading-8 text-rg-ink/75 sm:text-lg">
             <p>
-              It is an editorial audit system. Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is strong, where it is vulnerable, and what kind of editorial support it may need next.
+              It is an editorial audit system. Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is already working, where readiness can be improved, and what kind of editorial support may help next.
             </p>
             <p>
               Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions included with your audit or available in packs.
             </p>
-            <p className="font-rg-serif text-3xl leading-tight text-rg-ink">
+            <p className="font-rg-serif text-2xl leading-tight text-rg-ink sm:text-3xl">
               Before you pay for polish, diagnose readiness.
             </p>
           </div>
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-20">
+      <section className="mx-auto max-w-7xl px-5 py-16 sm:px-6 md:py-20">
         <SectionLabel>FAQ</SectionLabel>
-        <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl">
+        <h2 className="mt-4 font-rg-serif text-3xl text-rg-cream sm:text-4xl md:text-5xl">
           Fixed-price audit. Metered repair.
         </h2>
-        <div className="mt-10 grid gap-4 md:grid-cols-2">
+        <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2">
           {faqs.map((item) => (
-            <article key={item.question} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6">
+            <article key={item.question} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6 md:p-7">
               <h3 className="font-rg-serif text-2xl text-rg-cream">{item.question}</h3>
               <p className="mt-4 leading-7 text-rg-cream2/75">{item.answer}</p>
             </article>

--- a/docs/brand/pricing-readiness.md
+++ b/docs/brand/pricing-readiness.md
@@ -4,7 +4,7 @@
 
 RevisionGrade uses a fixed-price audit and metered repair model.
 
-> The audit reveals the condition of the manuscript. Editorial Actions unlock and repair specific opportunities.
+> The audit reveals the manuscript’s readiness profile. Editorial Actions unlock and repair specific opportunities.
 
 This separates bounded diagnosis from variable-cost revision execution.
 
@@ -54,10 +54,10 @@ The fixed-price audit includes:
 
 - readiness verdict
 - criteria or WAVE results as applicable
-- strengths and weaknesses
+- strengths and priority signals
 - opportunity count
 - severity distribution
-- top systemic risks
+- top systemic readiness risks
 - recommended editorial path
 
 Editorial Actions unlock:
@@ -74,7 +74,7 @@ Editorial Actions unlock:
 
 Unlimited revision is not allowed in the RevisionGrade pricing doctrine.
 
-Revision is variable. A strong manuscript may need only a few targeted repairs. A structurally weak manuscript may produce hundreds of opportunities. Unlimited revision pricing would force strong manuscripts to subsidize weak ones and would encourage low-value generation.
+Revision is variable. Some manuscripts need only a few targeted refinements. Others benefit from deeper staged repair. Unlimited revision pricing would dilute the audit standard and encourage low-value generation instead of focused, high-impact revision work.
 
 ## Action lifecycle doctrine
 
@@ -145,7 +145,7 @@ A Note on Editorial Readiness:
 
 RevisionGrade™ is not a writing tool. It is an editorial audit system.
 
-Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is strong, where it is vulnerable, and what kind of editorial support it may need next.
+Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is already working, where readiness can be improved, and what kind of editorial support may help next.
 
 Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions included with your audit or available in packs.
 


### PR DESCRIPTION
## Summary

Hotfixes the public pricing page to improve mobile/tablet readability and remove negative public-facing readiness language.

## What changed

- Changes pricing audit cards from a compressed 5-card desktop row to a premium responsive grid:
  - mobile: 1 column
  - tablet: 2 columns
  - desktop: 3 columns / 3+2 flow
- Enlarges card spacing and typography for a more white-glove presentation.
- Replaces public language such as `weaknesses`, `vulnerable`, `structurally weak`, and `hundreds of opportunities` with safer readiness language:
  - readiness profile
  - priority signals
  - where readiness can be improved
  - targeted refinements
  - deeper staged repair
- Updates `docs/brand/pricing-readiness.md` to match the safer public-facing language.

## Scope boundaries

This PR does **not** change:

- pricing amounts
- Stripe or checkout logic
- database schema
- Editorial Actions ledger enforcement
- opportunity unlock endpoints
- auth
- evaluation pipeline
- Revise execution
- dashboard/workbench behavior

## Files changed

- `app/pricing/page.tsx`
- `docs/brand/pricing-readiness.md`

## Validation

Recommended:

```bash
npm run build
```

Visual smoke test:

- `/pricing` desktop
- `/pricing` tablet width
- `/pricing` mobile width
