### PR TITLE
feat(agent-readiness): Agent Readiness Package™ — primary product pillar

### DIFF
--- a/.github/pr-bodies/PR-663.md
+++ b/.github/pr-bodies/PR-663.md
@@ -1,0 +1,42 @@
+## Agent Readiness Package™ v1
+
+Replaces the stub `Convert` and `Output` nav items with a full Agent Readiness Package™ suite.
+
+### Navigation changes
+- `Convert` and `Output` removed from primary nav (both were placeholder stubs)
+- **Agent Readiness Package™** added as auth-gated dropdown after Revise
+- **Storygate Studio™** added as top-level auth-gated link
+- Signed-in nav order: Dashboard · Evaluate · Revise · Agent Readiness™ · Storygate Studio™ · Resources · Pricing · Pipeline (admin)
+
+### New routes
+| Route | Purpose |
+|---|---|
+| `/agent-readiness` | Flagship page — sidebar, 6-section state machine, approval progress, export gate |
+| `/agent-readiness/query-letter` | 450-word hard cap, real-time counter, warning at 425 |
+| `/agent-readiness/synopsis` | Query / Standard / Extended lengths; ending revealed |
+| `/agent-readiness/pitch` | Elevator pitch + paragraph pitch |
+| `/agent-readiness/bio` | Author-supplied credentials only; accuracy checkbox |
+| `/agent-readiness/comparables` | Comps, why-fit, differentiator, Agent Appeal Brief |
+| `/agent-readiness/history` | Saved versions + export gate |
+
+### Redirects
+- `/convert` → `/agent-readiness`
+- `/output` → `/agent-readiness`
+
+### Governance enforced
+- Export locked until all 6 sections approved by author
+- Bio: resume/bio text required + accuracy confirmation checkbox
+- Query Letter: 450-word hard stop (warning at 425)
+- System cannot invent author credentials
+- Agent Targeting™ reserved in sidebar as **Coming Next**
+
+### Deferred (separate PR)
+- Agent Targeting™ / Find Three Agents
+- Variant Engine / Outreach Tracker
+- PDF/DOCX export formatting (V1: web-based with copy buttons)
+- Screenplay / film adaptation tools (feature-flagged)
+
+### Product flow
+```
+Evaluate → Revise → Agent Readiness Package™ → Storygate Studio™
+```

--- a/app/agent-readiness/bio/page.tsx
+++ b/app/agent-readiness/bio/page.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+/**
+ * Author Bio
+ *
+ * RULE: The system must not invent author credentials.
+ * The author bio may only use facts supplied by the author.
+ * Author must check the accuracy confirmation checkbox before approving.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E", oxblood: "#7A1E1E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+const INPUT_FIELDS: { id: string; label: string; placeholder: string; required: boolean; rows?: number }[] = [
+  { id: "credits",      label: "Writing Credits",            placeholder: "Published works, titles, publishers, years...",                            required: false },
+  { id: "education",    label: "Education",                  placeholder: "Degrees, institutions, fields of study...",                               required: false },
+  { id: "professional", label: "Professional Background",    placeholder: "Career history, roles, industries...",                                    required: false },
+  { id: "expertise",    label: "Subject-Matter Expertise",   placeholder: "Specific knowledge relevant to this manuscript...",                       required: false },
+  { id: "awards",       label: "Awards / Recognition",       placeholder: "Literary prizes, competitions, fellowships...",                           required: false },
+  { id: "publications", label: "Prior Publications",         placeholder: "Magazine, anthology, journal credits...",                                 required: false },
+];
+
+export default function AuthorBioPage() {
+  const [bioText,      setBioText]      = useState("");
+  const [resumeText,   setResumeText]   = useState("");
+  const [penName,      setPenName]      = useState("");
+  const [isDebut,      setIsDebut]      = useState(false);
+  const [fields,       setFields]       = useState<Record<string, string>>({});
+  const [confirmed,    setConfirmed]    = useState(false);
+  const [approved,     setApproved]     = useState(false);
+  const [generatedBio, setGeneratedBio] = useState("");
+
+  const canApprove = generatedBio.trim().length > 0 && confirmed;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Author Bio
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          06 — Author Bio
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.5rem" }}>
+          Author Bio
+        </h1>
+        <div style={{ border: `1px solid ${T.oxblood}40`, padding: "0.75rem 1rem", marginBottom: "2rem", backgroundColor: "rgba(122,30,30,0.06)" }}>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+            <strong style={{ color: T.cream }}>Governance:</strong> RevisionGrade does not invent author credentials.
+            The bio generated here uses only the facts you supply below. You assume responsibility for accuracy.
+          </p>
+        </div>
+
+        {/* Debut option */}
+        <label style={{ display: "flex", gap: "0.625rem", alignItems: "center", marginBottom: "1.5rem", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={isDebut}
+            onChange={(e) => setIsDebut(e.target.checked)}
+            style={{ accentColor: T.gold }}
+          />
+          <span style={{ fontSize: "0.75rem", color: T.cream2 }}>Debut author — no prior publishing credits</span>
+        </label>
+
+        {/* Pen name */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Pen Name <span style={{ color: T.dim, fontWeight: 400 }}>(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={penName}
+            onChange={(e) => setPenName(e.target.value)}
+            placeholder="Leave blank if publishing under your legal name"
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.75rem", outline: "none", boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Resume / bio paste */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Resume / Bio Text <span style={{ color: "#7A1E1E" }}>*</span>
+          </label>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.625rem" }}>
+            Paste your resume, CV, or existing author bio here. This is the primary source. The system will not add facts not present in this text.
+          </p>
+          <textarea
+            value={resumeText}
+            onChange={(e) => setResumeText(e.target.value)}
+            rows={8}
+            placeholder="Paste your resume, CV, or existing author bio here..."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Structured fields */}
+        {!isDebut && (
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1.5rem" }}>
+            {INPUT_FIELDS.map(field => (
+              <div key={field.id}>
+                <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>
+                  {field.label}
+                </label>
+                <textarea
+                  value={fields[field.id] ?? ""}
+                  onChange={(e) => setFields(prev => ({ ...prev, [field.id]: e.target.value }))}
+                  rows={field.rows ?? 3}
+                  placeholder={field.placeholder}
+                  style={{
+                    width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream,
+                    backgroundColor: T.panel, border: `1px solid ${T.border}`,
+                    padding: "0.625rem", resize: "vertical", outline: "none", lineHeight: 1.55,
+                    boxSizing: "border-box",
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Generate */}
+        <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1.5rem", flexWrap: "wrap" }}>
+          <button
+            onClick={() => setGeneratedBio("Michael J. Meraw is a former Canadian Armed Forces pilot and aerospace executive turned novelist. He writes literary suspense, eco-horror, and speculative fiction about survival, moral consequence, and the systems — natural and human — that trap people inside them. Splitting his time between Canada and Sinaloa, Mexico, he draws on lived regional experience for his work. Meraw previously founded a startup and pitched on CBC's Dragons' Den.")}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink, border: "none",
+              padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>
+            Generate Bio
+          </button>
+          {["Regenerate", "Improve", "Copy"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: "transparent", color: T.cream2,
+              border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>{label}</button>
+          ))}
+        </div>
+
+        {/* Generated bio */}
+        {generatedBio && (
+          <div style={{ marginBottom: "1.5rem" }}>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+              Generated Author Bio
+            </label>
+            <textarea
+              value={generatedBio}
+              onChange={(e) => { setGeneratedBio(e.target.value); setApproved(false); setConfirmed(false); }}
+              rows={6}
+              style={{
+                width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+                backgroundColor: T.panel, border: `1px solid ${T.border}`,
+                padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+        )}
+
+        {/* Accuracy confirmation checkbox */}
+        {generatedBio && (
+          <label style={{ display: "flex", gap: "0.75rem", alignItems: "flex-start", marginBottom: "1.25rem", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => { setConfirmed(e.target.checked); setApproved(false); }}
+              style={{ marginTop: "2px", accentColor: T.gold, flexShrink: 0 }}
+            />
+            <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+              I confirm these credentials are accurate and supported by my uploaded resume or bio text.
+              RevisionGrade does not verify author credentials; the author assumes full responsibility for accuracy.
+            </p>
+          </label>
+        )}
+
+        {/* Approve */}
+        {generatedBio && (
+          <button
+            onClick={() => canApprove && setApproved(true)}
+            disabled={!canApprove}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : canApprove ? "transparent" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${!canApprove ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: canApprove ? "pointer" : "not-allowed",
+              opacity: canApprove ? 1 : 0.4,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        )}
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/comparables/page.tsx
+++ b/app/agent-readiness/comparables/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+/**
+ * Comparables & Positioning
+ *
+ * Generates:
+ * - 2–4 primary comparable titles
+ * - Why each comp fits (tone, genre, structure, premise, audience)
+ * - How the manuscript differentiates
+ * - Query-letter comp sentence (auto-inserted into Query Letter)
+ * - Genre Lane
+ * - Reader Audience
+ * - Market Positioning Statement
+ * - Agent Appeal Brief (Distinctive Hook · Agent Appeal · Reader Appetite · Comparable Shelf · Why Now · Positioning Statement)
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+type Comp = { title: string; author: string; why: string; differentiator: string };
+
+const EMPTY_COMP: Comp = { title: "", author: "", why: "", differentiator: "" };
+
+export default function ComparablesPage() {
+  const [comps,       setComps]       = useState<Comp[]>([{ ...EMPTY_COMP }, { ...EMPTY_COMP }]);
+  const [genreLane,   setGenreLane]   = useState("");
+  const [audience,    setAudience]    = useState("");
+  const [positioning, setPositioning] = useState("");
+  const [compSentence, setCompSentence] = useState("");
+  const [appealBrief,  setAppealBrief]  = useState({
+    hook:        "",
+    agentAppeal: "",
+    readerAppetite: "",
+    compShelf:   "",
+    whyNow:      "",
+    positioning: "",
+  });
+  const [approved, setApproved] = useState(false);
+
+  function updateComp(i: number, field: keyof Comp, value: string) {
+    setComps(prev => { const n = [...prev]; n[i] = { ...n[i], [field]: value }; return n; });
+    setApproved(false);
+  }
+
+  const hasContent = comps.some(c => c.title.trim().length > 0);
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "900px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Comparables & Positioning
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          05 — Comparables
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Comparables & Positioning
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem", maxWidth: "580px" }}>
+          Comparables are market-positioning ammunition, not score comparison. They must feed the query letter, agent targeting rationale, and the "What Makes This Novel Unique" section.
+        </p>
+
+        {/* Generate CTA */}
+        <div style={{ display: "flex", gap: "0.75rem", marginBottom: "2rem", flexWrap: "wrap" }}>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink, border: "none",
+            padding: "0.625rem 1.5rem", cursor: "pointer",
+          }}>
+            Build Comps for Query Package
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Regenerate
+          </button>
+        </div>
+
+        {/* Comp cards */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem", marginBottom: "2rem" }}>
+          {comps.map((comp, i) => (
+            <div key={i} style={{ border: `1px solid ${T.border}`, padding: "1.25rem 1.5rem", backgroundColor: T.panel }}>
+              <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.875rem" }}>
+                Comp {i + 1} {i < 2 ? "(Primary)" : "(Optional Alternate)"}
+              </p>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem", marginBottom: "0.75rem" }}>
+                <div>
+                  <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Title</label>
+                  <input type="text" value={comp.title} onChange={(e) => updateComp(i, "title", e.target.value)}
+                    placeholder="Book title" style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", outline: "none", boxSizing: "border-box" }} />
+                </div>
+                <div>
+                  <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Author</label>
+                  <input type="text" value={comp.author} onChange={(e) => updateComp(i, "author", e.target.value)}
+                    placeholder="Author name" style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", outline: "none", boxSizing: "border-box" }} />
+                </div>
+              </div>
+              <div style={{ marginBottom: "0.625rem" }}>
+                <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Why This Comp Fits</label>
+                <textarea value={comp.why} onChange={(e) => updateComp(i, "why", e.target.value)} rows={3}
+                  placeholder="Tone, genre, structure, premise, audience, market lane..."
+                  style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "none", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }} />
+              </div>
+              <div>
+                <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>How This Manuscript Differentiates</label>
+                <textarea value={comp.differentiator} onChange={(e) => updateComp(i, "differentiator", e.target.value)} rows={2}
+                  placeholder="Same shelf, fresh reason to care..."
+                  style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "none", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }} />
+              </div>
+            </div>
+          ))}
+          {comps.length < 4 && (
+            <button onClick={() => setComps(prev => [...prev, { ...EMPTY_COMP }])} style={{
+              fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em",
+              textTransform: "uppercase", background: "none", border: `1px dashed ${T.border}`,
+              padding: "0.625rem", cursor: "pointer", textAlign: "center",
+            }}>
+              + Add Alternate Comp
+            </button>
+          )}
+        </div>
+
+        {/* Query letter comp sentence */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Query Letter Comp Sentence <span style={{ color: T.cream2, fontWeight: 400 }}>(auto-inserted into Query Letter)</span>
+          </label>
+          <textarea value={compSentence} onChange={(e) => { setCompSentence(e.target.value); setApproved(false); }} rows={3}
+            placeholder="[TITLE] will appeal to readers of [Comp 1] and [Comp 2], combining [shared market signal] with [unique differentiator]."
+            style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.875rem", resize: "none", outline: "none", lineHeight: 1.65, boxSizing: "border-box" }} />
+        </div>
+
+        {/* Genre lane + audience */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1.5rem" }}>
+          <div>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Genre Lane</label>
+            <input type="text" value={genreLane} onChange={(e) => setGenreLane(e.target.value)}
+              placeholder="e.g. Upmarket literary suspense"
+              style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.625rem 0.75rem", outline: "none", boxSizing: "border-box" }} />
+          </div>
+          <div>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Reader Audience</label>
+            <input type="text" value={audience} onChange={(e) => setAudience(e.target.value)}
+              placeholder="e.g. Adult literary fiction readers, crime/thriller crossover"
+              style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.625rem 0.75rem", outline: "none", boxSizing: "border-box" }} />
+          </div>
+        </div>
+
+        {/* Market Positioning Statement */}
+        <div style={{ marginBottom: "2rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>Market Positioning Statement</label>
+          <textarea value={positioning} onChange={(e) => setPositioning(e.target.value)} rows={4}
+            placeholder="This manuscript combines [genre lane] with [distinctive hook], offering agents a commercially legible project with a clear audience, strong emotional engine, and marketable point of difference."
+            style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65, boxSizing: "border-box" }} />
+        </div>
+
+        {/* Agent Appeal Brief */}
+        <div style={{ border: `1px solid ${T.gold}30`, padding: "1.5rem", marginBottom: "2rem", backgroundColor: "rgba(169,142,74,0.03)" }}>
+          <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "1rem" }}>
+            Agent Appeal Brief
+          </p>
+          {[
+            { key: "hook",           label: "Distinctive Hook",   placeholder: "What makes this manuscript different from other books in the genre?" },
+            { key: "agentAppeal",    label: "Agent Appeal",       placeholder: "The professional acquisition argument: voice, concept, market fit, execution, urgency." },
+            { key: "readerAppetite", label: "Reader Appetite",    placeholder: "Why the public would want this story now." },
+            { key: "compShelf",      label: "Comparable Shelf",   placeholder: "The market shelf and comparable titles signal." },
+            { key: "whyNow",         label: "Why Now",            placeholder: "Cultural relevance, timeliness, or emotional urgency." },
+            { key: "positioning",    label: "Positioning Statement", placeholder: "Concise market-facing summary connecting genre, audience, comps, and emotional promise." },
+          ].map(({ key, label, placeholder }) => (
+            <div key={key} style={{ marginBottom: "0.875rem" }}>
+              <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>{label}</label>
+              <textarea
+                value={(appealBrief as any)[key]}
+                onChange={(e) => setAppealBrief(prev => ({ ...prev, [key]: e.target.value }))}
+                rows={2}
+                placeholder={placeholder}
+                style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "vertical", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          {["Copy", "Restore Version"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: "transparent", color: T.cream2,
+              border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>{label}</button>
+          ))}
+          <button
+            onClick={() => hasContent && setApproved(true)}
+            disabled={!hasContent}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${!hasContent ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: hasContent ? "pointer" : "not-allowed",
+              opacity: hasContent ? 1 : 0.4,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/history/page.tsx
+++ b/app/agent-readiness/history/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+export default function PackageHistoryPage() {
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Package History / Export
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          Package History / Export
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Package History / Export
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2.5rem" }}>
+          Saved package versions appear here. Export is available once all six required sections are approved.
+          DOCX export is active; PDF export will be enabled once formatting is validated.
+        </p>
+
+        {/* Empty state */}
+        <div style={{ border: `1px solid ${T.border}`, padding: "3rem 2rem", textAlign: "center" }}>
+          <p style={{ fontFamily: T.serif, fontSize: "1rem", color: T.cream2, marginBottom: "0.5rem" }}>
+            No saved packages yet.
+          </p>
+          <p style={{ fontSize: "0.75rem", color: T.dim, lineHeight: 1.6 }}>
+            Complete and approve all six required sections, then save a version to see it here.
+          </p>
+          <Link
+            href="/agent-readiness"
+            style={{
+              display: "inline-block", marginTop: "1.5rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink, textDecoration: "none",
+              padding: "0.625rem 1.25rem",
+            }}
+          >
+            Back to Package Overview
+          </Link>
+        </div>
+
+        {/* Export note */}
+        <div style={{ marginTop: "2rem", border: `1px solid ${T.border}`, padding: "1rem 1.25rem" }}>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.65 }}>
+            <strong style={{ color: T.cream2 }}>Export policy:</strong> PDF and DOCX export are locked until all six required package sections are approved.
+            A "Submit to Storygate Studio™" option appears for manuscripts with a readiness score of 8.0 or above.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/page.tsx
+++ b/app/agent-readiness/page.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+/**
+ * Agent Readiness Package™ — Flagship page
+ *
+ * Generates the full professional query package:
+ *   1. Query Letter          (450-word hard cap)
+ *   2. What Makes This Novel Unique
+ *   3. Synopsis
+ *   4. Elevator Pitch
+ *   5. Comparables
+ *   6. Author Bio            (author-supplied credentials only)
+ *
+ *   Deferred (Coming Next):
+ *   7. Agent Targeting™
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type SectionId =
+  | "query-letter"
+  | "unique"
+  | "synopsis"
+  | "elevator-pitch"
+  | "comparables"
+  | "author-bio";
+
+type SectionState = {
+  status: "empty" | "draft" | "approved";
+  content: string;
+  wordCount?: number;
+};
+
+const REQUIRED_SECTIONS: { id: SectionId; label: string; href: string; description: string }[] = [
+  {
+    id: "query-letter",
+    label: "Query Letter",
+    href: "/agent-readiness/query-letter",
+    description: "Hook · metadata · comparables sentence · unique differentiator · short bio · closing. 450-word hard cap.",
+  },
+  {
+    id: "unique",
+    label: "What Makes This Novel Unique",
+    href: "/agent-readiness/query-letter",
+    description: "Standalone section and summarized inside the query letter.",
+  },
+  {
+    id: "synopsis",
+    label: "Synopsis",
+    href: "/agent-readiness/synopsis",
+    description: "Query synopsis (100–150 words), standard (250–500), or extended (700–1,000). Ending revealed.",
+  },
+  {
+    id: "elevator-pitch",
+    label: "Elevator Pitch",
+    href: "/agent-readiness/pitch",
+    description: "One sentence. Suitable for query forms, verbal pitching, and metadata.",
+  },
+  {
+    id: "comparables",
+    label: "Comparables",
+    href: "/agent-readiness/comparables",
+    description: "2–4 comps with rationale. Also integrated into the query letter.",
+  },
+  {
+    id: "author-bio",
+    label: "Author Bio",
+    href: "/agent-readiness/bio",
+    description: "Third-person, professional. Requires author-supplied resume or bio text — no invented credentials.",
+  },
+];
+
+// ── Shared style tokens ───────────────────────────────────────────────────────
+
+const T = {
+  bg:       "#0F0D0A",
+  panel:    "#1A1612",
+  border:   "#2A2420",
+  gold:     "#A98E4A",
+  cream:    "#F2EFEA",
+  cream2:   "#C8BFB0",
+  dim:      "#7B7060",
+  oxblood:  "#7A1E1E",
+  ink:      "#0E0E0E",
+  serif:    "'Playfair Display', 'Georgia', serif",
+  mono:     "'Inter', 'Courier New', monospace",
+};
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: SectionState["status"] }) {
+  const map = {
+    empty:    { label: "Not Started", color: T.dim },
+    draft:    { label: "Draft",       color: T.gold },
+    approved: { label: "Approved",    color: "#5A8A5A" },
+  } as const;
+  const { label, color } = map[status];
+  return (
+    <span style={{
+      fontFamily: T.mono, fontSize: "0.5625rem", letterSpacing: "0.12em",
+      textTransform: "uppercase", color, border: `1px solid ${color}40`,
+      padding: "0.2rem 0.5rem",
+    }}>
+      {label}
+    </span>
+  );
+}
+
+// ── Section card ──────────────────────────────────────────────────────────────
+
+function SectionCard({
+  section,
+  index,
+  state,
+}: {
+  section: typeof REQUIRED_SECTIONS[number];
+  index: number;
+  state: SectionState;
+}) {
+  return (
+    <div style={{
+      border: `1px solid ${state.status === "approved" ? "#5A8A5A40" : T.border}`,
+      padding: "1.25rem 1.5rem",
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.625rem",
+      backgroundColor: state.status === "approved" ? "rgba(90,138,90,0.04)" : T.panel,
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <span style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim,
+            letterSpacing: "0.1em", width: "1.25rem", textAlign: "right", flexShrink: 0,
+          }}>
+            0{index + 1}
+          </span>
+          <h3 style={{ fontFamily: T.serif, fontSize: "0.9375rem", color: T.cream, lineHeight: 1.2 }}>
+            {section.label}
+          </h3>
+        </div>
+        <StatusBadge status={state.status} />
+      </div>
+      <p style={{ fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim, lineHeight: 1.6, paddingLeft: "2rem" }}>
+        {section.description}
+      </p>
+      <div style={{ paddingLeft: "2rem", display: "flex", gap: "0.625rem", flexWrap: "wrap" }}>
+        <Link
+          href={section.href}
+          style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink,
+            border: "none", padding: "0.375rem 0.75rem", cursor: "pointer",
+            textDecoration: "none", display: "inline-block",
+          }}
+        >
+          {state.status === "empty" ? "Generate" : "Edit"}
+        </Link>
+        {state.status === "draft" && (
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: "#5A8A5A",
+            border: "1px solid #5A8A5A", padding: "0.375rem 0.75rem", cursor: "pointer",
+          }}>
+            Approve
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function AgentReadinessPage() {
+  const [sectionStates] = useState<Record<SectionId, SectionState>>({
+    "query-letter":  { status: "empty", content: "" },
+    "unique":        { status: "empty", content: "" },
+    "synopsis":      { status: "empty", content: "" },
+    "elevator-pitch":{ status: "empty", content: "" },
+    "comparables":   { status: "empty", content: "" },
+    "author-bio":    { status: "empty", content: "" },
+  });
+
+  const approvedCount = Object.values(sectionStates).filter(s => s.status === "approved").length;
+  const allApproved   = approvedCount === REQUIRED_SECTIONS.length;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "3rem 2rem 6rem", display: "flex", gap: "2.5rem" }}>
+
+        {/* ── Left sidebar ─────────────────────────────────────────────── */}
+        <aside style={{ width: "220px", flexShrink: 0 }}>
+          <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "1.25rem" }}>
+            Package Sections
+          </p>
+          <nav style={{ display: "flex", flexDirection: "column", gap: "0.125rem" }}>
+            {REQUIRED_SECTIONS.map((s) => {
+              const state = sectionStates[s.id];
+              return (
+                <Link
+                  key={s.id}
+                  href={s.href}
+                  style={{
+                    display: "flex", alignItems: "center", justifyContent: "space-between",
+                    padding: "0.5rem 0.75rem",
+                    fontFamily: T.mono, fontSize: "0.6875rem", color: state.status === "approved" ? "#5A8A5A" : T.cream2,
+                    textDecoration: "none",
+                    border: "1px solid transparent",
+                  }}
+                >
+                  <span>{s.label}</span>
+                  {state.status === "approved" && <span style={{ color: "#5A8A5A", fontSize: "0.625rem" }}>✓</span>}
+                  {state.status === "draft"    && <span style={{ color: T.gold,    fontSize: "0.625rem" }}>●</span>}
+                </Link>
+              );
+            })}
+
+            {/* Divider */}
+            <div style={{ height: "1px", backgroundColor: T.border, margin: "0.75rem 0" }} />
+
+            {/* Deferred step */}
+            <div style={{
+              padding: "0.5rem 0.75rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim,
+              borderLeft: `2px solid ${T.dim}40`,
+            }}>
+              <div>Agent Targeting&#8482;</div>
+              <div style={{ fontSize: "0.5625rem", marginTop: "0.25rem", color: `${T.dim}90` }}>Coming Next</div>
+            </div>
+
+            <Link href="/agent-readiness/history" style={{
+              padding: "0.5rem 0.75rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim,
+              textDecoration: "none",
+            }}>
+              Package History / Export
+            </Link>
+          </nav>
+
+          {/* Approval progress */}
+          <div style={{ marginTop: "2rem", border: `1px solid ${T.border}`, padding: "1rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.625rem" }}>
+              Approval Progress
+            </p>
+            <div style={{ display: "flex", alignItems: "baseline", gap: "0.25rem", marginBottom: "0.625rem" }}>
+              <span style={{ fontFamily: T.serif, fontSize: "1.5rem", color: allApproved ? "#5A8A5A" : T.cream }}>
+                {approvedCount}
+              </span>
+              <span style={{ fontSize: "0.75rem", color: T.dim }}>/ {REQUIRED_SECTIONS.length}</span>
+            </div>
+            <div style={{ height: "3px", backgroundColor: T.border, borderRadius: "2px", overflow: "hidden" }}>
+              <div style={{
+                height: "100%",
+                width: `${(approvedCount / REQUIRED_SECTIONS.length) * 100}%`,
+                backgroundColor: allApproved ? "#5A8A5A" : T.gold,
+                transition: "width 0.3s ease",
+              }} />
+            </div>
+          </div>
+        </aside>
+
+        {/* ── Main content ─────────────────────────────────────────────── */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+
+          {/* Header */}
+          <div style={{ marginBottom: "2.5rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+              Agent Readiness Package™
+            </p>
+            <h1 style={{ fontFamily: T.serif, fontSize: "2rem", color: T.cream, lineHeight: 1.1, marginBottom: "0.875rem" }}>
+              Generate Full Agent Readiness Package
+            </h1>
+            <p style={{ fontSize: "0.875rem", color: T.cream2, lineHeight: 1.65, maxWidth: "600px" }}>
+              One manuscript. One professional submission package. Generate your query letter, synopsis, elevator pitch, comparables, market positioning, and author bio — then approve each section before export.
+            </p>
+          </div>
+
+          {/* Manuscript eligibility notice */}
+          <div style={{
+            border: `1px solid ${T.gold}40`, padding: "0.875rem 1.25rem",
+            marginBottom: "2rem", display: "flex", gap: "1rem", alignItems: "flex-start",
+          }}>
+            <span style={{ color: T.gold, fontSize: "0.75rem", flexShrink: 0 }}>ⓘ</span>
+            <div>
+              <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+                <strong style={{ color: T.cream }}>Eligibility:</strong> Full manuscripts may generate a complete Query Package. Excerpt or chapter submissions are eligible for craft evaluation only. Storygate Studio™ submission requires a readiness score of 8.0 or above.
+              </p>
+            </div>
+          </div>
+
+          {/* Generate all CTA */}
+          <div style={{ marginBottom: "2.5rem", display: "flex", gap: "0.875rem", flexWrap: "wrap", alignItems: "center" }}>
+            <button style={{
+              fontFamily: T.mono, fontSize: "0.75rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink,
+              border: "none", padding: "0.875rem 1.75rem", cursor: "pointer",
+            }}>
+              Generate Complete Package
+            </button>
+            <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
+              Generates all six required sections from your manuscript and provided bio inputs.
+            </p>
+          </div>
+
+          {/* Section cards */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginBottom: "2.5rem" }}>
+            {REQUIRED_SECTIONS.map((section, i) => (
+              <SectionCard key={section.id} section={section} index={i} state={sectionStates[section.id]} />
+            ))}
+          </div>
+
+          {/* Agent Targeting teaser */}
+          <div style={{
+            border: `1px solid ${T.border}`, padding: "1.25rem 1.5rem",
+            display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem",
+            opacity: 0.6,
+          }}>
+            <div>
+              <p style={{ fontFamily: T.serif, fontSize: "0.9375rem", color: T.cream2, marginBottom: "0.25rem" }}>
+                Agent Targeting™ — Coming Next
+              </p>
+              <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
+                Find three target agents. Generate agent-specific query variants. Build your outreach plan.
+              </p>
+            </div>
+            <span style={{
+              fontFamily: T.mono, fontSize: "0.5625rem", letterSpacing: "0.12em",
+              textTransform: "uppercase", color: T.dim, border: `1px solid ${T.border}`,
+              padding: "0.25rem 0.625rem", flexShrink: 0,
+            }}>
+              Locked
+            </span>
+          </div>
+
+          {/* Export section */}
+          <div style={{ marginTop: "2.5rem", borderTop: `1px solid ${T.border}`, paddingTop: "2rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: "1rem" }}>
+              Export
+            </p>
+            <p style={{ fontSize: "0.75rem", color: T.dim, lineHeight: 1.6, marginBottom: "1.25rem" }}>
+              Export is locked until all six required sections are approved by the author.
+              {approvedCount > 0 && approvedCount < REQUIRED_SECTIONS.length && (
+                <> {REQUIRED_SECTIONS.length - approvedCount} section{REQUIRED_SECTIONS.length - approvedCount > 1 ? "s" : ""} remaining.</>
+              )}
+            </p>
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              {[
+                { label: "Download Editable DOCX", available: allApproved },
+                { label: "Download Professional PDF", available: false /* expose once PDF formatting stable */ },
+                { label: "Copy Query Package",     available: allApproved },
+                { label: "Save Package Version",   available: approvedCount > 0 },
+              ].map(({ label, available }) => (
+                <button
+                  key={label}
+                  disabled={!available}
+                  style={{
+                    fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+                    letterSpacing: "0.1em", textTransform: "uppercase",
+                    backgroundColor: available ? T.gold : "transparent",
+                    color: available ? T.ink : T.dim,
+                    border: available ? "none" : `1px solid ${T.border}`,
+                    padding: "0.5rem 1rem", cursor: available ? "pointer" : "not-allowed",
+                    opacity: available ? 1 : 0.5,
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, marginTop: "1rem", lineHeight: 1.6 }}>
+              Note: "Submit to Storygate Studio™" appears as an export option once the manuscript holds a readiness score of 8.0 or above and all package sections are approved.
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/pitch/page.tsx
+++ b/app/agent-readiness/pitch/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * Pitch Builder
+ * - Elevator Pitch: one sentence
+ * - Paragraph Pitch: one compact paragraph
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+export default function PitchPage() {
+  const [elevator,         setElevator]        = useState("");
+  const [paragraph,        setParagraph]        = useState("");
+  const [elevatorApproved, setElevatorApproved] = useState(false);
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Pitch Builder
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          04 — Elevator Pitch
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "2rem" }}>
+          Pitch Builder
+        </h1>
+
+        {/* Elevator Pitch */}
+        <div style={{ marginBottom: "2.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Elevator Pitch — one sentence
+          </label>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6, marginBottom: "0.875rem" }}>
+            A compact, high-impact sentence suitable for query forms, verbal pitching, and manuscript metadata.
+          </p>
+          <textarea
+            value={elevator}
+            onChange={(e) => { setElevator(e.target.value); setElevatorApproved(false); }}
+            rows={3}
+            placeholder="[TITLE] is a [genre] novel in which [protagonist] must [central conflict] or [stakes]."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "none", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+          <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.75rem", flexWrap: "wrap" }}>
+            {["Generate", "Regenerate", "Improve", "Copy"].map(label => (
+              <button key={label} style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: label === "Generate" ? T.gold : "transparent",
+                color: label === "Generate" ? T.ink : T.cream2,
+                border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+                padding: "0.5rem 1rem", cursor: "pointer",
+              }}>{label}</button>
+            ))}
+            <button
+              onClick={() => elevator.trim().length > 10 && setElevatorApproved(true)}
+              disabled={elevator.trim().length < 10}
+              style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: elevatorApproved ? "#5A8A5A" : "transparent",
+                color: elevatorApproved ? "#F2EFEA" : "#5A8A5A",
+                border: `1px solid ${elevator.trim().length < 10 ? T.border : "#5A8A5A"}`,
+                padding: "0.5rem 1rem",
+                cursor: elevator.trim().length < 10 ? "not-allowed" : "pointer",
+                opacity: elevator.trim().length < 10 ? 0.4 : 1,
+              }}
+            >
+              {elevatorApproved ? "✓ Approved" : "Lock / Approve"}
+            </button>
+          </div>
+        </div>
+
+        {/* Paragraph Pitch */}
+        <div>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Paragraph Pitch <span style={{ color: "#7B7060", fontWeight: 400 }}>(optional — for email, networking, query forms)</span>
+          </label>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6, marginBottom: "0.875rem" }}>
+            One compact paragraph suitable for email queries, agent networking, and package summaries.
+          </p>
+          <textarea
+            value={paragraph}
+            onChange={(e) => setParagraph(e.target.value)}
+            rows={6}
+            placeholder="Expand the elevator pitch into a short paragraph with the hook, the core conflict, the stakes, and the market positioning."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+          <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.75rem", flexWrap: "wrap" }}>
+            {["Generate", "Regenerate", "Improve", "Copy"].map(label => (
+              <button key={label} style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: label === "Generate" ? T.gold : "transparent",
+                color: label === "Generate" ? T.ink : T.cream2,
+                border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+                padding: "0.5rem 1rem", cursor: "pointer",
+              }}>{label}</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/query-letter/page.tsx
+++ b/app/agent-readiness/query-letter/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+/**
+ * Query / Cover Letter builder
+ *
+ * Rules:
+ * - 450-word hard cap on the query letter body
+ * - Warning at 425 words
+ * - Comparables sentence and "What Makes This Novel Unique" must appear inside the letter
+ * - Author Bio paragraph drawn only from author-supplied inputs
+ */
+
+import Link from "next/link";
+import { useCallback, useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", oxblood: "#7A1E1E", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+const WORD_LIMIT = 450;
+const WORD_WARN  = 425;
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export default function QueryLetterPage() {
+  const [body, setBody] = useState("");
+  const [unique, setUnique] = useState("");
+  const [approved, setApproved] = useState(false);
+
+  const wordCount = countWords(body);
+  const overLimit = wordCount > WORD_LIMIT;
+  const nearLimit = wordCount >= WORD_WARN && !overLimit;
+
+  const handleBodyChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    const wc  = countWords(val);
+    if (wc <= WORD_LIMIT + 20) setBody(val); // soft buffer for typing — gate on submit
+    setApproved(false);
+  }, []);
+
+  const wordCountColor = overLimit ? T.oxblood : nearLimit ? T.gold : T.dim;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        {/* Breadcrumb */}
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{"  "}Query / Cover Letter
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          01 — Query / Cover Letter
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Query / Cover Letter
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem", maxWidth: "560px" }}>
+          The agent-facing submission letter. Must include: hook, manuscript metadata (title · genre · word count), comparables sentence, what makes it unique, short bio, and professional closing. Hard cap: 450 words.
+        </p>
+
+        {/* What Makes This Novel Unique — standalone field */}
+        <div style={{ marginBottom: "1.75rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            What Makes This Novel Unique <span style={{ color: T.cream2 }}>(standalone section — also appears inside the letter)</span>
+          </label>
+          <textarea
+            value={unique}
+            onChange={(e) => setUnique(e.target.value)}
+            rows={4}
+            placeholder="Describe the specific hook, premise, voice, or structural element that sets this manuscript apart..."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Query letter body */}
+        <div style={{ marginBottom: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "0.5rem" }}>
+            <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              Query Letter Body
+            </label>
+            <span style={{ fontFamily: T.mono, fontSize: "0.6875rem", color: wordCountColor, fontWeight: overLimit ? 700 : 400 }}>
+              {overLimit && "OVER LIMIT — "}
+              {nearLimit && "NEAR LIMIT — "}
+              Query Letter: {wordCount} / {WORD_LIMIT} words
+            </span>
+          </div>
+          <textarea
+            value={body}
+            onChange={handleBodyChange}
+            rows={20}
+            placeholder={`Dear [Agent Name],\n\n[Hook paragraph — the story pitch.]\n\n[Title], [Genre], [Word Count], [Audience]. [TITLE] will appeal to readers of [Comp 1] and [Comp 2], combining [shared appeal] with [unique differentiator].\n\n[What makes it unique — one or two compact sentences.]\n\n[Author bio paragraph — pulled only from author-supplied resume/bio facts.]\n\nThank you for your time and consideration.\n\n[Your Name]`}
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel,
+              border: `1px solid ${overLimit ? T.oxblood : nearLimit ? T.gold : T.border}`,
+              padding: "1rem", resize: "vertical", outline: "none", lineHeight: 1.75,
+              boxSizing: "border-box",
+            }}
+          />
+          {overLimit && (
+            <p style={{ fontSize: "0.6875rem", color: T.oxblood, marginTop: "0.375rem", lineHeight: 1.5 }}>
+              Query letter exceeds the 450-word limit. Trim before approving. Export is blocked until the limit is met.
+            </p>
+          )}
+          {nearLimit && (
+            <p style={{ fontSize: "0.6875rem", color: T.gold, marginTop: "0.375rem" }}>
+              Approaching limit — {WORD_LIMIT - wordCount} words remaining.
+            </p>
+          )}
+        </div>
+
+        {/* Action row */}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", marginBottom: "2rem" }}>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink, border: "none",
+            padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Generate
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Regenerate
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Improve
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Copy
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.dim,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Restore Version
+          </button>
+          <button
+            onClick={() => !overLimit && setApproved(true)}
+            disabled={overLimit || body.trim().length < 50}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${overLimit ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: overLimit || body.trim().length < 50 ? "not-allowed" : "pointer",
+              opacity: overLimit || body.trim().length < 50 ? 0.4 : 1,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        {approved && (
+          <div style={{
+            border: `1px solid #5A8A5A40`, padding: "0.75rem 1.25rem",
+            backgroundColor: "rgba(90,138,90,0.06)", fontSize: "0.75rem", color: "#5A8A5A",
+          }}>
+            Query Letter approved and locked. Return to the package to approve remaining sections.
+          </div>
+        )}
+
+        <div style={{ marginTop: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim,
+            letterSpacing: "0.1em", textDecoration: "none",
+          }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/synopsis/page.tsx
+++ b/app/agent-readiness/synopsis/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * Synopsis Builder
+ *
+ * Three lengths:
+ *   Query synopsis:   100–150 words
+ *   Standard synopsis: 250–500 words  (default MVP)
+ *   Extended synopsis: 700–1,000 words
+ *
+ * Rule: must reveal the ending. No teaser language.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+type SynopsisLength = "query" | "standard" | "extended";
+
+const LENGTHS: { id: SynopsisLength; label: string; range: string; description: string }[] = [
+  { id: "query",    label: "Query Synopsis",    range: "100–150 words",   description: "Suitable for query forms and agent intake." },
+  { id: "standard", label: "Standard Synopsis", range: "250–500 words",   description: "Default. Suitable for most agency submissions." },
+  { id: "extended", label: "Extended Synopsis", range: "700–1,000 words", description: "Full submission synopsis for agencies that require it." },
+];
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export default function SynopsisPage() {
+  const [selected, setSelected] = useState<SynopsisLength>("standard");
+  const [content,  setContent]  = useState("");
+  const [approved, setApproved] = useState(false);
+
+  const wordCount = countWords(content);
+  const limits: Record<SynopsisLength, [number, number]> = {
+    query:    [100, 150],
+    standard: [250, 500],
+    extended: [700, 1000],
+  };
+  const [min, max] = limits[selected];
+  const overLimit  = wordCount > max;
+  const underMin   = content.trim().length > 0 && wordCount < min;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "} Synopsis Builder
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          03 — Synopsis
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Synopsis Builder
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem" }}>
+          The synopsis must reveal the ending. No teaser language. Agents need to see the complete story arc.
+        </p>
+
+        {/* Length selector */}
+        <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1.75rem", flexWrap: "wrap" }}>
+          {LENGTHS.map(l => (
+            <button
+              key={l.id}
+              onClick={() => { setSelected(l.id); setApproved(false); }}
+              style={{
+                fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                padding: "0.5rem 1rem",
+                backgroundColor: selected === l.id ? T.gold : "transparent",
+                color: selected === l.id ? T.ink : T.cream2,
+                border: `1px solid ${selected === l.id ? T.gold : T.border}`,
+                cursor: "pointer",
+              }}
+            >
+              {l.label} <span style={{ fontWeight: 400, opacity: 0.7 }}>· {l.range}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={{ marginBottom: "1.75rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "0.5rem" }}>
+            <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              {LENGTHS.find(l => l.id === selected)?.label}
+            </label>
+            <span style={{
+              fontFamily: T.mono, fontSize: "0.6875rem",
+              color: overLimit ? "#7A1E1E" : underMin ? T.gold : T.dim,
+            }}>
+              {wordCount} / {max} words
+            </span>
+          </div>
+          <textarea
+            value={content}
+            onChange={(e) => { setContent(e.target.value); setApproved(false); }}
+            rows={16}
+            placeholder="Begin with the protagonist and inciting incident. Follow the central conflict through to resolution — include the ending. Do not use teaser language."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel,
+              border: `1px solid ${overLimit ? "#7A1E1E" : T.border}`,
+              padding: "1rem", resize: "vertical", outline: "none", lineHeight: 1.75,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          {["Generate", "Regenerate", "Improve", "Copy", "Restore Version"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: label === "Generate" ? T.gold : "transparent",
+              color: label === "Generate" ? T.ink : T.cream2,
+              border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+              padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>
+              {label}
+            </button>
+          ))}
+          <button
+            onClick={() => !overLimit && content.trim().length > 50 && setApproved(true)}
+            disabled={overLimit || content.trim().length < 50}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${overLimit ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: overLimit || content.trim().length < 50 ? "not-allowed" : "pointer",
+              opacity: overLimit || content.trim().length < 50 ? 0.4 : 1,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/convert/page.tsx
+++ b/app/convert/page.tsx
@@ -1,8 +1,6 @@
-export default function ConvertPage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Convert</h1>
-      <p className="text-slate-600">Content conversion tools are coming soon. Transform manuscripts between formats with fidelity scoring.</p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+
+// Convert has been replaced by Agent Readiness Package™
+export default function ConvertRedirect() {
+  redirect("/agent-readiness");
 }

--- a/app/output/page.tsx
+++ b/app/output/page.tsx
@@ -1,8 +1,6 @@
-export default function OutputPage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Output</h1>
-      <p className="text-slate-600">Publication output tools are coming soon. Generate submission-ready packages for agents and publishers.</p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+
+// Output has been replaced by Agent Readiness Package™
+export default function OutputRedirect() {
+  redirect("/agent-readiness");
 }

--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -3,19 +3,22 @@
 /**
  * HeaderNav — RevisionGrade canonical navigation shell
  *
- * Governed OS principle: core product actions stay top-level; reference pages
- * live behind Resources; auth state controls Dashboard vs Sign In/Sign Out.
+ * Signed-in nav order (per product doctrine):
+ *   Dashboard · Evaluate · Revise · Agent Readiness Package™ · Storygate Studio™ · Resources · Pricing
+ *   Admin-only: Pipeline
  *
  * Auth states:
- *   authState = "loading"   — session check in-flight; render nav skeleton (no flash)
- *   authState = "authed"    — valid session; show Dashboard + optional Pipeline
- *   authState = "anon"      — no session; show Sign In
+ *   "loading" — session check in-flight; render skeleton (no flash)
+ *   "authed"  — valid session
+ *   "anon"    — no session
  */
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { isPipelineHealthAdminEmail } from "@/lib/admin/pipelineHealthAllowlist";
+
+// ── Dropdown configs ──────────────────────────────────────────────────────────
 
 const resourceLinks = [
   ["The Black Box Problem", "/black-box-problem"],
@@ -31,20 +34,37 @@ const resourceActiveHrefs = [
   "/reliability",
 ];
 
+const arpLinks = [
+  ["Generate Full Agent Package", "/agent-readiness"],
+  ["Query / Cover Letter",        "/agent-readiness/query-letter"],
+  ["Synopsis Builder",            "/agent-readiness/synopsis"],
+  ["Pitch Builder",               "/agent-readiness/pitch"],
+  ["Author Bio",                  "/agent-readiness/bio"],
+  ["Comparables & Positioning",   "/agent-readiness/comparables"],
+  ["Package History / Export",    "/agent-readiness/history"],
+];
+
+const arpActiveHref = "/agent-readiness";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 export default function HeaderNav() {
   const pathname = usePathname() || "/";
   const router = useRouter();
+
   const resourcesMenuRef = useRef(null);
+  const arpMenuRef       = useRef(null);
 
-  // "loading" prevents the nav from flashing between authed/anon states on mount
-  const [authState, setAuthState] = useState("loading"); // "loading" | "authed" | "anon"
-  const [email, setEmail] = useState(null);
-  const [signingOut, setSigningOut] = useState(false);
+  const [authState,    setAuthState]    = useState("loading");
+  const [email,        setEmail]        = useState(null);
+  const [signingOut,   setSigningOut]   = useState(false);
   const [resourcesOpen, setResourcesOpen] = useState(false);
+  const [arpOpen,       setArpOpen]       = useState(false);
 
-  const isAdmin = isPipelineHealthAdminEmail(email);
+  const isAdmin  = isPipelineHealthAdminEmail(email);
   const isAuthed = authState === "authed";
 
+  // ── Auth check ─────────────────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
     fetch("/api/auth/user", { credentials: "include", cache: "no-store" })
@@ -56,97 +76,108 @@ export default function HeaderNav() {
         setAuthState(resolvedEmail ? "authed" : "anon");
       })
       .catch(() => {
-        if (!cancelled) {
-          setEmail(null);
-          setAuthState("anon");
-        }
+        if (!cancelled) { setEmail(null); setAuthState("anon"); }
       });
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [pathname]);
 
+  // ── Dropdown outside-click / Escape ────────────────────────────────────────
   useEffect(() => {
-    if (!resourcesOpen) return;
-
-    function handlePointerDown(event) {
-      if (!resourcesMenuRef.current) return;
-      if (!resourcesMenuRef.current.contains(event.target)) {
-        setResourcesOpen(false);
-      }
+    if (!resourcesOpen && !arpOpen) return;
+    function handlePointerDown(e) {
+      if (resourcesOpen && resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target)) setResourcesOpen(false);
+      if (arpOpen      && arpMenuRef.current       && !arpMenuRef.current.contains(e.target))       setArpOpen(false);
     }
-
-    function handleKeyDown(event) {
-      if (event.key === "Escape") {
-        setResourcesOpen(false);
-      }
+    function handleKeyDown(e) {
+      if (e.key === "Escape") { setResourcesOpen(false); setArpOpen(false); }
     }
-
     document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [resourcesOpen]);
+  }, [resourcesOpen, arpOpen]);
 
+  // ── Sign out ───────────────────────────────────────────────────────────────
   async function handleSignOut() {
     if (signingOut) return;
     setSigningOut(true);
-    try {
-      await fetch("/api/auth/signout", {
-        method: "POST",
-        credentials: "include",
-        cache: "no-store",
-      });
-    } catch {
-      // best-effort
-    }
-    setEmail(null);
-    setAuthState("anon");
-    router.push("/");
-    router.refresh();
+    try { await fetch("/api/auth/signout", { method: "POST", credentials: "include", cache: "no-store" }); }
+    catch { /* best-effort */ }
+    setEmail(null); setAuthState("anon");
+    router.push("/"); router.refresh();
     setSigningOut(false);
   }
 
-  const linkCls =
-    "text-xs tracking-widest uppercase font-rg-mono text-rg-cream2 hover:text-rg-cream transition-colors duration-150";
-  const activeLinkCls =
-    "text-xs tracking-widest uppercase font-rg-mono text-rg-gold";
+  // ── Style helpers ──────────────────────────────────────────────────────────
+  const linkCls       = "text-xs tracking-widest uppercase font-rg-mono text-rg-cream2 hover:text-rg-cream transition-colors duration-150";
+  const activeLinkCls = "text-xs tracking-widest uppercase font-rg-mono text-rg-gold";
 
   function NavLink({ href, children }) {
     const active = pathname === href || pathname.startsWith(href + "/");
-    return (
-      <Link href={href} className={active ? activeLinkCls : linkCls}>
-        {children}
-      </Link>
-    );
+    return <Link href={href} className={active ? activeLinkCls : linkCls}>{children}</Link>;
   }
 
-  const resourcesActive = resourceActiveHrefs.some(
-    (href) => pathname === href || pathname.startsWith(`${href}/`)
-  );
+  const resourcesActive = resourceActiveHrefs.some((h) => pathname === h || pathname.startsWith(`${h}/`));
+  const arpActive       = pathname === arpActiveHref || pathname.startsWith(`${arpActiveHref}/`);
+
+  // ── Dropdown panel shared style ────────────────────────────────────────────
+  const dropdownCls = "absolute left-1/2 top-8 z-50 -translate-x-1/2 border border-rg-cream2/15 bg-rg-ink2 p-3 shadow-xl shadow-black/30";
+  const dropdownItemCls = "block px-3 py-2 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-cream2 hover:text-rg-cream whitespace-nowrap";
 
   return (
     <header className="w-full bg-rg-ink border-b border-rg-cream2/10 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between gap-8">
+
+        {/* Wordmark */}
         <Link href="/" className="flex items-center gap-3 shrink-0 group">
-          <span className="inline-flex h-8 w-8 items-center justify-center border border-rg-gold/60 text-rg-gold font-rg-serif text-sm group-hover:border-rg-gold transition-colors duration-150">
-            R
-          </span>
-          <span className="text-rg-cream font-rg-serif text-sm tracking-wide hidden sm:block">
-            RevisionGrade&#8482;
-          </span>
+          <span className="inline-flex h-8 w-8 items-center justify-center border border-rg-gold/60 text-rg-gold font-rg-serif text-sm group-hover:border-rg-gold transition-colors duration-150">R</span>
+          <span className="text-rg-cream font-rg-serif text-sm tracking-wide hidden sm:block">RevisionGrade&#8482;</span>
         </Link>
 
+        {/* Nav links */}
         <nav className="flex items-center gap-6 flex-1 justify-center">
+
+          {/* Auth-gated: Dashboard first */}
+          {isAuthed && <NavLink href="/dashboard">Dashboard</NavLink>}
+
           <NavLink href="/evaluate">Evaluate</NavLink>
           <NavLink href="/revise">Revise</NavLink>
-          <NavLink href="/reliability">Reliability</NavLink>
+
+          {/* Agent Readiness Package™ dropdown (auth-gated) */}
+          {isAuthed && (
+            <div className="relative" ref={arpMenuRef}>
+              <button
+                type="button"
+                onClick={() => { setArpOpen((v) => !v); setResourcesOpen(false); }}
+                className={arpActive ? activeLinkCls : linkCls}
+                aria-expanded={arpOpen}
+                aria-haspopup="menu"
+                aria-controls="arp-menu"
+              >
+                Agent Readiness&#8482;
+              </button>
+              {arpOpen && (
+                <div id="arp-menu" className={`${dropdownCls} w-64`} role="menu">
+                  {arpLinks.map(([label, href]) => (
+                    <Link key={href} href={href} role="menuitem" onClick={() => setArpOpen(false)} className={dropdownItemCls}>
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Storygate Studio™ top-level link (auth-gated) */}
+          {isAuthed && <NavLink href="/storygate-studio">Storygate Studio&#8482;</NavLink>}
+
+          {/* Resources dropdown */}
           <div className="relative" ref={resourcesMenuRef}>
             <button
               type="button"
-              onClick={() => setResourcesOpen((value) => !value)}
+              onClick={() => { setResourcesOpen((v) => !v); setArpOpen(false); }}
               className={resourcesActive ? activeLinkCls : linkCls}
               aria-expanded={resourcesOpen}
               aria-haspopup="menu"
@@ -155,36 +186,25 @@ export default function HeaderNav() {
               Resources
             </button>
             {resourcesOpen && (
-              <div
-                id="resources-menu"
-                className="absolute left-1/2 top-8 z-50 w-56 -translate-x-1/2 border border-rg-cream2/15 bg-rg-ink2 p-3 shadow-xl shadow-black/30"
-                role="menu"
-              >
+              <div id="resources-menu" className={`${dropdownCls} w-56`} role="menu">
                 {resourceLinks.map(([label, href]) => (
-                  <Link
-                    key={href}
-                    href={href}
-                    role="menuitem"
-                    onClick={() => setResourcesOpen(false)}
-                    className="block px-3 py-2 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-cream2 hover:text-rg-cream"
-                  >
+                  <Link key={href} href={href} role="menuitem" onClick={() => setResourcesOpen(false)} className={dropdownItemCls}>
                     {label}
                   </Link>
                 ))}
               </div>
             )}
           </div>
+
           <NavLink href="/pricing">Pricing</NavLink>
 
-          {/* Auth-gated items — only render once auth check resolves (no flash) */}
-          {isAuthed && <NavLink href="/dashboard">Dashboard</NavLink>}
-          {isAuthed && isAdmin && (
-            <NavLink href="/admin/pipeline-health">Pipeline</NavLink>
-          )}
+          {/* Admin-only */}
+          {isAuthed && isAdmin && <NavLink href="/admin/pipeline-health">Pipeline</NavLink>}
+
         </nav>
 
+        {/* Auth button */}
         <div className="shrink-0">
-          {/* While loading: render a ghost placeholder to prevent layout shift */}
           {authState === "loading" && (
             <span className="inline-block w-14 h-5 rounded bg-rg-cream2/10 animate-pulse" />
           )}
@@ -200,15 +220,12 @@ export default function HeaderNav() {
             </button>
           )}
           {authState === "anon" && (
-            <Link
-              href="/login"
-              data-testid="nav-signin"
-              className="text-xs tracking-widest uppercase font-rg-mono border border-rg-gold text-rg-gold px-3 py-1.5 hover:bg-rg-gold hover:text-rg-ink transition-colors duration-150"
-            >
+            <Link href="/login" data-testid="nav-signin" className="text-xs tracking-widest uppercase font-rg-mono border border-rg-gold text-rg-gold px-3 py-1.5 hover:bg-rg-gold hover:text-rg-ink transition-colors duration-150">
               Sign in
             </Link>
           )}
         </div>
+
       </div>
     </header>
   );


### PR DESCRIPTION
## Agent Readiness Package™ v1

Replaces the stub `Convert` and `Output` nav items with a full Agent Readiness Package™ suite.

### Navigation changes
- `Convert` and `Output` removed from primary nav (both were placeholder stubs)
- **Agent Readiness Package™** added as auth-gated dropdown after Revise
- **Storygate Studio™** added as top-level auth-gated link
- Signed-in nav order: Dashboard · Evaluate · Revise · Agent Readiness™ · Storygate Studio™ · Resources · Pricing · Pipeline (admin)

### New routes
| Route | Purpose |
|---|---|
| `/agent-readiness` | Flagship page — sidebar, 6-section state machine, approval progress, export gate |
| `/agent-readiness/query-letter` | 450-word hard cap, real-time counter, warning at 425 |
| `/agent-readiness/synopsis` | Query / Standard / Extended lengths; ending revealed |
| `/agent-readiness/pitch` | Elevator pitch + paragraph pitch |
| `/agent-readiness/bio` | Author-supplied credentials only; accuracy checkbox |
| `/agent-readiness/comparables` | Comps, why-fit, differentiator, Agent Appeal Brief |
| `/agent-readiness/history` | Saved versions + export gate |

### Redirects
- `/convert` → `/agent-readiness`
- `/output` → `/agent-readiness`

### Governance enforced
- Export locked until all 6 sections approved by author
- Bio: resume/bio text required + accuracy confirmation checkbox
- Query Letter: 450-word hard stop (warning at 425)
- System cannot invent author credentials
- Agent Targeting™ reserved in sidebar as **Coming Next**

### Deferred (separate PR)
- Agent Targeting™ / Find Three Agents
- Variant Engine / Outreach Tracker
- PDF/DOCX export formatting (V1: web-based with copy buttons)
- Screenplay / film adaptation tools (feature-flagged)

### Product flow
```
Evaluate → Revise → Agent Readiness Package™ → Storygate Studio™
```