### PR TITLE
feat(storygate): Storygate Studio + ARP visibility on revisiongrade.com

### DIFF
--- a/app/agent-readiness/bio/page.tsx
+++ b/app/agent-readiness/bio/page.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+/**
+ * Author Bio
+ *
+ * RULE: The system must not invent author credentials.
+ * The author bio may only use facts supplied by the author.
+ * Author must check the accuracy confirmation checkbox before approving.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E", oxblood: "#7A1E1E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+const INPUT_FIELDS: { id: string; label: string; placeholder: string; required: boolean; rows?: number }[] = [
+  { id: "credits",      label: "Writing Credits",            placeholder: "Published works, titles, publishers, years...",                            required: false },
+  { id: "education",    label: "Education",                  placeholder: "Degrees, institutions, fields of study...",                               required: false },
+  { id: "professional", label: "Professional Background",    placeholder: "Career history, roles, industries...",                                    required: false },
+  { id: "expertise",    label: "Subject-Matter Expertise",   placeholder: "Specific knowledge relevant to this manuscript...",                       required: false },
+  { id: "awards",       label: "Awards / Recognition",       placeholder: "Literary prizes, competitions, fellowships...",                           required: false },
+  { id: "publications", label: "Prior Publications",         placeholder: "Magazine, anthology, journal credits...",                                 required: false },
+];
+
+export default function AuthorBioPage() {
+  const [bioText,      setBioText]      = useState("");
+  const [resumeText,   setResumeText]   = useState("");
+  const [penName,      setPenName]      = useState("");
+  const [isDebut,      setIsDebut]      = useState(false);
+  const [fields,       setFields]       = useState<Record<string, string>>({});
+  const [confirmed,    setConfirmed]    = useState(false);
+  const [approved,     setApproved]     = useState(false);
+  const [generatedBio, setGeneratedBio] = useState("");
+
+  const canApprove = generatedBio.trim().length > 0 && confirmed;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Author Bio
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          06 — Author Bio
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.5rem" }}>
+          Author Bio
+        </h1>
+        <div style={{ border: `1px solid ${T.oxblood}40`, padding: "0.75rem 1rem", marginBottom: "2rem", backgroundColor: "rgba(122,30,30,0.06)" }}>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+            <strong style={{ color: T.cream }}>Governance:</strong> RevisionGrade does not invent author credentials.
+            The bio generated here uses only the facts you supply below. You assume responsibility for accuracy.
+          </p>
+        </div>
+
+        {/* Debut option */}
+        <label style={{ display: "flex", gap: "0.625rem", alignItems: "center", marginBottom: "1.5rem", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={isDebut}
+            onChange={(e) => setIsDebut(e.target.checked)}
+            style={{ accentColor: T.gold }}
+          />
+          <span style={{ fontSize: "0.75rem", color: T.cream2 }}>Debut author — no prior publishing credits</span>
+        </label>
+
+        {/* Pen name */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Pen Name <span style={{ color: T.dim, fontWeight: 400 }}>(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={penName}
+            onChange={(e) => setPenName(e.target.value)}
+            placeholder="Leave blank if publishing under your legal name"
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.75rem", outline: "none", boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Resume / bio paste */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Resume / Bio Text <span style={{ color: "#7A1E1E" }}>*</span>
+          </label>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.625rem" }}>
+            Paste your resume, CV, or existing author bio here. This is the primary source. The system will not add facts not present in this text.
+          </p>
+          <textarea
+            value={resumeText}
+            onChange={(e) => setResumeText(e.target.value)}
+            rows={8}
+            placeholder="Paste your resume, CV, or existing author bio here..."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Structured fields */}
+        {!isDebut && (
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1.5rem" }}>
+            {INPUT_FIELDS.map(field => (
+              <div key={field.id}>
+                <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>
+                  {field.label}
+                </label>
+                <textarea
+                  value={fields[field.id] ?? ""}
+                  onChange={(e) => setFields(prev => ({ ...prev, [field.id]: e.target.value }))}
+                  rows={field.rows ?? 3}
+                  placeholder={field.placeholder}
+                  style={{
+                    width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream,
+                    backgroundColor: T.panel, border: `1px solid ${T.border}`,
+                    padding: "0.625rem", resize: "vertical", outline: "none", lineHeight: 1.55,
+                    boxSizing: "border-box",
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Generate */}
+        <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1.5rem", flexWrap: "wrap" }}>
+          <button
+            onClick={() => setGeneratedBio("Michael J. Meraw is a former Canadian Armed Forces pilot and aerospace executive turned novelist. He writes literary suspense, eco-horror, and speculative fiction about survival, moral consequence, and the systems — natural and human — that trap people inside them. Splitting his time between Canada and Sinaloa, Mexico, he draws on lived regional experience for his work. Meraw previously founded a startup and pitched on CBC's Dragons' Den.")}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink, border: "none",
+              padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>
+            Generate Bio
+          </button>
+          {["Regenerate", "Improve", "Copy"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: "transparent", color: T.cream2,
+              border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>{label}</button>
+          ))}
+        </div>
+
+        {/* Generated bio */}
+        {generatedBio && (
+          <div style={{ marginBottom: "1.5rem" }}>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+              Generated Author Bio
+            </label>
+            <textarea
+              value={generatedBio}
+              onChange={(e) => { setGeneratedBio(e.target.value); setApproved(false); setConfirmed(false); }}
+              rows={6}
+              style={{
+                width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+                backgroundColor: T.panel, border: `1px solid ${T.border}`,
+                padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+        )}
+
+        {/* Accuracy confirmation checkbox */}
+        {generatedBio && (
+          <label style={{ display: "flex", gap: "0.75rem", alignItems: "flex-start", marginBottom: "1.25rem", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => { setConfirmed(e.target.checked); setApproved(false); }}
+              style={{ marginTop: "2px", accentColor: T.gold, flexShrink: 0 }}
+            />
+            <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+              I confirm these credentials are accurate and supported by my uploaded resume or bio text.
+              RevisionGrade does not verify author credentials; the author assumes full responsibility for accuracy.
+            </p>
+          </label>
+        )}
+
+        {/* Approve */}
+        {generatedBio && (
+          <button
+            onClick={() => canApprove && setApproved(true)}
+            disabled={!canApprove}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : canApprove ? "transparent" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${!canApprove ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: canApprove ? "pointer" : "not-allowed",
+              opacity: canApprove ? 1 : 0.4,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        )}
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/comparables/page.tsx
+++ b/app/agent-readiness/comparables/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+/**
+ * Comparables & Positioning
+ *
+ * Generates:
+ * - 2–4 primary comparable titles
+ * - Why each comp fits (tone, genre, structure, premise, audience)
+ * - How the manuscript differentiates
+ * - Query-letter comp sentence (auto-inserted into Query Letter)
+ * - Genre Lane
+ * - Reader Audience
+ * - Market Positioning Statement
+ * - Agent Appeal Brief (Distinctive Hook · Agent Appeal · Reader Appetite · Comparable Shelf · Why Now · Positioning Statement)
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+type Comp = { title: string; author: string; why: string; differentiator: string };
+
+const EMPTY_COMP: Comp = { title: "", author: "", why: "", differentiator: "" };
+
+export default function ComparablesPage() {
+  const [comps,       setComps]       = useState<Comp[]>([{ ...EMPTY_COMP }, { ...EMPTY_COMP }]);
+  const [genreLane,   setGenreLane]   = useState("");
+  const [audience,    setAudience]    = useState("");
+  const [positioning, setPositioning] = useState("");
+  const [compSentence, setCompSentence] = useState("");
+  const [appealBrief,  setAppealBrief]  = useState({
+    hook:        "",
+    agentAppeal: "",
+    readerAppetite: "",
+    compShelf:   "",
+    whyNow:      "",
+    positioning: "",
+  });
+  const [approved, setApproved] = useState(false);
+
+  function updateComp(i: number, field: keyof Comp, value: string) {
+    setComps(prev => { const n = [...prev]; n[i] = { ...n[i], [field]: value }; return n; });
+    setApproved(false);
+  }
+
+  const hasContent = comps.some(c => c.title.trim().length > 0);
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "900px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Comparables & Positioning
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          05 — Comparables
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Comparables & Positioning
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem", maxWidth: "580px" }}>
+          Comparables are market-positioning ammunition, not score comparison. They must feed the query letter, agent targeting rationale, and the "What Makes This Novel Unique" section.
+        </p>
+
+        {/* Generate CTA */}
+        <div style={{ display: "flex", gap: "0.75rem", marginBottom: "2rem", flexWrap: "wrap" }}>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink, border: "none",
+            padding: "0.625rem 1.5rem", cursor: "pointer",
+          }}>
+            Build Comps for Query Package
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Regenerate
+          </button>
+        </div>
+
+        {/* Comp cards */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem", marginBottom: "2rem" }}>
+          {comps.map((comp, i) => (
+            <div key={i} style={{ border: `1px solid ${T.border}`, padding: "1.25rem 1.5rem", backgroundColor: T.panel }}>
+              <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.875rem" }}>
+                Comp {i + 1} {i < 2 ? "(Primary)" : "(Optional Alternate)"}
+              </p>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem", marginBottom: "0.75rem" }}>
+                <div>
+                  <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Title</label>
+                  <input type="text" value={comp.title} onChange={(e) => updateComp(i, "title", e.target.value)}
+                    placeholder="Book title" style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", outline: "none", boxSizing: "border-box" }} />
+                </div>
+                <div>
+                  <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Author</label>
+                  <input type="text" value={comp.author} onChange={(e) => updateComp(i, "author", e.target.value)}
+                    placeholder="Author name" style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", outline: "none", boxSizing: "border-box" }} />
+                </div>
+              </div>
+              <div style={{ marginBottom: "0.625rem" }}>
+                <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Why This Comp Fits</label>
+                <textarea value={comp.why} onChange={(e) => updateComp(i, "why", e.target.value)} rows={3}
+                  placeholder="Tone, genre, structure, premise, audience, market lane..."
+                  style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "none", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }} />
+              </div>
+              <div>
+                <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>How This Manuscript Differentiates</label>
+                <textarea value={comp.differentiator} onChange={(e) => updateComp(i, "differentiator", e.target.value)} rows={2}
+                  placeholder="Same shelf, fresh reason to care..."
+                  style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "none", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }} />
+              </div>
+            </div>
+          ))}
+          {comps.length < 4 && (
+            <button onClick={() => setComps(prev => [...prev, { ...EMPTY_COMP }])} style={{
+              fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em",
+              textTransform: "uppercase", background: "none", border: `1px dashed ${T.border}`,
+              padding: "0.625rem", cursor: "pointer", textAlign: "center",
+            }}>
+              + Add Alternate Comp
+            </button>
+          )}
+        </div>
+
+        {/* Query letter comp sentence */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Query Letter Comp Sentence <span style={{ color: T.cream2, fontWeight: 400 }}>(auto-inserted into Query Letter)</span>
+          </label>
+          <textarea value={compSentence} onChange={(e) => { setCompSentence(e.target.value); setApproved(false); }} rows={3}
+            placeholder="[TITLE] will appeal to readers of [Comp 1] and [Comp 2], combining [shared market signal] with [unique differentiator]."
+            style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.875rem", resize: "none", outline: "none", lineHeight: 1.65, boxSizing: "border-box" }} />
+        </div>
+
+        {/* Genre lane + audience */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem", marginBottom: "1.5rem" }}>
+          <div>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Genre Lane</label>
+            <input type="text" value={genreLane} onChange={(e) => setGenreLane(e.target.value)}
+              placeholder="e.g. Upmarket literary suspense"
+              style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.625rem 0.75rem", outline: "none", boxSizing: "border-box" }} />
+          </div>
+          <div>
+            <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>Reader Audience</label>
+            <input type="text" value={audience} onChange={(e) => setAudience(e.target.value)}
+              placeholder="e.g. Adult literary fiction readers, crime/thriller crossover"
+              style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.625rem 0.75rem", outline: "none", boxSizing: "border-box" }} />
+          </div>
+        </div>
+
+        {/* Market Positioning Statement */}
+        <div style={{ marginBottom: "2rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>Market Positioning Statement</label>
+          <textarea value={positioning} onChange={(e) => setPositioning(e.target.value)} rows={4}
+            placeholder="This manuscript combines [genre lane] with [distinctive hook], offering agents a commercially legible project with a clear audience, strong emotional engine, and marketable point of difference."
+            style={{ width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream, backgroundColor: T.panel, border: `1px solid ${T.border}`, padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65, boxSizing: "border-box" }} />
+        </div>
+
+        {/* Agent Appeal Brief */}
+        <div style={{ border: `1px solid ${T.gold}30`, padding: "1.5rem", marginBottom: "2rem", backgroundColor: "rgba(169,142,74,0.03)" }}>
+          <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "1rem" }}>
+            Agent Appeal Brief
+          </p>
+          {[
+            { key: "hook",           label: "Distinctive Hook",   placeholder: "What makes this manuscript different from other books in the genre?" },
+            { key: "agentAppeal",    label: "Agent Appeal",       placeholder: "The professional acquisition argument: voice, concept, market fit, execution, urgency." },
+            { key: "readerAppetite", label: "Reader Appetite",    placeholder: "Why the public would want this story now." },
+            { key: "compShelf",      label: "Comparable Shelf",   placeholder: "The market shelf and comparable titles signal." },
+            { key: "whyNow",         label: "Why Now",            placeholder: "Cultural relevance, timeliness, or emotional urgency." },
+            { key: "positioning",    label: "Positioning Statement", placeholder: "Concise market-facing summary connecting genre, audience, comps, and emotional promise." },
+          ].map(({ key, label, placeholder }) => (
+            <div key={key} style={{ marginBottom: "0.875rem" }}>
+              <label style={{ display: "block", fontSize: "0.5rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.375rem" }}>{label}</label>
+              <textarea
+                value={(appealBrief as any)[key]}
+                onChange={(e) => setAppealBrief(prev => ({ ...prev, [key]: e.target.value }))}
+                rows={2}
+                placeholder={placeholder}
+                style={{ width: "100%", fontFamily: T.mono, fontSize: "0.75rem", color: T.cream, backgroundColor: T.bg, border: `1px solid ${T.border}`, padding: "0.5rem 0.625rem", resize: "vertical", outline: "none", lineHeight: 1.55, boxSizing: "border-box" }}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          {["Copy", "Restore Version"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: "transparent", color: T.cream2,
+              border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>{label}</button>
+          ))}
+          <button
+            onClick={() => hasContent && setApproved(true)}
+            disabled={!hasContent}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${!hasContent ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: hasContent ? "pointer" : "not-allowed",
+              opacity: hasContent ? 1 : 0.4,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/history/page.tsx
+++ b/app/agent-readiness/history/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+export default function PackageHistoryPage() {
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Package History / Export
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          Package History / Export
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Package History / Export
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2.5rem" }}>
+          Saved package versions appear here. Export is available once all six required sections are approved.
+          DOCX export is active; PDF export will be enabled once formatting is validated.
+        </p>
+
+        {/* Empty state */}
+        <div style={{ border: `1px solid ${T.border}`, padding: "3rem 2rem", textAlign: "center" }}>
+          <p style={{ fontFamily: T.serif, fontSize: "1rem", color: T.cream2, marginBottom: "0.5rem" }}>
+            No saved packages yet.
+          </p>
+          <p style={{ fontSize: "0.75rem", color: T.dim, lineHeight: 1.6 }}>
+            Complete and approve all six required sections, then save a version to see it here.
+          </p>
+          <Link
+            href="/agent-readiness"
+            style={{
+              display: "inline-block", marginTop: "1.5rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink, textDecoration: "none",
+              padding: "0.625rem 1.25rem",
+            }}
+          >
+            Back to Package Overview
+          </Link>
+        </div>
+
+        {/* Export note */}
+        <div style={{ marginTop: "2rem", border: `1px solid ${T.border}`, padding: "1rem 1.25rem" }}>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.65 }}>
+            <strong style={{ color: T.cream2 }}>Export policy:</strong> PDF and DOCX export are locked until all six required package sections are approved.
+            A "Submit to Storygate Studio™" option appears for manuscripts with a readiness score of 8.0 or above.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/page.tsx
+++ b/app/agent-readiness/page.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+/**
+ * Agent Readiness Package™ — Flagship page
+ *
+ * Generates the full professional query package:
+ *   1. Query Letter          (450-word hard cap)
+ *   2. What Makes This Novel Unique
+ *   3. Synopsis
+ *   4. Elevator Pitch
+ *   5. Comparables
+ *   6. Author Bio            (author-supplied credentials only)
+ *
+ *   Deferred (Coming Next):
+ *   7. Agent Targeting™
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type SectionId =
+  | "query-letter"
+  | "unique"
+  | "synopsis"
+  | "elevator-pitch"
+  | "comparables"
+  | "author-bio";
+
+type SectionState = {
+  status: "empty" | "draft" | "approved";
+  content: string;
+  wordCount?: number;
+};
+
+const REQUIRED_SECTIONS: { id: SectionId; label: string; href: string; description: string }[] = [
+  {
+    id: "query-letter",
+    label: "Query Letter",
+    href: "/agent-readiness/query-letter",
+    description: "Hook · metadata · comparables sentence · unique differentiator · short bio · closing. 450-word hard cap.",
+  },
+  {
+    id: "unique",
+    label: "What Makes This Novel Unique",
+    href: "/agent-readiness/query-letter",
+    description: "Standalone section and summarized inside the query letter.",
+  },
+  {
+    id: "synopsis",
+    label: "Synopsis",
+    href: "/agent-readiness/synopsis",
+    description: "Query synopsis (100–150 words), standard (250–500), or extended (700–1,000). Ending revealed.",
+  },
+  {
+    id: "elevator-pitch",
+    label: "Elevator Pitch",
+    href: "/agent-readiness/pitch",
+    description: "One sentence. Suitable for query forms, verbal pitching, and metadata.",
+  },
+  {
+    id: "comparables",
+    label: "Comparables",
+    href: "/agent-readiness/comparables",
+    description: "2–4 comps with rationale. Also integrated into the query letter.",
+  },
+  {
+    id: "author-bio",
+    label: "Author Bio",
+    href: "/agent-readiness/bio",
+    description: "Third-person, professional. Requires author-supplied resume or bio text — no invented credentials.",
+  },
+];
+
+// ── Shared style tokens ───────────────────────────────────────────────────────
+
+const T = {
+  bg:       "#0F0D0A",
+  panel:    "#1A1612",
+  border:   "#2A2420",
+  gold:     "#A98E4A",
+  cream:    "#F2EFEA",
+  cream2:   "#C8BFB0",
+  dim:      "#7B7060",
+  oxblood:  "#7A1E1E",
+  ink:      "#0E0E0E",
+  serif:    "'Playfair Display', 'Georgia', serif",
+  mono:     "'Inter', 'Courier New', monospace",
+};
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: SectionState["status"] }) {
+  const map = {
+    empty:    { label: "Not Started", color: T.dim },
+    draft:    { label: "Draft",       color: T.gold },
+    approved: { label: "Approved",    color: "#5A8A5A" },
+  } as const;
+  const { label, color } = map[status];
+  return (
+    <span style={{
+      fontFamily: T.mono, fontSize: "0.5625rem", letterSpacing: "0.12em",
+      textTransform: "uppercase", color, border: `1px solid ${color}40`,
+      padding: "0.2rem 0.5rem",
+    }}>
+      {label}
+    </span>
+  );
+}
+
+// ── Section card ──────────────────────────────────────────────────────────────
+
+function SectionCard({
+  section,
+  index,
+  state,
+}: {
+  section: typeof REQUIRED_SECTIONS[number];
+  index: number;
+  state: SectionState;
+}) {
+  return (
+    <div style={{
+      border: `1px solid ${state.status === "approved" ? "#5A8A5A40" : T.border}`,
+      padding: "1.25rem 1.5rem",
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.625rem",
+      backgroundColor: state.status === "approved" ? "rgba(90,138,90,0.04)" : T.panel,
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <span style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim,
+            letterSpacing: "0.1em", width: "1.25rem", textAlign: "right", flexShrink: 0,
+          }}>
+            0{index + 1}
+          </span>
+          <h3 style={{ fontFamily: T.serif, fontSize: "0.9375rem", color: T.cream, lineHeight: 1.2 }}>
+            {section.label}
+          </h3>
+        </div>
+        <StatusBadge status={state.status} />
+      </div>
+      <p style={{ fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim, lineHeight: 1.6, paddingLeft: "2rem" }}>
+        {section.description}
+      </p>
+      <div style={{ paddingLeft: "2rem", display: "flex", gap: "0.625rem", flexWrap: "wrap" }}>
+        <Link
+          href={section.href}
+          style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink,
+            border: "none", padding: "0.375rem 0.75rem", cursor: "pointer",
+            textDecoration: "none", display: "inline-block",
+          }}
+        >
+          {state.status === "empty" ? "Generate" : "Edit"}
+        </Link>
+        {state.status === "draft" && (
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: "#5A8A5A",
+            border: "1px solid #5A8A5A", padding: "0.375rem 0.75rem", cursor: "pointer",
+          }}>
+            Approve
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function AgentReadinessPage() {
+  const [sectionStates] = useState<Record<SectionId, SectionState>>({
+    "query-letter":  { status: "empty", content: "" },
+    "unique":        { status: "empty", content: "" },
+    "synopsis":      { status: "empty", content: "" },
+    "elevator-pitch":{ status: "empty", content: "" },
+    "comparables":   { status: "empty", content: "" },
+    "author-bio":    { status: "empty", content: "" },
+  });
+
+  const approvedCount = Object.values(sectionStates).filter(s => s.status === "approved").length;
+  const allApproved   = approvedCount === REQUIRED_SECTIONS.length;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "3rem 2rem 6rem", display: "flex", gap: "2.5rem" }}>
+
+        {/* ── Left sidebar ─────────────────────────────────────────────── */}
+        <aside style={{ width: "220px", flexShrink: 0 }}>
+          <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "1.25rem" }}>
+            Package Sections
+          </p>
+          <nav style={{ display: "flex", flexDirection: "column", gap: "0.125rem" }}>
+            {REQUIRED_SECTIONS.map((s) => {
+              const state = sectionStates[s.id];
+              return (
+                <Link
+                  key={s.id}
+                  href={s.href}
+                  style={{
+                    display: "flex", alignItems: "center", justifyContent: "space-between",
+                    padding: "0.5rem 0.75rem",
+                    fontFamily: T.mono, fontSize: "0.6875rem", color: state.status === "approved" ? "#5A8A5A" : T.cream2,
+                    textDecoration: "none",
+                    border: "1px solid transparent",
+                  }}
+                >
+                  <span>{s.label}</span>
+                  {state.status === "approved" && <span style={{ color: "#5A8A5A", fontSize: "0.625rem" }}>✓</span>}
+                  {state.status === "draft"    && <span style={{ color: T.gold,    fontSize: "0.625rem" }}>●</span>}
+                </Link>
+              );
+            })}
+
+            {/* Divider */}
+            <div style={{ height: "1px", backgroundColor: T.border, margin: "0.75rem 0" }} />
+
+            {/* Deferred step */}
+            <div style={{
+              padding: "0.5rem 0.75rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim,
+              borderLeft: `2px solid ${T.dim}40`,
+            }}>
+              <div>Agent Targeting&#8482;</div>
+              <div style={{ fontSize: "0.5625rem", marginTop: "0.25rem", color: `${T.dim}90` }}>Coming Next</div>
+            </div>
+
+            <Link href="/agent-readiness/history" style={{
+              padding: "0.5rem 0.75rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim,
+              textDecoration: "none",
+            }}>
+              Package History / Export
+            </Link>
+          </nav>
+
+          {/* Approval progress */}
+          <div style={{ marginTop: "2rem", border: `1px solid ${T.border}`, padding: "1rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.625rem" }}>
+              Approval Progress
+            </p>
+            <div style={{ display: "flex", alignItems: "baseline", gap: "0.25rem", marginBottom: "0.625rem" }}>
+              <span style={{ fontFamily: T.serif, fontSize: "1.5rem", color: allApproved ? "#5A8A5A" : T.cream }}>
+                {approvedCount}
+              </span>
+              <span style={{ fontSize: "0.75rem", color: T.dim }}>/ {REQUIRED_SECTIONS.length}</span>
+            </div>
+            <div style={{ height: "3px", backgroundColor: T.border, borderRadius: "2px", overflow: "hidden" }}>
+              <div style={{
+                height: "100%",
+                width: `${(approvedCount / REQUIRED_SECTIONS.length) * 100}%`,
+                backgroundColor: allApproved ? "#5A8A5A" : T.gold,
+                transition: "width 0.3s ease",
+              }} />
+            </div>
+          </div>
+        </aside>
+
+        {/* ── Main content ─────────────────────────────────────────────── */}
+        <div style={{ flex: 1, minWidth: 0 }}>
+
+          {/* Header */}
+          <div style={{ marginBottom: "2.5rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+              Agent Readiness Package™
+            </p>
+            <h1 style={{ fontFamily: T.serif, fontSize: "2rem", color: T.cream, lineHeight: 1.1, marginBottom: "0.875rem" }}>
+              Generate Full Agent Readiness Package
+            </h1>
+            <p style={{ fontSize: "0.875rem", color: T.cream2, lineHeight: 1.65, maxWidth: "600px" }}>
+              One manuscript. One professional submission package. Generate your query letter, synopsis, elevator pitch, comparables, market positioning, and author bio — then approve each section before export.
+            </p>
+          </div>
+
+          {/* Manuscript eligibility notice */}
+          <div style={{
+            border: `1px solid ${T.gold}40`, padding: "0.875rem 1.25rem",
+            marginBottom: "2rem", display: "flex", gap: "1rem", alignItems: "flex-start",
+          }}>
+            <span style={{ color: T.gold, fontSize: "0.75rem", flexShrink: 0 }}>ⓘ</span>
+            <div>
+              <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
+                <strong style={{ color: T.cream }}>Eligibility:</strong> Full manuscripts may generate a complete Query Package. Excerpt or chapter submissions are eligible for craft evaluation only. Storygate Studio™ submission requires a readiness score of 8.0 or above.
+              </p>
+            </div>
+          </div>
+
+          {/* Generate all CTA */}
+          <div style={{ marginBottom: "2.5rem", display: "flex", gap: "0.875rem", flexWrap: "wrap", alignItems: "center" }}>
+            <button style={{
+              fontFamily: T.mono, fontSize: "0.75rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: T.gold, color: T.ink,
+              border: "none", padding: "0.875rem 1.75rem", cursor: "pointer",
+            }}>
+              Generate Complete Package
+            </button>
+            <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
+              Generates all six required sections from your manuscript and provided bio inputs.
+            </p>
+          </div>
+
+          {/* Section cards */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem", marginBottom: "2.5rem" }}>
+            {REQUIRED_SECTIONS.map((section, i) => (
+              <SectionCard key={section.id} section={section} index={i} state={sectionStates[section.id]} />
+            ))}
+          </div>
+
+          {/* Agent Targeting teaser */}
+          <div style={{
+            border: `1px solid ${T.border}`, padding: "1.25rem 1.5rem",
+            display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem",
+            opacity: 0.6,
+          }}>
+            <div>
+              <p style={{ fontFamily: T.serif, fontSize: "0.9375rem", color: T.cream2, marginBottom: "0.25rem" }}>
+                Agent Targeting™ — Coming Next
+              </p>
+              <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
+                Find three target agents. Generate agent-specific query variants. Build your outreach plan.
+              </p>
+            </div>
+            <span style={{
+              fontFamily: T.mono, fontSize: "0.5625rem", letterSpacing: "0.12em",
+              textTransform: "uppercase", color: T.dim, border: `1px solid ${T.border}`,
+              padding: "0.25rem 0.625rem", flexShrink: 0,
+            }}>
+              Locked
+            </span>
+          </div>
+
+          {/* Export section */}
+          <div style={{ marginTop: "2.5rem", borderTop: `1px solid ${T.border}`, paddingTop: "2rem" }}>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: "1rem" }}>
+              Export
+            </p>
+            <p style={{ fontSize: "0.75rem", color: T.dim, lineHeight: 1.6, marginBottom: "1.25rem" }}>
+              Export is locked until all six required sections are approved by the author.
+              {approvedCount > 0 && approvedCount < REQUIRED_SECTIONS.length && (
+                <> {REQUIRED_SECTIONS.length - approvedCount} section{REQUIRED_SECTIONS.length - approvedCount > 1 ? "s" : ""} remaining.</>
+              )}
+            </p>
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              {[
+                { label: "Download Editable DOCX", available: allApproved },
+                { label: "Download Professional PDF", available: false /* expose once PDF formatting stable */ },
+                { label: "Copy Query Package",     available: allApproved },
+                { label: "Save Package Version",   available: approvedCount > 0 },
+              ].map(({ label, available }) => (
+                <button
+                  key={label}
+                  disabled={!available}
+                  style={{
+                    fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+                    letterSpacing: "0.1em", textTransform: "uppercase",
+                    backgroundColor: available ? T.gold : "transparent",
+                    color: available ? T.ink : T.dim,
+                    border: available ? "none" : `1px solid ${T.border}`,
+                    padding: "0.5rem 1rem", cursor: available ? "pointer" : "not-allowed",
+                    opacity: available ? 1 : 0.5,
+                  }}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <p style={{ fontSize: "0.5625rem", color: T.dim, marginTop: "1rem", lineHeight: 1.6 }}>
+              Note: "Submit to Storygate Studio™" appears as an export option once the manuscript holds a readiness score of 8.0 or above and all package sections are approved.
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/pitch/page.tsx
+++ b/app/agent-readiness/pitch/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * Pitch Builder
+ * - Elevator Pitch: one sentence
+ * - Paragraph Pitch: one compact paragraph
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+export default function PitchPage() {
+  const [elevator,         setElevator]        = useState("");
+  const [paragraph,        setParagraph]        = useState("");
+  const [elevatorApproved, setElevatorApproved] = useState(false);
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "}Pitch Builder
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          04 — Elevator Pitch
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "2rem" }}>
+          Pitch Builder
+        </h1>
+
+        {/* Elevator Pitch */}
+        <div style={{ marginBottom: "2.5rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Elevator Pitch — one sentence
+          </label>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6, marginBottom: "0.875rem" }}>
+            A compact, high-impact sentence suitable for query forms, verbal pitching, and manuscript metadata.
+          </p>
+          <textarea
+            value={elevator}
+            onChange={(e) => { setElevator(e.target.value); setElevatorApproved(false); }}
+            rows={3}
+            placeholder="[TITLE] is a [genre] novel in which [protagonist] must [central conflict] or [stakes]."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "none", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+          <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.75rem", flexWrap: "wrap" }}>
+            {["Generate", "Regenerate", "Improve", "Copy"].map(label => (
+              <button key={label} style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: label === "Generate" ? T.gold : "transparent",
+                color: label === "Generate" ? T.ink : T.cream2,
+                border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+                padding: "0.5rem 1rem", cursor: "pointer",
+              }}>{label}</button>
+            ))}
+            <button
+              onClick={() => elevator.trim().length > 10 && setElevatorApproved(true)}
+              disabled={elevator.trim().length < 10}
+              style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: elevatorApproved ? "#5A8A5A" : "transparent",
+                color: elevatorApproved ? "#F2EFEA" : "#5A8A5A",
+                border: `1px solid ${elevator.trim().length < 10 ? T.border : "#5A8A5A"}`,
+                padding: "0.5rem 1rem",
+                cursor: elevator.trim().length < 10 ? "not-allowed" : "pointer",
+                opacity: elevator.trim().length < 10 ? 0.4 : 1,
+              }}
+            >
+              {elevatorApproved ? "✓ Approved" : "Lock / Approve"}
+            </button>
+          </div>
+        </div>
+
+        {/* Paragraph Pitch */}
+        <div>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            Paragraph Pitch <span style={{ color: "#7B7060", fontWeight: 400 }}>(optional — for email, networking, query forms)</span>
+          </label>
+          <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6, marginBottom: "0.875rem" }}>
+            One compact paragraph suitable for email queries, agent networking, and package summaries.
+          </p>
+          <textarea
+            value={paragraph}
+            onChange={(e) => setParagraph(e.target.value)}
+            rows={6}
+            placeholder="Expand the elevator pitch into a short paragraph with the hook, the core conflict, the stakes, and the market positioning."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+          <div style={{ display: "flex", gap: "0.75rem", marginTop: "0.75rem", flexWrap: "wrap" }}>
+            {["Generate", "Regenerate", "Improve", "Copy"].map(label => (
+              <button key={label} style={{
+                fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                backgroundColor: label === "Generate" ? T.gold : "transparent",
+                color: label === "Generate" ? T.ink : T.cream2,
+                border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+                padding: "0.5rem 1rem", cursor: "pointer",
+              }}>{label}</button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/query-letter/page.tsx
+++ b/app/agent-readiness/query-letter/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+/**
+ * Query / Cover Letter builder
+ *
+ * Rules:
+ * - 450-word hard cap on the query letter body
+ * - Warning at 425 words
+ * - Comparables sentence and "What Makes This Novel Unique" must appear inside the letter
+ * - Author Bio paragraph drawn only from author-supplied inputs
+ */
+
+import Link from "next/link";
+import { useCallback, useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", oxblood: "#7A1E1E", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+const WORD_LIMIT = 450;
+const WORD_WARN  = 425;
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export default function QueryLetterPage() {
+  const [body, setBody] = useState("");
+  const [unique, setUnique] = useState("");
+  const [approved, setApproved] = useState(false);
+
+  const wordCount = countWords(body);
+  const overLimit = wordCount > WORD_LIMIT;
+  const nearLimit = wordCount >= WORD_WARN && !overLimit;
+
+  const handleBodyChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value;
+    const wc  = countWords(val);
+    if (wc <= WORD_LIMIT + 20) setBody(val); // soft buffer for typing — gate on submit
+    setApproved(false);
+  }, []);
+
+  const wordCountColor = overLimit ? T.oxblood : nearLimit ? T.gold : T.dim;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        {/* Breadcrumb */}
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{"  "}Query / Cover Letter
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          01 — Query / Cover Letter
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Query / Cover Letter
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem", maxWidth: "560px" }}>
+          The agent-facing submission letter. Must include: hook, manuscript metadata (title · genre · word count), comparables sentence, what makes it unique, short bio, and professional closing. Hard cap: 450 words.
+        </p>
+
+        {/* What Makes This Novel Unique — standalone field */}
+        <div style={{ marginBottom: "1.75rem" }}>
+          <label style={{ display: "block", fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+            What Makes This Novel Unique <span style={{ color: T.cream2 }}>(standalone section — also appears inside the letter)</span>
+          </label>
+          <textarea
+            value={unique}
+            onChange={(e) => setUnique(e.target.value)}
+            rows={4}
+            placeholder="Describe the specific hook, premise, voice, or structural element that sets this manuscript apart..."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel, border: `1px solid ${T.border}`,
+              padding: "0.875rem", resize: "vertical", outline: "none", lineHeight: 1.65,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Query letter body */}
+        <div style={{ marginBottom: "1rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "0.5rem" }}>
+            <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              Query Letter Body
+            </label>
+            <span style={{ fontFamily: T.mono, fontSize: "0.6875rem", color: wordCountColor, fontWeight: overLimit ? 700 : 400 }}>
+              {overLimit && "OVER LIMIT — "}
+              {nearLimit && "NEAR LIMIT — "}
+              Query Letter: {wordCount} / {WORD_LIMIT} words
+            </span>
+          </div>
+          <textarea
+            value={body}
+            onChange={handleBodyChange}
+            rows={20}
+            placeholder={`Dear [Agent Name],\n\n[Hook paragraph — the story pitch.]\n\n[Title], [Genre], [Word Count], [Audience]. [TITLE] will appeal to readers of [Comp 1] and [Comp 2], combining [shared appeal] with [unique differentiator].\n\n[What makes it unique — one or two compact sentences.]\n\n[Author bio paragraph — pulled only from author-supplied resume/bio facts.]\n\nThank you for your time and consideration.\n\n[Your Name]`}
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel,
+              border: `1px solid ${overLimit ? T.oxblood : nearLimit ? T.gold : T.border}`,
+              padding: "1rem", resize: "vertical", outline: "none", lineHeight: 1.75,
+              boxSizing: "border-box",
+            }}
+          />
+          {overLimit && (
+            <p style={{ fontSize: "0.6875rem", color: T.oxblood, marginTop: "0.375rem", lineHeight: 1.5 }}>
+              Query letter exceeds the 450-word limit. Trim before approving. Export is blocked until the limit is met.
+            </p>
+          )}
+          {nearLimit && (
+            <p style={{ fontSize: "0.6875rem", color: T.gold, marginTop: "0.375rem" }}>
+              Approaching limit — {WORD_LIMIT - wordCount} words remaining.
+            </p>
+          )}
+        </div>
+
+        {/* Action row */}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", marginBottom: "2rem" }}>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: T.gold, color: T.ink, border: "none",
+            padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Generate
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Regenerate
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Improve
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.cream2,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Copy
+          </button>
+          <button style={{
+            fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            backgroundColor: "transparent", color: T.dim,
+            border: `1px solid ${T.border}`, padding: "0.625rem 1.25rem", cursor: "pointer",
+          }}>
+            Restore Version
+          </button>
+          <button
+            onClick={() => !overLimit && setApproved(true)}
+            disabled={overLimit || body.trim().length < 50}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${overLimit ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: overLimit || body.trim().length < 50 ? "not-allowed" : "pointer",
+              opacity: overLimit || body.trim().length < 50 ? 0.4 : 1,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        {approved && (
+          <div style={{
+            border: `1px solid #5A8A5A40`, padding: "0.75rem 1.25rem",
+            backgroundColor: "rgba(90,138,90,0.06)", fontSize: "0.75rem", color: "#5A8A5A",
+          }}>
+            Query Letter approved and locked. Return to the package to approve remaining sections.
+          </div>
+        )}
+
+        <div style={{ marginTop: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{
+            fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim,
+            letterSpacing: "0.1em", textDecoration: "none",
+          }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/agent-readiness/synopsis/page.tsx
+++ b/app/agent-readiness/synopsis/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * Synopsis Builder
+ *
+ * Three lengths:
+ *   Query synopsis:   100–150 words
+ *   Standard synopsis: 250–500 words  (default MVP)
+ *   Extended synopsis: 700–1,000 words
+ *
+ * Rule: must reveal the ending. No teaser language.
+ */
+
+import Link from "next/link";
+import { useState } from "react";
+
+const T = {
+  bg: "#0F0D0A", panel: "#1A1612", border: "#2A2420",
+  gold: "#A98E4A", cream: "#F2EFEA", cream2: "#C8BFB0",
+  dim: "#7B7060", ink: "#0E0E0E",
+  serif: "'Playfair Display', 'Georgia', serif",
+  mono: "'Inter', 'Courier New', monospace",
+};
+
+type SynopsisLength = "query" | "standard" | "extended";
+
+const LENGTHS: { id: SynopsisLength; label: string; range: string; description: string }[] = [
+  { id: "query",    label: "Query Synopsis",    range: "100–150 words",   description: "Suitable for query forms and agent intake." },
+  { id: "standard", label: "Standard Synopsis", range: "250–500 words",   description: "Default. Suitable for most agency submissions." },
+  { id: "extended", label: "Extended Synopsis", range: "700–1,000 words", description: "Full submission synopsis for agencies that require it." },
+];
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export default function SynopsisPage() {
+  const [selected, setSelected] = useState<SynopsisLength>("standard");
+  const [content,  setContent]  = useState("");
+  const [approved, setApproved] = useState(false);
+
+  const wordCount = countWords(content);
+  const limits: Record<SynopsisLength, [number, number]> = {
+    query:    [100, 150],
+    standard: [250, 500],
+    extended: [700, 1000],
+  };
+  const [min, max] = limits[selected];
+  const overLimit  = wordCount > max;
+  const underMin   = content.trim().length > 0 && wordCount < min;
+
+  return (
+    <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
+      <div style={{ maxWidth: "860px", margin: "0 auto", padding: "3rem 2rem 6rem" }}>
+
+        <p style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", marginBottom: "1.5rem" }}>
+          <Link href="/agent-readiness" style={{ color: T.gold, textDecoration: "none" }}>Agent Readiness Package™</Link>
+          {" "}/{" "} Synopsis Builder
+        </p>
+
+        <p style={{ fontSize: "0.5625rem", color: T.gold, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: "0.5rem" }}>
+          03 — Synopsis
+        </p>
+        <h1 style={{ fontFamily: T.serif, fontSize: "1.75rem", color: T.cream, marginBottom: "0.75rem" }}>
+          Synopsis Builder
+        </h1>
+        <p style={{ fontSize: "0.8125rem", color: T.cream2, lineHeight: 1.65, marginBottom: "2rem" }}>
+          The synopsis must reveal the ending. No teaser language. Agents need to see the complete story arc.
+        </p>
+
+        {/* Length selector */}
+        <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1.75rem", flexWrap: "wrap" }}>
+          {LENGTHS.map(l => (
+            <button
+              key={l.id}
+              onClick={() => { setSelected(l.id); setApproved(false); }}
+              style={{
+                fontFamily: T.mono, fontSize: "0.5625rem", fontWeight: 700,
+                letterSpacing: "0.1em", textTransform: "uppercase",
+                padding: "0.5rem 1rem",
+                backgroundColor: selected === l.id ? T.gold : "transparent",
+                color: selected === l.id ? T.ink : T.cream2,
+                border: `1px solid ${selected === l.id ? T.gold : T.border}`,
+                cursor: "pointer",
+              }}
+            >
+              {l.label} <span style={{ fontWeight: 400, opacity: 0.7 }}>· {l.range}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={{ marginBottom: "1.75rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "0.5rem" }}>
+            <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              {LENGTHS.find(l => l.id === selected)?.label}
+            </label>
+            <span style={{
+              fontFamily: T.mono, fontSize: "0.6875rem",
+              color: overLimit ? "#7A1E1E" : underMin ? T.gold : T.dim,
+            }}>
+              {wordCount} / {max} words
+            </span>
+          </div>
+          <textarea
+            value={content}
+            onChange={(e) => { setContent(e.target.value); setApproved(false); }}
+            rows={16}
+            placeholder="Begin with the protagonist and inciting incident. Follow the central conflict through to resolution — include the ending. Do not use teaser language."
+            style={{
+              width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
+              backgroundColor: T.panel,
+              border: `1px solid ${overLimit ? "#7A1E1E" : T.border}`,
+              padding: "1rem", resize: "vertical", outline: "none", lineHeight: 1.75,
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          {["Generate", "Regenerate", "Improve", "Copy", "Restore Version"].map(label => (
+            <button key={label} style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: label === "Generate" ? T.gold : "transparent",
+              color: label === "Generate" ? T.ink : T.cream2,
+              border: label === "Generate" ? "none" : `1px solid ${T.border}`,
+              padding: "0.625rem 1.25rem", cursor: "pointer",
+            }}>
+              {label}
+            </button>
+          ))}
+          <button
+            onClick={() => !overLimit && content.trim().length > 50 && setApproved(true)}
+            disabled={overLimit || content.trim().length < 50}
+            style={{
+              fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
+              letterSpacing: "0.1em", textTransform: "uppercase",
+              backgroundColor: approved ? "#5A8A5A" : "transparent",
+              color: approved ? "#F2EFEA" : "#5A8A5A",
+              border: `1px solid ${overLimit ? T.border : "#5A8A5A"}`,
+              padding: "0.625rem 1.25rem",
+              cursor: overLimit || content.trim().length < 50 ? "not-allowed" : "pointer",
+              opacity: overLimit || content.trim().length < 50 ? 0.4 : 1,
+            }}
+          >
+            {approved ? "✓ Approved" : "Lock / Approve"}
+          </button>
+        </div>
+
+        <div style={{ marginTop: "2rem" }}>
+          <Link href="/agent-readiness" style={{ fontFamily: T.mono, fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textDecoration: "none" }}>
+            ← Back to Package Overview
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/convert/page.tsx
+++ b/app/convert/page.tsx
@@ -1,8 +1,6 @@
-export default function ConvertPage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Convert</h1>
-      <p className="text-slate-600">Content conversion tools are coming soon. Transform manuscripts between formats with fidelity scoring.</p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+
+// Convert has been replaced by Agent Readiness Package™
+export default function ConvertRedirect() {
+  redirect("/agent-readiness");
 }

--- a/app/output/page.tsx
+++ b/app/output/page.tsx
@@ -1,8 +1,6 @@
-export default function OutputPage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Output</h1>
-      <p className="text-slate-600">Publication output tools are coming soon. Generate submission-ready packages for agents and publishers.</p>
-    </main>
-  );
+import { redirect } from "next/navigation";
+
+// Output has been replaced by Agent Readiness Package™
+export default function OutputRedirect() {
+  redirect("/agent-readiness");
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,6 +115,98 @@ export default function Home() {
           <div className="border border-rg-cream2/12 bg-rg-ink2/60 p-8"><SectionLabel>Conversion surface</SectionLabel><h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Pricing and resources must be routes, not dead anchors.</h2><p className="mt-5 leading-7 text-rg-cream2/75">Every public navigation destination should be shareable, crawlable, and inside the same app shell as Evaluate and Revise.</p><div className="mt-7 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/pricing" className="text-rg-gold hover:text-rg-cream">Pricing →</Link><Link href="/resources" className="text-rg-gold hover:text-rg-cream">Resources →</Link></div></div>
         </div>
       </section>
+
+      {/* ── AGENT READINESS PACKAGE™ ────────────────────────────────── */}
+      <section className="border-t border-rg-cream2/10 bg-rg-ink2/50">
+        <div className="mx-auto max-w-7xl px-6 py-20">
+          <div className="grid gap-12 lg:grid-cols-[1fr_1fr] items-start">
+            <div>
+              <SectionLabel>Agent Readiness Package™</SectionLabel>
+              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
+                One manuscript. One professional submission package.
+              </h2>
+              <p className="mt-6 text-base leading-7 text-rg-cream2/75">
+                Generate your query letter, synopsis, elevator pitch, comparables, market positioning, and author bio — then approve each section before export. Built for authors who are ready to submit, not authors who are still drafting.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-4">
+                <Link href="/agent-readiness" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
+                  Build My Package
+                </Link>
+                <Link href="/agent-readiness" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">
+                  See What&apos;s Included
+                </Link>
+              </div>
+            </div>
+            <div className="grid gap-3">
+              {[
+                ["01", "Query Letter", "Hook, metadata, comparables, differentiator, and bio. 450-word hard cap."],
+                ["02", "Synopsis", "Query (100–150 words), standard (250–500), or extended (700–1,000)."],
+                ["03", "Elevator Pitch", "One sentence. Suitable for query forms, verbal pitching, and metadata."],
+                ["04", "Comparables & Positioning", "2–4 comps with rationale and Agent Appeal Brief."],
+                ["05", "Author Bio", "Third-person, professional. Author-supplied credentials only."],
+                ["06", "Package History / Export", "Approve all sections, then export as DOCX or copy."],
+              ].map(([num, title, desc]) => (
+                <div key={num} className="flex items-start gap-4 border border-rg-cream2/10 bg-rg-ink px-4 py-3">
+                  <span className="font-rg-mono text-xs text-rg-gold shrink-0 mt-0.5">{num}</span>
+                  <div>
+                    <p className="font-rg-mono text-xs uppercase tracking-[0.1em] text-rg-cream">{title}</p>
+                    <p className="mt-1 font-rg-mono text-[0.6875rem] text-rg-cream2/60 leading-5">{desc}</p>
+                  </div>
+                </div>
+              ))}
+              <div className="flex items-start gap-4 border border-rg-cream2/10 bg-rg-ink px-4 py-3 opacity-50">
+                <span className="font-rg-mono text-xs text-rg-gold shrink-0 mt-0.5">07</span>
+                <div>
+                  <p className="font-rg-mono text-xs uppercase tracking-[0.1em] text-rg-cream2/60">Agent Targeting™ — Coming Next</p>
+                  <p className="mt-1 font-rg-mono text-[0.6875rem] text-rg-cream2/40 leading-5">Find target agents. Generate agent-specific query variants.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── STORYGATE STUDIO™ ─────────────────────────────────────── */}
+      <section className="border-t border-rg-cream2/10">
+        <div className="mx-auto max-w-7xl px-6 py-20">
+          <div className="grid gap-12 lg:grid-cols-[1fr_1fr] items-start">
+            <div>
+              <SectionLabel>Storygate Studio™</SectionLabel>
+              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
+                A curated access layer for readiness-vetted projects.
+              </h2>
+              <p className="mt-6 text-base leading-7 text-rg-cream2/75">
+                Projects that clear the 8.0 readiness threshold can enter Storygate Studio — a controlled environment where verified industry professionals request access to specific manuscripts, screenplays, and adaptation packages.
+              </p>
+              <p className="mt-3 text-sm leading-7 text-rg-cream2/60">
+                No public marketplace. No cold outreach. Access is requested, approved by the creator, and logged.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-4">
+                <Link href="/storygate-studio" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
+                  Learn About Storygate
+                </Link>
+                <Link href="/storygate-studio/industry" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">
+                  Industry Access
+                </Link>
+              </div>
+            </div>
+            <div className="grid gap-3">
+              {[
+                ["Verified Access Only",       "Industry users are approved before viewing any project materials."],
+                ["Creator-Controlled Visibility", "Creators decide what is visible and to whom. Access requires their approval."],
+                ["8.0+ Readiness Gate",        "Projects must clear a minimum readiness threshold before eligibility."],
+                ["Logged Activity",             "All access events are recorded and append-only. No anonymous actions."],
+                ["Not a Marketplace",           "No public search. No cold contact. No fee to submit your project."],
+              ].map(([title, desc]) => (
+                <div key={title} className="border border-rg-cream2/10 bg-rg-ink2/60 px-5 py-4">
+                  <p className="font-rg-mono text-xs uppercase tracking-[0.1em] text-rg-gold">{title}</p>
+                  <p className="mt-1 text-sm text-rg-cream2/65 leading-6">{desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/storygate-studio/apply/page.tsx
+++ b/app/storygate-studio/apply/page.tsx
@@ -1,0 +1,188 @@
+/**
+ * /storygate-studio/apply — Creator eligibility + preparation page
+ * Public. Canonical Storygate palette.
+ */
+
+import Link from "next/link";
+
+const C = {
+  bg:        "#0E0E0E",
+  text:      "#F2EFEA",
+  gold:      "#A98E4A",
+  oxblood:   "#7A1E1E",
+  ash:       "#7B7B7B",
+  panel:     "#161616",
+  border:    "rgba(161,142,74,0.18)",
+  borderAsh: "rgba(123,123,123,0.18)",
+} as const;
+
+export default function StorygateApply() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif", minHeight: "100vh" }}
+    >
+      {/* Header */}
+      <section className="pt-24 pb-16 px-6 max-w-3xl mx-auto">
+        <p className="text-xs tracking-[0.22em] uppercase font-mono mb-4" style={{ color: C.gold }}>
+          Storygate Studio™ — Creators
+        </p>
+        <h1
+          className="text-4xl font-bold mb-6 leading-tight"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Prepare a Project for Storygate
+        </h1>
+        <p className="text-base leading-relaxed mb-4" style={{ color: C.ash }}>
+          Storygate Studio is not open to all projects. Placement requires two gates — a professional presentation package and a minimum readiness threshold. Here is what you need to prepare.
+        </p>
+        <p
+          className="text-xs px-4 py-3 border"
+          style={{ borderColor: C.border, backgroundColor: C.panel, color: C.ash }}
+        >
+          There is no requirement to purchase RevisionGrade services to qualify. Creators may use equivalent professional materials created independently or through another service.
+        </p>
+      </section>
+
+      {/* Gate 1 */}
+      <section
+        className="px-6 pb-16 max-w-3xl mx-auto"
+        style={{ borderTop: `1px solid ${C.borderAsh}`, paddingTop: "3rem" }}
+      >
+        <p className="text-xs tracking-[0.18em] uppercase font-mono mb-1" style={{ color: C.gold }}>Gate 1</p>
+        <h2
+          className="text-2xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Professional Presentation Package
+        </h2>
+        <p className="text-sm mb-8 leading-relaxed" style={{ color: C.ash }}>
+          Depending on project type, your package must include the relevant materials below. All materials must be professionally formatted and submission-ready — not works in progress.
+        </p>
+
+        {[
+          {
+            type: "Manuscript / Publishing",
+            items: ["Query letter or professional pitch material", "Synopsis or series overview", "Author bio", "Sample pages (typically first 10–50 pages)", "Optional: evaluation summary or readiness assessment"],
+          },
+          {
+            type: "Screen / Adaptation",
+            items: ["Film/TV pitch deck or equivalent screen-development package", "Source-material summary", "Lookbook (optional but recommended)", "Comparable titles and audience positioning", "Optional: adaptation notes or development memo"],
+          },
+          {
+            type: "Series / Franchise",
+            items: ["Series overview", "World or character materials", "Adaptation positioning", "Multi-volume or multi-season development package"],
+          },
+        ].map(({ type, items }) => (
+          <div key={type} className="mb-6 p-6" style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}` }}>
+            <p className="text-xs tracking-[0.14em] uppercase font-mono mb-4" style={{ color: C.gold }}>{type}</p>
+            <ul className="space-y-2">
+              {items.map((item) => (
+                <li key={item} className="flex items-start gap-3 text-sm" style={{ color: C.ash }}>
+                  <span style={{ color: C.gold, flexShrink: 0, marginTop: 2 }}>—</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </section>
+
+      {/* Gate 2 */}
+      <section
+        className="px-6 pb-16 max-w-3xl mx-auto"
+        style={{ borderTop: `1px solid ${C.borderAsh}`, paddingTop: "3rem" }}
+      >
+        <p className="text-xs tracking-[0.18em] uppercase font-mono mb-1" style={{ color: C.gold }}>Gate 2</p>
+        <h2
+          className="text-2xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Minimum Readiness Threshold
+        </h2>
+        <p className="text-sm mb-8 leading-relaxed" style={{ color: C.ash }}>
+          Your project must demonstrate a minimum professional standard through one of the following:
+        </p>
+        <div className="space-y-4">
+          {[
+            {
+              label: "RevisionGrade Score 8.0+",
+              desc: "A RevisionGrade evaluation score of 8.0 or higher in the relevant manuscript or script evaluation. The score must be from a full-manuscript evaluation, not an excerpt.",
+            },
+            {
+              label: "Equivalent Professional Assessment",
+              desc: "A written assessment from a qualified third party — a literary agent, acquiring editor, producer, development executive, or recognized industry evaluator — confirming the project is submission-ready or professionally prepared.",
+            },
+          ].map(({ label, desc }) => (
+            <div key={label} className="p-6" style={{ border: `1px solid ${C.border}` }}>
+              <p className="text-sm font-semibold mb-2" style={{ fontFamily: "Playfair Display, Georgia, serif", color: C.text }}>{label}</p>
+              <p className="text-sm leading-relaxed" style={{ color: C.ash }}>{desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* How to use RevisionGrade */}
+      <section
+        className="px-6 pb-16 max-w-3xl mx-auto"
+        style={{ borderTop: `1px solid ${C.borderAsh}`, paddingTop: "3rem" }}
+      >
+        <h2
+          className="text-xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Using RevisionGrade to Prepare
+        </h2>
+        <p className="text-sm mb-8 leading-relaxed" style={{ color: C.ash }}>
+          If you want to use RevisionGrade to build your package and meet Gate 2, the path is:
+        </p>
+        <div className="space-y-3">
+          {[
+            ["Evaluate", "Upload your full manuscript. Receive a scored evaluation across the literary criteria canon."],
+            ["Revise", "Work through the revision queue to address identified weaknesses before submission."],
+            ["Agent Readiness Package™", "Generate your query letter, synopsis, elevator pitch, comparables, and author bio."],
+            ["Storygate Submission", "Once your score reaches 8.0+ and all package sections are approved, the Storygate submission option unlocks."],
+          ].map(([step, desc], i) => (
+            <div key={step} className="flex items-start gap-4 px-4 py-3" style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}` }}>
+              <span className="font-mono text-xs shrink-0 mt-0.5" style={{ color: C.gold }}>0{i + 1}</span>
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.1em] mb-1" style={{ color: C.text }}>{step}</p>
+                <p className="text-xs leading-relaxed" style={{ color: C.ash }}>{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-8 flex flex-wrap gap-4">
+          <Link
+            href="/evaluate"
+            className="inline-block px-6 py-3 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80"
+            style={{ backgroundColor: C.gold, color: C.bg }}
+          >
+            Start with Evaluate
+          </Link>
+          <Link
+            href="/agent-readiness"
+            className="inline-block px-6 py-3 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80"
+            style={{ backgroundColor: "transparent", color: C.gold, border: `1px solid ${C.gold}` }}
+          >
+            Build Your Package
+          </Link>
+        </div>
+      </section>
+
+      {/* Footer note */}
+      <footer
+        className="py-8 px-6 text-center"
+        style={{ borderTop: `1px solid ${C.borderAsh}` }}
+      >
+        <p className="text-xs max-w-xl mx-auto leading-relaxed" style={{ color: C.ash }}>
+          Storygate Studio™ does not guarantee representation, publication, sale, option, financing, or production. It provides a controlled access environment for professionally prepared projects.
+        </p>
+        <p className="mt-4">
+          <Link href="/storygate-studio" className="text-xs font-mono tracking-[0.14em] uppercase transition-opacity hover:opacity-70" style={{ color: C.gold }}>
+            ← Back to Storygate Studio Overview
+          </Link>
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/app/storygate-studio/industry/dashboard/page.tsx
+++ b/app/storygate-studio/industry/dashboard/page.tsx
@@ -1,0 +1,88 @@
+/**
+ * /storygate-studio/industry/dashboard
+ *
+ * Shell page only — actual dashboard logic lives in the Storygate Studio app
+ * (storygate-studio/client/src/pages/IndustryDashboard.tsx).
+ *
+ * This page is the revisiongrade.com entry point. It checks auth via the
+ * sg_industry_session cookie on the server side (middleware) and redirects
+ * unauthenticated users back to /storygate-studio/industry.
+ *
+ * Authenticated users see a message + link to the live dashboard.
+ * Production: this page should either proxy the embedded dashboard or
+ * redirect directly to the deployed Storygate Studio app URL.
+ */
+
+import Link from "next/link";
+
+const C = {
+  bg:        "#0E0E0E",
+  text:      "#F2EFEA",
+  gold:      "#A98E4A",
+  ash:       "#7B7B7B",
+  panel:     "#161616",
+  border:    "rgba(161,142,74,0.18)",
+  borderAsh: "rgba(123,123,123,0.18)",
+} as const;
+
+export default function IndustryDashboardEntry() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif", minHeight: "100vh" }}
+    >
+      <section className="pt-24 pb-20 px-6 max-w-2xl mx-auto text-center">
+        <p className="text-xs tracking-[0.22em] uppercase font-mono mb-4" style={{ color: C.gold }}>
+          Storygate Studio™
+        </p>
+        <h1
+          className="text-3xl font-bold mb-6"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Industry Dashboard
+        </h1>
+        <p className="text-sm leading-relaxed mb-10" style={{ color: C.ash }}>
+          You are entering the verified industry access area. This environment is logged. All activity — views, access requests, notes, and packet interactions — is recorded and append-only.
+        </p>
+
+        <div className="p-8 mb-6 text-left" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}>
+          <p className="text-xs tracking-[0.14em] uppercase font-mono mb-3" style={{ color: C.gold }}>
+            Access Policy
+          </p>
+          <ul className="space-y-3">
+            {[
+              "Materials may not be copied, shared, or distributed outside this verified account.",
+              "Access does not imply representation, endorsement, or obligation.",
+              "Decisions on materials are final and append-only within the system.",
+              "Violation of access terms may result in immediate revocation.",
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-xs" style={{ color: C.ash }}>
+                <span style={{ color: C.gold, flexShrink: 0 }}>—</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Primary CTA — links to the deployed Storygate Studio app */}
+        <Link
+          href="https://www.perplexity.ai/computer/a/storygate-studio-9n2UVN40RGiCPIz5u5tlwg#/storygate-studio/industry/dashboard"
+          className="inline-block w-full text-center px-6 py-4 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80 mb-4"
+          style={{ backgroundColor: C.gold, color: C.bg }}
+        >
+          Open Industry Dashboard
+        </Link>
+
+        <p className="text-xs" style={{ color: C.ash }}>
+          Not your account?{" "}
+          <Link href="/storygate-studio/industry" className="underline underline-offset-2 hover:opacity-70" style={{ color: C.gold }}>
+            Sign in with a different account
+          </Link>
+        </p>
+
+        <p className="mt-10 text-xs leading-relaxed" style={{ color: C.ash, opacity: 0.6 }}>
+          All project views, access requests, notes, and packet activity are logged and append-only.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/storygate-studio/industry/forgot-password/page.tsx
+++ b/app/storygate-studio/industry/forgot-password/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * /storygate-studio/industry/forgot-password
+ * Industry user password reset request.
+ * Canonical Storygate palette.
+ */
+
+import Link from "next/link";
+
+const C = {
+  bg:        "#0E0E0E",
+  text:      "#F2EFEA",
+  gold:      "#A98E4A",
+  ash:       "#7B7B7B",
+  panel:     "#161616",
+  border:    "rgba(161,142,74,0.18)",
+  borderAsh: "rgba(123,123,123,0.18)",
+} as const;
+
+export default function IndustryForgotPassword() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif", minHeight: "100vh" }}
+    >
+      <section className="pt-24 pb-20 px-6 max-w-md mx-auto">
+        <p className="text-xs tracking-[0.22em] uppercase font-mono mb-4" style={{ color: C.gold }}>
+          Storygate Studio™ — Industry
+        </p>
+        <h1
+          className="text-3xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Reset Your Password
+        </h1>
+        <p className="text-sm mb-10 leading-relaxed" style={{ color: C.ash }}>
+          Enter the email address associated with your verified industry account. If the address is on record, you will receive a reset link.
+        </p>
+
+        <div className="p-8" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}>
+          <label className="block text-xs tracking-[0.14em] uppercase font-mono mb-2" style={{ color: C.gold }}>
+            Professional Email Address
+          </label>
+          <input
+            type="email"
+            placeholder="you@agency.com"
+            className="w-full px-4 py-3 text-sm bg-transparent outline-none mb-6"
+            style={{
+              border: `1px solid ${C.borderAsh}`,
+              color: C.text,
+              fontFamily: "Inter, system-ui, sans-serif",
+            }}
+          />
+          <button
+            type="submit"
+            className="w-full px-6 py-3 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80"
+            style={{ backgroundColor: C.gold, color: C.bg, border: "none" }}
+          >
+            Send Reset Link
+          </button>
+          <p className="mt-4 text-xs text-center" style={{ color: C.ash }}>
+            Reset links expire after 1 hour and are single-use.
+          </p>
+        </div>
+
+        <p className="mt-8 text-center">
+          <Link
+            href="/storygate-studio/industry"
+            className="text-xs font-mono tracking-[0.14em] uppercase transition-opacity hover:opacity-70"
+            style={{ color: C.gold }}
+          >
+            ← Back to Sign In
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/storygate-studio/industry/page.tsx
+++ b/app/storygate-studio/industry/page.tsx
@@ -1,0 +1,106 @@
+/**
+ * /storygate-studio/industry — Industry user sign-in / registration gate
+ * Public. Canonical Storygate palette.
+ */
+
+import Link from "next/link";
+
+const C = {
+  bg:        "#0E0E0E",
+  text:      "#F2EFEA",
+  gold:      "#A98E4A",
+  oxblood:   "#7A1E1E",
+  ash:       "#7B7B7B",
+  panel:     "#161616",
+  border:    "rgba(161,142,74,0.18)",
+  borderAsh: "rgba(123,123,123,0.18)",
+} as const;
+
+export default function IndustryGate() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif", minHeight: "100vh" }}
+    >
+      <section className="pt-24 pb-20 px-6 max-w-2xl mx-auto">
+        <p className="text-xs tracking-[0.22em] uppercase font-mono mb-4" style={{ color: C.gold }}>
+          Storygate Studio™ — Industry Access
+        </p>
+        <h1
+          className="text-4xl font-bold mb-6 leading-tight"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Verified Industry Access
+        </h1>
+        <p className="text-sm leading-relaxed mb-10" style={{ color: C.ash }}>
+          Storygate Studio is not a public marketplace. Access is available only to verified publishing and screen industry professionals. Sign in to your existing account, or request access to apply for verification.
+        </p>
+
+        {/* Sign in panel */}
+        <div className="p-8 mb-6" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}>
+          <p className="text-xs tracking-[0.16em] uppercase font-mono mb-6" style={{ color: C.gold }}>
+            Existing Account
+          </p>
+          <Link
+            href="/storygate-studio/industry/dashboard"
+            className="inline-block w-full text-center px-6 py-4 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80"
+            style={{ backgroundColor: C.gold, color: C.bg }}
+          >
+            Sign In to Industry Dashboard
+          </Link>
+          <p className="mt-4 text-center">
+            <Link
+              href="/storygate-studio/industry/forgot-password"
+              className="text-xs font-mono tracking-[0.12em] transition-opacity hover:opacity-70"
+              style={{ color: C.ash }}
+            >
+              Forgot password?
+            </Link>
+          </p>
+        </div>
+
+        {/* Request access panel */}
+        <div className="p-8" style={{ border: `1px solid ${C.borderAsh}` }}>
+          <p className="text-xs tracking-[0.16em] uppercase font-mono mb-3" style={{ color: C.gold }}>
+            New to Storygate Studio
+          </p>
+          <p className="text-sm leading-relaxed mb-6" style={{ color: C.ash }}>
+            Industry access requires verification. You will need to provide your professional affiliation, role, and contact information. Accounts are manually reviewed before access is granted.
+          </p>
+          <p className="text-xs mb-6 px-4 py-3" style={{ backgroundColor: C.bg, border: `1px solid ${C.borderAsh}`, color: C.ash }}>
+            Required: Full name, company or affiliation, professional role, professional email address (no free email domains), and LinkedIn or company website.
+          </p>
+          <button
+            disabled
+            className="inline-block w-full text-center px-6 py-4 text-xs tracking-[0.18em] uppercase font-mono opacity-40 cursor-not-allowed"
+            style={{ backgroundColor: "transparent", color: C.gold, border: `1px solid ${C.gold}` }}
+          >
+            Request Industry Access — Opening Soon
+          </button>
+          <p className="mt-4 text-xs text-center" style={{ color: C.ash }}>
+            Industry access applications are currently by invitation only during the initial rollout.
+          </p>
+        </div>
+
+        {/* Trust line */}
+        <p
+          className="mt-10 text-xs text-center leading-relaxed"
+          style={{ color: C.ash, borderTop: `1px solid ${C.borderAsh}`, paddingTop: "1.5rem" }}
+        >
+          All project views, access requests, notes, and packet activity are logged and append-only. Materials may not be copied, shared, or distributed outside this verified account.
+        </p>
+        <p
+          className="mt-3 text-xs text-center"
+          style={{ color: C.ash, opacity: 0.6 }}
+        >
+          Access does not imply representation or obligation.
+        </p>
+      </section>
+
+      <footer className="py-6 px-6 text-center" style={{ borderTop: `1px solid ${C.borderAsh}` }}>
+        <Link href="/storygate-studio" className="text-xs font-mono tracking-[0.14em] uppercase transition-opacity hover:opacity-70" style={{ color: C.gold }}>
+          ← Back to Storygate Studio Overview
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/app/storygate-studio/industry/reset-password/page.tsx
+++ b/app/storygate-studio/industry/reset-password/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * /storygate-studio/industry/reset-password
+ * Industry user password reset confirmation.
+ * Canonical Storygate palette.
+ */
+
+import Link from "next/link";
+
+const C = {
+  bg:        "#0E0E0E",
+  text:      "#F2EFEA",
+  gold:      "#A98E4A",
+  ash:       "#7B7B7B",
+  panel:     "#161616",
+  border:    "rgba(161,142,74,0.18)",
+  borderAsh: "rgba(123,123,123,0.18)",
+} as const;
+
+export default function IndustryResetPassword() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif", minHeight: "100vh" }}
+    >
+      <section className="pt-24 pb-20 px-6 max-w-md mx-auto">
+        <p className="text-xs tracking-[0.22em] uppercase font-mono mb-4" style={{ color: C.gold }}>
+          Storygate Studio™ — Industry
+        </p>
+        <h1
+          className="text-3xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Set New Password
+        </h1>
+        <p className="text-sm mb-10 leading-relaxed" style={{ color: C.ash }}>
+          Enter your new password below. The link in your email is single-use and expires after 1 hour.
+        </p>
+
+        <div className="p-8" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}>
+          <label className="block text-xs tracking-[0.14em] uppercase font-mono mb-2" style={{ color: C.gold }}>
+            New Password
+          </label>
+          <input
+            type="password"
+            className="w-full px-4 py-3 text-sm bg-transparent outline-none mb-5"
+            style={{ border: `1px solid ${C.borderAsh}`, color: C.text, fontFamily: "Inter, system-ui, sans-serif" }}
+          />
+          <label className="block text-xs tracking-[0.14em] uppercase font-mono mb-2" style={{ color: C.gold }}>
+            Confirm New Password
+          </label>
+          <input
+            type="password"
+            className="w-full px-4 py-3 text-sm bg-transparent outline-none mb-6"
+            style={{ border: `1px solid ${C.borderAsh}`, color: C.text, fontFamily: "Inter, system-ui, sans-serif" }}
+          />
+          <button
+            type="submit"
+            className="w-full px-6 py-3 text-xs tracking-[0.18em] uppercase font-mono transition-opacity hover:opacity-80"
+            style={{ backgroundColor: C.gold, color: C.bg, border: "none" }}
+          >
+            Update Password
+          </button>
+        </div>
+
+        <p className="mt-8 text-center">
+          <Link
+            href="/storygate-studio/industry"
+            className="text-xs font-mono tracking-[0.14em] uppercase transition-opacity hover:opacity-70"
+            style={{ color: C.gold }}
+          >
+            ← Back to Sign In
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/storygate-studio/page.tsx
+++ b/app/storygate-studio/page.tsx
@@ -1,0 +1,566 @@
+/**
+ * /storygate-studio — Storygate Studio™ public landing page
+ *
+ * Canonical palette (locked):
+ *   Obsidian     #0E0E0E   background
+ *   Bone White   #F2EFEA   primary text
+ *   Blood Oxblood #7A1E1E  CTAs, decline
+ *   Tarnished Gold #A98E4A eligibility, approval
+ *   Ash Gray     #7B7B7B   secondary text, borders
+ *
+ * Fonts: Playfair Display (headings) + Inter (body)
+ * Visible to all users — no auth gate.
+ */
+
+import Link from "next/link";
+
+// ── Palette constants ─────────────────────────────────────────────────────────
+const C = {
+  bg:       "#0E0E0E",
+  text:     "#F2EFEA",
+  oxblood:  "#7A1E1E",
+  gold:     "#A98E4A",
+  ash:      "#7B7B7B",
+  panel:    "#161616",
+  border:   "rgba(161,142,74,0.18)",
+  borderAsh:"rgba(123,123,123,0.18)",
+} as const;
+
+// ── Shared micro-components ───────────────────────────────────────────────────
+
+function Divider() {
+  return (
+    <div
+      style={{ height: 1, background: `linear-gradient(90deg, transparent, ${C.gold}44, transparent)` }}
+      className="my-20 w-full max-w-3xl mx-auto"
+    />
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-xs tracking-[0.22em] uppercase mb-4 font-mono"
+      style={{ color: C.gold }}
+    >
+      {children}
+    </p>
+  );
+}
+
+function CTAButton({
+  href,
+  children,
+  variant = "gold",
+}: {
+  href: string;
+  children: React.ReactNode;
+  variant?: "gold" | "oxblood" | "ghost";
+}) {
+  const styles: Record<string, React.CSSProperties> = {
+    gold: {
+      backgroundColor: C.gold,
+      color: C.bg,
+      border: `1px solid ${C.gold}`,
+    },
+    oxblood: {
+      backgroundColor: C.oxblood,
+      color: C.text,
+      border: `1px solid ${C.oxblood}`,
+    },
+    ghost: {
+      backgroundColor: "transparent",
+      color: C.gold,
+      border: `1px solid ${C.gold}`,
+    },
+  };
+
+  return (
+    <Link
+      href={href}
+      className="inline-block px-6 py-3 text-xs tracking-[0.18em] uppercase font-mono transition-opacity duration-150 hover:opacity-80"
+      style={styles[variant]}
+    >
+      {children}
+    </Link>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function StorygateStudioLanding() {
+  return (
+    <main
+      style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif" }}
+      className="min-h-screen"
+    >
+
+      {/* ── HERO ─────────────────────────────────────────────────────────────── */}
+      <section
+        className="pt-28 pb-24 px-6 text-center"
+        style={{ borderBottom: `1px solid ${C.borderAsh}` }}
+      >
+        <SectionLabel>Storygate Studio™</SectionLabel>
+        <h1
+          className="text-4xl md:text-5xl font-bold mb-6 max-w-3xl mx-auto leading-tight"
+          style={{ fontFamily: "Playfair Display, Georgia, serif", color: C.text }}
+        >
+          A curated industry-access layer for readiness-vetted books, manuscripts, and screen projects.
+        </h1>
+        <p className="text-base max-w-2xl mx-auto mb-3" style={{ color: C.ash }}>
+          Verified publishing and screen professionals can request access to specific projects. Creators control what materials are visible, who can view them, and when access is approved.
+        </p>
+        <p className="text-xs mb-10 tracking-wide" style={{ color: C.ash }}>
+          Verified access only. Creator-approved visibility. Logged project activity.
+        </p>
+        <div className="flex flex-wrap gap-4 justify-center">
+          <CTAButton href="/storygate-studio/industry" variant="gold">
+            Request Industry Access
+          </CTAButton>
+          <CTAButton href="/storygate-studio/industry" variant="ghost">
+            Sign In as Industry User
+          </CTAButton>
+          <CTAButton href="/storygate-studio/apply" variant="oxblood">
+            Prepare a Project for Storygate
+          </CTAButton>
+        </div>
+      </section>
+
+      {/* ── TRUST MODEL ──────────────────────────────────────────────────────── */}
+      <section className="py-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Trust Model</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-12"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Built for controlled discovery, not open browsing.
+        </h2>
+        <p className="text-sm mb-12 max-w-2xl" style={{ color: C.ash }}>
+          Storygate Studio is designed for serious creators and legitimate industry professionals. Projects are not publicly searchable. Access is granted by request, by role, and by creator approval.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {[
+            ["Verified Access Only", "Industry users must be approved before viewing project materials."],
+            ["Creator Approval", "Industry users request access to specific projects. Creators approve or decline on a per-project basis."],
+            ["Creator-Controlled Visibility", "Creators decide which materials are visible to which viewers and roles."],
+            ["Logged Activity", "Project access and key viewer activity are recorded to support accountability and creator confidence."],
+          ].map(([title, body]) => (
+            <div
+              key={title}
+              className="p-6"
+              style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}
+            >
+              <p
+                className="text-xs tracking-[0.16em] uppercase mb-3 font-mono"
+                style={{ color: C.gold }}
+              >
+                {title}
+              </p>
+              <p className="text-sm leading-relaxed" style={{ color: C.ash }}>
+                {body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* ── WHAT INDUSTRY USERS MAY SEE ─────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Materials</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-6"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          A clean professional package, not a cluttered submission dump.
+        </h2>
+        <p className="text-sm mb-10 max-w-2xl" style={{ color: C.ash }}>
+          Depending on creator permissions, verified industry users may view:
+        </p>
+        <ul className="space-y-3 mb-8">
+          {[
+            "Logline and short pitch",
+            "One-page synopsis or series overview",
+            "Sample pages, screenplay pages, or pilot materials",
+            "Optional evaluation summary or professional readiness assessment",
+            "Optional adaptation materials — Film/TV pitch deck, lookbook, comparable titles, audience positioning, and development notes",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-3 text-sm" style={{ color: C.text }}>
+              <span style={{ color: C.gold, flexShrink: 0, marginTop: 2 }}>—</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs italic" style={{ color: C.ash }}>
+          Storygate Studio gives professionals enough to assess interest without forcing creators to expose everything by default.
+        </p>
+      </section>
+
+      <Divider />
+
+      {/* ── TWO AUDIENCES ────────────────────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Who It&apos;s For</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-12"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          For industry professionals and creators.
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {/* Industry */}
+          <div
+            className="p-8"
+            style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}
+          >
+            <p className="text-xs tracking-[0.16em] uppercase mb-4 font-mono" style={{ color: C.gold }}>
+              Industry Professionals
+            </p>
+            <p className="text-sm leading-relaxed mb-8" style={{ color: C.ash }}>
+              Discover readiness-vetted narrative projects through a secure, request-based access layer. You can request access to projects that match your role, interests, and professional focus. Once approved, you see only the materials the creator has chosen to share.
+            </p>
+            <CTAButton href="/storygate-studio/industry" variant="gold">
+              Request Industry Access
+            </CTAButton>
+          </div>
+
+          {/* Creators */}
+          <div
+            className="p-8"
+            style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}` }}
+          >
+            <p className="text-xs tracking-[0.16em] uppercase mb-4 font-mono" style={{ color: C.gold }}>
+              Creators
+            </p>
+            <p className="text-sm leading-relaxed mb-8" style={{ color: C.ash }}>
+              Prepare your project for professional consideration without losing control of access. Storygate Studio is for projects that have cleared a professional presentation and readiness threshold. Once eligible, your project can be placed into a controlled access environment where verified professionals may request review.
+            </p>
+            <CTAButton href="/storygate-studio/apply" variant="ghost">
+              Learn How to Qualify
+            </CTAButton>
+          </div>
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* ── ELIGIBILITY ──────────────────────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Eligibility</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-4"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Storygate placement requires two gates.
+        </h2>
+        <p className="text-sm mb-12 max-w-2xl" style={{ color: C.ash }}>
+          Storygate Studio is selective. Projects must satisfy both requirements before placement.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {/* Gate 1 */}
+          <div
+            className="p-8"
+            style={{ border: `1px solid ${C.border}` }}
+          >
+            <p className="text-xs tracking-[0.18em] uppercase mb-1 font-mono" style={{ color: C.gold }}>
+              Gate 1
+            </p>
+            <p
+              className="text-lg font-bold mb-4"
+              style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+            >
+              Professional Presentation Package
+            </p>
+            <p className="text-sm mb-5" style={{ color: C.ash }}>
+              Creators must provide a clear, professionally formatted package that communicates the project quickly and credibly. Depending on project type, this may include:
+            </p>
+            <ul className="space-y-2 mb-6">
+              {[
+                "Query letter or professional pitch material",
+                "Synopsis or series overview",
+                "Author or creator bio",
+                "Sample pages, screenplay pages, or pilot materials",
+                "Supporting materials — comparables, audience positioning, lookbook, adaptation notes, or Film/TV pitch deck",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-xs" style={{ color: C.ash }}>
+                  <span style={{ color: C.gold, flexShrink: 0, marginTop: 1 }}>—</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <p
+              className="text-xs p-3 border"
+              style={{ color: C.ash, borderColor: C.border, backgroundColor: C.panel }}
+            >
+              A RevisionGrade-generated package may satisfy this requirement, but creators may also use equivalent professional materials created independently or through another service.{" "}
+              <strong style={{ color: C.text }}>There is no requirement to purchase RevisionGrade services to qualify.</strong>
+            </p>
+          </div>
+
+          {/* Gate 2 */}
+          <div
+            className="p-8"
+            style={{ border: `1px solid ${C.border}` }}
+          >
+            <p className="text-xs tracking-[0.18em] uppercase mb-1 font-mono" style={{ color: C.gold }}>
+              Gate 2
+            </p>
+            <p
+              className="text-lg font-bold mb-4"
+              style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+            >
+              Minimum Readiness / Quality Threshold
+            </p>
+            <p className="text-sm mb-5" style={{ color: C.ash }}>
+              Projects must demonstrate a minimum professional standard through one of the following:
+            </p>
+            <ul className="space-y-2 mb-6">
+              {[
+                "A RevisionGrade score of 8.0 or higher in the relevant evaluation, or",
+                "An equivalent professional assessment from a qualified third party — a literary agent, editor, producer, development executive, or recognized industry evaluator",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-xs" style={{ color: C.ash }}>
+                  <span style={{ color: C.gold, flexShrink: 0, marginTop: 1 }}>—</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <p
+              className="text-xs p-3 border"
+              style={{ color: C.ash, borderColor: C.border, backgroundColor: C.panel }}
+            >
+              Storygate Studio is not designed to replace professional judgment. It is designed to make professionally prepared projects easier to review, route, and protect.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* ── WHY STORYGATE EXISTS ─────────────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Why It Exists</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-6 max-w-2xl"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Good projects should not disappear into the black box.
+        </h2>
+        <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: C.ash }}>
+          Writers and creators often face the same problem: silence, generic rejection, or no clear signal about whether the issue is project readiness, market fit, timing, or access.
+        </p>
+        <p className="text-sm mb-8 max-w-2xl" style={{ color: C.ash }}>
+          Storygate Studio does not promise representation, publication, or production. It creates a more disciplined bridge between prepared creators and verified professionals:
+        </p>
+        <ul className="space-y-3 mb-10 max-w-xl">
+          {[
+            "Creators keep control of their materials.",
+            "Professionals see organized, readiness-vetted packages.",
+            "Access is requested, approved, and logged.",
+            "Projects are presented through a standard designed for serious review.",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-3 text-sm" style={{ color: C.text }}>
+              <span style={{ color: C.gold, flexShrink: 0, marginTop: 2 }}>—</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <Divider />
+
+      {/* ── PROJECT TYPES ────────────────────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Project Types</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-12"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Built for books, manuscripts, and screen adaptation pathways.
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[
+            {
+              type: "Manuscript / Publishing",
+              desc: "For novels, memoirs, nonfiction books, and other manuscript-based submissions.",
+              materials: "Professional query letter, synopsis, author bio, sample pages, and optional evaluation summary.",
+            },
+            {
+              type: "Screen / Adaptation",
+              desc: "For projects seeking film, television, streaming, or development consideration.",
+              materials: "Film/TV pitch deck, source-material summary, lookbook, comparable titles, audience positioning, and optional adaptation notes.",
+            },
+            {
+              type: "Series / Franchise",
+              desc: "For projects with multi-book, multi-season, or expanded-world potential.",
+              materials: "Series overview, world or character materials, adaptation positioning, and development package.",
+            },
+          ].map(({ type, desc, materials }) => (
+            <div
+              key={type}
+              className="p-6"
+              style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}` }}
+            >
+              <p
+                className="text-xs tracking-[0.14em] uppercase mb-3 font-mono"
+                style={{ color: C.gold }}
+              >
+                {type}
+              </p>
+              <p className="text-sm mb-4 leading-relaxed" style={{ color: C.text }}>
+                {desc}
+              </p>
+              <p className="text-xs leading-relaxed" style={{ color: C.ash }}>
+                {materials}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <Divider />
+
+      {/* ── WHAT STORYGATE IS NOT ────────────────────────────────────────────── */}
+      <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
+        <SectionLabel>Scope</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-6"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          A professional gateway, not a guarantee.
+        </h2>
+        <p className="text-sm mb-6" style={{ color: C.ash }}>
+          Storygate Studio is not:
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
+          {[
+            "A literary agency",
+            "A production company",
+            "A publisher",
+            "A contest",
+            "A public marketplace",
+            "A guarantee of representation, publication, sale, option, financing, or production",
+          ].map((item) => (
+            <div
+              key={item}
+              className="px-4 py-3 text-xs"
+              style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}`, color: C.ash }}
+            >
+              {item}
+            </div>
+          ))}
+        </div>
+        <p className="text-sm italic max-w-2xl" style={{ color: C.ash }}>
+          Storygate Studio is a selective access layer for professionally prepared narrative projects. Industry response remains subjective and market-dependent.
+        </p>
+      </section>
+
+      <Divider />
+
+      {/* ── CTA BAND ─────────────────────────────────────────────────────────── */}
+      <section
+        className="py-20 px-6 text-center"
+        style={{ backgroundColor: C.panel, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}
+      >
+        <SectionLabel>Enter the Right Door</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-12"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Ready to proceed?
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-2xl mx-auto text-left">
+          <div>
+            <p className="text-xs tracking-[0.16em] uppercase mb-2 font-mono" style={{ color: C.gold }}>
+              Industry Professionals
+            </p>
+            <p className="text-sm mb-5" style={{ color: C.ash }}>
+              Request verified access to review selected projects.
+            </p>
+            <CTAButton href="/storygate-studio/industry" variant="gold">
+              Request Industry Access
+            </CTAButton>
+          </div>
+          <div>
+            <p className="text-xs tracking-[0.16em] uppercase mb-2 font-mono" style={{ color: C.gold }}>
+              Creators
+            </p>
+            <p className="text-sm mb-5" style={{ color: C.ash }}>
+              Prepare your project for eligibility and controlled industry review.
+            </p>
+            <CTAButton href="/storygate-studio/apply" variant="ghost">
+              Prepare a Project for Storygate
+            </CTAButton>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ PREVIEW ──────────────────────────────────────────────────────── */}
+      <section className="py-24 px-6 max-w-3xl mx-auto">
+        <SectionLabel>FAQ</SectionLabel>
+        <h2
+          className="text-2xl md:text-3xl font-bold mb-12"
+          style={{ fontFamily: "Playfair Display, Georgia, serif" }}
+        >
+          Questions before you apply?
+        </h2>
+        <div className="space-y-8">
+          {[
+            {
+              q: "Do I need to use RevisionGrade to qualify?",
+              a: "No. A RevisionGrade package may satisfy eligibility requirements, but creators may also qualify with equivalent professional materials created independently or through another service.",
+            },
+            {
+              q: "Does Storygate guarantee representation or production?",
+              a: "No. Storygate Studio does not guarantee representation, publication, sale, option, financing, or production.",
+            },
+            {
+              q: "Do I need to keep paying to remain in Storygate Studio?",
+              a: "No. Once a project has been submitted into Storygate Studio, remaining eligible for consideration does not require an active paid subscription. Paid tools may be required later only if you want to revise, update, or resubmit materials.",
+            },
+            {
+              q: "What materials are required for manuscript submissions?",
+              a: "Manuscript projects typically require a professional query letter, synopsis, and author bio. The pitch or hook belongs inside the query letter, not as a redundant separate document.",
+            },
+            {
+              q: "Is a Film/TV pitch deck required for screen or adaptation submissions?",
+              a: "Yes. Screen and adaptation submissions should include a Film/TV pitch deck or equivalent professional screen-development package.",
+            },
+          ].map(({ q, a }) => (
+            <div
+              key={q}
+              className="pb-8"
+              style={{ borderBottom: `1px solid ${C.borderAsh}` }}
+            >
+              <p
+                className="text-sm font-semibold mb-2"
+                style={{ fontFamily: "Playfair Display, Georgia, serif", color: C.text }}
+              >
+                {q}
+              </p>
+              <p className="text-sm leading-relaxed" style={{ color: C.ash }}>
+                {a}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── FOOTER TRUST NOTE ────────────────────────────────────────────────── */}
+      <footer
+        className="py-8 px-6 text-center"
+        style={{ borderTop: `1px solid ${C.borderAsh}` }}
+      >
+        <p className="text-xs max-w-xl mx-auto leading-relaxed" style={{ color: C.ash }}>
+          Storygate Studio™ is part of the RevisionGrade™ ecosystem. It is designed to support professional readiness, controlled access, and accountable review pathways for serious narrative projects.
+        </p>
+        <p className="text-xs mt-3" style={{ color: C.gold, opacity: 0.6 }}>
+          All project views, access requests, notes, and packet activity are logged and append-only. Materials may not be copied, shared, or distributed outside this verified account.
+        </p>
+      </footer>
+
+    </main>
+  );
+}

--- a/app/storygate/page.tsx
+++ b/app/storygate/page.tsx
@@ -1,9 +1,10 @@
-export default function StorygatePage() {
-  return (
-    <main className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-2">Storygate Studio</h1>
-      <p className="text-red-600 font-medium mb-4">Premium Feature</p>
-      <p className="text-slate-600">Storygate Studio is coming soon. Film adaptation analysis, screenplay evaluation, and storytelling tools.</p>
-    </main>
-  );
+/**
+ * /storygate — legacy route
+ * Redirects to /storygate-studio (canonical landing page)
+ */
+
+import { redirect } from "next/navigation";
+
+export default function StorygateLegacyRedirect() {
+  redirect("/storygate-studio");
 }

--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -3,19 +3,22 @@
 /**
  * HeaderNav — RevisionGrade canonical navigation shell
  *
- * Governed OS principle: core product actions stay top-level; reference pages
- * live behind Resources; auth state controls Dashboard vs Sign In/Sign Out.
+ * Signed-in nav order (per product doctrine):
+ *   Dashboard · Evaluate · Revise · Agent Readiness Package™ · Storygate Studio™ · Resources · Pricing
+ *   Admin-only: Pipeline
  *
  * Auth states:
- *   authState = "loading"   — session check in-flight; render nav skeleton (no flash)
- *   authState = "authed"    — valid session; show Dashboard + optional Pipeline
- *   authState = "anon"      — no session; show Sign In
+ *   "loading" — session check in-flight; render skeleton (no flash)
+ *   "authed"  — valid session
+ *   "anon"    — no session
  */
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { isPipelineHealthAdminEmail } from "@/lib/admin/pipelineHealthAllowlist";
+
+// ── Dropdown configs ──────────────────────────────────────────────────────────
 
 const resourceLinks = [
   ["The Black Box Problem", "/black-box-problem"],
@@ -31,20 +34,37 @@ const resourceActiveHrefs = [
   "/reliability",
 ];
 
+const arpLinks = [
+  ["Generate Full Agent Package", "/agent-readiness"],
+  ["Query / Cover Letter",        "/agent-readiness/query-letter"],
+  ["Synopsis Builder",            "/agent-readiness/synopsis"],
+  ["Pitch Builder",               "/agent-readiness/pitch"],
+  ["Author Bio",                  "/agent-readiness/bio"],
+  ["Comparables & Positioning",   "/agent-readiness/comparables"],
+  ["Package History / Export",    "/agent-readiness/history"],
+];
+
+const arpActiveHref = "/agent-readiness";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 export default function HeaderNav() {
   const pathname = usePathname() || "/";
   const router = useRouter();
+
   const resourcesMenuRef = useRef(null);
+  const arpMenuRef       = useRef(null);
 
-  // "loading" prevents the nav from flashing between authed/anon states on mount
-  const [authState, setAuthState] = useState("loading"); // "loading" | "authed" | "anon"
-  const [email, setEmail] = useState(null);
-  const [signingOut, setSigningOut] = useState(false);
+  const [authState,    setAuthState]    = useState("loading");
+  const [email,        setEmail]        = useState(null);
+  const [signingOut,   setSigningOut]   = useState(false);
   const [resourcesOpen, setResourcesOpen] = useState(false);
+  const [arpOpen,       setArpOpen]       = useState(false);
 
-  const isAdmin = isPipelineHealthAdminEmail(email);
+  const isAdmin  = isPipelineHealthAdminEmail(email);
   const isAuthed = authState === "authed";
 
+  // ── Auth check ─────────────────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
     fetch("/api/auth/user", { credentials: "include", cache: "no-store" })
@@ -56,97 +76,108 @@ export default function HeaderNav() {
         setAuthState(resolvedEmail ? "authed" : "anon");
       })
       .catch(() => {
-        if (!cancelled) {
-          setEmail(null);
-          setAuthState("anon");
-        }
+        if (!cancelled) { setEmail(null); setAuthState("anon"); }
       });
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [pathname]);
 
+  // ── Dropdown outside-click / Escape ────────────────────────────────────────
   useEffect(() => {
-    if (!resourcesOpen) return;
-
-    function handlePointerDown(event) {
-      if (!resourcesMenuRef.current) return;
-      if (!resourcesMenuRef.current.contains(event.target)) {
-        setResourcesOpen(false);
-      }
+    if (!resourcesOpen && !arpOpen) return;
+    function handlePointerDown(e) {
+      if (resourcesOpen && resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target)) setResourcesOpen(false);
+      if (arpOpen      && arpMenuRef.current       && !arpMenuRef.current.contains(e.target))       setArpOpen(false);
     }
-
-    function handleKeyDown(event) {
-      if (event.key === "Escape") {
-        setResourcesOpen(false);
-      }
+    function handleKeyDown(e) {
+      if (e.key === "Escape") { setResourcesOpen(false); setArpOpen(false); }
     }
-
     document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [resourcesOpen]);
+  }, [resourcesOpen, arpOpen]);
 
+  // ── Sign out ───────────────────────────────────────────────────────────────
   async function handleSignOut() {
     if (signingOut) return;
     setSigningOut(true);
-    try {
-      await fetch("/api/auth/signout", {
-        method: "POST",
-        credentials: "include",
-        cache: "no-store",
-      });
-    } catch {
-      // best-effort
-    }
-    setEmail(null);
-    setAuthState("anon");
-    router.push("/");
-    router.refresh();
+    try { await fetch("/api/auth/signout", { method: "POST", credentials: "include", cache: "no-store" }); }
+    catch { /* best-effort */ }
+    setEmail(null); setAuthState("anon");
+    router.push("/"); router.refresh();
     setSigningOut(false);
   }
 
-  const linkCls =
-    "text-xs tracking-widest uppercase font-rg-mono text-rg-cream2 hover:text-rg-cream transition-colors duration-150";
-  const activeLinkCls =
-    "text-xs tracking-widest uppercase font-rg-mono text-rg-gold";
+  // ── Style helpers ──────────────────────────────────────────────────────────
+  const linkCls       = "text-xs tracking-widest uppercase font-rg-mono text-rg-cream2 hover:text-rg-cream transition-colors duration-150";
+  const activeLinkCls = "text-xs tracking-widest uppercase font-rg-mono text-rg-gold";
 
   function NavLink({ href, children }) {
     const active = pathname === href || pathname.startsWith(href + "/");
-    return (
-      <Link href={href} className={active ? activeLinkCls : linkCls}>
-        {children}
-      </Link>
-    );
+    return <Link href={href} className={active ? activeLinkCls : linkCls}>{children}</Link>;
   }
 
-  const resourcesActive = resourceActiveHrefs.some(
-    (href) => pathname === href || pathname.startsWith(`${href}/`)
-  );
+  const resourcesActive = resourceActiveHrefs.some((h) => pathname === h || pathname.startsWith(`${h}/`));
+  const arpActive       = pathname === arpActiveHref || pathname.startsWith(`${arpActiveHref}/`);
+
+  // ── Dropdown panel shared style ────────────────────────────────────────────
+  const dropdownCls = "absolute left-1/2 top-8 z-50 -translate-x-1/2 border border-rg-cream2/15 bg-rg-ink2 p-3 shadow-xl shadow-black/30";
+  const dropdownItemCls = "block px-3 py-2 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-cream2 hover:text-rg-cream whitespace-nowrap";
 
   return (
     <header className="w-full bg-rg-ink border-b border-rg-cream2/10 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-6 h-14 flex items-center justify-between gap-8">
+
+        {/* Wordmark */}
         <Link href="/" className="flex items-center gap-3 shrink-0 group">
-          <span className="inline-flex h-8 w-8 items-center justify-center border border-rg-gold/60 text-rg-gold font-rg-serif text-sm group-hover:border-rg-gold transition-colors duration-150">
-            R
-          </span>
-          <span className="text-rg-cream font-rg-serif text-sm tracking-wide hidden sm:block">
-            RevisionGrade&#8482;
-          </span>
+          <span className="inline-flex h-8 w-8 items-center justify-center border border-rg-gold/60 text-rg-gold font-rg-serif text-sm group-hover:border-rg-gold transition-colors duration-150">R</span>
+          <span className="text-rg-cream font-rg-serif text-sm tracking-wide hidden sm:block">RevisionGrade&#8482;</span>
         </Link>
 
+        {/* Nav links */}
         <nav className="flex items-center gap-6 flex-1 justify-center">
+
+          {/* Auth-gated: Dashboard first */}
+          {isAuthed && <NavLink href="/dashboard">Dashboard</NavLink>}
+
           <NavLink href="/evaluate">Evaluate</NavLink>
           <NavLink href="/revise">Revise</NavLink>
-          <NavLink href="/reliability">Reliability</NavLink>
+
+          {/* Agent Readiness Package™ dropdown (auth-gated) */}
+          {isAuthed && (
+            <div className="relative" ref={arpMenuRef}>
+              <button
+                type="button"
+                onClick={() => { setArpOpen((v) => !v); setResourcesOpen(false); }}
+                className={arpActive ? activeLinkCls : linkCls}
+                aria-expanded={arpOpen}
+                aria-haspopup="menu"
+                aria-controls="arp-menu"
+              >
+                Agent Readiness&#8482;
+              </button>
+              {arpOpen && (
+                <div id="arp-menu" className={`${dropdownCls} w-64`} role="menu">
+                  {arpLinks.map(([label, href]) => (
+                    <Link key={href} href={href} role="menuitem" onClick={() => setArpOpen(false)} className={dropdownItemCls}>
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Storygate Studio™ top-level link (auth-gated) */}
+          {isAuthed && <NavLink href="/storygate-studio">Storygate Studio&#8482;</NavLink>}
+
+          {/* Resources dropdown */}
           <div className="relative" ref={resourcesMenuRef}>
             <button
               type="button"
-              onClick={() => setResourcesOpen((value) => !value)}
+              onClick={() => { setResourcesOpen((v) => !v); setArpOpen(false); }}
               className={resourcesActive ? activeLinkCls : linkCls}
               aria-expanded={resourcesOpen}
               aria-haspopup="menu"
@@ -155,36 +186,25 @@ export default function HeaderNav() {
               Resources
             </button>
             {resourcesOpen && (
-              <div
-                id="resources-menu"
-                className="absolute left-1/2 top-8 z-50 w-56 -translate-x-1/2 border border-rg-cream2/15 bg-rg-ink2 p-3 shadow-xl shadow-black/30"
-                role="menu"
-              >
+              <div id="resources-menu" className={`${dropdownCls} w-56`} role="menu">
                 {resourceLinks.map(([label, href]) => (
-                  <Link
-                    key={href}
-                    href={href}
-                    role="menuitem"
-                    onClick={() => setResourcesOpen(false)}
-                    className="block px-3 py-2 font-rg-mono text-xs uppercase tracking-[0.14em] text-rg-cream2 hover:text-rg-cream"
-                  >
+                  <Link key={href} href={href} role="menuitem" onClick={() => setResourcesOpen(false)} className={dropdownItemCls}>
                     {label}
                   </Link>
                 ))}
               </div>
             )}
           </div>
+
           <NavLink href="/pricing">Pricing</NavLink>
 
-          {/* Auth-gated items — only render once auth check resolves (no flash) */}
-          {isAuthed && <NavLink href="/dashboard">Dashboard</NavLink>}
-          {isAuthed && isAdmin && (
-            <NavLink href="/admin/pipeline-health">Pipeline</NavLink>
-          )}
+          {/* Admin-only */}
+          {isAuthed && isAdmin && <NavLink href="/admin/pipeline-health">Pipeline</NavLink>}
+
         </nav>
 
+        {/* Auth button */}
         <div className="shrink-0">
-          {/* While loading: render a ghost placeholder to prevent layout shift */}
           {authState === "loading" && (
             <span className="inline-block w-14 h-5 rounded bg-rg-cream2/10 animate-pulse" />
           )}
@@ -200,15 +220,12 @@ export default function HeaderNav() {
             </button>
           )}
           {authState === "anon" && (
-            <Link
-              href="/login"
-              data-testid="nav-signin"
-              className="text-xs tracking-widest uppercase font-rg-mono border border-rg-gold text-rg-gold px-3 py-1.5 hover:bg-rg-gold hover:text-rg-ink transition-colors duration-150"
-            >
+            <Link href="/login" data-testid="nav-signin" className="text-xs tracking-widest uppercase font-rg-mono border border-rg-gold text-rg-gold px-3 py-1.5 hover:bg-rg-gold hover:text-rg-ink transition-colors duration-150">
               Sign in
             </Link>
           )}
         </div>
+
       </div>
     </header>
   );

--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -20,6 +20,15 @@ import { isPipelineHealthAdminEmail } from "@/lib/admin/pipelineHealthAllowlist"
 
 // ── Dropdown configs ──────────────────────────────────────────────────────────
 
+const storygateLinks = [
+  ["Overview",              "/storygate-studio"],
+  ["Prepare a Project",    "/storygate-studio/apply"],
+  ["Request Industry Access", "/storygate-studio/industry"],
+  ["Agent Dashboard",      "/storygate-studio/industry/dashboard"],
+];
+
+const storygateActiveHref = "/storygate-studio";
+
 const resourceLinks = [
   ["The Black Box Problem", "/black-box-problem"],
   ["FAQs", "/resources"],
@@ -54,12 +63,14 @@ export default function HeaderNav() {
 
   const resourcesMenuRef = useRef(null);
   const arpMenuRef       = useRef(null);
+  const sgMenuRef        = useRef(null);
 
-  const [authState,    setAuthState]    = useState("loading");
-  const [email,        setEmail]        = useState(null);
-  const [signingOut,   setSigningOut]   = useState(false);
+  const [authState,     setAuthState]    = useState("loading");
+  const [email,         setEmail]        = useState(null);
+  const [signingOut,    setSigningOut]   = useState(false);
   const [resourcesOpen, setResourcesOpen] = useState(false);
   const [arpOpen,       setArpOpen]       = useState(false);
+  const [sgOpen,        setSgOpen]        = useState(false);
 
   const isAdmin  = isPipelineHealthAdminEmail(email);
   const isAuthed = authState === "authed";
@@ -83,13 +94,14 @@ export default function HeaderNav() {
 
   // ── Dropdown outside-click / Escape ────────────────────────────────────────
   useEffect(() => {
-    if (!resourcesOpen && !arpOpen) return;
+    if (!resourcesOpen && !arpOpen && !sgOpen) return;
     function handlePointerDown(e) {
       if (resourcesOpen && resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target)) setResourcesOpen(false);
       if (arpOpen      && arpMenuRef.current       && !arpMenuRef.current.contains(e.target))       setArpOpen(false);
+      if (sgOpen       && sgMenuRef.current        && !sgMenuRef.current.contains(e.target))        setSgOpen(false);
     }
     function handleKeyDown(e) {
-      if (e.key === "Escape") { setResourcesOpen(false); setArpOpen(false); }
+      if (e.key === "Escape") { setResourcesOpen(false); setArpOpen(false); setSgOpen(false); }
     }
     document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleKeyDown);
@@ -97,7 +109,7 @@ export default function HeaderNav() {
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [resourcesOpen, arpOpen]);
+  }, [resourcesOpen, arpOpen, sgOpen]);
 
   // ── Sign out ───────────────────────────────────────────────────────────────
   async function handleSignOut() {
@@ -145,12 +157,12 @@ export default function HeaderNav() {
           <NavLink href="/evaluate">Evaluate</NavLink>
           <NavLink href="/revise">Revise</NavLink>
 
-          {/* Agent Readiness Package™ dropdown (auth-gated) */}
-          {isAuthed && (
+          {/* Agent Readiness Package™ dropdown — authed: full menu; anon: overview link */}
+          {isAuthed ? (
             <div className="relative" ref={arpMenuRef}>
               <button
                 type="button"
-                onClick={() => { setArpOpen((v) => !v); setResourcesOpen(false); }}
+                onClick={() => { setArpOpen((v) => !v); setResourcesOpen(false); setSgOpen(false); }}
                 className={arpActive ? activeLinkCls : linkCls}
                 aria-expanded={arpOpen}
                 aria-haspopup="menu"
@@ -168,10 +180,32 @@ export default function HeaderNav() {
                 </div>
               )}
             </div>
+          ) : (
+            <NavLink href="/agent-readiness">Agent Readiness&#8482;</NavLink>
           )}
 
-          {/* Storygate Studio™ top-level link (auth-gated) */}
-          {isAuthed && <NavLink href="/storygate-studio">Storygate Studio&#8482;</NavLink>}
+          {/* Storygate Studio™ dropdown — visible to all users */}
+          <div className="relative" ref={sgMenuRef}>
+            <button
+              type="button"
+              onClick={() => { setSgOpen((v) => !v); setArpOpen(false); setResourcesOpen(false); }}
+              className={(pathname === storygateActiveHref || pathname.startsWith(storygateActiveHref + "/") || pathname.startsWith("/storygate")) ? activeLinkCls : linkCls}
+              aria-expanded={sgOpen}
+              aria-haspopup="menu"
+              aria-controls="sg-menu"
+            >
+              Storygate Studio&#8482;
+            </button>
+            {sgOpen && (
+              <div id="sg-menu" className={`${dropdownCls} w-64`} role="menu">
+                {storygateLinks.map(([label, href]) => (
+                  <Link key={href} href={href} role="menuitem" onClick={() => setSgOpen(false)} className={dropdownItemCls}>
+                    {label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
 
           {/* Resources dropdown */}
           <div className="relative" ref={resourcesMenuRef}>


### PR DESCRIPTION
## What this adds

### Header Nav
- **Storygate Studio™** dropdown now visible to **all users** (anon + authed) — 4 items: Overview, Prepare a Project, Request Industry Access, Agent Dashboard
- **Agent Readiness™** now visible to **anon users** as a direct link (full dropdown remains for authed users)
- Proper outside-click + Escape handling for the new SG dropdown

### Root Landing Page (`app/page.tsx`)
Two new product discovery sections appended above the footer:
1. **Agent Readiness Package™** — 6-section breakdown with Generate Package + See What's Included CTAs
2. **Storygate Studio™** — 5-point trust model (Verified Access, Creator-Controlled, 8.0+ Gate, Logged, Not a Marketplace) with dual CTAs

### New Routes
| Route | Page |
|---|---|
| `/storygate-studio` | Full public landing page — Hero, Trust Model, Materials, Two Audiences, Eligibility (Gate 1 + Gate 2), Why It Exists, Project Types, Scope, CTA Band, FAQ, Footer |
| `/storygate-studio/apply` | Creator eligibility + preparation (Gate 1 package requirements + Gate 2 threshold + RevisionGrade path) |
| `/storygate-studio/industry` | Industry sign-in gate (existing account + request access panels + trust/policy lines) |
| `/storygate-studio/industry/dashboard` | Dashboard entry shell with access policy + link to live Storygate Studio app |
| `/storygate-studio/industry/forgot-password` | Password reset request |
| `/storygate-studio/industry/reset-password` | Password reset confirmation |
| `/storygate` | Redirect → `/storygate-studio` (legacy route) |

### Canon compliance
- All pages use locked Storygate palette: Obsidian `#0E0E0E`, Bone White `#F2EFEA`, Oxblood `#7A1E1E`, Gold `#A98E4A`, Ash `#7B7B7B`
- Fonts: Playfair Display (headings) + Inter (body)
- Trust lines present: access policy, non-representation disclaimer, append-only logging notice
- No payment references on apply or industry pages
- Eligibility paywalling explicitly avoided (`There is no requirement to purchase RevisionGrade services to qualify`)

## Review notes
- `/storygate-studio/industry/dashboard` currently links to the deployed Storygate Studio app URL — this should eventually be replaced with a server-side proxy or embedded iframe once the production URL is stable
- `Request Industry Access` button is disabled (`cursor-not-allowed`) with "Opening Soon" copy — ready to wire to backend when agent registration endpoint ships