### PR TITLE
fix(reports): restore download endpoint UUID validation

### DIFF
--- a/.github/pr-bodies/PR-666.md
+++ b/.github/pr-bodies/PR-666.md
@@ -1,0 +1,58 @@
+## Summary
+
+Fixes the report download endpoint rejecting valid evaluation job IDs.
+
+The live failure shown on the Evaluation Report page was:
+
+```json
+{"error":"Invalid job ID"}
+```
+
+for a canonical UUID like:
+
+```txt
+3b7a549b-ea34-4b3d-ae85-30bc8b234576
+```
+
+## Root cause
+
+`app/api/reports/[jobId]/download/route.ts` used a malformed UUID validator:
+
+```ts
+/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+```
+
+That pattern is missing the fourth UUID group (`-[0-9a-f]{4}`), so every normal UUID with five groups was rejected before auth, ownership, release-gate, or format logic ran.
+
+## Fix
+
+Corrected the regex to the canonical UUID shape:
+
+```ts
+/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+```
+
+This repairs every download button that routes through:
+
+```txt
+/api/reports/:jobId/download?format=pdf|docx|txt
+```
+
+including:
+
+- Evaluation Report page `Download Report`
+- Ledger `Save / Download`
+- Any other current UI button using the shared report download route
+
+## Verification target
+
+After deploy, retest:
+
+```txt
+/evaluate/3b7a549b-ea34-4b3d-ae85-30bc8b234576?approved=1
+/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=docx
+/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=pdf
+/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=txt
+```
+
+Expected: no `Invalid job ID`; either a file download or the next legitimate auth/release/result response.

--- a/app/api/reports/[jobId]/download/route.ts
+++ b/app/api/reports/[jobId]/download/route.ts
@@ -12,7 +12,7 @@ import { Document, Packer, Paragraph, TextRun, HeadingLevel } from 'docx';
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type ExportFormat = 'pdf' | 'docx' | 'txt';
 type ExportableResult = EvaluationResultV1 | EvaluationResultV2;


### PR DESCRIPTION
## Summary

Fixes the report download endpoint rejecting valid evaluation job IDs.

The live failure shown on the Evaluation Report page was:

```json
{"error":"Invalid job ID"}
```

for a canonical UUID like:

```txt
3b7a549b-ea34-4b3d-ae85-30bc8b234576
```

## Root cause

`app/api/reports/[jobId]/download/route.ts` used a malformed UUID validator:

```ts
/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
```

That pattern is missing the fourth UUID group (`-[0-9a-f]{4}`), so every normal UUID with five groups was rejected before auth, ownership, release-gate, or format logic ran.

## Fix

Corrected the regex to the canonical UUID shape:

```ts
/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
```

This repairs every download button that routes through:

```txt
/api/reports/:jobId/download?format=pdf|docx|txt
```

including:

- Evaluation Report page `Download Report`
- Ledger `Save / Download`
- Any other current UI button using the shared report download route

## Verification target

After deploy, retest:

```txt
/evaluate/3b7a549b-ea34-4b3d-ae85-30bc8b234576?approved=1
/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=docx
/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=pdf
/api/reports/3b7a549b-ea34-4b3d-ae85-30bc8b234576/download?format=txt
```

Expected: no `Invalid job ID`; either a file download or the next legitimate auth/release/result response.