### PR TITLE
docs: add Story Ledger threat-force extraction doctrine

### DIFF
--- a/.github/pr-bodies/PR-668.md
+++ b/.github/pr-bodies/PR-668.md
@@ -1,0 +1,48 @@
+## Summary
+
+Adds a locked canon/training packet for the Story Ledger Layer 8 threat-force extraction miss surfaced by **The River Remembers Blood — Chapter 3**.
+
+This PR captures the lesson that RevisionGrade must extract **threat forces**, not only named-character antagonists. The failure case is the chapter where the true pressure system is the river + trespass/imbalance + missing man/truck + cultural/industrial encroachment, while a named-character antagonist-only extraction can miss the actual threat structure.
+
+## Adds
+
+- `docs/canon/THREAT_FORCE_EXTRACTION_LESSONS.md`
+  - Defines broadened Layer 8 doctrine
+  - Freezes the no-Layer-9 rule
+  - Documents `threat_forces` as a required substructure of `threat_antagonist_ending_layer`
+  - Defines expected threat-force vocabulary and failure codes
+  - Captures the River Remembers Blood fixture expectations
+
+- `scripts/pipeline/validate-threat-force-fixture.ts`
+  - Validates threat-force extraction artifacts
+  - Supports smoke output, Story Layer envelopes, raw Layer 8 objects, and Pass 1A chunk outputs
+  - Fails when required River Remembers Blood threat forces are missing
+  - Detects named-antagonist bias via `CHARACTER_ONLY_ANTAGONIST_BIAS`
+
+## Important scope note
+
+This PR makes the lesson durable in repo canon and provides the validator hook.
+
+It does **not** yet wire runtime extraction into Pass 1A. The follow-up implementation PR should:
+
+1. Add `threat_forces` to Pass 1A output.
+2. Preserve `threat_forces` in `runPass1a.ts`.
+3. Merge them into `CharacterLedgerV2.threatForceLedger`.
+4. Emit them from `buildStoryLayerFromLedger()` into `threat_antagonist_ending_layer_v2`.
+5. Add the River Remembers Blood regression fixture/test.
+
+## Non-goals
+
+- No DB migration
+- No UI change
+- No scoring change
+- No report renderer patch
+- No Layer 9
+- No model fine-tuning
+
+## Acceptance
+
+- Canon explicitly states that threat != named antagonist only.
+- Layer 8 doctrine includes non-character threat forces.
+- Validator can fail future artifacts that miss `river_judgment_force`, `trespass_imbalance`, or `missing_man_white_truck`.
+- Runtime behavior is unchanged until the follow-up implementation PR wires the validator into CI / Pass 1A artifacts.

--- a/docs/canon/THREAT_FORCE_EXTRACTION_LESSONS.md
+++ b/docs/canon/THREAT_FORCE_EXTRACTION_LESSONS.md
@@ -1,0 +1,311 @@
+# Threat Force Extraction Lessons — Story Ledger Layer 8
+
+**Status:** Canon addendum / training fixture doctrine  
+**Scope:** Phase 1A Story Ledger extraction, especially `threat_antagonist_ending_layer`  
+**Origin case:** `river_remembers_blood_ch3_threat_force_failure`  
+**Purpose:** Prevent future evaluations from treating threat as only a named-character antagonist.
+
+---
+
+## 1. Core lesson
+
+A Story Ledger threat is not limited to a named antagonist.
+
+A threat force is any person, animal, institution, environment, belief system, social pressure, mystery, deadline, psychological state, symbolic force, or unresolved consequence that creates:
+
+- danger
+- stakes
+- dread
+- escalation
+- narrative pressure
+- consequence
+- mystery
+- forward motion
+- ending instability
+
+The evaluation process must detect **what applies pressure**, not merely **who is the antagonist**.
+
+---
+
+## 2. Failure pattern
+
+The failed extraction pattern is:
+
+```ts
+named character with role_signal === "antagonist"
+```
+
+That pattern is insufficient because many literary, memoir, eco-thriller, speculative, historical, and Indigenous/place-based narratives use non-character pressure systems.
+
+Examples:
+
+- a river that judges or remembers
+- a mountain, storm, disease, fire, famine, or landscape
+- a police system, court, cartel, mine, church, school, government, or hospital
+- colonial pressure or industrial encroachment
+- cultural erasure
+- grief, shame, paranoia, addiction, trauma
+- a missing person or unresolved disappearance
+- social exclusion or non-belonging
+- animal/predator logic
+- spiritual or belief-based pressure
+- an ending where danger remains active
+
+If Phase 1A only extracts named antagonists, it will under-read threat-driven manuscripts.
+
+---
+
+## 3. Layer 8 canon
+
+`threat_antagonist_ending_layer` must include both:
+
+1. `named_antagonists`
+2. `threat_forces`
+
+This does **not** create Layer 9.
+
+Threat forces are a required substructure of Layer 8.
+
+Recommended Layer 8 shape:
+
+```ts
+threat_antagonist_ending_layer: {
+  schema_version: "threat_antagonist_ending_layer_v2";
+
+  named_antagonists: Array<NamedAntagonist>;
+  threat_forces: Array<ThreatForceLedgerEntry>;
+
+  pressure_map: {
+    primary_pressure: string | null;
+    secondary_pressures: string[];
+    false_leads: string[];
+    mirror_threats: string[];
+  };
+
+  ending_accountability: {
+    ending_state: "resolved" | "unresolved" | "escalated" | "ambiguous";
+    unresolved_threats: string[];
+    final_pressure_image: string | null;
+  };
+
+  extraction_quality: {
+    threat_force_count: number;
+    non_character_threat_count: number;
+    named_antagonist_count: number;
+    warnings: string[];
+  };
+}
+```
+
+---
+
+## 4. Threat force type contract
+
+```ts
+export type ThreatForceType =
+  | "named_character_antagonist"
+  | "environmental_force"
+  | "animal_predator_force"
+  | "institutional_force"
+  | "cultural_encroachment"
+  | "colonial_industrial_pressure"
+  | "supernatural_or_belief_force"
+  | "psychological_threat"
+  | "social_pressure"
+  | "time_deadline"
+  | "moral_spiritual_judgment"
+  | "unresolved_mystery"
+  | "existential_pressure";
+
+export type ThreatSignalType =
+  | "direct_threat_statement"
+  | "missing_person_or_disappearance"
+  | "environmental_anomaly"
+  | "animal_behavior_warning"
+  | "institutional_absence"
+  | "trespass_or_violation"
+  | "historical_precedent"
+  | "ending_threat_signal"
+  | "psychological_trigger"
+  | "social_or_cultural_pressure";
+
+export interface ThreatForceLedgerEntry {
+  threat_id: string;
+  display_name: string;
+  threat_type: ThreatForceType;
+  character_id: string | null;
+  object_id?: string | null;
+  location_id?: string | null;
+  pressure_function: string;
+  target_scope: "individual" | "family" | "community" | "land" | "culture" | "manuscript_global";
+  targets: string[];
+  first_detected_chunk: number;
+  last_detected_chunk: number;
+  escalation_state: "introduced" | "active" | "escalated" | "partially_resolved" | "resolved" | "unresolved";
+  evidence_anchors: Array<{
+    chunk_index: number;
+    excerpt: string;
+    signal_type: ThreatSignalType;
+    confidence: "explicit" | "strong_inference" | "weak_inference";
+  }>;
+  antagonist_function: "primary" | "secondary" | "mirror" | "false_lead" | "background_pressure" | "inciting_pressure";
+  ending_relevance: string;
+  extraction_confidence: "high" | "moderate" | "low";
+}
+```
+
+---
+
+## 5. Prompt doctrine
+
+Phase 1A must be instructed:
+
+```text
+Extract threat forces, not only antagonists.
+
+A threat force is anything that creates pressure, danger, stakes, dread, escalation,
+consequence, mystery, or forward motion.
+
+Threat forces may be:
+- named antagonists
+- unnamed groups or collectives
+- animals or predator systems
+- rivers, weather, fire, disease, hunger, isolation, geography
+- institutions such as police, cartel, courts, mines, churches, governments, hospitals, schools
+- cultural encroachment, colonial pressure, industrial intrusion, class pressure, racism, sexism, homophobia
+- spiritual, mythic, symbolic, or belief-based forces
+- trauma, paranoia, guilt, grief, shame, addiction
+- deadlines, disappearances, scarcity, exposure, pursuit, missing persons
+- unresolved mysteries or ending danger signals
+
+Do not require character_id.
+
+If the threat is not a character, emit character_id: null.
+```
+
+---
+
+## 6. River Remembers Blood — golden lesson
+
+The chapter-level failure case proved the need for this broadened extraction scope.
+
+Minimum acceptable extraction:
+
+```json
+{
+  "case_id": "river_remembers_blood_ch3_threat_force_failure",
+  "expected_minimum_threat_forces": [
+    {
+      "threat_id": "river_judgment_force",
+      "display_name": "The river",
+      "threat_type": "environmental_force",
+      "character_id": null,
+      "antagonist_function": "primary",
+      "required": true
+    },
+    {
+      "threat_id": "trespass_imbalance",
+      "display_name": "Trespass / imbalance",
+      "threat_type": "moral_spiritual_judgment",
+      "character_id": null,
+      "antagonist_function": "secondary",
+      "required": true
+    },
+    {
+      "threat_id": "missing_man_white_truck",
+      "display_name": "Missing man / vanished truck",
+      "threat_type": "unresolved_mystery",
+      "character_id": null,
+      "antagonist_function": "inciting_pressure",
+      "required": true
+    }
+  ],
+  "should_detect": [
+    "cultural_industrial_encroachment",
+    "pv115_shadow",
+    "predator_balance_logic",
+    "belonging_non_belonging",
+    "unresolved_ending_pressure"
+  ]
+}
+```
+
+Pass condition for this fixture:
+
+```text
+If Phase 1A extracts zero threats, it fails.
+
+If Phase 1A extracts only named or animal antagonists and misses the river,
+it fails.
+
+If Phase 1A extracts the river + trespass/imbalance + missing man/truck,
+it passes.
+
+If it also extracts cultural/industrial encroachment, predator mirror logic,
+PV115 as false lead, and unresolved ending pressure, it passes strongly.
+```
+
+---
+
+## 7. Failure codes
+
+Use these codes in validators, quality reports, or CI fixtures.
+
+| Code | Severity | Meaning |
+|---|---:|---|
+| `THREAT_FORCE_UNDEREXTRACTED` | hard fail | No threat forces were captured where pressure signals exist. |
+| `NON_CHARACTER_PRIMARY_THREAT_MISSING` | hard fail | The primary threat is non-character, but no non-character threat force was emitted. |
+| `CHARACTER_ONLY_ANTAGONIST_BIAS` | hard fail | Layer 8 only contains named antagonists even though environmental/institutional/thematic pressure is present. |
+| `THEMATIC_INSTITUTIONAL_PRESSURE_MISSING` | warning | Cultural, institutional, colonial, industrial, or social pressure was likely missed. |
+| `FALSE_LEAD_NOT_CLASSIFIED` | warning | A psychological or prior-threat residue was treated as absent or primary rather than false lead. |
+| `MIRROR_THREAT_MISCLASSIFIED` | warning | Animal/predator/ecological logic was not classified as mirror threat. |
+| `ENDING_PRESSURE_MISSING` | warning | Final unresolved danger or pressure image was not captured. |
+
+---
+
+## 8. Learning loop
+
+Do not treat this as fine-tuning first.
+
+The RevisionGrade learning loop is:
+
+1. Find an extraction miss.
+2. Name the failure.
+3. Write a golden fixture.
+4. Add a validator.
+5. Add a regression test or CI script.
+6. Update prompt doctrine only where extraction behavior needs guidance.
+7. Rerun the same chapter.
+8. Require proof that the same mistake cannot silently pass again.
+
+The system learns because the failure becomes non-repeatable.
+
+---
+
+## 9. Non-goals
+
+This doctrine does not require:
+
+- a new Story Ledger layer
+- UI changes
+- scoring changes
+- database migrations
+- model fine-tuning
+- rendering hacks
+- report-only patches
+
+This is a Phase 1A / Story Ledger extraction-contract improvement.
+
+---
+
+## 10. Acceptance criteria
+
+A future evaluation satisfies this broadened scope when:
+
+- `threat_antagonist_ending_layer.threat_forces` exists.
+- At least one non-character threat can be represented with `character_id: null`.
+- Environmental, institutional, thematic, psychological, animal/predator, and unresolved-mystery threats have valid `threat_type` values.
+- Named antagonists still work as before.
+- The River Remembers Blood fixture detects `river_judgment_force`.
+- Empty threat lists are blocked or warned when pressure signals are present.
+- Layer 8 exposes `pressure_map` and `extraction_quality`.

--- a/scripts/pipeline/validate-threat-force-fixture.ts
+++ b/scripts/pipeline/validate-threat-force-fixture.ts
@@ -1,0 +1,328 @@
+#!/usr/bin/env tsx
+/**
+ * validate-threat-force-fixture.ts
+ *
+ * Validates that a Pass 1A / Story Ledger artifact captures broadened threat scope:
+ * named antagonists AND non-character threat forces.
+ *
+ * Usage:
+ *   npx tsx scripts/pipeline/validate-threat-force-fixture.ts \
+ *     --artifact=artifacts/smoke-pass1a/example.json \
+ *     --case=river_remembers_blood_ch3
+ *
+ * Supported input shapes:
+ *   1. Smoke output containing characterLedgerV2.threatForceLedger
+ *   2. Story layer artifact containing story_layer.threat_antagonist_ending_layer.threat_forces
+ *   3. Raw layer object containing threat_forces
+ *   4. Pass 1A chunk output containing threat_forces
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+type Severity = "hard_fail" | "warn" | "pass";
+
+type ValidationIssue = {
+  code: string;
+  severity: Severity;
+  message: string;
+};
+
+type ThreatForce = {
+  threat_id?: string;
+  display_name?: string;
+  threat_type?: string;
+  character_id?: string | null;
+  antagonist_function?: string;
+  pressure_function?: string;
+  ending_relevance?: string;
+  evidence_anchors?: Array<{
+    excerpt?: string;
+    signal_type?: string;
+    confidence?: string;
+  }>;
+};
+
+type FixtureCase = {
+  caseId: string;
+  requiredThreatIds: string[];
+  requiredNonCharacterThreatIds: string[];
+  shouldDetectThreatIds: string[];
+  minimumThreatCount: number;
+};
+
+const CASES: Record<string, FixtureCase> = {
+  river_remembers_blood_ch3: {
+    caseId: "river_remembers_blood_ch3",
+    requiredThreatIds: [
+      "river_judgment_force",
+      "trespass_imbalance",
+      "missing_man_white_truck",
+    ],
+    requiredNonCharacterThreatIds: [
+      "river_judgment_force",
+      "trespass_imbalance",
+      "missing_man_white_truck",
+    ],
+    shouldDetectThreatIds: [
+      "cultural_industrial_encroachment",
+      "pv115_shadow",
+      "predator_balance_logic",
+      "belonging_non_belonging",
+      "unresolved_ending_pressure",
+    ],
+    minimumThreatCount: 3,
+  },
+};
+
+function getArg(name: string, fallback?: string): string | undefined {
+  const prefix = `--${name}=`;
+  const eq = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  if (eq) return eq.slice(prefix.length);
+
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx !== -1 && idx + 1 < process.argv.length) return process.argv[idx + 1];
+
+  return fallback;
+}
+
+function normalizeThreatId(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function readJson(path: string): unknown {
+  if (!existsSync(path)) {
+    throw new Error(`Artifact not found: ${path}`);
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function extractThreatForces(payload: unknown): ThreatForce[] {
+  const root = asRecord(payload);
+
+  const characterLedgerV2 = asRecord(root.characterLedgerV2);
+  const ledgerThreats = asArray(characterLedgerV2.threatForceLedger);
+  if (ledgerThreats.length > 0) return ledgerThreats as ThreatForce[];
+
+  const storyLayer = asRecord(root.story_layer);
+  const layerFromEnvelope = asRecord(storyLayer.threat_antagonist_ending_layer);
+  const envelopeThreats = asArray(layerFromEnvelope.threat_forces);
+  if (envelopeThreats.length > 0) return envelopeThreats as ThreatForce[];
+
+  const directLayer = asRecord(root.threat_antagonist_ending_layer);
+  const directLayerThreats = asArray(directLayer.threat_forces);
+  if (directLayerThreats.length > 0) return directLayerThreats as ThreatForce[];
+
+  const rawThreats = asArray(root.threat_forces);
+  if (rawThreats.length > 0) return rawThreats as ThreatForce[];
+
+  const chunks = asArray(root.chunkOutputs);
+  if (chunks.length > 0) {
+    return chunks.flatMap((chunk) => asArray(asRecord(chunk).threat_forces)) as ThreatForce[];
+  }
+
+  const pass1aResult = asRecord(root.pass1a_result);
+  const nestedChunks = asArray(pass1aResult.chunkOutputs);
+  if (nestedChunks.length > 0) {
+    return nestedChunks.flatMap((chunk) => asArray(asRecord(chunk).threat_forces)) as ThreatForce[];
+  }
+
+  return [];
+}
+
+function hasPressureSignals(payload: unknown): boolean {
+  const text = JSON.stringify(payload).toLowerCase();
+  const signalTerms = [
+    "missing",
+    "vanished",
+    "disappearance",
+    "threat",
+    "danger",
+    "pressure",
+    "judg",
+    "belong",
+    "river",
+    "coyote",
+    "predator",
+    "police",
+    "rcmp",
+    "institution",
+    "encroachment",
+    "industrial",
+    "colonial",
+    "trespass",
+    "poison",
+    "imbalance",
+    "ending",
+    "unresolved",
+  ];
+
+  return signalTerms.some((term) => text.includes(term));
+}
+
+function validateThreatForces(
+  payload: unknown,
+  threatForces: ThreatForce[],
+  fixture: FixtureCase,
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const ids = new Set(
+    threatForces.map((threat) => normalizeThreatId(threat.threat_id || threat.display_name)),
+  );
+
+  const nonCharacterIds = new Set(
+    threatForces
+      .filter((threat) => threat.character_id === null || threat.character_id === undefined)
+      .map((threat) => normalizeThreatId(threat.threat_id || threat.display_name)),
+  );
+
+  if (threatForces.length === 0) {
+    issues.push({
+      code: "THREAT_FORCE_UNDEREXTRACTED",
+      severity: hasPressureSignals(payload) ? "hard_fail" : "warn",
+      message:
+        "No threat forces were found. Layer 8 must capture pressure systems, not only named antagonists.",
+    });
+    return issues;
+  }
+
+  if (threatForces.length < fixture.minimumThreatCount) {
+    issues.push({
+      code: "THREAT_FORCE_COUNT_BELOW_MINIMUM",
+      severity: "hard_fail",
+      message: `Expected at least ${fixture.minimumThreatCount} threat forces, found ${threatForces.length}.`,
+    });
+  }
+
+  const nonCharacterThreats = threatForces.filter(
+    (threat) => threat.character_id === null || threat.character_id === undefined,
+  );
+
+  if (nonCharacterThreats.length === 0) {
+    issues.push({
+      code: "CHARACTER_ONLY_ANTAGONIST_BIAS",
+      severity: "hard_fail",
+      message:
+        "Threat list contains no non-character threat forces. This indicates named-antagonist bias.",
+    });
+  }
+
+  for (const required of fixture.requiredThreatIds) {
+    if (!ids.has(required)) {
+      issues.push({
+        code: "REQUIRED_THREAT_FORCE_MISSING",
+        severity: "hard_fail",
+        message: `Missing required threat force: ${required}`,
+      });
+    }
+  }
+
+  for (const requiredNonCharacter of fixture.requiredNonCharacterThreatIds) {
+    if (!nonCharacterIds.has(requiredNonCharacter)) {
+      issues.push({
+        code: "NON_CHARACTER_PRIMARY_THREAT_MISSING",
+        severity: "hard_fail",
+        message: `Required threat must be represented as non-character with character_id null/undefined: ${requiredNonCharacter}`,
+      });
+    }
+  }
+
+  for (const optional of fixture.shouldDetectThreatIds) {
+    if (!ids.has(optional)) {
+      issues.push({
+        code: "OPTIONAL_THREAT_FORCE_NOT_DETECTED",
+        severity: "warn",
+        message: `Should-detect threat force not found: ${optional}`,
+      });
+    }
+  }
+
+  for (const threat of threatForces) {
+    const id = normalizeThreatId(threat.threat_id || threat.display_name);
+
+    if (!threat.threat_type) {
+      issues.push({
+        code: "THREAT_TYPE_MISSING",
+        severity: "hard_fail",
+        message: `Threat ${id || "(unknown)"} is missing threat_type.`,
+      });
+    }
+
+    if (!threat.pressure_function || threat.pressure_function.trim().length < 20) {
+      issues.push({
+        code: "PRESSURE_FUNCTION_UNDERDESCRIBED",
+        severity: "warn",
+        message: `Threat ${id || "(unknown)"} has weak or missing pressure_function.`,
+      });
+    }
+
+    if (!Array.isArray(threat.evidence_anchors) || threat.evidence_anchors.length === 0) {
+      issues.push({
+        code: "THREAT_EVIDENCE_MISSING",
+        severity: "warn",
+        message: `Threat ${id || "(unknown)"} has no evidence anchors.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function main() {
+  const artifactPath = getArg("artifact");
+  const caseName = getArg("case", "river_remembers_blood_ch3");
+
+  if (!artifactPath) {
+    throw new Error(
+      "Missing --artifact path. Example: --artifact=artifacts/smoke-pass1a/example.json",
+    );
+  }
+
+  const fixture = CASES[caseName ?? ""];
+  if (!fixture) {
+    throw new Error(
+      `Unknown --case=${caseName}. Supported cases: ${Object.keys(CASES).join(", ")}`,
+    );
+  }
+
+  const payload = readJson(artifactPath);
+  const threatForces = extractThreatForces(payload);
+  const issues = validateThreatForces(payload, threatForces, fixture);
+
+  const hardFails = issues.filter((issue) => issue.severity === "hard_fail");
+  const warnings = issues.filter((issue) => issue.severity === "warn");
+
+  const summary = {
+    case_id: fixture.caseId,
+    artifact: artifactPath,
+    threat_force_count: threatForces.length,
+    non_character_threat_count: threatForces.filter(
+      (threat) => threat.character_id === null || threat.character_id === undefined,
+    ).length,
+    hard_fail_count: hardFails.length,
+    warning_count: warnings.length,
+    detected_threat_ids: threatForces.map((threat) =>
+      normalizeThreatId(threat.threat_id || threat.display_name),
+    ),
+    issues,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (hardFails.length > 0) {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a locked canon/training packet for the Story Ledger Layer 8 threat-force extraction miss surfaced by **The River Remembers Blood — Chapter 3**.

This PR captures the lesson that RevisionGrade must extract **threat forces**, not only named-character antagonists. The failure case is the chapter where the true pressure system is the river + trespass/imbalance + missing man/truck + cultural/industrial encroachment, while a named-character antagonist-only extraction can miss the actual threat structure.

## Adds

- `docs/canon/THREAT_FORCE_EXTRACTION_LESSONS.md`
  - Defines broadened Layer 8 doctrine
  - Freezes the no-Layer-9 rule
  - Documents `threat_forces` as a required substructure of `threat_antagonist_ending_layer`
  - Defines expected threat-force vocabulary and failure codes
  - Captures the River Remembers Blood fixture expectations

- `scripts/pipeline/validate-threat-force-fixture.ts`
  - Validates threat-force extraction artifacts
  - Supports smoke output, Story Layer envelopes, raw Layer 8 objects, and Pass 1A chunk outputs
  - Fails when required River Remembers Blood threat forces are missing
  - Detects named-antagonist bias via `CHARACTER_ONLY_ANTAGONIST_BIAS`

## Important scope note

This PR makes the lesson durable in repo canon and provides the validator hook.

It does **not** yet wire runtime extraction into Pass 1A. The follow-up implementation PR should:

1. Add `threat_forces` to Pass 1A output.
2. Preserve `threat_forces` in `runPass1a.ts`.
3. Merge them into `CharacterLedgerV2.threatForceLedger`.
4. Emit them from `buildStoryLayerFromLedger()` into `threat_antagonist_ending_layer_v2`.
5. Add the River Remembers Blood regression fixture/test.

## Non-goals

- No DB migration
- No UI change
- No scoring change
- No report renderer patch
- No Layer 9
- No model fine-tuning

## Acceptance

- Canon explicitly states that threat != named antagonist only.
- Layer 8 doctrine includes non-character threat forces.
- Validator can fail future artifacts that miss `river_judgment_force`, `trespass_imbalance`, or `missing_man_white_truck`.
- Runtime behavior is unchanged until the follow-up implementation PR wires the validator into CI / Pass 1A artifacts.