### PR TITLE
Harden public scope and evaluation-mode doctrine

### DIFF
--- a/.github/pr-bodies/PR-670.md
+++ b/.github/pr-bodies/PR-670.md
@@ -1,0 +1,18 @@
+## Summary
+
+Updates the public website copy to match the current manuscript-first RevisionGrade scope.
+
+## Changes
+
+- Homepage copy and CTAs tightened.
+- Resources page changed from placeholder FAQ to a hub plus Author FAQ.
+- Methodology expanded with short-form, long-form, and long-form multi-layer evaluation modes.
+- Reliability expanded with manuscript sovereignty, scope discipline, diagnosis-before-polish, and author control.
+- Pricing aligned with evaluation modes and manuscript audit tiers.
+- Storygate overview reframed as controlled manuscript discovery for publishing professionals.
+
+## Notes
+
+No backend logic, database, or archived canon files changed.
+
+Storygate apply page still needs a follow-up pass.

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -1,11 +1,19 @@
 import Link from "next/link";
 
 const methods = [
-  { title: "Criteria-led reading", copy: "The manuscript is read through a stable set of literary criteria so feedback is not a random chat response." },
-  { title: "Evidence before verdict", copy: "Findings should be traceable to the manuscript and explained in terms the author can understand." },
+  { title: "Criteria-led reading", copy: "The manuscript is read through stable editorial criteria so feedback is not a random chat response or a matter of taste alone." },
+  { title: "Evidence before verdict", copy: "Major findings should be traceable to the submitted pages and explained in terms the author can act on." },
   { title: "Long-form continuity", copy: "Novel-length work requires attention to recurrence, payoff, pacing, character behavior, and cumulative reader experience." },
   { title: "Revision restraint", copy: "A recommendation is not automatically an instruction to rewrite. Some passages should be protected, not compressed." },
 ];
+
+const modes = [
+  { title: "Short-Form Evaluation", range: "Under 25,000 words", copy: "Evaluates the submitted pages against the 13 story criteria only. Designed for openings, chapters, excerpts, short stories, and shorter works where full manuscript continuity cannot yet be judged." },
+  { title: "Long-Form Evaluation", range: "25,000+ words", copy: "Adds manuscript-scale analysis: continuity, recurrence, setup/payoff, pacing over distance, character behavior, structural readiness, and cumulative reader experience." },
+  { title: "Long-Form Multi-Layer Evaluation", range: "Complex long-form manuscripts", copy: "A deeper architecture audit for manuscripts that need layered story ledgers, Golden Spine/WAVE governance, long-form canon/gates, dialogue and speech protection, and deeper continuity analysis." },
+];
+
+const criteria = ["Concept", "Narrative Drive", "Character", "Voice", "Scene Construction", "Dialogue", "Theme", "Worldbuilding", "Pacing", "Prose Control", "Tone", "Narrative Closure", "Marketability"];
 
 export default function MethodologyPage() {
   return (
@@ -13,11 +21,31 @@ export default function MethodologyPage() {
       <section className="mx-auto max-w-7xl px-6 py-20">
         <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Methodology</p>
         <h1 className="mt-6 max-w-5xl font-rg-serif text-5xl leading-tight md:text-6xl">How RevisionGrade thinks about manuscripts.</h1>
-        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">This public methodology route explains the editorial model at a useful level without exposing proprietary implementation internals.</p>
+        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">RevisionGrade evaluates manuscripts through stable criteria, evidence-backed diagnosis, and revision restraint. The goal is not generic feedback. The goal is to identify what the manuscript asks the reader to believe, where that trust holds, and where it breaks.</p>
         <div className="mt-12 grid gap-5 md:grid-cols-2">
           {methods.map((item) => <article key={item.title} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6"><h2 className="font-rg-serif text-3xl">{item.title}</h2><p className="mt-4 leading-7 text-rg-cream2/75">{item.copy}</p></article>)}
         </div>
-        <div className="mt-12 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/reliability" className="text-rg-gold hover:text-rg-cream">Reliability →</Link><Link href="/resources" className="text-rg-gold hover:text-rg-cream">Resources →</Link><Link href="/evaluate" className="text-rg-gold hover:text-rg-cream">Evaluate →</Link></div>
+      </section>
+
+      <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
+        <div className="mx-auto max-w-7xl px-6 py-20">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Evaluation Modes</p>
+          <h2 className="mt-4 max-w-4xl font-rg-serif text-4xl leading-tight md:text-5xl">Different manuscript lengths require different diagnostic depth.</h2>
+          <div className="mt-10 grid gap-5 md:grid-cols-3">
+            {modes.map((mode) => <article key={mode.title} className="border border-rg-cream2/12 bg-rg-ink/60 p-6"><p className="font-rg-mono text-[0.68rem] uppercase tracking-[0.18em] text-rg-gold">{mode.range}</p><h3 className="mt-3 font-rg-serif text-2xl text-rg-cream">{mode.title}</h3><p className="mt-4 text-sm leading-7 text-rg-cream2/75">{mode.copy}</p></article>)}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-rg-cream text-rg-ink">
+        <div className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.9fr_1.1fr]">
+          <div><p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Thirteen Story Criteria</p><h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">The core evaluation language stays stable.</h2></div>
+          <div className="grid gap-2 sm:grid-cols-2">{criteria.map((item) => <div key={item} className="border border-rg-ink/15 bg-white/45 px-4 py-3 font-rg-mono text-[0.68rem] uppercase tracking-[0.12em] text-rg-ink/80">{item}</div>)}</div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-20">
+        <div className="border border-rg-gold/35 bg-rg-ink2/60 p-8"><h2 className="font-rg-serif text-4xl">From diagnosis to governed revision.</h2><p className="mt-5 max-w-3xl leading-8 text-rg-cream2/75">Evaluation identifies the weakness. Revise turns the weakness into a governed repair opportunity: evidence, diagnosis, options, voice risk, and explicit author decision.</p><div className="mt-7 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/reliability" className="text-rg-gold hover:text-rg-cream">Reliability →</Link><Link href="/revise" className="text-rg-gold hover:text-rg-cream">Revise →</Link><Link href="/evaluate" className="text-rg-gold hover:text-rg-cream">Evaluate →</Link></div></div>
       </section>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,8 +25,8 @@ const workflow = [
   },
   {
     step: "02",
-    title: "Evaluate against the canon",
-    copy: "The system scores the manuscript through a governed set of literary criteria, surfacing evidence instead of generic praise or vague warnings.",
+    title: "Evaluate at the right depth",
+    copy: "Short-form uses the 13 story criteria. Long-form adds manuscript-scale continuity. Multi-layer audits add deeper architecture and governance where appropriate.",
   },
   {
     step: "03",
@@ -47,11 +47,11 @@ const workflow = [
 
 const proofPoints = [
   "Evidence-linked findings",
-  "Long-form routing for manuscripts over 25,000 words",
+  "Short-form / long-form / multi-layer evaluation modes",
   "Separate Evaluate and Revise surfaces",
   "Queue-based repair model",
-  "Trust pages as first-class routes",
-  "Shared header, footer, and auth shell",
+  "TrustedPath™ governed automation",
+  "Author-controlled revision decisions",
 ];
 
 function SectionLabel({ children }: { children: ReactNode }) {
@@ -72,18 +72,18 @@ export default function Home() {
             A governed revision operating system for serious manuscripts.
           </h1>
           <p className="mt-8 max-w-2xl text-lg leading-8 text-rg-cream2/85">
-            RevisionGrade is built for authors who need more than encouragement. It evaluates the manuscript, explains the editorial diagnosis, and turns weaknesses into a governed revision path without erasing the writer's voice.
+            RevisionGrade evaluates your manuscript across 13 story criteria, explains the editorial diagnosis with evidence, and turns weaknesses into a controlled revision path without erasing the writer&apos;s voice.
           </p>
           <div className="mt-10 flex flex-wrap gap-4">
-            <Link href="/evaluate" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">Open Evaluate</Link>
-            <Link href="/revise" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">See Revise Layer</Link>
+            <Link href="/evaluate" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">Begin Evaluation</Link>
+            <Link href="/revise" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">See Revision Workbench</Link>
           </div>
         </div>
         <div className="border border-rg-cream2/15 bg-rg-ink2/70 p-6 shadow-2xl shadow-black/30">
           <div className="border border-rg-gold/30 p-6">
-            <SectionLabel>Evaluation canon</SectionLabel>
-            <h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Two canons. One coherent grade.</h2>
-            <p className="mt-4 text-sm leading-7 text-rg-cream2/75">The public surface gives authors a clear product promise while the governed engine keeps criteria, evidence, and repair decisions aligned.</p>
+            <SectionLabel>Manuscript readiness system</SectionLabel>
+            <h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Thirteen dimensions. One governed diagnosis.</h2>
+            <p className="mt-4 text-sm leading-7 text-rg-cream2/75">Every score is tied to evidence, editorial criteria, and a revision path the author controls.</p>
             <div className="mt-6 grid grid-cols-1 gap-2 sm:grid-cols-2">
               {criteria.map((criterion) => <div key={criterion} className="border border-rg-cream2/10 px-3 py-2 font-rg-mono text-[0.68rem] uppercase tracking-[0.12em] text-rg-cream2/80">{criterion}</div>)}
             </div>
@@ -93,7 +93,7 @@ export default function Home() {
       <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
         <div className="mx-auto grid max-w-7xl gap-8 px-6 py-16 md:grid-cols-3">
           <div><SectionLabel>The instrument</SectionLabel><h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Author-facing diagnosis.</h2><p className="mt-4 leading-7 text-rg-cream2/75">The report is the visible editorial instrument: scores, evidence, confidence, warnings, and revision priorities presented in language an author can act on.</p></div>
-          <div><SectionLabel>The engine</SectionLabel><h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Governed execution.</h2><p className="mt-4 leading-7 text-rg-cream2/75">The pipeline exists to keep long-form evaluation, criteria coverage, failure states, and repair handoff deterministic enough to trust.</p></div>
+          <div><SectionLabel>The engine</SectionLabel><h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Governed execution.</h2><p className="mt-4 leading-7 text-rg-cream2/75">The pipeline exists to keep evaluation depth, criteria coverage, failure states, and repair handoff deterministic enough to trust.</p></div>
           <div><SectionLabel>The methodology</SectionLabel><h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Readable trust layer.</h2><p className="mt-4 leading-7 text-rg-cream2/75">The public methodology explains what RevisionGrade evaluates and why, without exposing private prompt internals or weakening the moat.</p></div>
         </div>
       </section>
@@ -111,12 +111,11 @@ export default function Home() {
       </section>
       <section className="mx-auto max-w-7xl px-6 py-20">
         <div className="grid gap-8 lg:grid-cols-[1fr_1fr]">
-          <div className="border border-rg-cream2/12 bg-rg-ink2/60 p-8"><SectionLabel>Trust surface</SectionLabel><h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Reliability is not a footer link. It is part of the product promise.</h2><p className="mt-5 leading-7 text-rg-cream2/75">The Reliability page now has to exist as a real route, because your buyers need to understand why the system can be trusted before they upload a manuscript.</p><Link href="/reliability" className="mt-7 inline-block font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Read reliability doctrine →</Link></div>
-          <div className="border border-rg-cream2/12 bg-rg-ink2/60 p-8"><SectionLabel>Conversion surface</SectionLabel><h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Pricing and resources must be routes, not dead anchors.</h2><p className="mt-5 leading-7 text-rg-cream2/75">Every public navigation destination should be shareable, crawlable, and inside the same app shell as Evaluate and Revise.</p><div className="mt-7 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/pricing" className="text-rg-gold hover:text-rg-cream">Pricing →</Link><Link href="/resources" className="text-rg-gold hover:text-rg-cream">Resources →</Link></div></div>
+          <div className="border border-rg-cream2/12 bg-rg-ink2/60 p-8"><SectionLabel>Trust surface</SectionLabel><h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Reliability is not a footer link. It is part of the product promise.</h2><p className="mt-5 leading-7 text-rg-cream2/75">The Reliability page explains manuscript sovereignty, evidence-backed diagnosis, scope discipline, and author control before a writer uploads a manuscript.</p><Link href="/reliability" className="mt-7 inline-block font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Read reliability doctrine →</Link></div>
+          <div className="border border-rg-cream2/12 bg-rg-ink2/60 p-8"><SectionLabel>Conversion surface</SectionLabel><h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Pricing and resources must clarify the path.</h2><p className="mt-5 leading-7 text-rg-cream2/75">Every public navigation destination should explain the manuscript-first workflow: Evaluate, Revise, Agent Readiness, and controlled Storygate access where eligible.</p><div className="mt-7 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/pricing" className="text-rg-gold hover:text-rg-cream">Pricing →</Link><Link href="/resources" className="text-rg-gold hover:text-rg-cream">Resources →</Link></div></div>
         </div>
       </section>
 
-      {/* ── AGENT READINESS PACKAGE™ ────────────────────────────────── */}
       <section className="border-t border-rg-cream2/10 bg-rg-ink2/50">
         <div className="mx-auto max-w-7xl px-6 py-20">
           <div className="grid gap-12 lg:grid-cols-[1fr_1fr] items-start">
@@ -126,7 +125,7 @@ export default function Home() {
                 One manuscript. One professional submission package.
               </h2>
               <p className="mt-6 text-base leading-7 text-rg-cream2/75">
-                Generate your query letter, synopsis, elevator pitch, comparables, market positioning, and author bio — then approve each section before export. Built for authors who are ready to submit, not authors who are still drafting.
+                Generate your query letter, synopsis, query pitch, comparables, manuscript positioning, and author bio — then approve each section before export. Built for authors who are ready to submit, not authors who are still drafting.
               </p>
               <div className="mt-8 flex flex-wrap gap-4">
                 <Link href="/agent-readiness" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
@@ -141,7 +140,7 @@ export default function Home() {
               {[
                 ["01", "Query Letter", "Hook, metadata, comparables, differentiator, and bio. 450-word hard cap."],
                 ["02", "Synopsis", "Query (100–150 words), standard (250–500), or extended (700–1,000)."],
-                ["03", "Elevator Pitch", "One sentence. Suitable for query forms, verbal pitching, and metadata."],
+                ["03", "Query Pitch", "One sentence and paragraph versions for manuscript submission materials."],
                 ["04", "Comparables & Positioning", "2–4 comps with rationale and Agent Appeal Brief."],
                 ["05", "Author Bio", "Third-person, professional. Author-supplied credentials only."],
                 ["06", "Package History / Export", "Approve all sections, then export as DOCX or copy."],
@@ -166,17 +165,16 @@ export default function Home() {
         </div>
       </section>
 
-      {/* ── STORYGATE STUDIO™ ─────────────────────────────────────── */}
       <section className="border-t border-rg-cream2/10">
         <div className="mx-auto max-w-7xl px-6 py-20">
           <div className="grid gap-12 lg:grid-cols-[1fr_1fr] items-start">
             <div>
               <SectionLabel>Storygate Studio™</SectionLabel>
               <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
-                A curated access layer for readiness-vetted projects.
+                A curated access layer for readiness-vetted manuscript projects.
               </h2>
               <p className="mt-6 text-base leading-7 text-rg-cream2/75">
-                Projects that clear the 8.0 readiness threshold can enter Storygate Studio — a controlled environment where verified industry professionals request access to specific manuscripts, screenplays, and adaptation packages.
+                Manuscript projects that clear the readiness threshold can enter Storygate Studio — a controlled environment where verified publishing professionals request access to creator-approved materials.
               </p>
               <p className="mt-3 text-sm leading-7 text-rg-cream2/60">
                 No public marketplace. No cold outreach. Access is requested, approved by the creator, and logged.
@@ -186,13 +184,13 @@ export default function Home() {
                   Learn About Storygate
                 </Link>
                 <Link href="/storygate-studio/industry" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">
-                  Industry Access
+                  Publishing Access
                 </Link>
               </div>
             </div>
             <div className="grid gap-3">
               {[
-                ["Verified Access Only",       "Industry users are approved before viewing any project materials."],
+                ["Verified Access Only",       "Publishing users are approved before viewing any project materials."],
                 ["Creator-Controlled Visibility", "Creators decide what is visible and to whom. Access requires their approval."],
                 ["8.0+ Readiness Gate",        "Projects must clear a minimum readiness threshold before eligibility."],
                 ["Logged Activity",             "All access events are recorded and append-only. No anonymous actions."],

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -12,41 +12,41 @@ const auditTiers = [
     wordCount: "Up to 3,000 words",
     price: "$0",
     actionAccess: "Readiness preview",
-    bestFor: "Testing hook, voice, and narrative pressure.",
-    features: ["Opening hook", "Voice signal", "Readiness preview", "Long-form diagnostics not included"],
+    bestFor: "Testing hook, voice, and opening-page narrative pressure.",
+    features: ["Opening hook", "Voice signal", "Readiness preview", "Full-manuscript diagnostics not included"],
   },
   {
-    name: "Short-Form Evaluation",
+    name: "Short-Form Story Evaluation",
     wordCount: "Up to 24,999 words",
     price: "$49",
-    actionAccess: "Starter Editorial Actions",
-    bestFor: "Novellas, short stories, and early concept tests.",
-    features: ["Core story diagnostics", "Readiness verdict", "Editorial path preview", "Advanced diagnostics not included"],
+    actionAccess: "13 story criteria only",
+    bestFor: "Chapters, excerpts, short stories, openings, and partial submissions.",
+    features: ["13 story criteria", "Evidence-backed diagnosis", "Readiness verdict", "Golden Spine/WAVE not included"],
   },
   {
     name: "Full Manuscript Readiness Audit",
     wordCount: "25,000–120,000 words",
     price: "$249",
-    actionAccess: "Included Editorial Actions",
+    actionAccess: "Long-form evaluation",
     bestFor: "The Professional Standard for novels and long-form manuscripts.",
-    features: ["Core story diagnostics", "Long-form structural diagnostics", "Readiness diagnosis", "Long-form threshold diagnostics"],
+    features: ["13 story criteria", "Manuscript-scale continuity", "Readiness diagnosis", "Setup/payoff and pacing over distance"],
     highlighted: true,
   },
   {
     name: "Long Manuscript Readiness Audit",
     wordCount: "120,001–180,000 words",
     price: "$399",
-    actionAccess: "Expanded Editorial Actions",
+    actionAccess: "Expanded long-form evaluation",
     bestFor: "Epic-scale manuscripts and longer novels.",
-    features: ["Core story diagnostics", "Advanced continuity diagnostics", "Expanded long-form diagnostics", "Scale-aware opportunity summary"],
+    features: ["13 story criteria", "Advanced continuity diagnostics", "Expanded long-form analysis", "Scale-aware opportunity summary"],
   },
   {
-    name: "Complex Narrative Audit",
-    wordCount: "180,001+ words",
+    name: "Multi-Layer Manuscript Audit",
+    wordCount: "Complex long-form projects",
     price: "$499+",
-    actionAccess: "Priority Editorial Actions",
-    bestFor: "Multi-layer, transmedia, or franchise-scale work.",
-    features: ["Core story diagnostics", "Long-range readiness analysis", "Multi-POV architecture review", "Custom complexity handling"],
+    actionAccess: "Deep architecture audit",
+    bestFor: "Multi-POV, multi-timeline, genre-hybrid, experimental, memoir-fiction, or unusually structured long-form prose.",
+    features: ["13 story criteria", "Layered story-ledger analysis", "Golden Spine/WAVE where appropriate", "Custom complexity handling"],
   },
 ];
 
@@ -63,24 +63,24 @@ const faqs = [
       "An audit is the fixed-price diagnostic: it reveals the manuscript’s readiness profile, including strengths, priority signals, and the kind of editorial support the work may benefit from next. Editorial Actions unlock and repair specific opportunities through granular opportunity cards and governed repair proposals.",
   },
   {
-    question: "When do advanced long-form diagnostics apply?",
+    question: "When do long-form diagnostics apply?",
     answer:
-      "Advanced long-form diagnostics apply when long-range structural and continuity diagnostics are needed. They are designed for complex long-form readiness work where cumulative reader experience and payoff architecture matter most.",
+      "Short-form evaluations apply under 25,000 words and use the 13 story criteria only. Long-form evaluation begins at 25,000+ words, where manuscript-scale continuity, recurrence, payoff, pacing over distance, and structural readiness can be judged.",
   },
   {
-    question: "Can I see every granular opportunity after an audit?",
+    question: "When does multi-layer analysis apply?",
     answer:
-      "Every paid audit includes a readiness diagnosis and opportunity summary. Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions available with your audit tier or in packs.",
+      "Long-form multi-layer evaluation is the deeper architecture tier for complex manuscripts. It may include layered story ledgers, Golden Spine/WAVE governance, long-form canon/gates, dialogue and speech protection, and deeper continuity logic where appropriate.",
   },
   {
     question: "Why not offer unlimited revisions?",
     answer:
-      "Revision work is variable. Some manuscripts need only a few targeted refinements, while others benefit from deeper staged repair. Fixed-price unlimited revision would dilute the audit standard and encourage low-value generation instead of focused, high-impact revision work.",
+      "Unlimited revision encourages vague rewriting. RevisionGrade uses scoped repair opportunities so each change is tied to evidence, rationale, and author approval.",
   },
   {
     question: "Is RevisionGrade replacing human editors?",
     answer:
-      "No. RevisionGrade helps you understand what kind of editorial help your manuscript may benefit from before you spend money on professional human intervention: developmental editing, line editing, copyediting, proofreading, market positioning, or deeper structural repair.",
+      "No. RevisionGrade helps you understand what kind of editorial help your manuscript may benefit from before you spend money on the wrong intervention: developmental editing, line editing, copyediting, proofreading, market positioning, or deeper structural repair.",
   },
 ];
 
@@ -117,7 +117,7 @@ export default function PricingPage() {
               </h2>
             </div>
             <p className="max-w-xl text-sm leading-7 text-rg-cream2/70">
-              The Full Manuscript Readiness Audit is the professional standard for long-form authors preparing a serious manuscript for revision, editing, or submission.
+              The Full Manuscript Readiness Audit is the professional baseline for authors preparing a serious manuscript for revision, editing, querying, or submission.
             </p>
           </div>
 
@@ -198,18 +198,18 @@ export default function PricingPage() {
           <div>
             <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">A Note on Editorial Readiness</p>
             <h2 className="mt-4 font-rg-serif text-3xl leading-tight sm:text-4xl md:text-5xl">
-              RevisionGrade™ is not a writing tool.
+              RevisionGrade™ is not a blank-page writing tool.
             </h2>
           </div>
           <div className="space-y-5 text-base leading-8 text-rg-ink/75 sm:text-lg">
             <p>
-              It is an editorial audit system. Each paid audit provides a structural diagnosis of your manuscript’s readiness: where the story is already working, where readiness can be improved, and what kind of editorial support may help next.
+              It is a manuscript readiness and repair system for work that already exists. Each paid audit provides a structural diagnosis: where the story is already working, where readiness can be improved, and what kind of editorial support may help next.
             </p>
             <p>
-              Granular Opportunity Cards and governed repair proposals are unlocked through Editorial Actions available with your audit tier or in packs.
+              Do not buy sentence polish for a structural problem. RevisionGrade diagnoses the level of intervention before you spend money on the wrong one.
             </p>
             <p className="font-rg-serif text-2xl leading-tight text-rg-ink sm:text-3xl">
-              Before you pay for polish, diagnose readiness.
+              Structural problems need structural diagnosis. Polish comes later.
             </p>
           </div>
         </div>

--- a/app/reliability/page.tsx
+++ b/app/reliability/page.tsx
@@ -1,16 +1,26 @@
 import Link from "next/link";
 
 const pillars = [
-  { title: "Manuscript Sovereignty", copy: "Customer manuscripts, audit outputs, and revision history are not used as model-training material." },
-  { title: "Governed Structural Logic", copy: "RevisionGrade is not a style-imitation system. It evaluates through the 13 Story Criteria, WAVE Revision System logic, manuscript evidence, and readiness-focused editorial reasoning." },
-  { title: "Author-in-the-Loop", copy: "The author is the only human in the editorial decision loop. RevisionGrade provides evidence and repair pathways; the author decides what belongs in the manuscript." },
+  { title: "Manuscript Sovereignty", copy: "Your manuscript remains your creative property. RevisionGrade evaluates submitted text to produce editorial diagnosis and revision options; it does not claim authorship or replace the writer’s judgment." },
+  { title: "Evidence Before Authority", copy: "Findings should be traceable to the manuscript. A score or recommendation is not useful unless it is tied to evidence, severity, and reader effect." },
+  { title: "Author-in-the-Loop", copy: "No proposed repair becomes final authorial text without author choice. The author may accept, reject, defer, keep original, or write a custom revision." },
+  { title: "Scope Discipline", copy: "RevisionGrade distinguishes structural diagnosis, scene repair, line polish, market positioning, and voice protection before recommending intervention." },
 ];
 
 const guarantees = [
   "Your manuscript remains your intellectual property.",
-  "Your work is evaluated as a private creative project, not as training material.",
-  "Your manuscript is not routed to anonymous human editors as part of the audit.",
+  "Your work is evaluated as private creative work, not as public material.",
+  "Your manuscript is not routed to anonymous human editors as part of the standard audit.",
   "Evidence, not authority: RevisionGrade provides diagnostics, but you hold the pen.",
+  "Diagnosis before polish: structural problems should not be treated as sentence-cleanup projects.",
+  "AI is an instrument, not an authority. Final creative control remains with the author.",
+];
+
+const limits = [
+  "RevisionGrade does not guarantee representation, publication, sales, or market demand.",
+  "RevisionGrade does not rewrite by default or override author judgment.",
+  "RevisionGrade does not treat smoother prose as automatically better prose.",
+  "RevisionGrade does not pretend every manuscript needs the same level of intervention.",
 ];
 
 export default function ReliabilityPage() {
@@ -18,19 +28,35 @@ export default function ReliabilityPage() {
     <div className="bg-rg-ink text-rg-cream">
       <section className="mx-auto max-w-7xl px-6 py-20">
         <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Reliability</p>
-        <h1 className="mt-6 max-w-5xl font-rg-serif text-5xl leading-tight md:text-6xl">Trust means manuscript sovereignty, structural evidence, and author control.</h1>
-        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">RevisionGrade is a governed manuscript readiness audit system. It is not a remote human-editing service, not an autonomous writing assistant, and not a style-imitation system trained to mimic other authors’ prose.</p>
-        <div className="mt-12 grid gap-5 md:grid-cols-3">
+        <h1 className="mt-6 max-w-5xl font-rg-serif text-5xl leading-tight md:text-6xl">Trust means evidence, restraint, and author control.</h1>
+        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">RevisionGrade is a governed manuscript readiness system. It is not a remote human-editing service, not an autonomous writing assistant, and not a style-imitation system trained to flatten other authors’ prose.</p>
+        <p className="mt-5 max-w-3xl text-lg leading-8 text-rg-cream2/75">The problem is not human editing. The problem is ungoverned editing: feedback without stable criteria, polish before diagnosis, and revision without clear author control.</p>
+        <div className="mt-12 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
           {pillars.map((pillar) => <article key={pillar.title} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6"><h2 className="font-rg-serif text-3xl text-rg-cream">{pillar.title}</h2><p className="mt-4 leading-7 text-rg-cream2/75">{pillar.copy}</p></article>)}
         </div>
       </section>
+
       <section className="bg-rg-cream text-rg-ink">
         <div className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.9fr_1.1fr]">
           <div><p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Author authority</p><h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">Evidence, not authority. Proposals, not control.</h2></div>
           <div className="grid gap-3 sm:grid-cols-2">{guarantees.map((item) => <div key={item} className="border border-rg-ink/15 bg-white/40 p-4 text-sm leading-7 text-rg-ink/75">{item}</div>)}</div>
         </div>
       </section>
-      <section className="mx-auto max-w-7xl px-6 py-20"><div className="border border-rg-gold/35 bg-rg-ink2/60 p-8"><h2 className="font-rg-serif text-4xl">Reliability connects to methodology.</h2><p className="mt-5 max-w-3xl leading-8 text-rg-cream2/75">Methodology explains what the system evaluates. Reliability explains why authors can trust the process: manuscript sovereignty, structural logic, evidence-bound diagnostics, and final creative authority reserved for the author.</p><Link href="/methodology" className="mt-7 inline-block font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Read methodology →</Link></div></section>
+
+      <section className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.9fr_1.1fr]">
+        <div><p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">What reliability means in practice</p><h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">The system must know the level of intervention before asking the writer to change the work.</h2></div>
+        <div className="space-y-5 text-lg leading-8 text-rg-cream2/80"><p>A manuscript that needs structural repair should not receive only surface polish. A scene that needs pressure should not be smoothed until it loses force. A voice that is unusual should not be normalized merely because it is unusual.</p><p>RevisionGrade’s reliability doctrine is simple: diagnose first, rank the problem, protect the author’s voice, and leave the decision with the author.</p></div>
+      </section>
+
+      <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
+        <div className="mx-auto max-w-7xl px-6 py-20">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Boundaries</p>
+          <h2 className="mt-4 max-w-4xl font-rg-serif text-4xl leading-tight md:text-5xl">What RevisionGrade will not pretend to know.</h2>
+          <div className="mt-10 grid gap-4 md:grid-cols-2">{limits.map((item) => <div key={item} className="border border-rg-cream2/12 bg-rg-ink/60 p-5 leading-7 text-rg-cream2/80">{item}</div>)}</div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-20"><div className="border border-rg-gold/35 bg-rg-ink2/60 p-8"><h2 className="font-rg-serif text-4xl">Reliability connects to methodology and Revise.</h2><p className="mt-5 max-w-3xl leading-8 text-rg-cream2/75">Methodology explains how the system reads. Reliability explains why the author remains protected. Revise turns findings into controlled repair decisions instead of blind rewriting.</p><div className="mt-7 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/methodology" className="text-rg-gold hover:text-rg-cream">Read methodology →</Link><Link href="/revise" className="text-rg-gold hover:text-rg-cream">See Revise →</Link></div></div></section>
     </div>
   );
 }

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,25 +1,114 @@
 import Link from "next/link";
 
+const resourceCards = [
+  {
+    title: "The Black Box Problem",
+    href: "/black-box-problem",
+    copy: "Why writers need diagnosis before submission: publishing gives verdicts, not explanations.",
+  },
+  {
+    title: "Methodology",
+    href: "/methodology",
+    copy: "How RevisionGrade evaluates manuscripts through criteria, evidence, evaluation depth, and revision restraint.",
+  },
+  {
+    title: "Reliability / Editorial Doctrine",
+    href: "/reliability",
+    copy: "Why author control, manuscript sovereignty, evidence, and scope discipline are built into the process.",
+  },
+  {
+    title: "Pricing Doctrine",
+    href: "/pricing",
+    copy: "Fixed-price readiness audit first. Metered, governed repair only after the diagnosis is clear.",
+  },
+  {
+    title: "Agent Readiness™",
+    href: "/agent-readiness",
+    copy: "Build manuscript submission materials: query letter, synopsis, query pitch, comparables, and author bio.",
+  },
+  {
+    title: "Storygate Studio™",
+    href: "/storygate-studio",
+    copy: "Controlled manuscript discovery for readiness-vetted projects and verified publishing professionals.",
+  },
+];
+
 const faqs = [
-  { q: "What does RevisionGrade evaluate?", a: "RevisionGrade evaluates manuscript-level craft and market readiness across thirteen literary criteria, including concept, narrative drive, character, voice, dialogue, pacing, prose control, and marketability." },
-  { q: "Is this only a score?", a: "No. The score is only useful when it is connected to evidence, confidence, and revision priorities. The product goal is diagnosis plus a path to repair." },
-  { q: "What happens after evaluation?", a: "Findings should become a queue of revision opportunities. That queue is the bridge between Evaluate and Revise." },
-  { q: "Does the system rewrite my voice?", a: "The Revise layer is framed around voice protection. Zero compression is a valid outcome when a passage should be preserved." },
-  { q: "Why does long-form fiction need special handling?", a: "A novel is not a bundle of isolated pages. Character continuity, pacing, theme, scene function, and payoff depend on long-range context." },
-  { q: "Who can use RevisionGrade?", a: "Any author with a manuscript. Sign in and open Evaluate to begin. Protected routes require an account; public pages are open." },
+  {
+    q: "What does RevisionGrade evaluate?",
+    a: "RevisionGrade evaluates manuscript-level craft, structure, reader trust, and readiness across thirteen story criteria. Longer manuscripts may also qualify for long-form or multi-layer analysis.",
+  },
+  {
+    q: "Is this only a score?",
+    a: "No. A score is only useful when connected to evidence, confidence, issue severity, and revision priorities. RevisionGrade is designed to produce diagnosis, not just a number.",
+  },
+  {
+    q: "What are the evaluation modes?",
+    a: "Short-form evaluations cover submissions under 25,000 words and use the 13 story criteria only. Long-form evaluations begin at 25,000+ words and add manuscript-scale continuity. Long-form multi-layer evaluations add deeper architecture, story-ledger, Golden Spine/WAVE, and governance analysis where appropriate.",
+  },
+  {
+    q: "Does RevisionGrade rewrite my voice?",
+    a: "No. Revise is built around voice protection and author control. Some passages should be repaired; others should be preserved. A recommendation is not an instruction to flatten the prose.",
+  },
+  {
+    q: "Does RevisionGrade replace human editors?",
+    a: "No. RevisionGrade solves a different problem: ungoverned editing, scope confusion, and opaque diagnosis. It helps distinguish structural repair, line polish, market positioning, and voice protection before the author spends money on the wrong intervention.",
+  },
+  {
+    q: "Does RevisionGrade guarantee publication or representation?",
+    a: "No. RevisionGrade diagnoses manuscript readiness. It does not guarantee agent interest, representation, publication, sales, market timing, or commercial demand.",
+  },
 ];
 
 export default function ResourcesPage() {
   return (
     <div className="bg-rg-ink text-rg-cream">
-      <section className="mx-auto max-w-6xl px-6 py-20">
+      <section className="mx-auto max-w-7xl px-6 py-20">
         <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Resources</p>
-        <h1 className="mt-6 max-w-4xl font-rg-serif text-5xl leading-tight md:text-6xl">FAQ++ for authors evaluating a serious manuscript.</h1>
-        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">This page replaces the dead static Resources anchor with a real route for product explanation, author questions, and trust-building documentation.</p>
-        <div className="mt-12 grid gap-4 md:grid-cols-2">
-          {faqs.map((item) => <article key={item.q} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6"><h2 className="font-rg-serif text-2xl text-rg-cream">{item.q}</h2><p className="mt-4 leading-7 text-rg-cream2/75">{item.a}</p></article>)}
+        <h1 className="mt-6 max-w-5xl font-rg-serif text-5xl leading-tight md:text-6xl">
+          Resources for serious manuscript evaluation.
+        </h1>
+        <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">
+          Learn how RevisionGrade separates manuscript readiness from market rejection, evaluates long-form prose, protects author control, and turns diagnosis into revision decisions.
+        </p>
+
+        <div className="mt-12 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {resourceCards.map((item) => (
+            <Link key={item.title} href={item.href} className="border border-rg-cream2/12 bg-rg-ink2/60 p-6 transition hover:border-rg-gold/70">
+              <h2 className="font-rg-serif text-2xl text-rg-cream">{item.title}</h2>
+              <p className="mt-4 leading-7 text-rg-cream2/75">{item.copy}</p>
+              <p className="mt-5 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold">Open →</p>
+            </Link>
+          ))}
         </div>
-        <div className="mt-12 flex flex-wrap gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]"><Link href="/methodology" className="text-rg-gold hover:text-rg-cream">Methodology →</Link><Link href="/reliability" className="text-rg-gold hover:text-rg-cream">Reliability →</Link><Link href="/evaluate" className="text-rg-gold hover:text-rg-cream">Evaluate →</Link></div>
+      </section>
+
+      <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
+        <div className="mx-auto max-w-7xl px-6 py-20">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Author FAQ</p>
+          <h2 className="mt-4 max-w-4xl font-rg-serif text-4xl leading-tight md:text-5xl">
+            Practical answers before you evaluate.
+          </h2>
+          <div className="mt-10 grid gap-4 md:grid-cols-2">
+            {faqs.map((item) => (
+              <article key={item.q} className="border border-rg-cream2/12 bg-rg-ink/60 p-6">
+                <h3 className="font-rg-serif text-2xl text-rg-cream">{item.q}</h3>
+                <p className="mt-4 leading-7 text-rg-cream2/75">{item.a}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 py-20 text-center">
+        <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Start with diagnosis</p>
+        <h2 className="mt-5 font-rg-serif text-4xl leading-tight md:text-5xl">
+          Before you submit, know where the manuscript stands.
+        </h2>
+        <div className="mt-10 flex flex-wrap justify-center gap-4 font-rg-mono text-xs uppercase tracking-[0.18em]">
+          <Link href="/evaluate" className="border border-rg-gold bg-rg-gold px-5 py-3 text-rg-ink transition hover:bg-transparent hover:text-rg-gold">Begin Evaluation</Link>
+          <Link href="/black-box-problem" className="border border-rg-cream2/30 px-5 py-3 text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">Read the Black Box Problem</Link>
+        </div>
       </section>
     </div>
   );

--- a/app/storygate-studio/page.tsx
+++ b/app/storygate-studio/page.tsx
@@ -1,20 +1,13 @@
 /**
  * /storygate-studio — Storygate Studio™ public landing page
  *
- * Canonical palette (locked):
- *   Obsidian     #0E0E0E   background
- *   Bone White   #F2EFEA   primary text
- *   Blood Oxblood #7A1E1E  CTAs, decline
- *   Tarnished Gold #A98E4A eligibility, approval
- *   Ash Gray     #7B7B7B   secondary text, borders
- *
- * Fonts: Playfair Display (headings) + Inter (body)
- * Visible to all users — no auth gate.
+ * Current public scope: manuscript-first, publishing-facing controlled access.
+ * Film/TV, screenplay, pitch deck, adaptation, producer, and development
+ * workflows are intentionally excluded until those product paths exist.
  */
 
 import Link from "next/link";
 
-// ── Palette constants ─────────────────────────────────────────────────────────
 const C = {
   bg:       "#0E0E0E",
   text:     "#F2EFEA",
@@ -25,8 +18,6 @@ const C = {
   border:   "rgba(161,142,74,0.18)",
   borderAsh:"rgba(123,123,123,0.18)",
 } as const;
-
-// ── Shared micro-components ───────────────────────────────────────────────────
 
 function Divider() {
   return (
@@ -86,16 +77,12 @@ function CTAButton({
   );
 }
 
-// ── Page ─────────────────────────────────────────────────────────────────────
-
 export default function StorygateStudioLanding() {
   return (
     <main
       style={{ backgroundColor: C.bg, color: C.text, fontFamily: "Inter, system-ui, sans-serif" }}
       className="min-h-screen"
     >
-
-      {/* ── HERO ─────────────────────────────────────────────────────────────── */}
       <section
         className="pt-28 pb-24 px-6 text-center"
         style={{ borderBottom: `1px solid ${C.borderAsh}` }}
@@ -105,28 +92,27 @@ export default function StorygateStudioLanding() {
           className="text-4xl md:text-5xl font-bold mb-6 max-w-3xl mx-auto leading-tight"
           style={{ fontFamily: "Playfair Display, Georgia, serif", color: C.text }}
         >
-          A curated industry-access layer for readiness-vetted books, manuscripts, and screen projects.
+          Controlled access for readiness-vetted manuscript projects.
         </h1>
         <p className="text-base max-w-2xl mx-auto mb-3" style={{ color: C.ash }}>
-          Verified publishing and screen professionals can request access to specific projects. Creators control what materials are visible, who can view them, and when access is approved.
+          Storygate Studio gives verified publishing professionals controlled access to creator-approved manuscript projects. Materials are not publicly searchable. Access is requested, approved, and logged.
         </p>
         <p className="text-xs mb-10 tracking-wide" style={{ color: C.ash }}>
           Verified access only. Creator-approved visibility. Logged project activity.
         </p>
         <div className="flex flex-wrap gap-4 justify-center">
-          <CTAButton href="/storygate-studio/industry" variant="gold">
-            Request Industry Access
+          <CTAButton href="/storygate-studio/apply" variant="gold">
+            Prepare a Project for Storygate
           </CTAButton>
           <CTAButton href="/storygate-studio/industry" variant="ghost">
-            Sign In as Industry User
+            Request Publishing Access
           </CTAButton>
-          <CTAButton href="/storygate-studio/apply" variant="oxblood">
-            Prepare a Project for Storygate
+          <CTAButton href="/storygate-studio/industry" variant="oxblood">
+            Sign In as Industry User
           </CTAButton>
         </div>
       </section>
 
-      {/* ── TRUST MODEL ──────────────────────────────────────────────────────── */}
       <section className="py-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Trust Model</SectionLabel>
         <h2
@@ -136,13 +122,13 @@ export default function StorygateStudioLanding() {
           Built for controlled discovery, not open browsing.
         </h2>
         <p className="text-sm mb-12 max-w-2xl" style={{ color: C.ash }}>
-          Storygate Studio is designed for serious creators and legitimate industry professionals. Projects are not publicly searchable. Access is granted by request, by role, and by creator approval.
+          Storygate Studio is designed for serious authors and legitimate publishing professionals. Projects are not publicly searchable. Access is granted by request, by role, and by creator approval.
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {[
-            ["Verified Access Only", "Industry users must be approved before viewing project materials."],
-            ["Creator Approval", "Industry users request access to specific projects. Creators approve or decline on a per-project basis."],
-            ["Creator-Controlled Visibility", "Creators decide which materials are visible to which viewers and roles."],
+            ["Verified Access Only", "Publishing professionals must be approved before viewing project materials."],
+            ["Creator Approval", "Industry users request access to specific manuscript projects. Creators approve or decline on a per-project basis."],
+            ["Creator-Controlled Visibility", "Creators decide which manuscript materials are visible to which viewers and roles."],
             ["Logged Activity", "Project access and key viewer activity are recorded to support accountability and creator confidence."],
           ].map(([title, body]) => (
             <div
@@ -166,25 +152,25 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── WHAT INDUSTRY USERS MAY SEE ─────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Materials</SectionLabel>
         <h2
           className="text-2xl md:text-3xl font-bold mb-6"
           style={{ fontFamily: "Playfair Display, Georgia, serif" }}
         >
-          A clean professional package, not a cluttered submission dump.
+          A clean professional manuscript package, not a cluttered submission dump.
         </h2>
         <p className="text-sm mb-10 max-w-2xl" style={{ color: C.ash }}>
-          Depending on creator permissions, verified industry users may view:
+          Depending on creator permissions, verified publishing professionals may view:
         </p>
         <ul className="space-y-3 mb-8">
           {[
-            "Logline and short pitch",
-            "One-page synopsis or series overview",
-            "Sample pages, screenplay pages, or pilot materials",
+            "Query hook and short manuscript pitch",
+            "Synopsis or book-project overview",
+            "Author bio and project metadata",
+            "Sample pages or full manuscript materials selected by the creator",
             "Optional evaluation summary or professional readiness assessment",
-            "Optional adaptation materials — Film/TV pitch deck, lookbook, comparable titles, audience positioning, and development notes",
+            "Optional comparables and manuscript positioning notes",
           ].map((item) => (
             <li key={item} className="flex items-start gap-3 text-sm" style={{ color: C.text }}>
               <span style={{ color: C.gold, flexShrink: 0, marginTop: 2 }}>—</span>
@@ -199,42 +185,39 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── TWO AUDIENCES ────────────────────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Who It&apos;s For</SectionLabel>
         <h2
           className="text-2xl md:text-3xl font-bold mb-12"
           style={{ fontFamily: "Playfair Display, Georgia, serif" }}
         >
-          For industry professionals and creators.
+          For publishing professionals and manuscript creators.
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {/* Industry */}
           <div
             className="p-8"
             style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}
           >
             <p className="text-xs tracking-[0.16em] uppercase mb-4 font-mono" style={{ color: C.gold }}>
-              Industry Professionals
+              Publishing Professionals
             </p>
             <p className="text-sm leading-relaxed mb-8" style={{ color: C.ash }}>
-              Discover readiness-vetted narrative projects through a secure, request-based access layer. You can request access to projects that match your role, interests, and professional focus. Once approved, you see only the materials the creator has chosen to share.
+              Discover readiness-vetted manuscript projects through a secure, request-based access layer. You can request access to projects that match your role, interests, and professional focus. Once approved, you see only the materials the creator has chosen to share.
             </p>
             <CTAButton href="/storygate-studio/industry" variant="gold">
-              Request Industry Access
+              Request Publishing Access
             </CTAButton>
           </div>
 
-          {/* Creators */}
           <div
             className="p-8"
             style={{ backgroundColor: C.panel, border: `1px solid ${C.borderAsh}` }}
           >
             <p className="text-xs tracking-[0.16em] uppercase mb-4 font-mono" style={{ color: C.gold }}>
-              Creators
+              Authors and Creators
             </p>
             <p className="text-sm leading-relaxed mb-8" style={{ color: C.ash }}>
-              Prepare your project for professional consideration without losing control of access. Storygate Studio is for projects that have cleared a professional presentation and readiness threshold. Once eligible, your project can be placed into a controlled access environment where verified professionals may request review.
+              Prepare your manuscript project for professional consideration without losing control of access. Storygate Studio is for projects that have cleared a professional presentation and readiness threshold. Once eligible, your project can be placed into a controlled access environment where verified publishing professionals may request review.
             </p>
             <CTAButton href="/storygate-studio/apply" variant="ghost">
               Learn How to Qualify
@@ -245,7 +228,6 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── ELIGIBILITY ──────────────────────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Eligibility</SectionLabel>
         <h2
@@ -255,11 +237,10 @@ export default function StorygateStudioLanding() {
           Storygate placement requires two gates.
         </h2>
         <p className="text-sm mb-12 max-w-2xl" style={{ color: C.ash }}>
-          Storygate Studio is selective. Projects must satisfy both requirements before placement.
+          Storygate Studio is selective. Manuscript projects must satisfy both requirements before placement.
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          {/* Gate 1 */}
           <div
             className="p-8"
             style={{ border: `1px solid ${C.border}` }}
@@ -271,18 +252,18 @@ export default function StorygateStudioLanding() {
               className="text-lg font-bold mb-4"
               style={{ fontFamily: "Playfair Display, Georgia, serif" }}
             >
-              Professional Presentation Package
+              Professional Manuscript Package
             </p>
             <p className="text-sm mb-5" style={{ color: C.ash }}>
-              Creators must provide a clear, professionally formatted package that communicates the project quickly and credibly. Depending on project type, this may include:
+              Creators must provide a clear, professionally formatted package that communicates the manuscript quickly and credibly. This may include:
             </p>
             <ul className="space-y-2 mb-6">
               {[
-                "Query letter or professional pitch material",
-                "Synopsis or series overview",
-                "Author or creator bio",
-                "Sample pages, screenplay pages, or pilot materials",
-                "Supporting materials — comparables, audience positioning, lookbook, adaptation notes, or Film/TV pitch deck",
+                "Query letter with a clear hook paragraph",
+                "Synopsis or book-project overview",
+                "Author bio",
+                "Sample pages or manuscript materials",
+                "Supporting materials — comparables, audience positioning, or optional readiness assessment",
               ].map((item) => (
                 <li key={item} className="flex items-start gap-3 text-xs" style={{ color: C.ash }}>
                   <span style={{ color: C.gold, flexShrink: 0, marginTop: 1 }}>—</span>
@@ -299,7 +280,6 @@ export default function StorygateStudioLanding() {
             </p>
           </div>
 
-          {/* Gate 2 */}
           <div
             className="p-8"
             style={{ border: `1px solid ${C.border}` }}
@@ -314,12 +294,12 @@ export default function StorygateStudioLanding() {
               Minimum Readiness / Quality Threshold
             </p>
             <p className="text-sm mb-5" style={{ color: C.ash }}>
-              Projects must demonstrate a minimum professional standard through one of the following:
+              Manuscript projects must demonstrate a minimum professional standard through one of the following:
             </p>
             <ul className="space-y-2 mb-6">
               {[
-                "A RevisionGrade score of 8.0 or higher in the relevant evaluation, or",
-                "An equivalent professional assessment from a qualified third party — a literary agent, editor, producer, development executive, or recognized industry evaluator",
+                "A RevisionGrade score of 8.0 or higher from a full manuscript evaluation, or",
+                "An equivalent professional manuscript assessment from a qualified third party — such as a literary agent, acquiring editor, professional editor, or recognized publishing evaluator",
               ].map((item) => (
                 <li key={item} className="flex items-start gap-3 text-xs" style={{ color: C.ash }}>
                   <span style={{ color: C.gold, flexShrink: 0, marginTop: 1 }}>—</span>
@@ -331,7 +311,7 @@ export default function StorygateStudioLanding() {
               className="text-xs p-3 border"
               style={{ color: C.ash, borderColor: C.border, backgroundColor: C.panel }}
             >
-              Storygate Studio is not designed to replace professional judgment. It is designed to make professionally prepared projects easier to review, route, and protect.
+              Storygate Studio is not designed to replace professional judgment. It is designed to make professionally prepared manuscript projects easier to review, route, and protect.
             </p>
           </div>
         </div>
@@ -339,20 +319,19 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── WHY STORYGATE EXISTS ─────────────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Why It Exists</SectionLabel>
         <h2
           className="text-2xl md:text-3xl font-bold mb-6 max-w-2xl"
           style={{ fontFamily: "Playfair Display, Georgia, serif" }}
         >
-          Good projects should not disappear into the black box.
+          Good manuscript projects should not disappear into the black box.
         </h2>
         <p className="text-sm mb-6 max-w-2xl leading-relaxed" style={{ color: C.ash }}>
-          Writers and creators often face the same problem: silence, generic rejection, or no clear signal about whether the issue is project readiness, market fit, timing, or access.
+          Authors often face the same problem: silence, generic rejection, or no clear signal about whether the issue is manuscript readiness, market fit, timing, or access.
         </p>
         <p className="text-sm mb-8 max-w-2xl" style={{ color: C.ash }}>
-          Storygate Studio does not promise representation, publication, or production. It creates a more disciplined bridge between prepared creators and verified professionals:
+          Storygate Studio does not promise representation, publication, or commercial outcome. It creates a more disciplined bridge between prepared creators and verified publishing professionals:
         </p>
         <ul className="space-y-3 mb-10 max-w-xl">
           {[
@@ -371,31 +350,30 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── PROJECT TYPES ────────────────────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
-        <SectionLabel>Project Types</SectionLabel>
+        <SectionLabel>Current Scope</SectionLabel>
         <h2
           className="text-2xl md:text-3xl font-bold mb-12"
           style={{ fontFamily: "Playfair Display, Georgia, serif" }}
         >
-          Built for books, manuscripts, and screen adaptation pathways.
+          Built for manuscript-first publishing pathways.
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           {[
             {
-              type: "Manuscript / Publishing",
-              desc: "For novels, memoirs, nonfiction books, and other manuscript-based submissions.",
-              materials: "Professional query letter, synopsis, author bio, sample pages, and optional evaluation summary.",
+              type: "Novels",
+              desc: "For long-form fiction projects prepared for literary-agent or publishing review.",
+              materials: "Query letter, synopsis, author bio, sample pages, comparables, and optional evaluation summary.",
             },
             {
-              type: "Screen / Adaptation",
-              desc: "For projects seeking film, television, streaming, or development consideration.",
-              materials: "Film/TV pitch deck, source-material summary, lookbook, comparable titles, audience positioning, and optional adaptation notes.",
+              type: "Memoir / Serious Nonfiction",
+              desc: "For supported prose projects where author platform, subject relevance, and clear positioning matter.",
+              materials: "Query package, synopsis or proposal-style summary where appropriate, author bio, and positioning notes.",
             },
             {
-              type: "Series / Franchise",
-              desc: "For projects with multi-book, multi-season, or expanded-world potential.",
-              materials: "Series overview, world or character materials, adaptation positioning, and development package.",
+              type: "Complex Manuscripts",
+              desc: "For multi-POV, multi-timeline, genre-hybrid, or unusually structured manuscript projects.",
+              materials: "Professional manuscript package plus readiness evidence sufficient for controlled publishing review.",
             },
           ].map(({ type, desc, materials }) => (
             <div
@@ -422,7 +400,6 @@ export default function StorygateStudioLanding() {
 
       <Divider />
 
-      {/* ── WHAT STORYGATE IS NOT ────────────────────────────────────────────── */}
       <section className="py-0 pb-24 px-6 max-w-5xl mx-auto">
         <SectionLabel>Scope</SectionLabel>
         <h2
@@ -437,11 +414,11 @@ export default function StorygateStudioLanding() {
         <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-8">
           {[
             "A literary agency",
-            "A production company",
             "A publisher",
             "A contest",
             "A public marketplace",
-            "A guarantee of representation, publication, sale, option, financing, or production",
+            "A substitute for professional judgment",
+            "A guarantee of representation, publication, sale, or placement",
           ].map((item) => (
             <div
               key={item}
@@ -453,13 +430,12 @@ export default function StorygateStudioLanding() {
           ))}
         </div>
         <p className="text-sm italic max-w-2xl" style={{ color: C.ash }}>
-          Storygate Studio is a selective access layer for professionally prepared narrative projects. Industry response remains subjective and market-dependent.
+          Storygate Studio is a selective access layer for professionally prepared manuscript projects. Industry response remains subjective and market-dependent.
         </p>
       </section>
 
       <Divider />
 
-      {/* ── CTA BAND ─────────────────────────────────────────────────────────── */}
       <section
         className="py-20 px-6 text-center"
         style={{ backgroundColor: C.panel, borderTop: `1px solid ${C.border}`, borderBottom: `1px solid ${C.border}` }}
@@ -474,21 +450,21 @@ export default function StorygateStudioLanding() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-2xl mx-auto text-left">
           <div>
             <p className="text-xs tracking-[0.16em] uppercase mb-2 font-mono" style={{ color: C.gold }}>
-              Industry Professionals
+              Publishing Professionals
             </p>
             <p className="text-sm mb-5" style={{ color: C.ash }}>
-              Request verified access to review selected projects.
+              Request verified access to review selected manuscript projects.
             </p>
             <CTAButton href="/storygate-studio/industry" variant="gold">
-              Request Industry Access
+              Request Publishing Access
             </CTAButton>
           </div>
           <div>
             <p className="text-xs tracking-[0.16em] uppercase mb-2 font-mono" style={{ color: C.gold }}>
-              Creators
+              Authors and Creators
             </p>
             <p className="text-sm mb-5" style={{ color: C.ash }}>
-              Prepare your project for eligibility and controlled industry review.
+              Prepare your manuscript project for eligibility and controlled publishing review.
             </p>
             <CTAButton href="/storygate-studio/apply" variant="ghost">
               Prepare a Project for Storygate
@@ -497,7 +473,6 @@ export default function StorygateStudioLanding() {
         </div>
       </section>
 
-      {/* ── FAQ PREVIEW ──────────────────────────────────────────────────────── */}
       <section className="py-24 px-6 max-w-3xl mx-auto">
         <SectionLabel>FAQ</SectionLabel>
         <h2
@@ -513,8 +488,8 @@ export default function StorygateStudioLanding() {
               a: "No. A RevisionGrade package may satisfy eligibility requirements, but creators may also qualify with equivalent professional materials created independently or through another service.",
             },
             {
-              q: "Does Storygate guarantee representation or production?",
-              a: "No. Storygate Studio does not guarantee representation, publication, sale, option, financing, or production.",
+              q: "Does Storygate guarantee representation or publication?",
+              a: "No. Storygate Studio does not guarantee representation, publication, sale, placement, or any specific market response.",
             },
             {
               q: "Do I need to keep paying to remain in Storygate Studio?",
@@ -525,8 +500,8 @@ export default function StorygateStudioLanding() {
               a: "Manuscript projects typically require a professional query letter, synopsis, and author bio. The pitch or hook belongs inside the query letter, not as a redundant separate document.",
             },
             {
-              q: "Is a Film/TV pitch deck required for screen or adaptation submissions?",
-              a: "Yes. Screen and adaptation submissions should include a Film/TV pitch deck or equivalent professional screen-development package.",
+              q: "What kinds of projects are currently supported?",
+              a: "Storygate Studio currently supports manuscript-first publishing pathways: novels, supported memoir or serious nonfiction projects, and complex long-form prose manuscripts. Other media pathways are future scope and are not part of the current public service.",
             },
           ].map(({ q, a }) => (
             <div
@@ -548,19 +523,17 @@ export default function StorygateStudioLanding() {
         </div>
       </section>
 
-      {/* ── FOOTER TRUST NOTE ────────────────────────────────────────────────── */}
       <footer
         className="py-8 px-6 text-center"
         style={{ borderTop: `1px solid ${C.borderAsh}` }}
       >
         <p className="text-xs max-w-xl mx-auto leading-relaxed" style={{ color: C.ash }}>
-          Storygate Studio™ is part of the RevisionGrade™ ecosystem. It is designed to support professional readiness, controlled access, and accountable review pathways for serious narrative projects.
+          Storygate Studio™ is part of the RevisionGrade™ ecosystem. It is designed to support professional manuscript readiness, controlled access, and accountable review pathways for serious book projects.
         </p>
         <p className="text-xs mt-3" style={{ color: C.gold, opacity: 0.6 }}>
           All project views, access requests, notes, and packet activity are logged and append-only. Materials may not be copied, shared, or distributed outside this verified account.
         </p>
       </footer>
-
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Updates the public website copy to match the current manuscript-first RevisionGrade scope.

## Changes

- Homepage copy and CTAs tightened.
- Resources page changed from placeholder FAQ to a hub plus Author FAQ.
- Methodology expanded with short-form, long-form, and long-form multi-layer evaluation modes.
- Reliability expanded with manuscript sovereignty, scope discipline, diagnosis-before-polish, and author control.
- Pricing aligned with evaluation modes and manuscript audit tiers.
- Storygate overview reframed as controlled manuscript discovery for publishing professionals.

## Notes

No backend logic, database, or archived canon files changed.

Storygate apply page still needs a follow-up pass.
