### PR TITLE
Refine Evaluate guided submission experience

### DIFF
--- a/.github/pr-bodies/PR-672.md
+++ b/.github/pr-bodies/PR-672.md
@@ -1,0 +1,17 @@
+## Summary
+
+Upgrades the Evaluate entry page from a utilitarian upload console into a guided manuscript submission surface.
+
+## Changes
+
+- Adds a premium Evaluate hero with the three evaluation modes.
+- Reframes submission as a manuscript readiness process.
+- Adds estimated evaluation-mode guidance based on selected/pasted word count.
+- Removes user-facing admin clutter from the main Evaluate page, including purge old jobs and permanent-delete controls.
+- Renames CTA to Begin Editorial Evaluation.
+- Removes screenplay wording from the paste/upload label.
+- Keeps existing submission API and job creation behavior unchanged.
+
+## Notes
+
+No backend, database, or job-processing logic changed. This is UI/copy only.

--- a/components/evaluation/EvaluateEntry.jsx
+++ b/components/evaluation/EvaluateEntry.jsx
@@ -9,21 +9,28 @@ import { getJobDisplayInfo, getJobStatusBadge } from "../../lib/jobs/ui-helpers"
 import { formatRelativeTime, formatDuration } from "../../lib/ui/time-helpers";
 import { getPhaseSpecificCopy } from "../../lib/ui/phase-helpers";
 import ManuscriptSubmissionForm from "./ManuscriptSubmissionForm";
-import PurgeJobsButton from "./PurgeJobsButton";
 import PhaseBreadcrumb from "./PhaseBreadcrumb";
 import CompletionBanner from "./CompletionBanner";
 import { CancelEvaluationButton } from "./CancelEvaluationButton";
 
-/**
- * Day-1 Evaluation UI — Track A
- * 
- * Single entry point for users to:
- * 1. Submit manuscript text
- * 2. Start an evaluate_full job
- * 3. See live job status
- * 4. Reach "evaluation complete" state
- * 5. Click "View Evaluation Report" CTA
- */
+const evaluationModes = [
+  {
+    label: "Short-form evaluation",
+    range: "Under 25,000 words",
+    copy: "Evaluated against the 13 story criteria only. Best for openings, chapters, excerpts, and shorter works.",
+  },
+  {
+    label: "Long-form evaluation",
+    range: "25,000+ words",
+    copy: "Adds manuscript-scale continuity, pacing over distance, setup/payoff, and structural readiness signals.",
+  },
+  {
+    label: "Long-form multi-layer",
+    range: "Complex manuscripts",
+    copy: "Deeper architecture review for complex long-form prose where layered story logic and governance apply.",
+  },
+];
+
 export default function EvaluateEntry() {
   const router = useRouter();
   const { jobs, isLoading, isError } = useJobs();
@@ -37,49 +44,53 @@ export default function EvaluateEntry() {
     });
   }, []);
 
-  // Loading state
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-gray-600">Loading evaluations…</div>
+      <div className="flex items-center justify-center min-h-screen bg-[#F7F4EF]">
+        <div className="text-stone-600">Loading evaluations…</div>
       </div>
     );
   }
 
-  // Error state
   if (isError) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-red-600">Failed to load evaluations.</div>
+      <div className="flex items-center justify-center min-h-screen bg-[#F7F4EF]">
+        <div className="text-red-700">Failed to load evaluations.</div>
       </div>
     );
   }
 
-  // Sort jobs by created_at DESC (newest first)
-  const sortedJobs = [...jobs].sort((a, b) => {
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-  });
-
-  // Empty state: No jobs yet
+  const sortedJobs = [...jobs].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
   const hasNoJobs = sortedJobs.length === 0;
-  
-  // Track C: Check if most recent job is complete
   const mostRecentJob = sortedJobs[0];
   const showCompletionBanner = mostRecentJob && mostRecentJob.status === "complete";
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">
-            Manuscript Evaluation
-          </h1>
-          <p className="mt-2 text-gray-600">
-            Submit your manuscript for comprehensive AI-powered evaluation
-          </p>
-        </div>
+    <div className="min-h-screen bg-[#F7F4EF] py-8 text-stone-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section className="mb-8 rounded-3xl border border-stone-200 bg-white/80 p-6 shadow-sm md:p-8">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">Evaluate</p>
+          <div className="mt-4 grid gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-end">
+            <div>
+              <h1 className="font-rg-serif text-4xl leading-tight text-stone-950 md:text-5xl">
+                Begin manuscript evaluation.
+              </h1>
+              <p className="mt-4 max-w-3xl text-base leading-7 text-stone-600">
+                Submit existing writing into the correct diagnostic path. Short-form work is evaluated against the 13 story criteria; long-form manuscripts qualify for manuscript-scale readiness analysis.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+              {evaluationModes.map((mode) => (
+                <div key={mode.label} className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-4">
+                  <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.16em] text-rg-gold">{mode.range}</p>
+                  <h2 className="mt-2 font-rg-serif text-xl text-stone-950">{mode.label}</h2>
+                  <p className="mt-2 text-xs leading-5 text-stone-600">{mode.copy}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-        {/* Track A: Submission Form */}
         <ManuscriptSubmissionForm
           onSubmitSuccess={(data) => {
             const jobId = data?.job_id;
@@ -97,31 +108,26 @@ export default function EvaluateEntry() {
           }}
         />
 
-        {/* Track C: Completion Banner */}
         {showCompletionBanner && (
           <div className="mt-8">
             <CompletionBanner jobId={mostRecentJob.id} />
           </div>
         )}
 
-        {/* Job Status Section */}
-        <div className="mt-8">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold text-gray-900">
-              Evaluation History
-            </h2>
-            <PurgeJobsButton
-              terminalCount={sortedJobs.filter(j => j.status === "failed" || j.status === "complete").length}
-              onPurged={() => window.location.reload()}
-            />
+        <section className="mt-8 rounded-3xl border border-stone-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold">History</p>
+              <h2 className="mt-1 font-rg-serif text-3xl text-stone-950">Recent evaluations</h2>
+              <p className="mt-1 text-sm text-stone-600">Track submitted jobs, live progress, completed reports, and failed runs.</p>
+            </div>
           </div>
 
           {hasNoJobs ? (
-            // Empty State
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center">
-              <div className="max-w-md mx-auto">
+            <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-12 text-center">
+              <div className="mx-auto max-w-md">
                 <svg
-                  className="mx-auto h-12 w-12 text-gray-400"
+                  className="mx-auto h-12 w-12 text-stone-400"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -134,42 +140,25 @@ export default function EvaluateEntry() {
                     d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                   />
                 </svg>
-                <h3 className="mt-4 text-lg font-medium text-gray-900">
-                  No evaluations yet
-                </h3>
-                <p className="mt-2 text-sm text-gray-500">
-                  Submit your manuscript above to run your first evaluation
-                </p>
+                <h3 className="mt-4 font-rg-serif text-2xl text-stone-950">No evaluations yet</h3>
+                <p className="mt-2 text-sm text-stone-500">Choose a manuscript, upload a file, or paste text above to begin your first evaluation.</p>
               </div>
             </div>
           ) : (
-            // Jobs List
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            <div className="overflow-hidden rounded-2xl border border-stone-200 bg-white">
               <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
+                <table className="min-w-full divide-y divide-stone-200">
+                  <thead className="bg-stone-50">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Job ID
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Result
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider" style={{minWidth: "380px"}}>
-                        Pipeline — Entered &amp; Passed
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Activity
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Submitted
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Report
-                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500">Job ID</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500">Result</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500" style={{ minWidth: "380px" }}>Pipeline — Entered &amp; Passed</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500">Activity</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500">Submitted</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-stone-500">Report</th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
+                  <tbody className="divide-y divide-stone-200 bg-white">
                     {sortedJobs.map((job) => {
                       const displayInfo = getJobDisplayInfo(job);
                       const statusBadge = getJobStatusBadge(displayInfo.badge);
@@ -178,84 +167,61 @@ export default function EvaluateEntry() {
                       const isRunning = job.status === "running";
                       const isFailed = job.status === "failed";
                       const relativeTime = formatRelativeTime(job.created_at);
-                      
-                      // Track C: Phase-specific copy
-                      const phaseInfo = getPhaseSpecificCopy(
-                        displayInfo.phaseDetail.phase,
-                        displayInfo.phaseDetail.phase_status
-                      );
-                      
-                      // Track B + C: Reassuring progress messages with phase-specific copy
+                      const phaseInfo = getPhaseSpecificCopy(displayInfo.phaseDetail.phase, displayInfo.phaseDetail.phase_status);
+
                       let progressMessage = displayInfo.message || displayInfo.progress.display;
                       let subMessage = null;
-                      
+
                       if (isQueued) {
                         progressMessage = "Preparing evaluation…";
                         subMessage = "This usually takes ~2–3 minutes";
                       } else if (isRunning) {
                         const duration = formatDuration(job.created_at);
-                        // Track C: Use phase-specific copy
                         progressMessage = phaseInfo.displayCopy;
                         subMessage = `Running for ${duration} • ${phaseInfo.description}`;
                       } else if (isComplete) {
                         progressMessage = "Evaluation complete";
-                        subMessage = "Ready to view your comprehensive report";
+                        subMessage = "Ready to view your report";
                       } else if (isFailed) {
                         progressMessage = "Evaluation failed";
                         subMessage = displayInfo.message || "An error occurred during processing";
                       }
 
                       return (
-                        <tr key={job.id} className="hover:bg-gray-50">
-                          <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">
-                            <Link
-                              href={`/evaluate/${job.id}`}
-                              className="text-blue-600 hover:text-blue-800 hover:underline"
-                              title={job.id}
-                            >
+                        <tr key={job.id} className="hover:bg-stone-50">
+                          <td className="whitespace-nowrap px-6 py-4 font-mono text-sm">
+                            <Link href={`/evaluate/${job.id}`} className="text-blue-700 hover:text-blue-900 hover:underline" title={job.id}>
                               {job.id.slice(0, 8)}&hellip;
                             </Link>
                           </td>
-                          <td className="px-6 py-4 whitespace-nowrap">
-                            <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${statusBadge.className}`}>
+                          <td className="whitespace-nowrap px-6 py-4">
+                            <span className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${statusBadge.className}`}>
                               {statusBadge.label}
                             </span>
                           </td>
-                          <td className="px-6 py-4 text-sm text-gray-500" style={{minWidth: "380px"}}>
-                            <PhaseBreadcrumb
-                              phaseLog={job.progress?.phase_log ?? []}
-                              job={job}
-                              compact={true}
-                            />
+                          <td className="px-6 py-4 text-sm text-stone-500" style={{ minWidth: "380px" }}>
+                            <PhaseBreadcrumb phaseLog={job.progress?.phase_log ?? []} job={job} compact={true} />
                           </td>
                           <td className="px-6 py-4 text-sm">
-                            <div className="text-gray-900">{progressMessage}</div>
-                            {subMessage && (
-                              <div className="text-xs text-gray-500 mt-1">{subMessage}</div>
-                            )}
-                            {/* Show progress bar for running jobs */}
+                            <div className="text-stone-900">{progressMessage}</div>
+                            {subMessage && <div className="mt-1 text-xs text-stone-500">{subMessage}</div>}
                             {isRunning && displayInfo.progress.total > 0 && (
                               <div className="mt-2">
-                                <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                                <div className="mb-1 flex items-center justify-between text-xs text-stone-500">
                                   <span>Progress</span>
                                   <span>{displayInfo.progress.percentage}%</span>
                                 </div>
-                                <div className="w-full bg-gray-200 rounded-full h-1.5">
-                                  <div
-                                    className="bg-blue-600 h-1.5 rounded-full transition-all duration-500"
-                                    style={{ width: `${displayInfo.progress.percentage}%` }}
-                                  />
+                                <div className="h-1.5 w-full rounded-full bg-stone-200">
+                                  <div className="h-1.5 rounded-full bg-blue-600 transition-all duration-500" style={{ width: `${displayInfo.progress.percentage}%` }} />
                                 </div>
                               </div>
                             )}
                           </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          <td className="whitespace-nowrap px-6 py-4 text-sm text-stone-500">
                             <div>{relativeTime}</div>
-                            <div className="text-xs text-gray-400 mt-1">
-                              {new Date(job.created_at).toLocaleString()}
-                            </div>
+                            <div className="mt-1 text-xs text-stone-400">{new Date(job.created_at).toLocaleString()}</div>
                           </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm">
+                          <td className="whitespace-nowrap px-6 py-4 text-sm">
                             {isComplete ? (
                               <Link
                                 href={`/evaluate/${job.id}`}
@@ -268,30 +234,23 @@ export default function EvaluateEntry() {
                                     detail: `job_id=${job.id}`,
                                   });
                                 }}
-                                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors"
+                                className="inline-flex items-center rounded-md border border-transparent bg-green-700 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-green-800"
                               >
-                                View Evaluation Report
+                                View Report
                               </Link>
                             ) : isRunning || isQueued ? (
-                              <div className="flex items-center gap-3 flex-wrap">
-                                <Link
-                                  href={`/evaluate/${job.id}`}
-                                  className={`flex items-center ${isRunning ? 'text-blue-600' : 'text-gray-500'} hover:underline`}
-                                >
-                                  <svg className={`${isRunning ? 'animate-spin' : ''} h-4 w-4 mr-2`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                              <div className="flex flex-wrap items-center gap-3">
+                                <Link href={`/evaluate/${job.id}`} className={`flex items-center ${isRunning ? "text-blue-700" : "text-stone-500"} hover:underline`}>
+                                  <svg className={`${isRunning ? "animate-spin" : ""} mr-2 h-4 w-4`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                   </svg>
-                                  <span className="text-xs font-medium">{isRunning ? 'Live Progress' : 'Queued'}</span>
+                                  <span className="text-xs font-medium">{isRunning ? "Live Progress" : "Queued"}</span>
                                 </Link>
-                                <CancelEvaluationButton
-                                  jobId={job.id}
-                                  label="STOP"
-                                  buttonClassName="inline-flex items-center px-3 py-1.5 text-xs font-bold tracking-wide text-white bg-red-600 hover:bg-red-700 rounded-md shadow-sm transition-colors"
-                                />
+                                <CancelEvaluationButton jobId={job.id} label="STOP" buttonClassName="inline-flex items-center rounded-md bg-red-700 px-3 py-1.5 text-xs font-bold tracking-wide text-white shadow-sm transition-colors hover:bg-red-800" />
                               </div>
                             ) : (
-                              <span className="text-gray-400 text-xs">{statusBadge.label}</span>
+                              <span className="text-xs text-stone-400">{statusBadge.label}</span>
                             )}
                           </td>
                         </tr>
@@ -302,7 +261,7 @@ export default function EvaluateEntry() {
               </div>
             </div>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -2,6 +2,30 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
+function getEvaluationMode(wordCount) {
+  if (!wordCount) {
+    return {
+      label: "Awaiting text",
+      summary: "Select, upload, or paste writing to estimate the evaluation mode.",
+      detail: "RevisionGrade confirms the final mode during analysis.",
+    };
+  }
+
+  if (wordCount < 25000) {
+    return {
+      label: "Short-form evaluation",
+      summary: "13 story criteria only.",
+      detail: "Golden Spine/WAVE long-form analysis is reserved for manuscripts of 25,000 words or more.",
+    };
+  }
+
+  return {
+    label: "Long-form evaluation",
+    summary: "Manuscript-scale readiness analysis eligible.",
+    detail: "Long-form continuity, recurrence, payoff, pacing over distance, and structural readiness can be assessed.",
+  };
+}
+
 /**
  * Track A: Evaluation Entry
  * Single UI entry point to create evaluate_full jobs via POST /api/jobs
@@ -25,6 +49,14 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const wordCount = useMemo(() => {
     return manuscriptText.trim().split(/\s+/).filter(Boolean).length;
   }, [manuscriptText]);
+
+  const selectedDashboardManuscript = useMemo(
+    () => dashboardManuscripts.find((doc) => doc.id === selectedManuscriptId) || null,
+    [dashboardManuscripts, selectedManuscriptId],
+  );
+
+  const activeWordCount = selectedDashboardManuscript?.word_count ?? wordCount;
+  const evaluationMode = getEvaluationMode(activeWordCount);
 
   const visibleDashboardManuscripts = useMemo(
     () => dashboardManuscripts.filter((doc) => !hiddenManuscriptIds.includes(doc.id)),
@@ -76,35 +108,6 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const clearThisWindow = () => {
     setHiddenManuscriptIds(dashboardManuscripts.map((doc) => doc.id));
     setSelectedManuscriptId(null);
-  };
-
-  const deleteAllTitlesFromThisWindow = async () => {
-    if (visibleDashboardManuscripts.length === 0) return;
-
-    const confirmed = window.confirm(
-      `Delete all visible titles in this window? This permanently removes them from your dashboard and this window.`,
-    );
-
-    if (!confirmed) return;
-
-    setError(null);
-
-    try {
-      for (const doc of visibleDashboardManuscripts) {
-        const response = await fetch(`/api/manuscripts?id=${encodeURIComponent(String(doc.id))}`, {
-          method: "DELETE",
-        });
-        const data = await response.json();
-
-        if (!response.ok) {
-          throw new Error(data.error || `Delete failed for ${doc.title || "this manuscript"}`);
-        }
-
-        removeManuscriptLocally(doc.id);
-      }
-    } catch (err) {
-      setError(err.message || "Delete failed");
-    }
   };
 
   const restoreAllInThisWindow = () => {
@@ -185,7 +188,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     const hasPastedText = manuscriptText.trim().length > 0;
 
     if (!hasSelectedManuscript && !hasPastedText) {
-      setError("Select a dashboard manuscript, upload a file, or paste text to continue.");
+      setError("Select a saved manuscript, upload a file, or paste text to continue.");
       return;
     }
 
@@ -237,154 +240,47 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   };
 
   return (
-    <div className="max-w-7xl mx-auto p-4 lg:p-6">
-      <div className="rounded-2xl border border-gray-200 bg-white p-4 lg:p-8 shadow-sm">
-        <div className="text-center mb-8">
-          <h2 className="text-5xl font-semibold text-gray-900 tracking-tight mb-3">Your Writing</h2>
-          <p className="text-gray-600 max-w-3xl mx-auto">
-            Upload or paste your writing below. Formatting is preserved. We&apos;ll automatically determine
-            what you&apos;ve submitted and evaluate it accordingly.
+    <div className="mx-auto max-w-7xl">
+      <div className="rounded-3xl border border-stone-200 bg-white p-4 shadow-sm lg:p-8">
+        <div className="mb-8 text-center">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.22em] text-rg-gold">Submission workbench</p>
+          <h2 className="mt-3 font-rg-serif text-4xl font-semibold tracking-tight text-stone-950 md:text-5xl">Choose your writing</h2>
+          <p className="mx-auto mt-3 max-w-3xl text-stone-600">
+            Select a saved manuscript, upload a file, or paste text. RevisionGrade will route the submission into the correct evaluation depth based on length and complexity.
           </p>
         </div>
 
         <form onSubmit={handleSubmit}>
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <section className="lg:col-span-2 space-y-5">
-              <div className="rounded-xl border border-indigo-100 bg-indigo-50/60 p-4">
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">Writing Details</h3>
-                <p className="text-sm text-gray-600 mb-3">Choose a document from dashboard or upload a new one.</p>
-                <p className="text-xs text-gray-500 mb-3">Tip: Click a selected item again to unselect it.</p>
-
-                <div className="mb-3 flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={clearThisWindow}
-                    disabled={isUploading || isSubmitting || visibleDashboardManuscripts.length === 0}
-                    className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-                  >
-                    Clear this window
-                  </button>
-                  <button
-                    type="button"
-                    onClick={restoreAllInThisWindow}
-                    disabled={isUploading || isSubmitting || hiddenManuscriptIds.length === 0}
-                    className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-                  >
-                    Restore all items
-                  </button>
-                </div>
-
-                <div className="space-y-2 mb-3 min-h-[20rem] max-h-[36rem] overflow-y-auto pr-1">
-                  {isLoadingDashboard ? (
-                    <div className="text-sm text-gray-500">Loading dashboard documents...</div>
-                  ) : visibleDashboardManuscripts.length === 0 ? (
-                    <div className="text-sm text-gray-500">No documents found in dashboard yet.</div>
-                  ) : (
-                    visibleDashboardManuscripts.map((doc) => (
-                      <div
-                        key={doc.id}
-                        role="button"
-                        tabIndex={0}
-                        onClick={(event) => {
-                          if (event.target.closest("button") || event.target.closest("input")) {
-                            return;
-                          }
-                          toggleManuscriptSelection(doc.id);
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            toggleManuscriptSelection(doc.id);
-                          }
-                        }}
-                        className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer ${
-                          selectedManuscriptId === doc.id ? "border-indigo-500 bg-white" : "border-gray-200 bg-white/70"
-                        }`}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <section className="space-y-5 lg:col-span-2">
+              <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-4">
+                <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <h3 className="font-rg-serif text-2xl text-stone-950">Saved manuscripts</h3>
+                    <p className="mt-1 text-sm text-stone-600">Choose one saved manuscript, or upload a new file below.</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={triggerDashboardUpload}
+                      disabled={isUploading || isSubmitting}
+                      className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
+                    >
+                      {isUploading ? "Uploading..." : "Upload New Document"}
+                    </button>
+                    {hiddenManuscriptIds.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={restoreAllInThisWindow}
+                        disabled={isUploading || isSubmitting}
+                        className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
                       >
-                        <input
-                          type="radio"
-                          name="dashboard-manuscript"
-                          checked={selectedManuscriptId === doc.id}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            if (selectedManuscriptId === doc.id) {
-                              event.preventDefault();
-                              toggleManuscriptSelection(doc.id);
-                            }
-                          }}
-                          onChange={() => {
-                            if (selectedManuscriptId !== doc.id) {
-                              toggleManuscriptSelection(doc.id);
-                            }
-                          }}
-                          className="mt-1"
-                        />
-                        <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-                          <div className="min-w-0">
-                            <div className="font-medium text-sm text-gray-900">{doc.title || "Untitled Manuscript"}</div>
-                            <div className="text-xs text-gray-500">
-                              {doc.word_count ?? 0} words • {doc.source ?? "unknown"}
-                            </div>
-                          </div>
-                          <div className="flex flex-col gap-2 text-xs font-medium sm:flex-row sm:items-center lg:justify-end">
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                hideManuscriptHere(doc.id);
-                              }}
-                              className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-indigo-700 hover:bg-indigo-100 sm:whitespace-nowrap"
-                            >
-                              Hide from this window
-                            </button>
-                            <button
-                              type="button"
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                void deleteManuscriptFromDashboard(doc.id);
-                              }}
-                              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-red-700 hover:bg-red-100 sm:whitespace-nowrap"
-                            >
-                              Delete Permanently
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    ))
-                  )}
+                        Restore hidden
+                      </button>
+                    )}
+                  </div>
                 </div>
 
-                <div className="mb-3 flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={clearThisWindow}
-                    disabled={isUploading || isSubmitting || visibleDashboardManuscripts.length === 0}
-                    className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs font-medium text-indigo-700 hover:bg-indigo-100 disabled:opacity-60"
-                  >
-                    Hide all titles from this window
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void deleteAllTitlesFromThisWindow();
-                    }}
-                    disabled={isUploading || isSubmitting || visibleDashboardManuscripts.length === 0}
-                    className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs font-medium text-red-700 hover:bg-red-100 disabled:opacity-60"
-                  >
-                    Permanently delete all
-                  </button>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={triggerDashboardUpload}
-                  disabled={isUploading || isSubmitting}
-                  className="w-full rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
-                >
-                  {isUploading ? "Uploading..." : "Upload New Document to Dashboard"}
-                </button>
                 <input
                   ref={uploadInputRef}
                   type="file"
@@ -396,12 +292,86 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                     e.target.value = "";
                   }}
                 />
+
+                <div className="mb-3 max-h-[28rem] min-h-[12rem] space-y-2 overflow-y-auto pr-1">
+                  {isLoadingDashboard ? (
+                    <div className="text-sm text-stone-500">Loading saved manuscripts...</div>
+                  ) : visibleDashboardManuscripts.length === 0 ? (
+                    <div className="rounded-xl border border-stone-200 bg-white p-5 text-sm text-stone-500">No saved manuscripts found yet.</div>
+                  ) : (
+                    visibleDashboardManuscripts.map((doc) => (
+                      <div
+                        key={doc.id}
+                        role="button"
+                        tabIndex={0}
+                        onClick={(event) => {
+                          if (event.target.closest("button") || event.target.closest("input")) return;
+                          toggleManuscriptSelection(doc.id);
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            toggleManuscriptSelection(doc.id);
+                          }
+                        }}
+                        className={`cursor-pointer rounded-xl border p-3 ${
+                          selectedManuscriptId === doc.id ? "border-rg-gold bg-white shadow-sm" : "border-stone-200 bg-white/80"
+                        }`}
+                      >
+                        <div className="flex items-start gap-3">
+                          <input
+                            type="radio"
+                            name="dashboard-manuscript"
+                            checked={selectedManuscriptId === doc.id}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (selectedManuscriptId === doc.id) {
+                                event.preventDefault();
+                                toggleManuscriptSelection(doc.id);
+                              }
+                            }}
+                            onChange={() => {
+                              if (selectedManuscriptId !== doc.id) toggleManuscriptSelection(doc.id);
+                            }}
+                            className="mt-1"
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="font-medium text-sm text-stone-950">{doc.title || "Untitled Manuscript"}</div>
+                            <div className="text-xs text-stone-500">{doc.word_count ?? 0} words • {doc.source ?? "unknown"}</div>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              hideManuscriptHere(doc.id);
+                            }}
+                            className="rounded-md border border-stone-200 bg-stone-50 px-3 py-1.5 text-xs font-medium text-stone-600 hover:bg-stone-100"
+                          >
+                            Hide
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+
+                {visibleDashboardManuscripts.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={clearThisWindow}
+                    disabled={isUploading || isSubmitting}
+                    className="rounded-md border border-stone-200 bg-white px-3 py-2 text-xs font-medium text-stone-600 hover:bg-stone-50 disabled:opacity-60"
+                  >
+                    Hide all from this window
+                  </button>
+                )}
               </div>
 
-              <div className="text-center text-xs uppercase tracking-wide text-gray-400">OR UPLOAD/PASTE NEW TEXT</div>
+              <div className="text-center font-rg-mono text-xs uppercase tracking-[0.18em] text-stone-400">OR PASTE NEW TEXT</div>
 
               <div>
-                <label htmlFor="project-title" className="block text-sm font-medium text-gray-700 mb-2">
+                <label htmlFor="project-title" className="mb-2 block text-sm font-medium text-stone-700">
                   Project Title (optional)
                 </label>
                 <input
@@ -409,24 +379,24 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                   type="text"
                   value={projectTitle}
                   onChange={(e) => setProjectTitle(e.target.value)}
-                  placeholder="Helps you organize your submissions"
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 bg-white"
+                  placeholder="Helps organize submissions and reports"
+                  className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-950"
                   disabled={isSubmitting}
                 />
               </div>
 
               <div>
-                <div className="flex items-center justify-between mb-2">
-                  <label htmlFor="manuscript-text" className="text-sm font-medium text-gray-700">
-                    Paste a paragraph, scene, chapter, screenplay, or full manuscript here
+                <div className="mb-2 flex items-center justify-between">
+                  <label htmlFor="manuscript-text" className="text-sm font-medium text-stone-700">
+                    Paste a paragraph, scene, chapter, excerpt, or full manuscript here
                   </label>
                   <button
                     type="button"
                     onClick={triggerInlineUpload}
                     disabled={isUploading || isSubmitting}
-                    className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+                    className="rounded-md border border-stone-200 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
                   >
-                    Upload File (250k max)
+                    Upload File
                   </button>
                 </div>
                 <textarea
@@ -434,13 +404,11 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                   value={manuscriptText}
                   onChange={(e) => {
                     setManuscriptText(e.target.value);
-                    if (e.target.value.trim().length > 0) {
-                      setSelectedManuscriptId(null);
-                    }
+                    if (e.target.value.trim().length > 0) setSelectedManuscriptId(null);
                   }}
-                  placeholder="Formatting (italics, bold, spacing) is preserved..."
+                  placeholder="Formatting is preserved where supported..."
                   rows={12}
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 bg-white"
+                  className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-950"
                   disabled={isSubmitting}
                 />
                 <input
@@ -454,48 +422,48 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                     e.target.value = "";
                   }}
                 />
-                <p className="mt-2 text-xs text-gray-500">Word count: {wordCount}</p>
-                <p className="text-xs text-gray-500">Paste up to 150k words or upload files up to 250k words</p>
+                <p className="mt-2 text-xs text-stone-500">Current pasted word count: {wordCount}</p>
+                <p className="text-xs text-stone-500">Paste up to 150k words or upload files up to 250k words.</p>
               </div>
 
-              <div className="rounded-xl border border-gray-200 p-4">
-                <label className="block text-sm font-medium text-gray-700 mb-2">English Variant</label>
+              <div className="rounded-xl border border-stone-200 p-4">
+                <label className="mb-2 block text-sm font-medium text-stone-700">English Variant</label>
                 <select
                   value={englishVariant}
                   onChange={(e) => setEnglishVariant(e.target.value)}
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 bg-white"
+                  className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-950"
                 >
                   <option value="us">US English</option>
                   <option value="uk">UK English</option>
                 </select>
               </div>
-
-              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
-                <h4 className="text-sm font-semibold text-amber-900 mb-1">Mode confirmation happens after analysis</h4>
-                <p className="text-sm text-amber-800">
-                  Mode will be detected after analysis and confirmed with you before Revise.
-                </p>
-              </div>
             </section>
 
             <aside className="space-y-4">
-              <div className="rounded-xl bg-indigo-50 border border-indigo-100 p-4">
-                <h4 className="font-semibold text-gray-900 mb-2">How Evaluation Works</h4>
-                <p className="text-sm text-gray-600">Shorter submissions are evaluated directly. Full manuscripts are processed in chapters with progress tracking.</p>
+              <div className="rounded-2xl border border-rg-gold/30 bg-[#FBFAF7] p-5">
+                <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.16em] text-rg-gold">Estimated Mode</p>
+                <h4 className="mt-2 font-rg-serif text-2xl text-stone-950">{evaluationMode.label}</h4>
+                <p className="mt-2 text-sm font-medium text-stone-700">{evaluationMode.summary}</p>
+                <p className="mt-2 text-xs leading-5 text-stone-600">{evaluationMode.detail}</p>
+                <p className="mt-4 text-xs text-stone-500">Detected/selected words: {activeWordCount || 0}</p>
               </div>
-              <div className="rounded-xl bg-cyan-50 border border-cyan-100 p-4">
-                <h4 className="font-semibold text-gray-900 mb-2">Tips for Best Results</h4>
-                <ul className="list-disc pl-5 text-sm text-gray-600 space-y-1">
-                  <li>Evaluate larger sections when possible.</li>
-                  <li>Complete scenes or chapters improve reliability.</li>
-                  <li>Opening chapters benefit from focused hook/voice setup.</li>
+              <div className="rounded-2xl border border-stone-200 bg-white p-5">
+                <h4 className="font-rg-serif text-2xl text-stone-950">How evaluation works</h4>
+                <p className="mt-2 text-sm leading-6 text-stone-600">RevisionGrade diagnoses readiness before revision. It does not assume every submission needs the same depth of analysis.</p>
+              </div>
+              <div className="rounded-2xl border border-stone-200 bg-white p-5">
+                <h4 className="font-rg-serif text-2xl text-stone-950">Best results</h4>
+                <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-stone-600">
+                  <li>Use complete scenes or chapters when possible.</li>
+                  <li>Full manuscripts enable long-form continuity analysis.</li>
+                  <li>Short excerpts receive criteria-based story diagnosis only.</li>
                 </ul>
               </div>
             </aside>
           </div>
 
           {error && (
-            <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-md">
+            <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3">
               <p className="text-sm text-red-800">{error}</p>
             </div>
           )}
@@ -503,9 +471,9 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
           <button
             type="submit"
             disabled={isSubmitting || isUploading}
-            className="mt-6 w-full rounded-lg bg-gradient-to-r from-indigo-500 to-purple-500 px-6 py-3 text-white font-semibold shadow-sm hover:opacity-95 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="mt-6 w-full rounded-xl bg-rg-gold px-6 py-4 font-rg-mono text-xs font-semibold uppercase tracking-[0.18em] text-stone-950 shadow-sm hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {isSubmitting ? "Starting Evaluation..." : "Evaluate with RevisionGrade"}
+            {isSubmitting ? "Starting Evaluation..." : "Begin Editorial Evaluation"}
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Summary

Upgrades the Evaluate entry page from a utilitarian upload console into a guided manuscript submission surface.

## Changes

- Adds a premium Evaluate hero with the three evaluation modes.
- Reframes submission as a manuscript readiness process.
- Adds estimated evaluation-mode guidance based on selected/pasted word count.
- Removes user-facing admin clutter from the main Evaluate page, including purge old jobs and permanent-delete controls.
- Renames CTA to Begin Editorial Evaluation.
- Removes screenplay wording from the paste/upload label.
- Keeps existing submission API and job creation behavior unchanged.

## Notes

No backend, database, or job-processing logic changed. This is UI/copy only.
