### PR TITLE
Upgrade dashboard manuscript progress shell

### DIFF
--- a/.github/pr-bodies/PR-673.md
+++ b/.github/pr-bodies/PR-673.md
@@ -1,0 +1,17 @@
+## Summary
+
+Adds the next dashboard layer: current manuscript focus plus a progress analytics preview. This starts moving the dashboard from a passive evaluation table toward manuscript progress tracking.
+
+## Changes
+
+- Reframes dashboard header around manuscript progress and next action.
+- Adds a Current Manuscript Focus panel based on the latest evaluation.
+- Shows latest overall/readiness scores and prior-run comparison when available.
+- Adds direct actions: open report/details, continue Revise, re-evaluate.
+- Adds a Progress Analytics preview for criteria movement, issue frequency, and Revise/TrustedPath activity.
+- Updates dashboard footnote to clarify that measured improvement requires a follow-up evaluation.
+- Adds CSS for the new dashboard panels.
+
+## Notes
+
+No database, backend, evaluation, or scoring logic changed. This PR uses existing dashboard row data only.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ function formatScore(value: number | null | undefined): string {
 }
 
 function getScoreDelta(current: number | null, previous: number | null): string {
-  if (current == null || previous == null) return 'Awaiting comparison'
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return 'Awaiting comparison'
   const delta = current - previous
   return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)} vs prior evaluation`
 }
@@ -52,11 +52,8 @@ export default async function DashboardPage() {
   }
 
   const kpis = computeDashboardKpis(rows)
-  const sortedRows = [...rows].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  )
-  const latest = sortedRows[0]
-  const priorSameManuscript = sortedRows.find(
+  const latest = rows[0]
+  const priorSameManuscript = rows.find(
     (row) => row.manuscriptId === latest.manuscriptId && row.id !== latest.id,
   )
   const latestTopScore = Math.max(latest.overallScore ?? 0, latest.readinessScore ?? 0)

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import DashboardHeader from '@/components/dashboard/DashboardHeader'
 import KpiCard from '@/components/dashboard/KpiCard'
 import EvaluationHistoryTable from '@/components/dashboard/EvaluationHistoryTable'
@@ -8,6 +9,16 @@ import {
 } from '@/lib/dashboard/getDashboardEvaluations'
 
 export const dynamic = 'force-dynamic'
+
+function formatScore(value: number | null | undefined): string {
+  return typeof value === 'number' && Number.isFinite(value) ? value.toFixed(1) : '—'
+}
+
+function getScoreDelta(current: number | null, previous: number | null): string {
+  if (current == null || previous == null) return 'Awaiting comparison'
+  const delta = current - previous
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)} vs prior evaluation`
+}
 
 export default async function DashboardPage() {
   const { rows, error } = await getDashboardEvaluations({ limit: 15 })
@@ -41,10 +52,59 @@ export default async function DashboardPage() {
   }
 
   const kpis = computeDashboardKpis(rows)
+  const sortedRows = [...rows].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+  const latest = sortedRows[0]
+  const priorSameManuscript = sortedRows.find(
+    (row) => row.manuscriptId === latest.manuscriptId && row.id !== latest.id,
+  )
+  const latestTopScore = Math.max(latest.overallScore ?? 0, latest.readinessScore ?? 0)
+  const latestIsReady = latestTopScore >= 8
+  const latestIsActionable = latest.status === 'failed' || latest.status === 'running'
 
   return (
     <div className="rg-dash-page">
       <DashboardHeader />
+
+      <section className="rg-current-focus" aria-label="Current manuscript focus">
+        <div>
+          <div className="rg-dash-context-label">Current manuscript focus</div>
+          <h2>{latest.manuscriptTitle}</h2>
+          <p>
+            Latest status: {latest.status === 'running'
+              ? 'evaluation in progress'
+              : latest.status === 'failed'
+              ? 'needs attention'
+              : latestIsReady
+              ? 'readiness threshold met'
+              : 'below readiness threshold'}.
+          </p>
+        </div>
+        <div className="rg-current-focus-grid">
+          <div className="rg-current-focus-metric">
+            <span>Overall</span>
+            <strong>{formatScore(latest.overallScore)}</strong>
+            <small>{getScoreDelta(latest.overallScore, priorSameManuscript?.overallScore ?? null)}</small>
+          </div>
+          <div className="rg-current-focus-metric">
+            <span>Ready</span>
+            <strong>{formatScore(latest.readinessScore)}</strong>
+            <small>{getScoreDelta(latest.readinessScore, priorSameManuscript?.readinessScore ?? null)}</small>
+          </div>
+          <div className="rg-current-focus-actions">
+            <Link href={latest.reportHref} className="rg-current-primary">
+              {latestIsActionable ? 'Open details' : 'Open latest report'}
+            </Link>
+            <Link href="/revise" className="rg-current-secondary">
+              Continue Revise
+            </Link>
+            <Link href="/evaluate" className="rg-current-secondary">
+              Re-evaluate
+            </Link>
+          </div>
+        </div>
+      </section>
 
       <section className="rg-kpi-row" aria-label="Summary metrics">
         <KpiCard
@@ -77,12 +137,28 @@ export default async function DashboardPage() {
         />
       </section>
 
+      <section className="rg-progress-preview" aria-label="Revision progress analytics preview">
+        <div>
+          <div className="rg-dash-context-label">Progress analytics</div>
+          <h2>Diagnosis, repair, measurement.</h2>
+          <p>
+            This dashboard will track category movement, recurring issue reduction, Revise decisions, TrustedPath batches, and before/after evaluation deltas. Until a follow-up evaluation runs, revision activity is shown as activity—not confirmed improvement.
+          </p>
+        </div>
+        <div className="rg-progress-preview-grid">
+          <div><strong>Criteria movement</strong><span>Score deltas across the 13 story criteria.</span></div>
+          <div><strong>Issue frequency</strong><span>Recurring failure types reduced, unchanged, or increased.</span></div>
+          <div><strong>Revise decisions</strong><span>Accepted, custom, rejected, kept original, deferred, and TrustedPath activity.</span></div>
+        </div>
+      </section>
+
       <EvaluationHistoryTable rows={rows} />
 
       <p className="rg-dash-footnote">
         Submission readiness indicates a manuscript has reached a RevisionGrade quality
         threshold associated with stronger submission potential. It is a curation
-        threshold, not a promise of industry response.
+        threshold, not a promise of industry response. Progress claims require a later
+        evaluation to confirm measured movement.
       </p>
     </div>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -90,7 +90,9 @@
 .rg-dash-header,
 .rg-kpi-card,
 .rg-history-card,
-.rg-empty-state {
+.rg-empty-state,
+.rg-current-focus,
+.rg-progress-preview {
   background: var(--rg-surface);
   border: 1px solid var(--rg-border);
   border-radius: 20px;
@@ -119,12 +121,12 @@
   font-size: clamp(1.8rem, 3vw, 2.6rem);
   line-height: 1.1;
   color: var(--rg-ink);
-  max-width: 22ch;
+  max-width: 24ch;
 }
 
 .rg-dash-subtitle {
   margin: 0 0 28px;
-  max-width: 62ch;
+  max-width: 72ch;
   line-height: 1.7;
   color: var(--rg-ink-muted);
   font-size: 1rem;
@@ -187,6 +189,108 @@
 .rg-kpi-delta--gold {
   color: var(--rg-gold);
   font-weight: 700;
+}
+
+.rg-current-focus {
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 20px;
+  margin-bottom: 28px;
+  padding: 24px;
+}
+
+.rg-current-focus h2,
+.rg-progress-preview h2 {
+  margin: 8px 0 10px;
+  color: var(--rg-ink);
+  font-size: clamp(1.5rem, 2.4vw, 2.2rem);
+  line-height: 1.15;
+}
+
+.rg-current-focus p,
+.rg-progress-preview p {
+  margin: 0;
+  color: var(--rg-ink-muted);
+  line-height: 1.65;
+}
+
+.rg-current-focus-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.rg-current-focus-metric,
+.rg-current-focus-actions,
+.rg-progress-preview-grid > div {
+  background: var(--rg-surface-2);
+  border: 1px solid var(--rg-border);
+  border-radius: 14px;
+  padding: 16px;
+}
+
+.rg-current-focus-metric span,
+.rg-progress-preview-grid strong {
+  display: block;
+  color: var(--rg-ink-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.rg-current-focus-metric strong {
+  display: block;
+  margin-top: 8px;
+  color: var(--rg-ink);
+  font-size: 2rem;
+}
+
+.rg-current-focus-metric small,
+.rg-progress-preview-grid span {
+  display: block;
+  margin-top: 8px;
+  color: var(--rg-ink-muted);
+  line-height: 1.45;
+}
+
+.rg-current-focus-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.rg-current-primary,
+.rg-current-secondary {
+  border-radius: 999px;
+  padding: 10px 12px;
+  text-align: center;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.rg-current-primary {
+  background: var(--rg-primary);
+  color: white;
+}
+
+.rg-current-secondary {
+  border: 1px solid var(--rg-border);
+  color: var(--rg-primary);
+}
+
+.rg-progress-preview {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 20px;
+  margin-bottom: 28px;
+  padding: 24px;
+}
+
+.rg-progress-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .rg-history-card {
@@ -315,8 +419,15 @@
 
 @media (max-width: 1100px) {
   .rg-dash-context,
-  .rg-kpi-row {
+  .rg-kpi-row,
+  .rg-current-focus,
+  .rg-progress-preview {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .rg-current-focus-grid,
+  .rg-progress-preview-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -326,7 +437,11 @@
   }
 
   .rg-dash-context,
-  .rg-kpi-row {
+  .rg-kpi-row,
+  .rg-current-focus,
+  .rg-current-focus-grid,
+  .rg-progress-preview,
+  .rg-progress-preview-grid {
     grid-template-columns: 1fr;
   }
 

--- a/components/dashboard/DashboardHeader.jsx
+++ b/components/dashboard/DashboardHeader.jsx
@@ -1,13 +1,12 @@
 export default function DashboardHeader() {
   return (
     <header className="rg-dash-header">
-      <div className="rg-dash-eyebrow">Dashboard · Submission readiness</div>
+      <div className="rg-dash-eyebrow">Dashboard · Manuscript progress</div>
       <h1 className="rg-dash-title">
-        Track revision progress toward submission readiness.
+        See where each manuscript stands and what to do next.
       </h1>
       <p className="rg-dash-subtitle">
-        Review recent evaluations, open reports, and see which manuscripts are
-        approaching the 8.0 curation threshold.
+        Track readiness movement, recent evaluations, and the next best action for your current manuscript. Revision activity is not the same as measured improvement; follow-up evaluations confirm movement.
       </p>
 
       <div className="rg-dash-context">
@@ -15,21 +14,21 @@ export default function DashboardHeader() {
           <div className="rg-dash-context-label">Readiness rule</div>
           <div className="rg-dash-context-value">8.0 / 10</div>
           <div className="rg-dash-context-note">
-            Crossing 8.0 marks curation-ready status.
+            Marks manuscript readiness review eligibility, not a guarantee of market response.
           </div>
         </div>
         <div className="rg-dash-context-card">
-          <div className="rg-dash-context-label">Visible rows</div>
-          <div className="rg-dash-context-value">Latest 15</div>
+          <div className="rg-dash-context-label">Progress doctrine</div>
+          <div className="rg-dash-context-value">Measure</div>
           <div className="rg-dash-context-note">
-            Older evaluations load via deeper history.
+            Accepted revisions become improvement only when a later evaluation confirms movement.
           </div>
         </div>
         <div className="rg-dash-context-card">
-          <div className="rg-dash-context-label">Current focus</div>
-          <div className="rg-dash-context-value">Evaluation history</div>
+          <div className="rg-dash-context-label">Next layer</div>
+          <div className="rg-dash-context-value">Revise</div>
           <div className="rg-dash-context-note">
-            Charts and insights ship in a later release.
+            Use reports to repair, then re-evaluate to track score and issue reduction.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds the next dashboard layer: current manuscript focus plus a progress analytics preview. This starts moving the dashboard from a passive evaluation table toward manuscript progress tracking.

## Changes

- Reframes dashboard header around manuscript progress and next action.
- Adds a Current Manuscript Focus panel based on the latest evaluation.
- Shows latest overall/readiness scores and prior-run comparison when available.
- Adds direct actions: open report/details, continue Revise, re-evaluate.
- Adds a Progress Analytics preview for criteria movement, issue frequency, and Revise/TrustedPath activity.
- Updates dashboard footnote to clarify that measured improvement requires a follow-up evaluation.
- Adds CSS for the new dashboard panels.

## Notes

No database, backend, evaluation, or scoring logic changed. This PR uses existing dashboard row data only.
