### PR TITLE
fix: show canonical identity groups on Story Ledger

### DIFF
--- a/.github/pr-bodies/PR-674.md
+++ b/.github/pr-bodies/PR-674.md
@@ -1,0 +1,27 @@
+## Summary
+
+Fixes the Story Ledger Canonical Identity panel showing **“No identity groups extracted yet”** even when the generated `pass1a_story_layer_v1` artifact contains extracted identity data.
+
+## Root cause
+
+The story-layer writer emits Canonical Identity data under `identity_groups`, but the current Story Ledger UI renderer consumes `canonical_identity_group`. Because of that key mismatch, the layer was counted/populated but rendered as empty.
+
+## Fix
+
+Adds a server-side normalization seam in `app/evaluate/[jobId]/ledger/page.tsx`:
+
+- maps `canonical_identity_layer.identity_groups` → `canonical_identity_group`
+- preserves existing `canonical_identity_group` if already present
+- maps `narrative_role` → `role` for the existing renderer pill
+- maps `name_history` → `legal_name_states`
+- maps `final_status` → `post_resolution_name_states`
+- derives evidence anchors from first/last appearance when explicit anchors are absent
+- does **not** regenerate artifacts or change the extraction contract
+
+## Why this is safe
+
+This is a display adapter only. It leaves the artifact writer, extraction pipeline, scoring, approval gate, and Supabase artifact content untouched. Existing jobs should display correctly after deploy without rerunning Phase 1A.
+
+## Acceptance check
+
+On `/evaluate/<jobId>/ledger`, the Canonical Identity layer should render extracted character identity cards instead of the fallback empty-state card when `pass1a_story_layer_v1.content.layers.canonical_identity_layer.identity_groups` is populated.

--- a/app/evaluate/[jobId]/ledger/page.tsx
+++ b/app/evaluate/[jobId]/ledger/page.tsx
@@ -70,6 +70,74 @@ function relationOwner(job: LedgerJob): string | null {
   return job.user_id ?? relation?.user_id ?? null;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeCanonicalIdentityLayer(
+  layer: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!layer || Object.keys(layer).length === 0) return layer;
+
+  // Writer contract emits `identity_groups`; the current UI renderer consumes
+  // `canonical_identity_group`. Normalize at the page seam so existing
+  // pass1a_story_layer_v1 artifacts display without regeneration.
+  const rawGroups = Array.isArray(layer.identity_groups)
+    ? layer.identity_groups
+    : Array.isArray(layer.canonical_identity_group)
+      ? layer.canonical_identity_group
+      : [];
+
+  if (rawGroups.length === 0) return layer;
+
+  const canonicalIdentityGroup = rawGroups.filter(isRecord).map((group) => {
+    const existingAnchors = Array.isArray(group.evidence_anchors)
+      ? group.evidence_anchors
+      : [];
+    const firstAppearance = group.first_appearance ? String(group.first_appearance) : null;
+    const lastAppearance = group.last_appearance ? String(group.last_appearance) : null;
+    const evidenceAnchors =
+      existingAnchors.length > 0
+        ? existingAnchors
+        : [firstAppearance, lastAppearance].filter(Boolean);
+
+    return {
+      ...group,
+      role: group.role ?? group.narrative_role,
+      legal_name_states: group.legal_name_states ?? group.name_history,
+      post_resolution_name_states:
+        group.post_resolution_name_states ?? group.final_status,
+      evidence_anchors: evidenceAnchors,
+    };
+  });
+
+  return {
+    ...layer,
+    canonical_identity_group: canonicalIdentityGroup,
+    identity_group_count:
+      typeof layer.identity_group_count === 'number'
+        ? layer.identity_group_count
+        : canonicalIdentityGroup.length,
+  };
+}
+
+function normalizeStoryLayersForUi(
+  layers: Record<string, Record<string, unknown>> | null,
+): Record<string, Record<string, unknown>> | null {
+  if (!layers) return null;
+
+  const canonicalIdentityLayer = normalizeCanonicalIdentityLayer(
+    layers.canonical_identity_layer,
+  );
+
+  return {
+    ...layers,
+    ...(canonicalIdentityLayer
+      ? { canonical_identity_layer: canonicalIdentityLayer }
+      : {}),
+  };
+}
+
 // ─── Data fetching ────────────────────────────────────────────────────────────
 
 async function getLedgerContext(jobId: string, userId: string) {
@@ -145,7 +213,8 @@ export default async function StoryLedgerPage({
   const justRejected = searchParams?.rejected === '1';
 
   // ── Story layers (Module 1)
-  const storyLayers = storyLayerContent?.layers ?? null;
+  const rawStoryLayers = storyLayerContent?.layers ?? null;
+  const storyLayers = normalizeStoryLayersForUi(rawStoryLayers);
   const layerCompletionSummary = storyLayerContent?.layer_completion_summary ?? null;
 
   // ── Hard fails (from legacy character ledger, for Module 2 blocking alert)


### PR DESCRIPTION
## Summary

Fixes the Story Ledger Canonical Identity panel showing **“No identity groups extracted yet”** even when the generated `pass1a_story_layer_v1` artifact contains extracted identity data.

## Root cause

The story-layer writer emits Canonical Identity data under `identity_groups`, but the current Story Ledger UI renderer consumes `canonical_identity_group`. Because of that key mismatch, the layer was counted/populated but rendered as empty.

## Fix

Adds a server-side normalization seam in `app/evaluate/[jobId]/ledger/page.tsx`:

- maps `canonical_identity_layer.identity_groups` → `canonical_identity_group`
- preserves existing `canonical_identity_group` if already present
- maps `narrative_role` → `role` for the existing renderer pill
- maps `name_history` → `legal_name_states`
- maps `final_status` → `post_resolution_name_states`
- derives evidence anchors from first/last appearance when explicit anchors are absent
- does **not** regenerate artifacts or change the extraction contract

## Why this is safe

This is a display adapter only. It leaves the artifact writer, extraction pipeline, scoring, approval gate, and Supabase artifact content untouched. Existing jobs should display correctly after deploy without rerunning Phase 1A.

## Acceptance check

On `/evaluate/<jobId>/ledger`, the Canonical Identity layer should render extracted character identity cards instead of the fallback empty-state card when `pass1a_story_layer_v1.content.layers.canonical_identity_layer.identity_groups` is populated.