### PR TITLE
Normalize Story Ledger relationship payloads

### DIFF
--- a/.github/pr-bodies/PR-676.md
+++ b/.github/pr-bodies/PR-676.md
@@ -1,0 +1,22 @@
+## Summary
+
+Conflict-free follow-up to PR #674. PR #674 already fixed Canonical Identity by normalizing `identity_groups` into the renderer-compatible shape. This PR adds the second observed Story Ledger fix: Relationship Network rendering.
+
+## Why
+
+The Relationship Network renderer filters label-only/generic parties. That is correct for true descriptors, but the current filter can also drop valid extracted proper names when the extractor emits normalized lowercase multi-word names.
+
+## Changes
+
+- Adds a page-seam normalization for `relationship_network_layer`.
+- Normalizes lowercase multi-word relationship names before they reach the existing label-only filter.
+- Preserves true generic labels such as `unknown character`, `driver`, `guard`, `old man`, etc. so the renderer can still exclude them.
+- Keeps the Canonical Identity normalization already merged in PR #674.
+
+## Scope
+
+Display adapter only. No extraction, scoring, database, artifact, or pipeline logic changed.
+
+## Acceptance check
+
+On `/evaluate/<jobId>/ledger`, valid extracted relationship pairs with lowercase multi-word names should render instead of producing a false `No qualifying relationship pairs found` state.

--- a/app/evaluate/[jobId]/ledger/page.tsx
+++ b/app/evaluate/[jobId]/ledger/page.tsx
@@ -6,8 +6,6 @@ import { approveLedgerAction, rejectLedgerAction } from './actions';
 import { StoryLedgerShell } from '@/components/ledger/StoryLedgerShell';
 import LedgerDownloadButton from '@/components/ledger/LedgerDownloadButton';
 
-// ─── Types ───────────────────────────────────────────────────────────────────
-
 type LedgerJob = {
   id: string;
   user_id?: string | null;
@@ -58,8 +56,6 @@ type AcceptedLedgerContent = {
   story_layer?: Record<string, Record<string, unknown>>;
 };
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
 function relationTitle(job: LedgerJob): string {
   const relation = Array.isArray(job.manuscripts) ? job.manuscripts[0] : job.manuscripts;
   return relation?.title?.trim() || 'Untitled manuscript';
@@ -79,9 +75,6 @@ function normalizeCanonicalIdentityLayer(
 ): Record<string, unknown> | undefined {
   if (!layer || Object.keys(layer).length === 0) return layer;
 
-  // Writer contract emits `identity_groups`; the current UI renderer consumes
-  // `canonical_identity_group`. Normalize at the page seam so existing
-  // pass1a_story_layer_v1 artifacts display without regeneration.
   const rawGroups = Array.isArray(layer.identity_groups)
     ? layer.identity_groups
     : Array.isArray(layer.canonical_identity_group)
@@ -91,22 +84,18 @@ function normalizeCanonicalIdentityLayer(
   if (rawGroups.length === 0) return layer;
 
   const canonicalIdentityGroup = rawGroups.filter(isRecord).map((group) => {
-    const existingAnchors = Array.isArray(group.evidence_anchors)
-      ? group.evidence_anchors
-      : [];
+    const existingAnchors = Array.isArray(group.evidence_anchors) ? group.evidence_anchors : [];
     const firstAppearance = group.first_appearance ? String(group.first_appearance) : null;
     const lastAppearance = group.last_appearance ? String(group.last_appearance) : null;
-    const evidenceAnchors =
-      existingAnchors.length > 0
-        ? existingAnchors
-        : [firstAppearance, lastAppearance].filter(Boolean);
+    const evidenceAnchors = existingAnchors.length > 0
+      ? existingAnchors
+      : [firstAppearance, lastAppearance].filter(Boolean);
 
     return {
       ...group,
       role: group.role ?? group.narrative_role,
       legal_name_states: group.legal_name_states ?? group.name_history,
-      post_resolution_name_states:
-        group.post_resolution_name_states ?? group.final_status,
+      post_resolution_name_states: group.post_resolution_name_states ?? group.final_status,
       evidence_anchors: evidenceAnchors,
     };
   });
@@ -146,14 +135,8 @@ function normalizeRelationshipName(value: unknown): unknown {
   if (typeof value !== 'string') return value;
   const trimmed = value.trim();
   const normalized = trimmed.toLowerCase();
-
-  // Leave true generic descriptors untouched so the relationship renderer can
-  // still reject them as non-named parties.
   if (!trimmed || RELATIONSHIP_LABEL_ONLY_TERMS.has(normalized)) return value;
 
-  // The current renderer rejects lowercase multi-word names as label-only.
-  // The extractor can emit normalized lowercase proper names, so title-case
-  // likely names only at the UI seam without mutating stored artifacts.
   if (trimmed === normalized && normalized.includes(' ')) {
     return trimmed.replace(/\b[\p{L}]/gu, (char) => char.toLocaleUpperCase());
   }
@@ -210,34 +193,22 @@ function normalizeStoryLayersForUi(
 ): Record<string, Record<string, unknown>> | null {
   if (!layers) return null;
 
-  const canonicalIdentityLayer = normalizeCanonicalIdentityLayer(
-    layers.canonical_identity_layer,
-  );
-  const relationshipNetworkLayer = normalizeRelationshipNetworkLayer(
-    layers.relationship_network_layer,
-  );
+  const canonicalIdentityLayer = normalizeCanonicalIdentityLayer(layers.canonical_identity_layer);
+  const relationshipNetworkLayer = normalizeRelationshipNetworkLayer(layers.relationship_network_layer);
 
   return {
     ...layers,
-    ...(canonicalIdentityLayer
-      ? { canonical_identity_layer: canonicalIdentityLayer }
-      : {}),
-    ...(relationshipNetworkLayer
-      ? { relationship_network_layer: relationshipNetworkLayer }
-      : {}),
+    ...(canonicalIdentityLayer ? { canonical_identity_layer: canonicalIdentityLayer } : {}),
+    ...(relationshipNetworkLayer ? { relationship_network_layer: relationshipNetworkLayer } : {}),
   };
 }
-
-// ─── Data fetching ────────────────────────────────────────────────────────────
 
 async function getLedgerContext(jobId: string, userId: string) {
   const supabase = createAdminClient();
 
   const { data: job, error: jobError } = await supabase
     .from('evaluation_jobs')
-    .select(
-      'id, user_id, manuscript_id, status, phase, phase_status, ledger_approved_at, evaluation_project_id, manuscripts(user_id,title)',
-    )
+    .select('id, user_id, manuscript_id, status, phase, phase_status, ledger_approved_at, evaluation_project_id, manuscripts(user_id,title)')
     .eq('id', jobId)
     .maybeSingle();
 
@@ -246,7 +217,6 @@ async function getLedgerContext(jobId: string, userId: string) {
   const typedJob = job as LedgerJob;
   if (relationOwner(typedJob) !== userId) return null;
 
-  // ── pass1a_story_layer_v1 (Module 1 data)
   const { data: storyLayerArtifact } = await supabase
     .from('evaluation_artifacts')
     .select('id, content, created_at, source_hash')
@@ -254,7 +224,6 @@ async function getLedgerContext(jobId: string, userId: string) {
     .eq('artifact_type', 'pass1a_story_layer_v1')
     .maybeSingle();
 
-  // ── pass1a_character_ledger_v1 (legacy — used for hard_fail_triggers)
   const { data: characterArtifact } = await supabase
     .from('evaluation_artifacts')
     .select('id, content')
@@ -262,7 +231,6 @@ async function getLedgerContext(jobId: string, userId: string) {
     .eq('artifact_type', 'pass1a_character_ledger_v1')
     .maybeSingle();
 
-  // ── accepted_story_ledger_v1 (Module 3 data)
   const { data: acceptedLedgerArtifact } = await supabase
     .from('evaluation_artifacts')
     .select('id, content, created_at')
@@ -277,8 +245,6 @@ async function getLedgerContext(jobId: string, userId: string) {
     acceptedLedgerContent: (acceptedLedgerArtifact?.content ?? null) as AcceptedLedgerContent | null,
   };
 }
-
-// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function StoryLedgerPage({
   params,
@@ -295,25 +261,20 @@ export default async function StoryLedgerPage({
 
   const { job, storyLayerContent, characterContent, acceptedLedgerContent } = context;
 
-  // ── Gate / approval state
-  const atReviewGate =
-    job.phase === 'review_gate' && job.phase_status === 'awaiting_approval';
+  const atReviewGate = job.phase === 'review_gate' && job.phase_status === 'awaiting_approval';
   const approved = Boolean(job.ledger_approved_at) || job.phase === 'phase_2';
   const justApproved = searchParams?.approved === '1';
   const justRejected = searchParams?.rejected === '1';
 
-  // ── Story layers (Module 1)
   const rawStoryLayers = storyLayerContent?.layers ?? null;
   const storyLayers = normalizeStoryLayersForUi(rawStoryLayers);
   const layerCompletionSummary = storyLayerContent?.layer_completion_summary ?? null;
 
-  // ── Hard fails (from legacy character ledger, for Module 2 blocking alert)
   type CharContent = { ledger_v1?: { coverage_summary?: { hard_fail_triggers?: string[] } } };
   const charContent = characterContent as CharContent | null;
   const hardFails = charContent?.ledger_v1?.coverage_summary?.hard_fail_triggers ?? [];
   const hasHardFails = hardFails.length > 0;
 
-  // ── Accepted ledger (Module 3)
   const acceptedLedger = acceptedLedgerContent
     ? {
         approved_at: acceptedLedgerContent.approval?.approved_at ?? null,

--- a/app/evaluate/[jobId]/ledger/page.tsx
+++ b/app/evaluate/[jobId]/ledger/page.tsx
@@ -121,6 +121,90 @@ function normalizeCanonicalIdentityLayer(
   };
 }
 
+const RELATIONSHIP_LABEL_ONLY_TERMS = new Set([
+  'canadian',
+  'driver',
+  'driver from highway',
+  'foreigner',
+  'unnamed',
+  'unknown',
+  'unknown character',
+  'unnamed character',
+  'passenger',
+  'stranger',
+  'man',
+  'woman',
+  'boy',
+  'girl',
+  'old man',
+  'old woman',
+  'guard',
+  'soldier',
+]);
+
+function normalizeRelationshipName(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  const normalized = trimmed.toLowerCase();
+
+  // Leave true generic descriptors untouched so the relationship renderer can
+  // still reject them as non-named parties.
+  if (!trimmed || RELATIONSHIP_LABEL_ONLY_TERMS.has(normalized)) return value;
+
+  // The current renderer rejects lowercase multi-word names as label-only.
+  // The extractor can emit normalized lowercase proper names, so title-case
+  // likely names only at the UI seam without mutating stored artifacts.
+  if (trimmed === normalized && normalized.includes(' ')) {
+    return trimmed.replace(/\b[\p{L}]/gu, (char) => char.toLocaleUpperCase());
+  }
+
+  return value;
+}
+
+function normalizeRelationshipPair(pair: unknown): unknown {
+  if (!isRecord(pair)) return pair;
+
+  return {
+    ...pair,
+    ...(Object.prototype.hasOwnProperty.call(pair, 'character_a')
+      ? { character_a: normalizeRelationshipName(pair.character_a) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(pair, 'character_b')
+      ? { character_b: normalizeRelationshipName(pair.character_b) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(pair, 'from')
+      ? { from: normalizeRelationshipName(pair.from) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(pair, 'to')
+      ? { to: normalizeRelationshipName(pair.to) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(pair, 'a')
+      ? { a: normalizeRelationshipName(pair.a) }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(pair, 'b')
+      ? { b: normalizeRelationshipName(pair.b) }
+      : {}),
+  };
+}
+
+function normalizeRelationshipNetworkLayer(
+  layer: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!layer || Object.keys(layer).length === 0) return layer;
+
+  const normalizeArrayField = (key: string) =>
+    Array.isArray(layer[key])
+      ? { [key]: (layer[key] as unknown[]).map(normalizeRelationshipPair) }
+      : {};
+
+  return {
+    ...layer,
+    ...normalizeArrayField('relationship_pairs'),
+    ...normalizeArrayField('pairs'),
+    ...normalizeArrayField('relationships'),
+  };
+}
+
 function normalizeStoryLayersForUi(
   layers: Record<string, Record<string, unknown>> | null,
 ): Record<string, Record<string, unknown>> | null {
@@ -129,11 +213,17 @@ function normalizeStoryLayersForUi(
   const canonicalIdentityLayer = normalizeCanonicalIdentityLayer(
     layers.canonical_identity_layer,
   );
+  const relationshipNetworkLayer = normalizeRelationshipNetworkLayer(
+    layers.relationship_network_layer,
+  );
 
   return {
     ...layers,
     ...(canonicalIdentityLayer
       ? { canonical_identity_layer: canonicalIdentityLayer }
+      : {}),
+    ...(relationshipNetworkLayer
+      ? { relationship_network_layer: relationshipNetworkLayer }
       : {}),
   };
 }
@@ -236,10 +326,7 @@ export default async function StoryLedgerPage({
       }
     : null;
 
-  const manuscriptTitle = (() => {
-    const rel = Array.isArray(job.manuscripts) ? job.manuscripts[0] : job.manuscripts;
-    return rel?.title?.trim() || 'Untitled manuscript';
-  })();
+  const manuscriptTitle = relationTitle(job);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Conflict-free follow-up to PR #674. PR #674 already fixed Canonical Identity by normalizing `identity_groups` into the renderer-compatible shape. This PR adds the second observed Story Ledger fix: Relationship Network rendering.

## Why

The Relationship Network renderer filters label-only/generic parties. That is correct for true descriptors, but the current filter can also drop valid extracted proper names when the extractor emits normalized lowercase multi-word names.

## Changes

- Adds a page-seam normalization for `relationship_network_layer`.
- Normalizes lowercase multi-word relationship names before they reach the existing label-only filter.
- Preserves true generic labels such as `unknown character`, `driver`, `guard`, `old man`, etc. so the renderer can still exclude them.
- Keeps the Canonical Identity normalization already merged in PR #674.

## Scope

Display adapter only. No extraction, scoring, database, artifact, or pipeline logic changed.

## Acceptance check

On `/evaluate/<jobId>/ledger`, valid extracted relationship pairs with lowercase multi-word names should render instead of producing a false `No qualifying relationship pairs found` state.