### PR TITLE
Redact WAVE details across public pages

### DIFF
--- a/.github/pr-bodies/PR-681.md
+++ b/.github/pr-bodies/PR-681.md
@@ -1,0 +1,38 @@
+## Summary
+
+Follow-up to the homepage WAVE redaction. This keeps WAVE visible as RevisionGrade’s proprietary repair layer while removing public implementation breadcrumbs from support/education pages.
+
+## Why
+
+The public site should communicate the promise of WAVE without exposing internal architecture, gate names, detailed build order, or implementation taxonomy that could help copycats.
+
+## Changes
+
+- Methodology: replaces explicit `Golden Spine/WAVE governance` public wording with safer `proprietary repair governance` language.
+- Pricing: removes public `Golden Spine/WAVE` tier references and replaces them with long-form repair layer / proprietary repair governance wording.
+- Resources: redacts FAQ reference to `Golden Spine/WAVE` and uses safer multi-layer/proprietary governance language.
+- Revise: softens WAVE implementation wording by removing public sequencing details such as `structure before polish`, `continuity before local line repair`, and similar implementation breadcrumbs.
+- Keeps WAVE named as the proprietary repair layer after evaluation.
+
+## Explicit non-goals
+
+- No backend logic changes.
+- No database/schema changes.
+- No evaluation, scoring, WAVE runtime, Revise runtime, TrustedPath runtime, or pipeline logic changes.
+- No changes to internal canon/docs/runtime files.
+
+## Public copy rule enforced
+
+Safe public wording:
+
+> WAVE is RevisionGrade’s proprietary, evidence-backed, sequenced repair layer after evaluation.
+
+Not public:
+
+- wave counts
+- tsunami counts
+- internal gate names
+- Volume/canon identifiers
+- specific wave module names
+- build-order taxonomies
+- internal sequence rules

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -10,7 +10,7 @@ const methods = [
 const modes = [
   { title: "Short-Form Evaluation", range: "Under 25,000 words", copy: "Evaluates the submitted pages against the 13 story criteria only. Designed for openings, chapters, excerpts, short stories, and shorter works where full manuscript continuity cannot yet be judged." },
   { title: "Long-Form Evaluation", range: "25,000+ words", copy: "Adds manuscript-scale analysis: continuity, recurrence, setup/payoff, pacing over distance, character behavior, structural readiness, and cumulative reader experience." },
-  { title: "Long-Form Multi-Layer Evaluation", range: "Complex long-form manuscripts", copy: "A deeper architecture audit for manuscripts that need layered story ledgers, Golden Spine/WAVE governance, long-form canon/gates, dialogue and speech protection, and deeper continuity analysis." },
+  { title: "Long-Form Multi-Layer Evaluation", range: "Complex long-form manuscripts", copy: "A deeper architecture audit for manuscripts that need layered evidence views, manuscript-scale continuity, proprietary repair governance, dialogue and speech protection, and deeper structural analysis where appropriate." },
 ];
 
 const criteria = ["Concept", "Narrative Drive", "Character", "Voice", "Scene Construction", "Dialogue", "Theme", "Worldbuilding", "Pacing", "Prose Control", "Tone", "Narrative Closure", "Marketability"];

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -21,7 +21,7 @@ const auditTiers = [
     price: "$49",
     actionAccess: "13 story criteria only",
     bestFor: "Chapters, excerpts, short stories, openings, and partial submissions.",
-    features: ["13 story criteria", "Evidence-backed diagnosis", "Readiness verdict", "Golden Spine/WAVE not included"],
+    features: ["13 story criteria", "Evidence-backed diagnosis", "Readiness verdict", "Long-form repair layer not included"],
   },
   {
     name: "Full Manuscript Readiness Audit",
@@ -46,7 +46,7 @@ const auditTiers = [
     price: "$499+",
     actionAccess: "Deep architecture audit",
     bestFor: "Multi-POV, multi-timeline, genre-hybrid, experimental, memoir-fiction, or unusually structured long-form prose.",
-    features: ["13 story criteria", "Layered story-ledger analysis", "Golden Spine/WAVE where appropriate", "Custom complexity handling"],
+    features: ["13 story criteria", "Layered evidence analysis", "Proprietary repair governance where appropriate", "Custom complexity handling"],
   },
 ];
 
@@ -70,7 +70,7 @@ const faqs = [
   {
     question: "When does multi-layer analysis apply?",
     answer:
-      "Long-form multi-layer evaluation is the deeper architecture tier for complex manuscripts. It may include layered story ledgers, Golden Spine/WAVE governance, long-form canon/gates, dialogue and speech protection, and deeper continuity logic where appropriate.",
+      "Long-form multi-layer evaluation is the deeper architecture tier for complex manuscripts. It may include layered evidence views, manuscript-scale continuity, proprietary repair governance, dialogue and speech protection, and deeper structural analysis where appropriate.",
   },
   {
     question: "Why not offer unlimited revisions?",

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -44,7 +44,7 @@ const faqs = [
   },
   {
     q: "What are the evaluation modes?",
-    a: "Short-form evaluations cover submissions under 25,000 words and use the 13 story criteria only. Long-form evaluations begin at 25,000+ words and add manuscript-scale continuity. Long-form multi-layer evaluations add deeper architecture, story-ledger, Golden Spine/WAVE, and governance analysis where appropriate.",
+    a: "Short-form evaluations cover submissions under 25,000 words and use the 13 story criteria only. Long-form evaluations begin at 25,000+ words and add manuscript-scale continuity. Long-form multi-layer evaluations add deeper architecture, layered evidence, proprietary repair governance, and continuity analysis where appropriate.",
   },
   {
     q: "Does RevisionGrade rewrite my voice?",
@@ -69,7 +69,7 @@ export default function ResourcesPage() {
           Resources for serious manuscript evaluation.
         </h1>
         <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/80">
-          Learn how RevisionGrade separates manuscript readiness from market rejection, evaluates long-form prose, protects author control, and turns diagnosis into revision decisions.
+          Learn how RevisionGrade separates manuscript readiness from market rejection, evaluates long-form prose, protects author control, and turns diagnosis into governed revision decisions.
         </p>
 
         <div className="mt-12 grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/app/revise/page.tsx
+++ b/app/revise/page.tsx
@@ -35,7 +35,7 @@ const manualDecisions = [
 ];
 
 const trustedPathSafeguards = [
-  "Applies eligible Option A repairs only",
+  "Applies eligible recommended repairs only",
   "Creates a duplicate revised draft",
   "Preserves the original manuscript",
   "Generates a change log",
@@ -43,9 +43,9 @@ const trustedPathSafeguards = [
   "Supports follow-up evaluation to measure improvement",
 ];
 
-const waveSequence = [
-  "Structure before polish",
-  "Continuity before local line repair",
+const publicRepairPrinciples = [
+  "Diagnosis before repair",
+  "Evidence before edit",
   "Voice protection before compression",
   "Author decision before manuscript change",
   "Follow-up evaluation before claiming improvement",
@@ -53,7 +53,7 @@ const waveSequence = [
 
 const doctrine = [
   "Evaluation findings do not automatically become edits.",
-  "WAVE is the ordered repair layer after evaluation, not a single rewrite command.",
+  "WAVE is the proprietary repair layer after evaluation, not a single rewrite command.",
   "Revision activity is not measured improvement until a later evaluation confirms movement.",
   "The author may control every opportunity manually or authorize governed automation.",
   "TrustedPath™ is convenience with safeguards, not blind rewriting.",
@@ -70,14 +70,14 @@ export default function RevisePage() {
         <div>
           <Eyebrow>RevisionGrade™ Revise · WAVE Revision System™</Eyebrow>
           <h1 className="mt-6 font-rg-serif text-5xl leading-[0.95] tracking-tight md:text-7xl">
-            Choose your WAVE revision path.
+            Choose your governed revision path.
           </h1>
           <p className="mt-8 max-w-2xl text-lg leading-8 text-rg-cream2/85">
-            Revise is the WAVE Revision System™ in action: evaluation findings become ordered repair decisions. Work through the queue one opportunity at a time, or use TrustedPath™ to apply the eligible system-recommended path to a protected manuscript copy.
+            Revise is WAVE in action: evaluation findings become evidence-backed repair decisions. Work through the queue one opportunity at a time, or use TrustedPath™ to apply eligible recommended repairs to a protected manuscript copy.
           </p>
           <div className="mt-10 flex flex-wrap gap-4">
             <Link href="/workbench" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
-              Open WAVE Queue
+              Open Revise Queue
             </Link>
             <Link href="/evaluate" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">
               Start Evaluation
@@ -89,7 +89,7 @@ export default function RevisePage() {
           <Eyebrow>Core primitive</Eyebrow>
           <h2 className="mt-4 font-rg-serif text-3xl">RevisionOpportunity</h2>
           <p className="mt-4 text-sm leading-7 text-rg-cream2/75">
-            Each WAVE opportunity is a specific manuscript repair candidate, anchored to evidence and constrained by what the author must not lose.
+            Each opportunity is a specific manuscript repair candidate, anchored to evidence and constrained by what the author must not lose.
           </p>
           <div className="mt-6 space-y-3">
             {queueItems.map((item) => (
@@ -105,14 +105,14 @@ export default function RevisePage() {
         <div className="mx-auto max-w-7xl px-6 py-20">
           <Eyebrow>Two revision paths</Eyebrow>
           <h2 className="mt-4 max-w-4xl font-rg-serif text-4xl leading-tight md:text-5xl">
-            Manual WAVE control or governed automation.
+            Manual control or governed automation.
           </h2>
           <div className="mt-10 grid gap-6 lg:grid-cols-2">
             <article className="border border-rg-cream2/12 bg-rg-ink/70 p-7">
               <p className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold">Path 1</p>
               <h3 className="mt-4 font-rg-serif text-4xl">Revise Queue</h3>
               <p className="mt-4 leading-7 text-rg-cream2/75">
-                The author reviews each WAVE opportunity manually. Every decision is explicit: accept a proposed repair, keep the original, reject the opportunity, defer it, or write a custom revision.
+                The author reviews each repair opportunity manually. Every decision is explicit: accept a proposed repair, keep the original, reject the opportunity, defer it, or write a custom revision.
               </p>
               <div className="mt-6 grid gap-2 sm:grid-cols-2">
                 {manualDecisions.map((item) => (
@@ -130,7 +130,7 @@ export default function RevisePage() {
               <p className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold">Path 2</p>
               <h3 className="mt-4 font-rg-serif text-4xl">TrustedPath™</h3>
               <p className="mt-4 leading-7 text-rg-cream2/75">
-                TrustedPath™ is the one-click WAVE path for authors who do not want to review dozens or hundreds of repair opportunities. It applies the eligible Option A repairs to a duplicate manuscript draft.
+                TrustedPath™ is the convenience path for authors who do not want to review dozens or hundreds of repair opportunities. It applies eligible recommended repairs to a duplicate manuscript draft.
               </p>
               <div className="mt-6 grid gap-2 sm:grid-cols-2">
                 {trustedPathSafeguards.map((item) => (
@@ -154,7 +154,7 @@ export default function RevisePage() {
             Three proposed repairs, one author decision.
           </h2>
           <p className="mt-6 leading-8 text-rg-cream2/75">
-            The options are not random rewrites. They represent different levels of WAVE intervention, from recommended to conservative to bold.
+            The options are not random rewrites. They represent different levels of intervention, from recommended to conservative to bold.
           </p>
         </div>
         <div className="grid gap-4">
@@ -170,16 +170,16 @@ export default function RevisePage() {
       <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
         <div className="mx-auto grid max-w-7xl gap-10 px-6 py-20 lg:grid-cols-[0.85fr_1.15fr]">
           <div>
-            <Eyebrow>WAVE order</Eyebrow>
+            <Eyebrow>Repair discipline</Eyebrow>
             <h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">
-              WAVE keeps repair sequenced instead of scattered.
+              WAVE keeps repair governed instead of scattered.
             </h2>
             <p className="mt-6 leading-8 text-rg-cream2/75">
-              The system should not polish a sentence before it knows whether the scene, promise, voice, or continuity is structurally sound.
+              The public principle is simple: the system should not polish a sentence before it understands the evidence, risk, voice, and author decision attached to the change.
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
-            {waveSequence.map((item, index) => (
+            {publicRepairPrinciples.map((item, index) => (
               <div key={item} className="border border-rg-cream2/12 bg-rg-ink/70 p-5">
                 <p className="font-rg-mono text-xs text-rg-gold">0{index + 1}</p>
                 <p className="mt-3 leading-7 text-rg-cream2/85">{item}</p>
@@ -209,7 +209,7 @@ export default function RevisePage() {
         <div className="border border-rg-gold/35 bg-rg-ink2/60 p-8 md:p-10">
           <Eyebrow>Contract</Eyebrow>
           <h2 className="mt-4 max-w-4xl font-rg-serif text-4xl leading-tight md:text-5xl">
-            Manual WAVE proves rigor. TrustedPath™ delivers speed.
+            Manual review proves rigor. TrustedPath™ delivers speed.
           </h2>
           <p className="mt-6 max-w-3xl leading-8 text-rg-cream2/75">
             Both paths keep the same principle: the manuscript is diagnosed first, repairs are evidence-backed, and the author remains the final authority.


### PR DESCRIPTION
## Summary

Follow-up to the homepage WAVE redaction. This keeps WAVE visible as RevisionGrade’s proprietary repair layer while removing public implementation breadcrumbs from support/education pages.

## Why

The public site should communicate the promise of WAVE without exposing internal architecture, gate names, detailed build order, or implementation taxonomy that could help copycats.

## Changes

- Methodology: replaces explicit `Golden Spine/WAVE governance` public wording with safer `proprietary repair governance` language.
- Pricing: removes public `Golden Spine/WAVE` tier references and replaces them with long-form repair layer / proprietary repair governance wording.
- Resources: redacts FAQ reference to `Golden Spine/WAVE` and uses safer multi-layer/proprietary governance language.
- Revise: softens WAVE implementation wording by removing public sequencing details such as `structure before polish`, `continuity before local line repair`, and similar implementation breadcrumbs.
- Keeps WAVE named as the proprietary repair layer after evaluation.

## Explicit non-goals

- No backend logic changes.
- No database/schema changes.
- No evaluation, scoring, WAVE runtime, Revise runtime, TrustedPath runtime, or pipeline logic changes.
- No changes to internal canon/docs/runtime files.

## Public copy rule enforced

Safe public wording:

> WAVE is RevisionGrade’s proprietary, evidence-backed, sequenced repair layer after evaluation.

Not public:

- wave counts
- tsunami counts
- internal gate names
- Volume/canon identifiers
- specific wave module names
- build-order taxonomies
- internal sequence rules
