### PR TITLE
Add Agent Readiness FAQ and submission-package polish

### DIFF
--- a/.github/pr-bodies/PR-687.md
+++ b/.github/pr-bodies/PR-687.md
@@ -1,0 +1,53 @@
+## Summary
+
+Adds a dedicated Agent Readiness FAQ/support page and tightens the main Agent Readiness page around manuscript submission-package scope.
+
+## Why
+
+The upgrade list calls out that Agent Readiness still needs stronger help text, export framing, and a FAQ explaining query letter, synopsis, comps, bio, and package approval. This PR adds that support surface while keeping the page manuscript-only and publishing-facing.
+
+## Changes
+
+- Adds `/agent-readiness/faq`.
+- Explains the Agent Readiness package sections:
+  - Query Letter
+  - Query Pitch
+  - Synopsis
+  - Comparables
+  - Author Bio
+  - Package Export
+- Adds FAQ entries covering:
+  - what Agent Readiness is
+  - why evaluation should usually come first
+  - what the query letter includes
+  - what a query pitch is
+  - why synopsis reveals the ending
+  - author-supplied bio constraints
+  - comparable-title rationale
+  - no guarantee of agent response or outcome
+- Updates Agent Readiness navigation:
+  - `Pitch Builder` → `Query Pitch Builder`
+  - adds `Agent Readiness FAQ`
+- Polishes the main Agent Readiness page:
+  - reframes around professional manuscript submission package
+  - renames `Elevator Pitch` to `Query Pitch`
+  - clarifies that author bio inputs must be author-supplied
+  - improves Storygate eligibility wording
+  - adds sidebar link to Agent Readiness FAQ
+
+## Scope
+
+Public/help copy and page polish only. No backend, database, generation logic, export runtime, Agent Readiness runtime, Storygate runtime, evaluation, scoring, Revise, or TrustedPath changes.
+
+## Acceptance Criteria
+
+- Agent Readiness has a dedicated FAQ/support page.
+- Agent Readiness copy remains manuscript-submission focused.
+- Query letter, query pitch, synopsis, comparables, author bio, approval, and export are explained clearly.
+- Author bio copy makes clear credentials/facts must be author-supplied.
+- Page does not expand into unsupported non-manuscript workflows.
+- Navigation links to the new FAQ.
+
+## Notes
+
+I could not run the app locally from the connector environment. CI/preview should validate render and build.

--- a/app/agent-readiness/faq/page.tsx
+++ b/app/agent-readiness/faq/page.tsx
@@ -1,0 +1,156 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+const C = {
+  bg: "#0F0D0A",
+  panel: "#1A1612",
+  border: "#2A2420",
+  gold: "#A98E4A",
+  cream: "#F2EFEA",
+  cream2: "#C8BFB0",
+  dim: "#7B7060",
+  ink: "#0E0E0E",
+} as const;
+
+const packageSections = [
+  {
+    title: "Query letter",
+    body: "The professional letter that introduces the manuscript, hook, category, word count, comparable titles, author context, and closing. It should be clear, restrained, and ready for agent submission.",
+  },
+  {
+    title: "Query pitch",
+    body: "A compact hook or one-sentence positioning line used inside query forms and submission materials. It is not a separate hype document; it supports the query package.",
+  },
+  {
+    title: "Synopsis",
+    body: "A clear summary of the story, including the ending. The synopsis shows whether the manuscript has coherent plot movement, stakes, escalation, and resolution.",
+  },
+  {
+    title: "Comparables",
+    body: "A small set of useful comparison titles with rationale. Good comps help locate the manuscript on the publishing shelf without pretending the book is identical to anything else.",
+  },
+  {
+    title: "Author bio",
+    body: "A professional bio built from author-supplied facts only. RevisionGrade should not invent credentials, awards, publications, platform, or personal history.",
+  },
+  {
+    title: "Package export",
+    body: "A final approved package the author can review, save, and export after all required sections are complete and approved.",
+  },
+];
+
+const approvalRules = [
+  "Each section should be reviewed before export.",
+  "Author bio content must come from author-provided information.",
+  "Comparables should be plausible and explained, not name-dropped.",
+  "The query letter should stay focused on manuscript submission, not broad promotion.",
+  "Package approval does not guarantee agent interest, representation, publication, or market outcome.",
+];
+
+const faqs = [
+  {
+    q: "What is Agent Readiness Package™?",
+    a: "Agent Readiness Package™ helps an author prepare the core materials used for manuscript submission: query letter, query pitch, synopsis, comparables, author bio, manuscript positioning, and package export.",
+  },
+  {
+    q: "Is this the same as a manuscript evaluation?",
+    a: "No. Evaluation diagnoses manuscript readiness. Agent Readiness prepares submission materials after the manuscript is ready enough to present. A strong package cannot compensate for a structurally unready manuscript.",
+  },
+  {
+    q: "Should I use Agent Readiness before evaluation?",
+    a: "Usually no. The safer path is to diagnose readiness first, revise what needs repair, then build submission materials. Otherwise, the package may make a weak manuscript look polished without solving the underlying problem.",
+  },
+  {
+    q: "What does the query letter include?",
+    a: "The query letter should include the hook, manuscript metadata, category or shelf, concise story positioning, comparable titles where useful, a short author bio, and a professional closing.",
+  },
+  {
+    q: "What is a query pitch?",
+    a: "A query pitch is a short manuscript positioning line or hook that helps communicate the project quickly in query forms and package summaries. It should support the query letter rather than replace it.",
+  },
+  {
+    q: "Why does the synopsis reveal the ending?",
+    a: "Agents and publishing professionals use a synopsis to understand the full narrative arc. A synopsis is not back-cover copy; it should show how the story resolves.",
+  },
+  {
+    q: "Can RevisionGrade invent an author bio for me?",
+    a: "No. Author bios must be based on author-supplied facts. RevisionGrade can shape, compress, and professionalize the bio, but it should not invent credentials or personal history.",
+  },
+  {
+    q: "What makes a good comparable title?",
+    a: "A good comp helps identify audience, shelf, tone, structure, or market neighborhood. It should come with a reason: what the manuscript shares with the comp and where it differs.",
+  },
+  {
+    q: "Does a polished package guarantee an agent response?",
+    a: "No. A polished package can improve clarity and professionalism, but it cannot control agent taste, timing, list needs, or market appetite.",
+  },
+];
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return <p className="font-rg-mono text-xs uppercase tracking-[0.22em]" style={{ color: C.gold }}>{children}</p>;
+}
+
+function Card({ title, body }: { title: string; body: string }) {
+  return (
+    <article className="p-6" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}` }}>
+      <h3 className="mb-3 font-rg-serif text-xl" style={{ color: C.cream }}>{title}</h3>
+      <p className="text-sm leading-7" style={{ color: C.cream2 }}>{body}</p>
+    </article>
+  );
+}
+
+export default function AgentReadinessFaqPage() {
+  return (
+    <main className="min-h-screen" style={{ backgroundColor: C.bg, color: C.cream }}>
+      <section className="mx-auto max-w-5xl px-6 py-24 text-center" style={{ borderBottom: `1px solid ${C.border}` }}>
+        <SectionLabel>Agent Readiness Package™ FAQ</SectionLabel>
+        <h1 className="mx-auto mt-5 max-w-3xl font-rg-serif text-4xl font-bold leading-tight md:text-5xl">
+          Build submission materials only after the manuscript is ready to be represented clearly.
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-base leading-8" style={{ color: C.cream2 }}>
+          Agent Readiness is the manuscript submission package layer: query letter, query pitch, synopsis, comparables, author bio, approval, and export. It is not a substitute for manuscript diagnosis.
+        </p>
+        <div className="mt-10 flex flex-wrap justify-center gap-4">
+          <Link href="/agent-readiness" className="border px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em]" style={{ borderColor: C.gold, backgroundColor: C.gold, color: C.ink }}>
+            Open Agent Readiness
+          </Link>
+          <Link href="/evaluate" className="border px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em]" style={{ borderColor: C.gold, color: C.gold }}>
+            Diagnose Readiness First
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 py-20">
+        <SectionLabel>Package Sections</SectionLabel>
+        <h2 className="mt-4 mb-10 font-rg-serif text-3xl font-bold">What the package contains.</h2>
+        <div className="grid gap-5 md:grid-cols-2">
+          {packageSections.map((section) => <Card key={section.title} {...section} />)}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 py-4">
+        <SectionLabel>Approval Doctrine</SectionLabel>
+        <h2 className="mt-4 mb-8 font-rg-serif text-3xl font-bold">The author approves the package before export.</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {approvalRules.map((rule) => (
+            <div key={rule} className="p-4 text-sm leading-7" style={{ backgroundColor: C.panel, border: `1px solid ${C.border}`, color: C.cream2 }}>
+              <span style={{ color: C.gold }}>—</span> {rule}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-4xl px-6 py-20">
+        <SectionLabel>Frequently Asked Questions</SectionLabel>
+        <div className="mt-8 space-y-7">
+          {faqs.map((item) => (
+            <div key={item.q} className="pb-7" style={{ borderBottom: `1px solid ${C.border}` }}>
+              <h3 className="mb-2 font-rg-serif text-lg font-semibold">{item.q}</h3>
+              <p className="text-sm leading-7" style={{ color: C.cream2 }}>{item.a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/agent-readiness/page.tsx
+++ b/app/agent-readiness/page.tsx
@@ -3,11 +3,11 @@
 /**
  * Agent Readiness Package™ — Flagship page
  *
- * Generates the full professional query package:
+ * Generates the full professional manuscript submission package:
  *   1. Query Letter          (450-word hard cap)
  *   2. What Makes This Novel Unique
  *   3. Synopsis
- *   4. Elevator Pitch
+ *   4. Query Pitch
  *   5. Comparables
  *   6. Author Bio            (author-supplied credentials only)
  *
@@ -24,7 +24,7 @@ type SectionId =
   | "query-letter"
   | "unique"
   | "synopsis"
-  | "elevator-pitch"
+  | "query-pitch"
   | "comparables"
   | "author-bio";
 
@@ -45,7 +45,7 @@ const REQUIRED_SECTIONS: { id: SectionId; label: string; href: string; descripti
     id: "unique",
     label: "What Makes This Novel Unique",
     href: "/agent-readiness/query-letter",
-    description: "Standalone section and summarized inside the query letter.",
+    description: "A concise differentiator that can stand alone and also support the query letter.",
   },
   {
     id: "synopsis",
@@ -54,16 +54,16 @@ const REQUIRED_SECTIONS: { id: SectionId; label: string; href: string; descripti
     description: "Query synopsis (100–150 words), standard (250–500), or extended (700–1,000). Ending revealed.",
   },
   {
-    id: "elevator-pitch",
-    label: "Elevator Pitch",
+    id: "query-pitch",
+    label: "Query Pitch",
     href: "/agent-readiness/pitch",
-    description: "One sentence. Suitable for query forms, verbal pitching, and metadata.",
+    description: "One-sentence manuscript hook or positioning line for query forms and package summaries.",
   },
   {
     id: "comparables",
     label: "Comparables",
     href: "/agent-readiness/comparables",
-    description: "2–4 comps with rationale. Also integrated into the query letter.",
+    description: "2–4 comps with rationale. Also integrated into the query letter where useful.",
   },
   {
     id: "author-bio",
@@ -178,12 +178,12 @@ function SectionCard({
 
 export default function AgentReadinessPage() {
   const [sectionStates] = useState<Record<SectionId, SectionState>>({
-    "query-letter":  { status: "empty", content: "" },
-    "unique":        { status: "empty", content: "" },
-    "synopsis":      { status: "empty", content: "" },
-    "elevator-pitch":{ status: "empty", content: "" },
-    "comparables":   { status: "empty", content: "" },
-    "author-bio":    { status: "empty", content: "" },
+    "query-letter": { status: "empty", content: "" },
+    "unique":       { status: "empty", content: "" },
+    "synopsis":     { status: "empty", content: "" },
+    "query-pitch":  { status: "empty", content: "" },
+    "comparables":  { status: "empty", content: "" },
+    "author-bio":   { status: "empty", content: "" },
   });
 
   const approvedCount = Object.values(sectionStates).filter(s => s.status === "approved").length;
@@ -240,6 +240,13 @@ export default function AgentReadinessPage() {
             }}>
               Package History / Export
             </Link>
+            <Link href="/agent-readiness/faq" style={{
+              padding: "0.5rem 0.75rem",
+              fontFamily: T.mono, fontSize: "0.6875rem", color: T.dim,
+              textDecoration: "none",
+            }}>
+              Agent Readiness FAQ
+            </Link>
           </nav>
 
           {/* Approval progress */}
@@ -273,10 +280,10 @@ export default function AgentReadinessPage() {
               Agent Readiness Package™
             </p>
             <h1 style={{ fontFamily: T.serif, fontSize: "2rem", color: T.cream, lineHeight: 1.1, marginBottom: "0.875rem" }}>
-              Generate Full Agent Readiness Package
+              Build a Professional Manuscript Submission Package
             </h1>
-            <p style={{ fontSize: "0.875rem", color: T.cream2, lineHeight: 1.65, maxWidth: "600px" }}>
-              One manuscript. One professional submission package. Generate your query letter, synopsis, elevator pitch, comparables, market positioning, and author bio — then approve each section before export.
+            <p style={{ fontSize: "0.875rem", color: T.cream2, lineHeight: 1.65, maxWidth: "640px" }}>
+              One manuscript. One professional submission package. Generate your query letter, query pitch, synopsis, comparables, manuscript positioning, and author bio — then approve each section before export.
             </p>
           </div>
 
@@ -288,7 +295,7 @@ export default function AgentReadinessPage() {
             <span style={{ color: T.gold, fontSize: "0.75rem", flexShrink: 0 }}>ⓘ</span>
             <div>
               <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
-                <strong style={{ color: T.cream }}>Eligibility:</strong> Full manuscripts may generate a complete Query Package. Excerpt or chapter submissions are eligible for craft evaluation only. Storygate Studio™ submission requires a readiness score of 8.0 or above.
+                <strong style={{ color: T.cream }}>Eligibility:</strong> Agent Readiness is for manuscript submission materials. Excerpts or chapters are better handled through evaluation first. Storygate Studio™ submission requires a readiness score of 8.0 or above and an approved manuscript package.
               </p>
             </div>
           </div>
@@ -304,7 +311,7 @@ export default function AgentReadinessPage() {
               Generate Complete Package
             </button>
             <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
-              Generates all six required sections from your manuscript and provided bio inputs.
+              Generates all six required sections from your manuscript and author-supplied bio inputs.
             </p>
           </div>
 
@@ -326,7 +333,7 @@ export default function AgentReadinessPage() {
                 Agent Targeting™ — Coming Next
               </p>
               <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5 }}>
-                Find three target agents. Generate agent-specific query variants. Build your outreach plan.
+                Identify target agents, generate agent-specific query variants, and build your outreach plan after the core package is approved.
               </p>
             </div>
             <span style={{

--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -43,10 +43,11 @@ const arpLinks = [
   ["Generate Full Agent Package", "/agent-readiness"],
   ["Query / Cover Letter",        "/agent-readiness/query-letter"],
   ["Synopsis Builder",            "/agent-readiness/synopsis"],
-  ["Pitch Builder",               "/agent-readiness/pitch"],
+  ["Query Pitch Builder",         "/agent-readiness/pitch"],
   ["Author Bio",                  "/agent-readiness/bio"],
   ["Comparables & Positioning",   "/agent-readiness/comparables"],
   ["Package History / Export",    "/agent-readiness/history"],
+  ["Agent Readiness FAQ",         "/agent-readiness/faq"],
 ];
 
 const arpActiveHref = "/agent-readiness";


### PR DESCRIPTION
## Summary

Adds a dedicated Agent Readiness FAQ/support page and tightens the main Agent Readiness page around manuscript submission-package scope.

## Why

The upgrade list calls out that Agent Readiness still needs stronger help text, export framing, and a FAQ explaining query letter, synopsis, comps, bio, and package approval. This PR adds that support surface while keeping the page manuscript-only and publishing-facing.

## Changes

- Adds `/agent-readiness/faq`.
- Explains the Agent Readiness package sections:
  - Query Letter
  - Query Pitch
  - Synopsis
  - Comparables
  - Author Bio
  - Package Export
- Adds FAQ entries covering:
  - what Agent Readiness is
  - why evaluation should usually come first
  - what the query letter includes
  - what a query pitch is
  - why synopsis reveals the ending
  - author-supplied bio constraints
  - comparable-title rationale
  - no guarantee of agent response or outcome
- Updates Agent Readiness navigation:
  - `Pitch Builder` → `Query Pitch Builder`
  - adds `Agent Readiness FAQ`
- Polishes the main Agent Readiness page:
  - reframes around professional manuscript submission package
  - renames `Elevator Pitch` to `Query Pitch`
  - clarifies that author bio inputs must be author-supplied
  - improves Storygate eligibility wording
  - adds sidebar link to Agent Readiness FAQ

## Scope

Public/help copy and page polish only. No backend, database, generation logic, export runtime, Agent Readiness runtime, Storygate runtime, evaluation, scoring, Revise, or TrustedPath changes.

## Acceptance Criteria

- Agent Readiness has a dedicated FAQ/support page.
- Agent Readiness copy remains manuscript-submission focused.
- Query letter, query pitch, synopsis, comparables, author bio, approval, and export are explained clearly.
- Author bio copy makes clear credentials/facts must be author-supplied.
- Page does not expand into unsupported non-manuscript workflows.
- Navigation links to the new FAQ.

## Notes

I could not run the app locally from the connector environment. CI/preview should validate render and build.