### PR TITLE
Expose merged support pages in public navigation

### DIFF
--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -27,17 +27,27 @@ const storygateLinks = [
 ];
 
 const resourceLinks = [
-  ["The Black Box Problem", "/black-box-problem"],
-  ["FAQs", "/resources"],
-  ["Methodology", "/methodology"],
-  ["Editorial Doctrine", "/reliability"],
+  ["Resources Hub",                  "/resources"],
+  ["The Black Box Problem",          "/black-box-problem"],
+  ["Methodology",                    "/methodology"],
+  ["Editorial Doctrine",             "/reliability"],
+  ["Privacy & Research Controls",    "/privacy-research-controls"],
+  ["Security & Access Controls",     "/security"],
+  ["Genre & Classification FAQ",     "/genre-classification-faq"],
+  ["Agent Readiness FAQ",            "/agent-readiness/faq"],
+  ["Storygate Studio FAQ",           "/storygate-studio/faq"],
 ];
 
 const resourceActiveHrefs = [
-  "/black-box-problem",
   "/resources",
+  "/black-box-problem",
   "/methodology",
   "/reliability",
+  "/privacy-research-controls",
+  "/security",
+  "/genre-classification-faq",
+  "/agent-readiness/faq",
+  "/storygate-studio/faq",
 ];
 
 const arpLinks = [
@@ -204,7 +214,7 @@ export default function HeaderNav() {
               Resources
             </button>
             {resourcesOpen && (
-              <div id="resources-menu" className={`${dropdownCls} w-56`} role="menu">
+              <div id="resources-menu" className={`${dropdownCls} w-72`} role="menu">
                 {resourceLinks.map(([label, href]) => (
                   <Link key={href} href={href} role="menuitem" onClick={() => setResourcesOpen(false)} className={dropdownItemCls}>
                     {label}


### PR DESCRIPTION
## Summary

Updates the public header navigation so the support/trust pages that have already merged are actually discoverable from the live dropdowns.

## Why

The pages exist, but the screenshot showed the Resources dropdown still exposing the old four-item menu. This PR fixes the surfacing gap in `HeaderNav.jsx`.

## Changes

- Expands the Resources dropdown to include:
  - Resources Hub
  - The Black Box Problem
  - Methodology
  - Editorial Doctrine
  - Privacy & Research Controls
  - Security & Access Controls
  - Genre & Classification FAQ
  - Agent Readiness FAQ
  - Storygate Studio FAQ
- Adds all new Resources routes to `resourceActiveHrefs` so the Resources nav item highlights correctly.
- Keeps Storygate Studio FAQ in the Storygate Studio dropdown.
- Keeps Agent Readiness FAQ in the Agent Readiness dropdown for authenticated users.
- Widens the Resources dropdown from `w-56` to `w-72` so the longer page labels fit cleanly.

## Scope

Navigation surfacing only. No public page copy, backend, database, auth, evaluation, scoring, Storygate runtime, Agent Readiness runtime, Revise, TrustedPath, or export behavior changed.

## Acceptance Criteria

- Signed-out users can discover the merged support/trust pages through Resources.
- Resources dropdown includes the dedicated Privacy, Security, Genre, Storygate FAQ, and Agent Readiness FAQ pages.
- Resources nav active state works for the newly exposed routes.
- Existing Evaluate, Revise, Storygate Studio, Agent Readiness, and Pricing nav behavior remains unchanged.

## Notes

I could not run the app locally from the connector environment. CI/preview should validate render and build.