### PR TITLE
Surface trust and FAQ pages in navigation

### DIFF
--- a/.github/pr-bodies/public-nav-trust-pages.md
+++ b/.github/pr-bodies/public-nav-trust-pages.md
@@ -1,0 +1,39 @@
+## Summary
+
+Surfaces the newer trust, FAQ, and package-support pages in the public navigation, resources hub, and footer.
+
+## Why
+
+Several completed public pages were hard to discover from the main site shell. The header Resources dropdown still exposed only the older resource set, while newer trust/support pages such as Privacy & Research Controls, Security & Access Controls, Genre & Classification FAQ, Storygate FAQ, and Agent Readiness FAQ were not consistently surfaced.
+
+## Changes
+
+- Expands the HeaderNav Resources dropdown to include:
+  - Resources Hub
+  - The Black Box Problem
+  - Methodology
+  - Editorial Doctrine
+  - Privacy & Research Controls
+  - Security & Access Controls
+  - Genre & Classification FAQ
+  - Storygate Studio FAQ
+  - Agent Readiness FAQ
+- Updates active-route coverage for the new resource/trust pages.
+- Renames Agent Readiness dropdown entry from `Generate Full Agent Package` to `Package Workspace` to match the new manuscript-selection workflow.
+- Adds Security & Access Controls and Agent Readiness FAQ cards to `/resources`.
+- Reworks the footer into Product / Resources / Trust & Support link groups so important pages are discoverable outside the header menu.
+
+## Scope
+
+Navigation/discovery only.
+
+No auth, pricing, evaluation pipeline, report generation, Agent Readiness generation, Storygate runtime, database, or package persistence behavior changed.
+
+## Acceptance Criteria
+
+- Header Resources dropdown exposes the new trust and FAQ pages.
+- Header Resources active state covers the new resource/trust routes.
+- Agent Readiness dropdown uses package-workspace language instead of implying one-click package generation.
+- Resources hub includes Security & Access Controls and Agent Readiness FAQ cards.
+- Footer links include product, resource, and trust/support destinations.
+- No film/TV, screenplay, adaptation, pitch-deck, or screen-project language is introduced.

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -33,6 +33,12 @@ const resourceCards = [
     copy: "How uploaded work is treated, what external research means, and why the author controls what happens next.",
   },
   {
+    title: "Security & Access Controls",
+    href: "/security",
+    eyebrow: "Controlled workspace",
+    copy: "A plain-language trust page covering account-gated workspaces, manuscript boundaries, controlled downloads, and logged access.",
+  },
+  {
     title: "Genre & Classification FAQ",
     href: "/genre-classification-faq",
     eyebrow: "Positioning matters",
@@ -43,6 +49,12 @@ const resourceCards = [
     href: "/storygate-studio/faq",
     eyebrow: "Controlled manuscript access",
     copy: "How manuscript-only Storygate access, creator approval, package visibility, and verified publishing-professional review fit together.",
+  },
+  {
+    title: "Agent Readiness FAQ",
+    href: "/agent-readiness/faq",
+    eyebrow: "Submission package support",
+    copy: "How query letters, synopses, comparables, author bios, package approval, and manuscript-specific readiness materials fit together.",
   },
 ];
 

--- a/components/HeaderNav.jsx
+++ b/components/HeaderNav.jsx
@@ -27,20 +27,20 @@ const storygateLinks = [
 ];
 
 const resourceLinks = [
-  ["The Black Box Problem", "/black-box-problem"],
-  ["Resources Hub", "/resources"],
-  ["Methodology", "/methodology"],
-  ["Editorial Doctrine", "/reliability"],
-  ["Privacy & Research Controls", "/privacy-research-controls"],
-  ["Security & Access Controls", "/security"],
-  ["Genre & Classification FAQ", "/genre-classification-faq"],
-  ["Storygate Studio FAQ", "/storygate-studio/faq"],
-  ["Agent Readiness FAQ", "/agent-readiness/faq"],
+  ["Resources Hub",                 "/resources"],
+  ["The Black Box Problem",         "/black-box-problem"],
+  ["Methodology",                   "/methodology"],
+  ["Editorial Doctrine",            "/reliability"],
+  ["Privacy & Research Controls",   "/privacy-research-controls"],
+  ["Security & Access Controls",    "/security"],
+  ["Genre & Classification FAQ",    "/genre-classification-faq"],
+  ["Storygate Studio FAQ",          "/storygate-studio/faq"],
+  ["Agent Readiness FAQ",           "/agent-readiness/faq"],
 ];
 
 const resourceActiveHrefs = [
-  "/black-box-problem",
   "/resources",
+  "/black-box-problem",
   "/methodology",
   "/reliability",
   "/privacy-research-controls",
@@ -51,14 +51,14 @@ const resourceActiveHrefs = [
 ];
 
 const arpLinks = [
-  ["Generate Full Agent Package", "/agent-readiness"],
-  ["Query / Cover Letter",        "/agent-readiness/query-letter"],
-  ["Synopsis Builder",            "/agent-readiness/synopsis"],
-  ["Query Pitch Builder",         "/agent-readiness/pitch"],
-  ["Author Bio",                  "/agent-readiness/bio"],
-  ["Comparables & Positioning",   "/agent-readiness/comparables"],
-  ["Package History / Export",    "/agent-readiness/history"],
-  ["Agent Readiness FAQ",         "/agent-readiness/faq"],
+  ["Package Workspace",          "/agent-readiness"],
+  ["Query Letter",               "/agent-readiness/query-letter"],
+  ["Synopsis Builder",           "/agent-readiness/synopsis"],
+  ["Query Pitch Builder",        "/agent-readiness/pitch"],
+  ["Author Bio",                 "/agent-readiness/bio"],
+  ["Comparables & Positioning",  "/agent-readiness/comparables"],
+  ["Package History / Export",   "/agent-readiness/history"],
+  ["Agent Readiness FAQ",        "/agent-readiness/faq"],
 ];
 
 const arpActiveHref = "/agent-readiness";
@@ -214,7 +214,7 @@ export default function HeaderNav() {
               Resources
             </button>
             {resourcesOpen && (
-              <div id="resources-menu" className={`${dropdownCls} w-56`} role="menu">
+              <div id="resources-menu" className={`${dropdownCls} w-72`} role="menu">
                 {resourceLinks.map(([label, href]) => (
                   <Link key={href} href={href} role="menuitem" onClick={() => setResourcesOpen(false)} className={dropdownItemCls}>
                     {label}

--- a/components/SiteFooter.jsx
+++ b/components/SiteFooter.jsx
@@ -1,13 +1,68 @@
 import Link from "next/link";
 
+const footerGroups = [
+  {
+    title: "Product",
+    links: [
+      ["Evaluate", "/evaluate"],
+      ["Revise", "/revise"],
+      ["Agent Readiness", "/agent-readiness"],
+      ["Storygate Studio", "/storygate-studio"],
+      ["Pricing", "/pricing"],
+    ],
+  },
+  {
+    title: "Resources",
+    links: [
+      ["Resources Hub", "/resources"],
+      ["The Black Box Problem", "/black-box-problem"],
+      ["Methodology", "/methodology"],
+      ["Editorial Doctrine", "/reliability"],
+      ["Genre & Classification FAQ", "/genre-classification-faq"],
+    ],
+  },
+  {
+    title: "Trust & Support",
+    links: [
+      ["Privacy & Research Controls", "/privacy-research-controls"],
+      ["Security & Access Controls", "/security"],
+      ["Agent Readiness FAQ", "/agent-readiness/faq"],
+      ["Storygate Studio FAQ", "/storygate-studio/faq"],
+      ["Privacy", "/privacy"],
+      ["Terms", "/terms"],
+    ],
+  },
+];
+
 export default function SiteFooter() {
   return (
-    <footer className="border-t border-gray-200 bg-white px-6 py-5 text-gray-600">
-      <div className="mx-auto flex max-w-7xl flex-col gap-3 text-xs md:flex-row md:items-center md:justify-between">
-        <span>RevisionGrade. All rights reserved.</span>
-        <div className="flex gap-4">
-          <Link href="/privacy" className="transition hover:text-gray-900">Privacy</Link>
-          <Link href="/terms" className="transition hover:text-gray-900">Terms</Link>
+    <footer className="border-t border-rg-cream2/10 bg-rg-ink px-6 py-10 text-rg-cream2">
+      <div className="mx-auto grid max-w-7xl gap-8 md:grid-cols-[1.2fr_2fr]">
+        <div>
+          <Link href="/" className="font-rg-serif text-lg text-rg-cream">
+            RevisionGrade&#8482;
+          </Link>
+          <p className="mt-3 max-w-sm text-sm leading-6 text-rg-cream2/70">
+            Manuscript diagnosis, author-controlled revision, and professional submission preparation.
+          </p>
+          <p className="mt-5 text-xs text-rg-dim">RevisionGrade. All rights reserved.</p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-3">
+          {footerGroups.map((group) => (
+            <div key={group.title}>
+              <h2 className="font-rg-mono text-[0.68rem] uppercase tracking-[0.18em] text-rg-gold">
+                {group.title}
+              </h2>
+              <div className="mt-3 flex flex-col gap-2 text-sm">
+                {group.links.map(([label, href]) => (
+                  <Link key={href} href={href} className="transition hover:text-rg-cream">
+                    {label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

Surfaces the newer trust, FAQ, and package-support pages in the public navigation, resources hub, and footer.

## Why

Several completed public pages were hard to discover from the main site shell. The header Resources dropdown still exposed only the older resource set, while newer trust/support pages such as Privacy & Research Controls, Security & Access Controls, Genre & Classification FAQ, Storygate FAQ, and Agent Readiness FAQ were not consistently surfaced.

## Changes

- Expands the HeaderNav Resources dropdown to include:
  - Resources Hub
  - The Black Box Problem
  - Methodology
  - Editorial Doctrine
  - Privacy & Research Controls
  - Security & Access Controls
  - Genre & Classification FAQ
  - Storygate Studio FAQ
  - Agent Readiness FAQ
- Updates active-route coverage for the new resource/trust pages.
- Renames Agent Readiness dropdown entry from `Generate Full Agent Package` to `Package Workspace` to match the new manuscript-selection workflow.
- Adds Security & Access Controls and Agent Readiness FAQ cards to `/resources`.
- Reworks the footer into Product / Resources / Trust & Support link groups so important pages are discoverable outside the header menu.

## Scope

Navigation/discovery only.

No auth, pricing, evaluation pipeline, report generation, Agent Readiness generation, Storygate runtime, database, or package persistence behavior changed.

## Acceptance Criteria

- Header Resources dropdown exposes the new trust and FAQ pages.
- Header Resources active state covers the new resource/trust routes.
- Agent Readiness dropdown uses package-workspace language instead of implying one-click package generation.
- Resources hub includes Security & Access Controls and Agent Readiness FAQ cards.
- Footer links include product, resource, and trust/support destinations.
- No film/TV, screenplay, adaptation, pitch-deck, or screen-project language is introduced.
