### PR TITLE
Add Author Profile Sources upload to Author Bio

### DIFF
--- a/.github/pr-bodies/PR-694.md
+++ b/.github/pr-bodies/PR-694.md
@@ -1,0 +1,43 @@
+## Summary
+
+Adds an upload control to the Agent Readiness Author Bio page so authors can import a résumé/CV/author-bio source document instead of only pasting text manually.
+
+## Why
+
+The Author Bio section is fact-governed: RevisionGrade must not invent author credentials. Uploading a résumé/CV is the most natural source-of-truth input for this page and reduces friction for authors who already have professional material prepared.
+
+## Changes
+
+- Adds an `Upload Résumé / CV` button beside the Resume / CV / Bio Text field.
+- Adds a hidden file input wired to the upload button.
+- Supports immediate text import for:
+  - DOCX
+  - TXT
+  - MD / Markdown
+  - RTF
+  - CSV
+- Uses `mammoth.extractRawText` for DOCX import.
+- Appends uploaded text into the existing source text field instead of replacing existing author-entered text.
+- Shows upload status messaging:
+  - Reading
+  - Uploaded
+  - Upload issue
+- Clears generated/approved state after successful upload so the bio must be regenerated/reconfirmed from the updated source material.
+- Updates field labels and confirmation language from `Resume / Bio Text` to `Résumé / CV / Bio Text`.
+
+## Scope
+
+Client-side Author Bio UX only. No backend upload storage, database persistence, file retention, generation API behavior, Agent Readiness runtime contracts, evaluation, scoring, Storygate, Revise, or TrustedPath changes.
+
+## Acceptance Criteria
+
+- User can click `Upload Résumé / CV` on `/agent-readiness/bio`.
+- Selecting a supported text/DOCX source imports readable text into the source text area.
+- Existing pasted text is preserved and uploaded text is appended.
+- Upload status is visible to the user.
+- Generated bio approval is reset after source material changes via upload.
+- The page continues to make clear that generated bios use only author-supplied facts.
+
+## Notes
+
+This does not store uploaded files. It only extracts text client-side into the existing author-supplied source field. I could not run the app locally from the connector environment; CI/preview should validate render and build.

--- a/.github/pr-bodies/PR-694.md
+++ b/.github/pr-bodies/PR-694.md
@@ -1,29 +1,45 @@
 ## Summary
 
-Adds an upload control to the Agent Readiness Author Bio page so authors can import a résumé/CV/author-bio source document instead of only pasting text manually.
+Renames the Author Bio source upload from a narrow résumé/CV control to **Author Profile Sources**, so authors understand they may provide the broader set of materials needed to generate a governed author bio and writing-credentials section.
 
 ## Why
 
-The Author Bio section is fact-governed: RevisionGrade must not invent author credentials. Uploading a résumé/CV is the most natural source-of-truth input for this page and reduces friction for authors who already have professional material prepared.
+The Author Bio section is fact-governed: RevisionGrade must not invent author credentials. Authors may not think of their background as a résumé or CV, especially in publishing contexts. A broader **Author Profile Sources** label makes it clear they can supply the facts from whichever sources they already have: author bio, résumé/CV, LinkedIn profile text, author website copy, publication credits, awards, education, professional background, and subject-matter expertise.
+
+This preserves the product rule: only author-supplied or author-approved facts may be used.
 
 ## Changes
 
-- Adds an `Upload Résumé / CV` button beside the Resume / CV / Bio Text field.
-- Adds a hidden file input wired to the upload button.
+- Renames the main source field from `Résumé / CV / Bio Text` to `Author Profile Sources`.
+- Renames the upload button from `Upload Résumé / CV` to `Upload Sources`.
+- Adds explicit example copy under the source field:
+  - author bio
+  - résumé/CV
+  - LinkedIn profile text
+  - author website copy
+  - publication credits
+  - awards
+  - education
+  - professional background
+  - subject-matter expertise
+- Clarifies that users may paste a LinkedIn or author-website URL as a reference, without implying live URL scraping or LinkedIn API ingestion.
+- Keeps upload extraction client-side only.
 - Supports immediate text import for:
   - DOCX
   - TXT
   - MD / Markdown
-  - RTF
   - CSV
+- Removes RTF from claimed supported uploads because the implementation does not perform RTF-to-text conversion.
+- Adds explicit file type validation so unsupported/binary files are not imported as gibberish.
+- Adds a 5 MB client-side size guard before reading uploaded files.
 - Uses `mammoth.extractRawText` for DOCX import.
 - Appends uploaded text into the existing source text field instead of replacing existing author-entered text.
 - Shows upload status messaging:
   - Reading
   - Uploaded
   - Upload issue
-- Clears generated/approved state after successful upload so the bio must be regenerated/reconfirmed from the updated source material.
-- Updates field labels and confirmation language from `Resume / Bio Text` to `Résumé / CV / Bio Text`.
+- Clears generated/approved/confirmed state when the source text changes, including upload, manual edits, and mic input.
+- Updates confirmation language to refer to uploaded or pasted `Author Profile Sources`.
 
 ## Scope
 
@@ -31,12 +47,17 @@ Client-side Author Bio UX only. No backend upload storage, database persistence,
 
 ## Acceptance Criteria
 
-- User can click `Upload Résumé / CV` on `/agent-readiness/bio`.
-- Selecting a supported text/DOCX source imports readable text into the source text area.
+- User can click `Upload Sources` on `/agent-readiness/bio`.
+- The source field label reads `Author Profile Sources`.
+- The helper text lists examples so users know what counts as acceptable source material.
+- Selecting a supported DOCX/TXT/MD/CSV source imports readable text into the source text area.
+- Unsupported file types fail fast with clear messaging.
+- Files over 5 MB fail fast with clear messaging.
 - Existing pasted text is preserved and uploaded text is appended.
 - Upload status is visible to the user.
-- Generated bio approval is reset after source material changes via upload.
+- Generated bio approval is reset after source material changes by upload, manual edit, or mic input.
 - The page continues to make clear that generated bios use only author-supplied facts.
+- The page does not imply live LinkedIn scraping or hidden third-party ingestion.
 
 ## Notes
 

--- a/app/agent-readiness/bio/page.tsx
+++ b/app/agent-readiness/bio/page.tsx
@@ -9,11 +9,12 @@
  */
 
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 
 // ─── Web Speech API mic input ───────────────────────────────────────────────
 
 type SpeechState = "idle" | "listening" | "error";
+type ResumeUploadStatus = "idle" | "reading" | "success" | "error";
 
 function useSpeechInput(setValue: React.Dispatch<React.SetStateAction<string>>) {
   const [state, setState] = React.useState<SpeechState>("idle");
@@ -96,6 +97,16 @@ function downloadTxt(filename: string, content: string) {
   URL.revokeObjectURL(url);
 }
 
+async function extractResumeUploadText(file: File): Promise<string> {
+  const name = file.name.toLowerCase();
+  if (name.endsWith(".docx")) {
+    const mammoth = await import("mammoth");
+    const result = await mammoth.extractRawText({ arrayBuffer: await file.arrayBuffer() });
+    return result.value ?? "";
+  }
+  return await file.text();
+}
+
 const SAVE_BTN: React.CSSProperties = {
   fontFamily: "monospace",
   fontSize: "0.6875rem",
@@ -126,8 +137,45 @@ export default function AuthorBioPage() {
   const [confirmed,    setConfirmed]    = useState(false);
   const [approved,     setApproved]     = useState(false);
   const [generatedBio, setGeneratedBio] = useState("");
+  const [resumeUploadName, setResumeUploadName] = useState("");
+  const [resumeUploadStatus, setResumeUploadStatus] = useState<ResumeUploadStatus>("idle");
+  const [resumeUploadMessage, setResumeUploadMessage] = useState("");
+  const resumeUploadRef = useRef<HTMLInputElement | null>(null);
 
   const canApprove = generatedBio.trim().length > 0 && confirmed;
+
+  async function handleResumeUpload(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setResumeUploadName(file.name);
+    setResumeUploadStatus("reading");
+    setResumeUploadMessage("Reading uploaded résumé / CV...");
+
+    try {
+      const extracted = (await extractResumeUploadText(file)).trim();
+      if (!extracted) {
+        setResumeUploadStatus("error");
+        setResumeUploadMessage("No readable text was found. Please paste the résumé / CV text manually.");
+        return;
+      }
+
+      setResumeText(prev => {
+        const heading = `--- Uploaded résumé / CV: ${file.name} ---`;
+        return prev.trim() ? `${prev.trim()}\n\n${heading}\n${extracted}` : extracted;
+      });
+      setGeneratedBio("");
+      setApproved(false);
+      setConfirmed(false);
+      setResumeUploadStatus("success");
+      setResumeUploadMessage(`Imported ${file.name} into Resume / CV / Bio Text.`);
+    } catch {
+      setResumeUploadStatus("error");
+      setResumeUploadMessage("This file could not be imported. Please upload a DOCX/TXT/MD/RTF file or paste the text manually.");
+    } finally {
+      event.target.value = "";
+    }
+  }
 
   return (
     <div style={{ minHeight: "100vh", backgroundColor: T.bg, color: T.cream, fontFamily: T.mono }}>
@@ -183,22 +231,67 @@ export default function AuthorBioPage() {
           />
         </div>
 
-        {/* Resume / bio paste */}
+        {/* Resume / CV / bio source */}
         <div style={{ marginBottom: "1.5rem" }}>
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.75rem", marginBottom: "0.5rem" }}>
             <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
-              Resume / Bio Text <span style={{ color: "#7A1E1E" }}>*</span>
+              Résumé / CV / Bio Text <span style={{ color: "#7A1E1E" }}>*</span>
             </label>
-            <MicButton setValue={setResumeText} />
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
+              <button
+                type="button"
+                onClick={() => resumeUploadRef.current?.click()}
+                style={{
+                  padding: "4px 10px",
+                  borderRadius: 6,
+                  border: `1px solid ${T.gold}80`,
+                  background: "transparent",
+                  color: T.gold,
+                  fontSize: 12,
+                  cursor: "pointer",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                  flexShrink: 0,
+                }}
+              >
+                ⬆ Upload Résumé / CV
+              </button>
+              <MicButton setValue={setResumeText} />
+            </div>
           </div>
           <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.625rem" }}>
-            Paste your resume, CV, or existing author bio here. This is the primary source. The system will not add facts not present in this text.
+            Upload a résumé/CV or paste an existing author bio here. Supported upload formats: DOCX, TXT, MD, RTF, and CSV. This is the primary source. The system will not add facts not present in this text.
           </p>
+          <input
+            ref={resumeUploadRef}
+            type="file"
+            accept=".docx,.txt,.md,.markdown,.rtf,.csv,text/plain,text/markdown,text/rtf,text/csv,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            onChange={handleResumeUpload}
+            style={{ display: "none" }}
+          />
+          {(resumeUploadName || resumeUploadStatus !== "idle") && (
+            <div style={{
+              border: `1px solid ${resumeUploadStatus === "error" ? T.oxblood : T.border}`,
+              backgroundColor: resumeUploadStatus === "error" ? "rgba(122,30,30,0.08)" : "rgba(169,142,74,0.06)",
+              color: resumeUploadStatus === "error" ? "#D07070" : T.cream2,
+              padding: "0.5rem 0.625rem",
+              marginBottom: "0.75rem",
+              fontSize: "0.6875rem",
+              lineHeight: 1.5,
+            }}>
+              <strong style={{ color: resumeUploadStatus === "success" ? T.gold : "inherit" }}>
+                {resumeUploadStatus === "reading" ? "Reading" : resumeUploadStatus === "success" ? "Uploaded" : resumeUploadStatus === "error" ? "Upload issue" : "Selected"}
+              </strong>
+              {resumeUploadName ? ` — ${resumeUploadName}` : ""}
+              {resumeUploadMessage ? `: ${resumeUploadMessage}` : ""}
+            </div>
+          )}
           <textarea
             value={resumeText}
             onChange={(e) => setResumeText(e.target.value)}
             rows={8}
-            placeholder="Paste your resume, CV, or existing author bio here..."
+            placeholder="Paste your résumé, CV, or existing author bio here..."
             style={{
               width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
               backgroundColor: T.panel, border: `1px solid ${T.border}`,
@@ -315,7 +408,7 @@ export default function AuthorBioPage() {
               style={{ marginTop: "2px", accentColor: T.gold, flexShrink: 0 }}
             />
             <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
-              I confirm these credentials are accurate and supported by my uploaded resume or bio text.
+              I confirm these credentials are accurate and supported by my uploaded résumé / CV or bio text.
               RevisionGrade does not verify author credentials; the author assumes full responsibility for accuracy.
             </p>
           </label>

--- a/app/agent-readiness/bio/page.tsx
+++ b/app/agent-readiness/bio/page.tsx
@@ -14,7 +14,20 @@ import React, { useRef, useState } from "react";
 // ─── Web Speech API mic input ───────────────────────────────────────────────
 
 type SpeechState = "idle" | "listening" | "error";
-type ResumeUploadStatus = "idle" | "reading" | "success" | "error";
+type AuthorProfileSourceUploadStatus = "idle" | "reading" | "success" | "error";
+
+const AUTHOR_PROFILE_SOURCE_MAX_BYTES = 5 * 1024 * 1024;
+const AUTHOR_PROFILE_SOURCE_UPLOAD_FORMATS = "DOCX, TXT, MD, and CSV";
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const TEXT_SOURCE_MIME_TYPES = new Set([
+  "",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/csv",
+  "application/vnd.ms-excel",
+]);
+const TEXT_SOURCE_EXTENSIONS = new Set([".txt", ".md", ".markdown", ".csv"]);
 
 function useSpeechInput(setValue: React.Dispatch<React.SetStateAction<string>>) {
   const [state, setState] = React.useState<SpeechState>("idle");
@@ -97,13 +110,38 @@ function downloadTxt(filename: string, content: string) {
   URL.revokeObjectURL(url);
 }
 
-async function extractResumeUploadText(file: File): Promise<string> {
-  const name = file.name.toLowerCase();
-  if (name.endsWith(".docx")) {
+function getFileExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot >= 0 ? fileName.slice(dot).toLowerCase() : "";
+}
+
+function isDocxAuthorProfileSource(file: File): boolean {
+  return file.type === DOCX_MIME || getFileExtension(file.name) === ".docx";
+}
+
+function isTextAuthorProfileSource(file: File): boolean {
+  const extension = getFileExtension(file.name);
+  return TEXT_SOURCE_EXTENSIONS.has(extension) && TEXT_SOURCE_MIME_TYPES.has(file.type);
+}
+
+function assertAuthorProfileSourceUploadSupported(file: File): void {
+  if (file.size > AUTHOR_PROFILE_SOURCE_MAX_BYTES) {
+    throw new Error("FILE_TOO_LARGE");
+  }
+  if (!isDocxAuthorProfileSource(file) && !isTextAuthorProfileSource(file)) {
+    throw new Error("UNSUPPORTED_FILE_TYPE");
+  }
+}
+
+async function extractAuthorProfileSourceUploadText(file: File): Promise<string> {
+  assertAuthorProfileSourceUploadSupported(file);
+
+  if (isDocxAuthorProfileSource(file)) {
     const mammoth = await import("mammoth");
     const result = await mammoth.extractRawText({ arrayBuffer: await file.arrayBuffer() });
     return result.value ?? "";
   }
+
   return await file.text();
 }
 
@@ -137,41 +175,53 @@ export default function AuthorBioPage() {
   const [confirmed,    setConfirmed]    = useState(false);
   const [approved,     setApproved]     = useState(false);
   const [generatedBio, setGeneratedBio] = useState("");
-  const [resumeUploadName, setResumeUploadName] = useState("");
-  const [resumeUploadStatus, setResumeUploadStatus] = useState<ResumeUploadStatus>("idle");
-  const [resumeUploadMessage, setResumeUploadMessage] = useState("");
-  const resumeUploadRef = useRef<HTMLInputElement | null>(null);
+  const [authorProfileSourceUploadName, setAuthorProfileSourceUploadName] = useState("");
+  const [authorProfileSourceUploadStatus, setAuthorProfileSourceUploadStatus] = useState<AuthorProfileSourceUploadStatus>("idle");
+  const [authorProfileSourceUploadMessage, setAuthorProfileSourceUploadMessage] = useState("");
+  const authorProfileSourceUploadRef = useRef<HTMLInputElement | null>(null);
+  const previousResumeTextRef = useRef(resumeText);
 
   const canApprove = generatedBio.trim().length > 0 && confirmed;
 
-  async function handleResumeUpload(event: React.ChangeEvent<HTMLInputElement>) {
+  React.useEffect(() => {
+    if (previousResumeTextRef.current === resumeText) return;
+    previousResumeTextRef.current = resumeText;
+    setGeneratedBio("");
+    setApproved(false);
+    setConfirmed(false);
+  }, [resumeText]);
+
+  async function handleAuthorProfileSourceUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (!file) return;
 
-    setResumeUploadName(file.name);
-    setResumeUploadStatus("reading");
-    setResumeUploadMessage("Reading uploaded résumé / CV...");
+    setAuthorProfileSourceUploadName(file.name);
+    setAuthorProfileSourceUploadStatus("reading");
+    setAuthorProfileSourceUploadMessage("Reading uploaded author profile source...");
 
     try {
-      const extracted = (await extractResumeUploadText(file)).trim();
+      const extracted = (await extractAuthorProfileSourceUploadText(file)).trim();
       if (!extracted) {
-        setResumeUploadStatus("error");
-        setResumeUploadMessage("No readable text was found. Please paste the résumé / CV text manually.");
+        setAuthorProfileSourceUploadStatus("error");
+        setAuthorProfileSourceUploadMessage("No readable text was found. Please paste the source text manually.");
         return;
       }
 
       setResumeText(prev => {
-        const heading = `--- Uploaded résumé / CV: ${file.name} ---`;
-        return prev.trim() ? `${prev.trim()}\n\n${heading}\n${extracted}` : extracted;
+        const heading = `--- Uploaded Author Profile Source: ${file.name} ---`;
+        return prev.trim() ? `${prev.trim()}\n\n${heading}\n${extracted}` : `${heading}\n${extracted}`;
       });
-      setGeneratedBio("");
-      setApproved(false);
-      setConfirmed(false);
-      setResumeUploadStatus("success");
-      setResumeUploadMessage(`Imported ${file.name} into Resume / CV / Bio Text.`);
-    } catch {
-      setResumeUploadStatus("error");
-      setResumeUploadMessage("This file could not be imported. Please upload a DOCX/TXT/MD/RTF file or paste the text manually.");
+      setAuthorProfileSourceUploadStatus("success");
+      setAuthorProfileSourceUploadMessage(`Imported ${file.name} into Author Profile Sources.`);
+    } catch (err) {
+      setAuthorProfileSourceUploadStatus("error");
+      if (err instanceof Error && err.message === "FILE_TOO_LARGE") {
+        setAuthorProfileSourceUploadMessage("This file is too large. Please upload a file under 5 MB or paste the relevant source text manually.");
+      } else if (err instanceof Error && err.message === "UNSUPPORTED_FILE_TYPE") {
+        setAuthorProfileSourceUploadMessage(`Unsupported file type. Please upload ${AUTHOR_PROFILE_SOURCE_UPLOAD_FORMATS}, or paste the source text manually.`);
+      } else {
+        setAuthorProfileSourceUploadMessage(`This file could not be imported. Please upload ${AUTHOR_PROFILE_SOURCE_UPLOAD_FORMATS}, or paste the source text manually.`);
+      }
     } finally {
       event.target.value = "";
     }
@@ -231,16 +281,16 @@ export default function AuthorBioPage() {
           />
         </div>
 
-        {/* Resume / CV / bio source */}
+        {/* Author profile sources */}
         <div style={{ marginBottom: "1.5rem" }}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.75rem", marginBottom: "0.5rem" }}>
             <label style={{ fontSize: "0.5625rem", color: T.dim, letterSpacing: "0.1em", textTransform: "uppercase" }}>
-              Résumé / CV / Bio Text <span style={{ color: "#7A1E1E" }}>*</span>
+              Author Profile Sources <span style={{ color: "#7A1E1E" }}>*</span>
             </label>
             <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0 }}>
               <button
                 type="button"
-                onClick={() => resumeUploadRef.current?.click()}
+                onClick={() => authorProfileSourceUploadRef.current?.click()}
                 style={{
                   padding: "4px 10px",
                   borderRadius: 6,
@@ -255,43 +305,49 @@ export default function AuthorBioPage() {
                   flexShrink: 0,
                 }}
               >
-                ⬆ Upload Résumé / CV
+                ⬆ Upload Sources
               </button>
               <MicButton setValue={setResumeText} />
             </div>
           </div>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.5rem" }}>
+            Upload or paste any material RevisionGrade may use to help build your author bio and writing credentials.
+          </p>
+          <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.5rem" }}>
+            Examples: author bio, résumé/CV, LinkedIn profile text, author website copy, publication credits, awards, education, professional background, and subject-matter expertise.
+          </p>
           <p style={{ fontSize: "0.6875rem", color: T.dim, lineHeight: 1.5, marginBottom: "0.625rem" }}>
-            Upload a résumé/CV or paste an existing author bio here. Supported upload formats: DOCX, TXT, MD, RTF, and CSV. This is the primary source. The system will not add facts not present in this text.
+            Supported uploads: {AUTHOR_PROFILE_SOURCE_UPLOAD_FORMATS}. You may also paste a LinkedIn or author-website URL as a reference. RevisionGrade will not add facts not present in these sources.
           </p>
           <input
-            ref={resumeUploadRef}
+            ref={authorProfileSourceUploadRef}
             type="file"
-            accept=".docx,.txt,.md,.markdown,.rtf,.csv,text/plain,text/markdown,text/rtf,text/csv,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            onChange={handleResumeUpload}
+            accept=".docx,.txt,.md,.markdown,.csv,text/plain,text/markdown,text/csv,application/csv,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            onChange={handleAuthorProfileSourceUpload}
             style={{ display: "none" }}
           />
-          {(resumeUploadName || resumeUploadStatus !== "idle") && (
+          {(authorProfileSourceUploadName || authorProfileSourceUploadStatus !== "idle") && (
             <div style={{
-              border: `1px solid ${resumeUploadStatus === "error" ? T.oxblood : T.border}`,
-              backgroundColor: resumeUploadStatus === "error" ? "rgba(122,30,30,0.08)" : "rgba(169,142,74,0.06)",
-              color: resumeUploadStatus === "error" ? "#D07070" : T.cream2,
+              border: `1px solid ${authorProfileSourceUploadStatus === "error" ? T.oxblood : T.border}`,
+              backgroundColor: authorProfileSourceUploadStatus === "error" ? "rgba(122,30,30,0.08)" : "rgba(169,142,74,0.06)",
+              color: authorProfileSourceUploadStatus === "error" ? "#D07070" : T.cream2,
               padding: "0.5rem 0.625rem",
               marginBottom: "0.75rem",
               fontSize: "0.6875rem",
               lineHeight: 1.5,
             }}>
-              <strong style={{ color: resumeUploadStatus === "success" ? T.gold : "inherit" }}>
-                {resumeUploadStatus === "reading" ? "Reading" : resumeUploadStatus === "success" ? "Uploaded" : resumeUploadStatus === "error" ? "Upload issue" : "Selected"}
+              <strong style={{ color: authorProfileSourceUploadStatus === "success" ? T.gold : "inherit" }}>
+                {authorProfileSourceUploadStatus === "reading" ? "Reading" : authorProfileSourceUploadStatus === "success" ? "Uploaded" : authorProfileSourceUploadStatus === "error" ? "Upload issue" : "Selected"}
               </strong>
-              {resumeUploadName ? ` — ${resumeUploadName}` : ""}
-              {resumeUploadMessage ? `: ${resumeUploadMessage}` : ""}
+              {authorProfileSourceUploadName ? ` — ${authorProfileSourceUploadName}` : ""}
+              {authorProfileSourceUploadMessage ? `: ${authorProfileSourceUploadMessage}` : ""}
             </div>
           )}
           <textarea
             value={resumeText}
             onChange={(e) => setResumeText(e.target.value)}
             rows={8}
-            placeholder="Paste your résumé, CV, or existing author bio here..."
+            placeholder="Paste author profile sources here: existing author bio, résumé/CV, LinkedIn profile text, author website copy, publication credits, awards, education, professional background, or subject-matter expertise..."
             style={{
               width: "100%", fontFamily: T.mono, fontSize: "0.8125rem", color: T.cream,
               backgroundColor: T.panel, border: `1px solid ${T.border}`,
@@ -408,7 +464,7 @@ export default function AuthorBioPage() {
               style={{ marginTop: "2px", accentColor: T.gold, flexShrink: 0 }}
             />
             <p style={{ fontSize: "0.75rem", color: T.cream2, lineHeight: 1.6 }}>
-              I confirm these credentials are accurate and supported by my uploaded résumé / CV or bio text.
+              I confirm these credentials are accurate and supported by my uploaded or pasted Author Profile Sources.
               RevisionGrade does not verify author credentials; the author assumes full responsibility for accuracy.
             </p>
           </label>


### PR DESCRIPTION
## Summary

Renames the Author Bio source upload from a narrow résumé/CV control to **Author Profile Sources**, so authors understand they may provide the broader set of materials needed to generate a governed author bio and writing-credentials section.

## Why

The Author Bio section is fact-governed: RevisionGrade must not invent author credentials. Authors may not think of their background as a résumé or CV, especially in publishing contexts. A broader **Author Profile Sources** label makes it clear they can supply the facts from whichever sources they already have: author bio, résumé/CV, LinkedIn profile text, author website copy, publication credits, awards, education, professional background, and subject-matter expertise.

This preserves the product rule: only author-supplied or author-approved facts may be used.

## Changes

- Renames the main source field from `Résumé / CV / Bio Text` to `Author Profile Sources`.
- Renames the upload button from `Upload Résumé / CV` to `Upload Sources`.
- Adds explicit example copy under the source field:
  - author bio
  - résumé/CV
  - LinkedIn profile text
  - author website copy
  - publication credits
  - awards
  - education
  - professional background
  - subject-matter expertise
- Clarifies that users may paste a LinkedIn or author-website URL as a reference, without implying live URL scraping or LinkedIn API ingestion.
- Keeps upload extraction client-side only.
- Supports immediate text import for:
  - DOCX
  - TXT
  - MD / Markdown
  - CSV
- Removes RTF from claimed supported uploads because the implementation does not perform RTF-to-text conversion.
- Adds explicit file type validation so unsupported/binary files are not imported as gibberish.
- Adds a 5 MB client-side size guard before reading uploaded files.
- Uses `mammoth.extractRawText` for DOCX import.
- Appends uploaded text into the existing source text field instead of replacing existing author-entered text.
- Shows upload status messaging:
  - Reading
  - Uploaded
  - Upload issue
- Clears generated/approved/confirmed state when the source text changes, including upload, manual edits, and mic input.
- Updates confirmation language to refer to uploaded or pasted `Author Profile Sources`.

## Scope

Client-side Author Bio UX only. No backend upload storage, database persistence, file retention, generation API behavior, Agent Readiness runtime contracts, evaluation, scoring, Storygate, Revise, or TrustedPath changes.

## Acceptance Criteria

- User can click `Upload Sources` on `/agent-readiness/bio`.
- The source field label reads `Author Profile Sources`.
- The helper text lists examples so users know what counts as acceptable source material.
- Selecting a supported DOCX/TXT/MD/CSV source imports readable text into the source text area.
- Unsupported file types fail fast with clear messaging.
- Files over 5 MB fail fast with clear messaging.
- Existing pasted text is preserved and uploaded text is appended.
- Upload status is visible to the user.
- Generated bio approval is reset after source material changes by upload, manual edit, or mic input.
- The page continues to make clear that generated bios use only author-supplied facts.
- The page does not imply live LinkedIn scraping or hidden third-party ingestion.

## Notes

This does not store uploaded files. It only extracts text client-side into the existing author-supplied source field. I could not run the app locally from the connector environment; CI/preview should validate render and build.