### PR TITLE
PR A: WAVE FK hardening — resolve source_version_id via canonical manuscript version path

### DIFF
--- a/.github/pr-bodies/PR-696.md
+++ b/.github/pr-bodies/PR-696.md
@@ -1,0 +1,16 @@
+## Summary
+Hardens WAVE revision session source-version resolution to satisfy `revision_sessions.source_version_id` FK invariants under legacy/null version bindings.
+
+## Changes
+- Adds strict `resolveWaveSourceVersionId(...)` resolution flow in `lib/evaluation/waveRevision.ts`.
+- Removes unsafe fallback semantics and binds/validates canonical version IDs.
+- Adds regression tests in `lib/evaluation/__tests__/waveRevision.source-version.test.ts`.
+
+## Why
+Prevents invalid FK writes and enforces deterministic, auditable source-version lineage for WAVE session creation.
+
+## Verification
+- `npx jest lib/evaluation/__tests__/waveRevision.source-version.test.ts --runInBand` (pass)
+
+## Ordering
+This PR is **A** in the required sequence and should merge before PR B and PR C.

--- a/lib/evaluation/__tests__/waveRevision.source-version.test.ts
+++ b/lib/evaluation/__tests__/waveRevision.source-version.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const BASE_HANDOFF = {
+  manuscriptText: "Chapter one text for WAVE.",
+  synthesis: {
+    overall: {
+      weighted_composite_score: 7.8,
+      confidence: 0.8,
+      risk_flags: [],
+      adaptation_notes: [],
+      top_strengths: [],
+      top_risks: [],
+      summary: "ok",
+      verdict: "pass",
+    },
+    criteria: [],
+  },
+  characterLedgerV2: undefined,
+  wordCount: 30000,
+  jobId: "c67f69c5-7f08-4ece-b4e3-066f786ee591",
+  manuscriptVersionId: null,
+};
+
+describe("resolveWaveSourceVersionId", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("uses handoff manuscriptVersionId when it already exists", async () => {
+    const existingVersionId = "11111111-1111-4111-8111-111111111111";
+
+    const getVersionById = jest.fn().mockResolvedValue({
+      id: existingVersionId,
+      manuscript_id: 42,
+      version_number: 1,
+      source_version_id: null,
+      raw_text: "stored",
+      word_count: 10,
+      created_by: null,
+      created_at: new Date().toISOString(),
+    });
+
+    const createAdminClient = jest.fn();
+    const createInitialVersion = jest.fn();
+    const createDerivedVersion = jest.fn();
+
+    jest.doMock("@/lib/manuscripts/versions", () => ({
+      getVersionById,
+      createInitialVersion,
+      createDerivedVersion,
+    }));
+    jest.doMock("@/lib/supabase/admin", () => ({ createAdminClient }));
+    jest.doMock("@/lib/db/manuscriptVersions", () => ({
+      getLatestVersionForManuscript: jest.fn(),
+    }));
+
+    const { resolveWaveSourceVersionId } = await import("@/lib/evaluation/waveRevision");
+
+    const resolved = await resolveWaveSourceVersionId({
+      ...BASE_HANDOFF,
+      manuscriptVersionId: existingVersionId,
+    });
+
+    expect(resolved).toBe(existingVersionId);
+    expect(getVersionById).toHaveBeenCalledWith(existingVersionId);
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(createInitialVersion).not.toHaveBeenCalled();
+    expect(createDerivedVersion).not.toHaveBeenCalled();
+  });
+
+  it("creates and binds a derived snapshot when job is missing manuscript_version_id", async () => {
+    const sourceVersionId = "22222222-2222-4222-8222-222222222222";
+    const derivedVersionId = "33333333-3333-4333-8333-333333333333";
+
+    const getVersionById = jest.fn().mockResolvedValue({
+      id: derivedVersionId,
+      manuscript_id: 7,
+      version_number: 2,
+      source_version_id: sourceVersionId,
+      raw_text: BASE_HANDOFF.manuscriptText,
+      word_count: BASE_HANDOFF.wordCount,
+      created_by: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      created_at: new Date().toISOString(),
+    });
+    const createInitialVersion = jest.fn();
+    const createDerivedVersion = jest.fn().mockResolvedValue({
+      id: derivedVersionId,
+      manuscript_id: 7,
+      version_number: 2,
+      source_version_id: sourceVersionId,
+      raw_text: BASE_HANDOFF.manuscriptText,
+      word_count: BASE_HANDOFF.wordCount,
+      created_by: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      created_at: new Date().toISOString(),
+    });
+
+    const getLatestVersionForManuscript = jest.fn().mockResolvedValue({
+      id: sourceVersionId,
+      manuscript_id: 7,
+      version_number: 1,
+      source_version_id: null,
+      raw_text: "older text",
+      word_count: 3,
+      created_by: null,
+      created_at: new Date().toISOString(),
+    });
+
+    const updateEq = jest.fn().mockResolvedValue({ error: null });
+    const update = jest.fn(() => ({ eq: updateEq }));
+    const single = jest.fn().mockResolvedValue({
+      data: {
+        id: BASE_HANDOFF.jobId,
+        manuscript_id: 7,
+        user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        manuscript_version_id: null,
+      },
+      error: null,
+    });
+    const eq = jest.fn(() => ({ single }));
+    const select = jest.fn(() => ({ eq }));
+
+    const from = jest.fn((table: string) => {
+      if (table !== "evaluation_jobs") {
+        throw new Error(`Unexpected table ${table}`);
+      }
+      return { select, update };
+    });
+    const createAdminClient = jest.fn(() => ({ from }));
+
+    jest.doMock("@/lib/manuscripts/versions", () => ({
+      getVersionById,
+      createInitialVersion,
+      createDerivedVersion,
+    }));
+    jest.doMock("@/lib/db/manuscriptVersions", () => ({
+      getLatestVersionForManuscript,
+    }));
+    jest.doMock("@/lib/supabase/admin", () => ({ createAdminClient }));
+
+    const { resolveWaveSourceVersionId } = await import("@/lib/evaluation/waveRevision");
+
+    const resolved = await resolveWaveSourceVersionId({
+      ...BASE_HANDOFF,
+      manuscriptVersionId: null,
+    });
+
+    expect(resolved).toBe(derivedVersionId);
+    expect(createAdminClient).toHaveBeenCalled();
+    expect(getLatestVersionForManuscript).toHaveBeenCalledWith(7);
+    expect(createDerivedVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manuscript_id: 7,
+        source_version_id: sourceVersionId,
+        raw_text: BASE_HANDOFF.manuscriptText,
+        word_count: BASE_HANDOFF.wordCount,
+      }),
+    );
+    expect(update).toHaveBeenCalledWith({ manuscript_version_id: derivedVersionId });
+    expect(updateEq).toHaveBeenCalledWith("id", BASE_HANDOFF.jobId);
+  });
+
+  it("throws explicit invariant error when resolved source version cannot be found", async () => {
+    const ghostVersionId = "44444444-4444-4444-8444-444444444444";
+
+    const getVersionById = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const createInitialVersion = jest.fn();
+    const createDerivedVersion = jest.fn();
+
+    const getLatestVersionForManuscript = jest.fn().mockResolvedValue({
+      id: ghostVersionId,
+      manuscript_id: 7,
+      version_number: 1,
+      source_version_id: null,
+      raw_text: "",
+      word_count: 0,
+      created_by: null,
+      created_at: new Date().toISOString(),
+    });
+
+    const updateEq = jest.fn().mockResolvedValue({ error: null });
+    const update = jest.fn(() => ({ eq: updateEq }));
+    const single = jest.fn().mockResolvedValue({
+      data: {
+        id: BASE_HANDOFF.jobId,
+        manuscript_id: 7,
+        user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        manuscript_version_id: null,
+      },
+      error: null,
+    });
+    const eq = jest.fn(() => ({ single }));
+    const select = jest.fn(() => ({ eq }));
+    const from = jest.fn(() => ({ select, update }));
+    const createAdminClient = jest.fn(() => ({ from }));
+
+    jest.doMock("@/lib/manuscripts/versions", () => ({
+      getVersionById,
+      createInitialVersion,
+      createDerivedVersion,
+    }));
+    jest.doMock("@/lib/db/manuscriptVersions", () => ({
+      getLatestVersionForManuscript,
+    }));
+    jest.doMock("@/lib/supabase/admin", () => ({ createAdminClient }));
+
+    const { resolveWaveSourceVersionId } = await import("@/lib/evaluation/waveRevision");
+
+    await expect(
+      resolveWaveSourceVersionId({
+        ...BASE_HANDOFF,
+        manuscriptText: "",
+        manuscriptVersionId: null,
+      }),
+    ).rejects.toThrow("WAVE_SOURCE_VERSION_RESOLUTION_FAILED");
+  });
+});

--- a/lib/evaluation/waveRevision.ts
+++ b/lib/evaluation/waveRevision.ts
@@ -38,6 +38,13 @@ import type { SynthesisOutput, CharacterLedgerV2 } from '@/lib/evaluation/pipeli
 import { executeWaveLayer } from '@/lib/pipeline/wave-execution-layer';
 import { executeWaveModules } from '@/lib/revision/wave-executor';
 import { createRevisionSession } from '@/lib/revision/sessions';
+import { createAdminClient } from '@/lib/supabase/admin';
+import {
+  createDerivedVersion,
+  createInitialVersion,
+  getVersionById,
+} from '@/lib/manuscripts/versions';
+import { getLatestVersionForManuscript } from '@/lib/db/manuscriptVersions';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -48,6 +55,11 @@ export const WAVE_MIN_WORDS = 25_000;
 
 /** Minimum per-criterion score (0–10) for WAVE eligibility — no red criteria */
 export const WAVE_MIN_CRITERION_SCORE = 6.0;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const WAVE_SOURCE_VERSION_RESOLUTION_WARN_MS = 1_500;
+const WAVE_SESSION_CREATE_WARN_MS = 1_500;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -91,6 +103,132 @@ export interface WaveRunRecord {
 export interface WaveRevisionResult {
   plan: WaveRevisionPlanArtifact;
   runRecord: WaveRunRecord;
+}
+
+function isUuid(value: string | null | undefined): value is string {
+  return typeof value === 'string' && UUID_RE.test(value.trim());
+}
+
+/**
+ * Resolve a valid manuscript_versions.id for WAVE revision session creation.
+ *
+ * Root-cause fix:
+ * - Older jobs may have null/invalid evaluation_jobs.manuscript_version_id.
+ * - Falling back to jobId violates revision_sessions.source_version_id FK.
+ *
+ * Strategy:
+ * 1) Use handoff.manuscriptVersionId if present and exists.
+ * 2) Else use evaluation_jobs.manuscript_version_id if present and exists.
+ * 3) Else create/bind a manuscript version snapshot from evaluated text.
+ */
+export async function resolveWaveSourceVersionId(handoff: WaveHandoff): Promise<string> {
+  const directCandidate = handoff.manuscriptVersionId?.trim() ?? null;
+  if (isUuid(directCandidate)) {
+    const existing = await getVersionById(directCandidate);
+    if (existing) {
+      return directCandidate;
+    }
+    console.warn(
+      `[WAVE] handoff manuscriptVersionId ${directCandidate} not found; recovering via evaluation job binding`,
+      { job_id: handoff.jobId },
+    );
+  }
+
+  const supabase = createAdminClient();
+  if (!supabase) {
+    throw new Error('WAVE source version resolution failed: Supabase admin client unavailable');
+  }
+
+  const { data: jobRow, error: jobError } = await supabase
+    .from('evaluation_jobs')
+    .select('id, manuscript_id, user_id, manuscript_version_id')
+    .eq('id', handoff.jobId)
+    .single();
+
+  if (jobError || !jobRow) {
+    throw new Error(
+      `WAVE source version resolution failed for job ${handoff.jobId}: ${jobError?.message ?? 'job not found'}`,
+    );
+  }
+
+  const dbCandidate =
+    typeof jobRow.manuscript_version_id === 'string'
+      ? jobRow.manuscript_version_id.trim()
+      : null;
+  if (isUuid(dbCandidate)) {
+    const existing = await getVersionById(dbCandidate);
+    if (existing) {
+      return dbCandidate;
+    }
+    console.warn(
+      `[WAVE] evaluation_jobs.manuscript_version_id ${dbCandidate} not found; creating fresh snapshot`,
+      { job_id: handoff.jobId },
+    );
+  }
+
+  const manuscriptId = Number(jobRow.manuscript_id);
+  if (!Number.isInteger(manuscriptId) || manuscriptId <= 0) {
+    throw new Error(
+      `WAVE source version resolution failed for job ${handoff.jobId}: invalid manuscript_id ${String(jobRow.manuscript_id)}`,
+    );
+  }
+
+  const createdBy = typeof jobRow.user_id === 'string' ? jobRow.user_id : null;
+  const latestVersion = await getLatestVersionForManuscript(manuscriptId);
+
+  let resolvedVersionId: string;
+  if (!latestVersion) {
+    const initial = await createInitialVersion({
+      manuscript_id: manuscriptId,
+      raw_text: handoff.manuscriptText,
+      word_count: handoff.wordCount,
+      created_by: createdBy,
+    });
+    resolvedVersionId = initial.id;
+  } else {
+    const handoffText = handoff.manuscriptText ?? '';
+    const textMatches = latestVersion.raw_text === handoffText;
+    const wordsMatch = latestVersion.word_count === handoff.wordCount;
+
+    if (handoffText.trim().length === 0 || (textMatches && wordsMatch)) {
+      resolvedVersionId = latestVersion.id;
+    } else {
+      const derived = await createDerivedVersion({
+        manuscript_id: manuscriptId,
+        source_version_id: latestVersion.id,
+        raw_text: handoffText,
+        word_count: handoff.wordCount,
+        created_by: createdBy,
+      });
+      resolvedVersionId = derived.id;
+    }
+  }
+
+  const { error: bindError } = await supabase
+    .from('evaluation_jobs')
+    .update({ manuscript_version_id: resolvedVersionId })
+    .eq('id', handoff.jobId);
+
+  if (bindError) {
+    console.warn(
+      `[WAVE] Failed to bind evaluation_jobs.manuscript_version_id for job ${handoff.jobId} (non-fatal): ${bindError.message}`,
+    );
+  }
+
+  if (!isUuid(resolvedVersionId)) {
+    throw new Error(
+      `WAVE_SOURCE_VERSION_RESOLUTION_FAILED: resolved non-uuid source_version_id for job ${handoff.jobId}`,
+    );
+  }
+
+  const finalVersion = await getVersionById(resolvedVersionId);
+  if (!finalVersion) {
+    throw new Error(
+      `WAVE_SOURCE_VERSION_RESOLUTION_FAILED: resolved source_version_id not found for job ${handoff.jobId} (${resolvedVersionId})`,
+    );
+  }
+
+  return resolvedVersionId;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -195,11 +333,32 @@ export async function executeWaveRevision(
 
   // Step 1: Create revision session
   let revisionSessionId: string;
+  let sourceVersionResolutionMs = 0;
+  let revisionSessionCreateMs = 0;
   try {
+    const sourceVersionResolutionStartMs = Date.now();
+    const sourceVersionId = await resolveWaveSourceVersionId(handoff);
+    sourceVersionResolutionMs = Date.now() - sourceVersionResolutionStartMs;
+    if (sourceVersionResolutionMs > WAVE_SOURCE_VERSION_RESOLUTION_WARN_MS) {
+      console.warn(`[WAVE] source version resolution latency high for job ${handoff.jobId}`, {
+        source_version_resolution_ms: sourceVersionResolutionMs,
+        warn_threshold_ms: WAVE_SOURCE_VERSION_RESOLUTION_WARN_MS,
+      });
+    }
+
+    const revisionSessionCreateStartMs = Date.now();
     const session = await createRevisionSession({
       evaluation_run_id: handoff.jobId,
-      source_version_id: handoff.manuscriptVersionId ?? handoff.jobId,
+      source_version_id: sourceVersionId,
     });
+    revisionSessionCreateMs = Date.now() - revisionSessionCreateStartMs;
+    if (revisionSessionCreateMs > WAVE_SESSION_CREATE_WARN_MS) {
+      console.warn(`[WAVE] revision session create latency high for job ${handoff.jobId}`, {
+        revision_session_create_ms: revisionSessionCreateMs,
+        warn_threshold_ms: WAVE_SESSION_CREATE_WARN_MS,
+      });
+    }
+
     revisionSessionId = session.id;
     console.log(`[WAVE] Created revision session ${revisionSessionId} for job ${handoff.jobId}`);
   } catch (sessionErr) {
@@ -266,6 +425,8 @@ export async function executeWaveRevision(
         plan_valid: layerResult.validation.valid,
         violations: layerResult.validation.violations,
         persisted: layerResult.persisted,
+        source_version_resolution_ms: sourceVersionResolutionMs,
+        revision_session_create_ms: revisionSessionCreateMs,
       },
       generated_at: generatedAt,
     },


### PR DESCRIPTION
## Summary
Hardens WAVE revision session source-version resolution to satisfy `revision_sessions.source_version_id` FK invariants under legacy/null version bindings.

## Changes
- Adds strict `resolveWaveSourceVersionId(...)` resolution flow in `lib/evaluation/waveRevision.ts`.
- Removes unsafe fallback semantics and binds/validates canonical version IDs.
- Adds regression tests in `lib/evaluation/__tests__/waveRevision.source-version.test.ts`.

## Why
Prevents invalid FK writes and enforces deterministic, auditable source-version lineage for WAVE session creation.

## Verification
- `npx jest lib/evaluation/__tests__/waveRevision.source-version.test.ts --runInBand` (pass)

## Ordering
This PR is **A** in the required sequence and should merge before PR B and PR C.