### PR TITLE
Add Agent Readiness CTA to dashboard focus

### DIFF
--- a/.github/pr-bodies/PR-700.md
+++ b/.github/pr-bodies/PR-700.md
@@ -1,0 +1,27 @@
+## Summary
+
+Adds a direct Agent Readiness package CTA to the dashboard's Current Manuscript Focus card.
+
+## Why
+
+PR #690 made Agent Readiness manuscript-bound and added table-level entry points. The dashboard's most prominent manuscript area should also offer the next logical action when the latest evaluation is complete: build the Agent Readiness package for that manuscript.
+
+## Changes
+
+- Adds a dashboard helper to build `/agent-readiness?manuscriptId=...&evaluationJobId=...` links.
+- Adds a guard so the focus-card CTA appears only for completed/non-running/non-failed evaluations.
+- Adds `Build Agent Readiness Package` to the Current Manuscript Focus action stack for eligible latest manuscripts.
+- Leaves failed/running evaluations focused on `Open details`/progress instead of package generation.
+
+## Scope
+
+Dashboard UX/routing only.
+
+No Agent Readiness generation logic, persistence, export behavior, evaluation pipeline, scoring, database schema, or Storygate eligibility behavior changed.
+
+## Acceptance Criteria
+
+- Latest completed dashboard manuscript has a visible `Build Agent Readiness Package` action in Current Manuscript Focus.
+- CTA links to `/agent-readiness` with both `manuscriptId` and `evaluationJobId`.
+- Running or failed latest evaluations do not show the Agent Readiness CTA.
+- Existing `Open latest report`, `Continue Revise`, and `Re-evaluate` actions remain available.

--- a/.github/pr-bodies/dashboard-agent-readiness-focus.md
+++ b/.github/pr-bodies/dashboard-agent-readiness-focus.md
@@ -1,0 +1,27 @@
+## Summary
+
+Adds a direct Agent Readiness package CTA to the dashboard's Current Manuscript Focus card.
+
+## Why
+
+PR #690 made Agent Readiness manuscript-bound and added table-level entry points. The dashboard's most prominent manuscript area should also offer the next logical action when the latest evaluation is complete: build the Agent Readiness package for that manuscript.
+
+## Changes
+
+- Adds a dashboard helper to build `/agent-readiness?manuscriptId=...&evaluationJobId=...` links.
+- Adds a guard so the focus-card CTA appears only for completed/non-running/non-failed evaluations.
+- Adds `Build Agent Readiness Package` to the Current Manuscript Focus action stack for eligible latest manuscripts.
+- Leaves failed/running evaluations focused on `Open details`/progress instead of package generation.
+
+## Scope
+
+Dashboard UX/routing only.
+
+No Agent Readiness generation logic, persistence, export behavior, evaluation pipeline, scoring, database schema, or Storygate eligibility behavior changed.
+
+## Acceptance Criteria
+
+- Latest completed dashboard manuscript has a visible `Build Agent Readiness Package` action in Current Manuscript Focus.
+- CTA links to `/agent-readiness` with both `manuscriptId` and `evaluationJobId`.
+- Running or failed latest evaluations do not show the Agent Readiness CTA.
+- Existing `Open latest report`, `Continue Revise`, and `Re-evaluate` actions remain available.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -20,6 +20,18 @@ function getScoreDelta(current: number | null, previous: number | null): string 
   return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)} vs prior evaluation`
 }
 
+function getAgentReadinessHref(row: { manuscriptId: string; jobId: string }): string {
+  const params = new URLSearchParams({
+    manuscriptId: row.manuscriptId,
+    evaluationJobId: row.jobId,
+  })
+  return `/agent-readiness?${params.toString()}`
+}
+
+function canBuildAgentReadiness(status: string): boolean {
+  return status !== 'failed' && status !== 'running'
+}
+
 export default async function DashboardPage() {
   const { rows, error } = await getDashboardEvaluations({ limit: 15 })
 
@@ -59,6 +71,7 @@ export default async function DashboardPage() {
   const latestTopScore = Math.max(latest.overallScore ?? 0, latest.readinessScore ?? 0)
   const latestIsReady = latestTopScore >= 8
   const latestIsActionable = latest.status === 'failed' || latest.status === 'running'
+  const latestCanBuildAgentReadiness = canBuildAgentReadiness(latest.status)
 
   return (
     <div className="rg-dash-page">
@@ -93,6 +106,11 @@ export default async function DashboardPage() {
             <Link href={latest.reportHref} className="rg-current-primary">
               {latestIsActionable ? 'Open details' : 'Open latest report'}
             </Link>
+            {latestCanBuildAgentReadiness && (
+              <Link href={getAgentReadinessHref(latest)} className="rg-current-secondary">
+                Build Agent Readiness Package
+              </Link>
+            )}
             <Link href="/revise" className="rg-current-secondary">
               Continue Revise
             </Link>


### PR DESCRIPTION
## Summary

Adds a direct Agent Readiness package CTA to the dashboard's Current Manuscript Focus card.

## Why

PR #690 made Agent Readiness manuscript-bound and added table-level entry points. The dashboard's most prominent manuscript area should also offer the next logical action when the latest evaluation is complete: build the Agent Readiness package for that manuscript.

## Changes

- Adds a dashboard helper to build `/agent-readiness?manuscriptId=...&evaluationJobId=...` links.
- Adds a guard so the focus-card CTA appears only for completed/non-running/non-failed evaluations.
- Adds `Build Agent Readiness Package` to the Current Manuscript Focus action stack for eligible latest manuscripts.
- Leaves failed/running evaluations focused on `Open details`/progress instead of package generation.

## Scope

Dashboard UX/routing only.

No Agent Readiness generation logic, persistence, export behavior, evaluation pipeline, scoring, database schema, or Storygate eligibility behavior changed.

## Acceptance Criteria

- Latest completed dashboard manuscript has a visible `Build Agent Readiness Package` action in Current Manuscript Focus.
- CTA links to `/agent-readiness` with both `manuscriptId` and `evaluationJobId`.
- Running or failed latest evaluations do not show the Agent Readiness CTA.
- Existing `Open latest report`, `Continue Revise`, and `Re-evaluate` actions remain available.
