### PR TITLE
Update Agent Readiness FAQ for manuscript-bound workflow

### DIFF
--- a/.github/pr-bodies/PR-701.md
+++ b/.github/pr-bodies/PR-701.md
@@ -1,0 +1,37 @@
+## Summary
+
+Updates the Agent Readiness FAQ so the public/support copy matches the new manuscript-bound package workflow.
+
+## Why
+
+PR #690 moved Agent Readiness away from a misleading one-click package action and toward a clearer workflow: select manuscript first, complete sections second, generate final package last. The FAQ should explain that same mental model so users understand why the page starts with manuscript context and why final package generation lives after the section workflow.
+
+## Changes
+
+- Reframes the FAQ headline around building from a selected manuscript, not a blank page.
+- Adds a Workflow Order section:
+  - Confirm the manuscript
+  - Generate and review sections
+  - Generate the final package
+- Adds the product rule directly: `Top = manuscript. Middle = sections. Bottom = final package.`
+- Adds FAQ entries explaining:
+  - why manuscript selection is required
+  - which manuscript appears by default
+  - why final package generation is at the bottom
+- Adds `What Makes This Novel Unique` to the package-section list.
+- Expands approval doctrine to include manuscript-bound package requirements.
+
+## Scope
+
+Public/support copy only.
+
+No Agent Readiness runtime, generation, persistence, export behavior, dashboard routing, evaluation pipeline, scoring, database, Storygate, Revise, or TrustedPath behavior changed.
+
+## Acceptance Criteria
+
+- Agent Readiness FAQ explains that package generation is manuscript-bound.
+- FAQ describes the selected-manuscript-first workflow.
+- FAQ no longer implies Agent Readiness starts from a blank page or one top-level package button.
+- FAQ explains final package generation as the bottom/assembly step.
+- Package section list includes the uniqueness/differentiator section.
+- No film/TV, screenplay, adaptation, pitch-deck, or screen-project language is introduced.

--- a/.github/pr-bodies/agent-readiness-faq-manuscript-flow.md
+++ b/.github/pr-bodies/agent-readiness-faq-manuscript-flow.md
@@ -1,0 +1,37 @@
+## Summary
+
+Updates the Agent Readiness FAQ so the public/support copy matches the new manuscript-bound package workflow.
+
+## Why
+
+PR #690 moved Agent Readiness away from a misleading one-click package action and toward a clearer workflow: select manuscript first, complete sections second, generate final package last. The FAQ should explain that same mental model so users understand why the page starts with manuscript context and why final package generation lives after the section workflow.
+
+## Changes
+
+- Reframes the FAQ headline around building from a selected manuscript, not a blank page.
+- Adds a Workflow Order section:
+  - Confirm the manuscript
+  - Generate and review sections
+  - Generate the final package
+- Adds the product rule directly: `Top = manuscript. Middle = sections. Bottom = final package.`
+- Adds FAQ entries explaining:
+  - why manuscript selection is required
+  - which manuscript appears by default
+  - why final package generation is at the bottom
+- Adds `What Makes This Novel Unique` to the package-section list.
+- Expands approval doctrine to include manuscript-bound package requirements.
+
+## Scope
+
+Public/support copy only.
+
+No Agent Readiness runtime, generation, persistence, export behavior, dashboard routing, evaluation pipeline, scoring, database, Storygate, Revise, or TrustedPath behavior changed.
+
+## Acceptance Criteria
+
+- Agent Readiness FAQ explains that package generation is manuscript-bound.
+- FAQ describes the selected-manuscript-first workflow.
+- FAQ no longer implies Agent Readiness starts from a blank page or one top-level package button.
+- FAQ explains final package generation as the bottom/assembly step.
+- Package section list includes the uniqueness/differentiator section.
+- No film/TV, screenplay, adaptation, pitch-deck, or screen-project language is introduced.

--- a/app/agent-readiness/faq/page.tsx
+++ b/app/agent-readiness/faq/page.tsx
@@ -12,10 +12,29 @@ const C = {
   ink: "#0E0E0E",
 } as const;
 
+const workflowSteps = [
+  {
+    title: "1. Confirm the manuscript",
+    body: "Agent Readiness starts with a selected completed manuscript evaluation. The workspace should default to the latest eligible manuscript and let the author choose another completed manuscript from the dropdown.",
+  },
+  {
+    title: "2. Generate and review sections",
+    body: "The author works through query letter, unique positioning, synopsis, query pitch, comparables, and author bio as manuscript-specific materials. Each section remains reviewable before export.",
+  },
+  {
+    title: "3. Generate the final package",
+    body: "The complete package action belongs after the section workflow. The author should understand that final package generation is the assembly step, not the first action.",
+  },
+];
+
 const packageSections = [
   {
     title: "Query letter",
     body: "The professional letter that introduces the manuscript, hook, category, word count, comparable titles, author context, and closing. It should be clear, restrained, and ready for agent submission.",
+  },
+  {
+    title: "What makes this novel unique",
+    body: "A concise differentiator that explains the manuscript's specific promise without turning the package into hype copy or a generic marketing slogan.",
   },
   {
     title: "Query pitch",
@@ -33,13 +52,11 @@ const packageSections = [
     title: "Author bio",
     body: "A professional bio built from author-supplied facts only. RevisionGrade should not invent credentials, awards, publications, platform, or personal history.",
   },
-  {
-    title: "Package export",
-    body: "A final approved package the author can review, save, and export after all required sections are complete and approved.",
-  },
 ];
 
 const approvalRules = [
+  "Agent Readiness is manuscript-bound: every package must be tied to a selected completed evaluation.",
+  "The selected manuscript should be visible before any package section is generated.",
   "Each section should be reviewed before export.",
   "Author bio content must come from author-provided information.",
   "Comparables should be plausible and explained, not name-dropped.",
@@ -51,6 +68,18 @@ const faqs = [
   {
     q: "What is Agent Readiness Package™?",
     a: "Agent Readiness Package™ helps an author prepare the core materials used for manuscript submission: query letter, query pitch, synopsis, comparables, author bio, manuscript positioning, and package export.",
+  },
+  {
+    q: "Why do I have to choose a manuscript first?",
+    a: "Because every package depends on the specific manuscript, its latest completed evaluation, its readiness score, and its submission position. A query letter or synopsis cannot be responsibly generated without knowing which manuscript it belongs to.",
+  },
+  {
+    q: "Which manuscript appears by default?",
+    a: "The workspace should show the latest completed eligible manuscript by default. The dropdown lets the author switch to another completed manuscript without starting from a blank or confusing state.",
+  },
+  {
+    q: "Why is final package generation at the bottom?",
+    a: "The final package is the assembly step. First the author confirms the manuscript, then generates and reviews the required sections, and only then compiles the complete package for export or later submission use.",
   },
   {
     q: "Is this the same as a manuscript evaluation?",
@@ -105,10 +134,10 @@ export default function AgentReadinessFaqPage() {
       <section className="mx-auto max-w-5xl px-6 py-24 text-center" style={{ borderBottom: `1px solid ${C.border}` }}>
         <SectionLabel>Agent Readiness Package™ FAQ</SectionLabel>
         <h1 className="mx-auto mt-5 max-w-3xl font-rg-serif text-4xl font-bold leading-tight md:text-5xl">
-          Build submission materials only after the manuscript is ready to be represented clearly.
+          Build submission materials from a selected manuscript, not from a blank page.
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-base leading-8" style={{ color: C.cream2 }}>
-          Agent Readiness is the manuscript submission package layer: query letter, query pitch, synopsis, comparables, author bio, approval, and export. It is not a substitute for manuscript diagnosis.
+          Agent Readiness is the manuscript-bound submission package layer: confirm the completed manuscript, generate the required sections, approve the materials, then compile the final package.
         </p>
         <div className="mt-10 flex flex-wrap justify-center gap-4">
           <Link href="/agent-readiness" className="border px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em]" style={{ borderColor: C.gold, backgroundColor: C.gold, color: C.ink }}>
@@ -117,6 +146,14 @@ export default function AgentReadinessFaqPage() {
           <Link href="/evaluate" className="border px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em]" style={{ borderColor: C.gold, color: C.gold }}>
             Diagnose Readiness First
           </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 py-20">
+        <SectionLabel>Workflow Order</SectionLabel>
+        <h2 className="mt-4 mb-10 font-rg-serif text-3xl font-bold">Top = manuscript. Middle = sections. Bottom = final package.</h2>
+        <div className="grid gap-5 md:grid-cols-3">
+          {workflowSteps.map((step) => <Card key={step.title} {...step} />)}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Updates the Agent Readiness FAQ so the public/support copy matches the new manuscript-bound package workflow.

## Why

PR #690 moved Agent Readiness away from a misleading one-click package action and toward a clearer workflow: select manuscript first, complete sections second, generate final package last. The FAQ should explain that same mental model so users understand why the page starts with manuscript context and why final package generation lives after the section workflow.

## Changes

- Reframes the FAQ headline around building from a selected manuscript, not a blank page.
- Adds a Workflow Order section:
  - Confirm the manuscript
  - Generate and review sections
  - Generate the final package
- Adds the product rule directly: `Top = manuscript. Middle = sections. Bottom = final package.`
- Adds FAQ entries explaining:
  - why manuscript selection is required
  - which manuscript appears by default
  - why final package generation is at the bottom
- Adds `What Makes This Novel Unique` to the package-section list.
- Expands approval doctrine to include manuscript-bound package requirements.

## Scope

Public/support copy only.

No Agent Readiness runtime, generation, persistence, export behavior, dashboard routing, evaluation pipeline, scoring, database, Storygate, Revise, or TrustedPath behavior changed.

## Acceptance Criteria

- Agent Readiness FAQ explains that package generation is manuscript-bound.
- FAQ describes the selected-manuscript-first workflow.
- FAQ no longer implies Agent Readiness starts from a blank page or one top-level package button.
- FAQ explains final package generation as the bottom/assembly step.
- Package section list includes the uniqueness/differentiator section.
- No film/TV, screenplay, adaptation, pitch-deck, or screen-project language is introduced.
