### PR TITLE
Improve evaluation report paragraph spacing

### DIFF
--- a/.github/pr-bodies/PR-703.md
+++ b/.github/pr-bodies/PR-703.md
@@ -1,0 +1,31 @@
+## Summary
+
+Improves readability on evaluation report pages by adding more paragraph rhythm and vertical spacing inside report cards and long-form ledger rows.
+
+## Why
+
+The current report view compresses dense editorial analysis into visually packed blocks. The content is valuable, but the paragraphs read like a database dump. This PR keeps the same report content while making it easier for authors to read long analysis sections.
+
+## Changes
+
+- Adds report-specific paragraph rhythm in `app/globals.css` for evaluation/report surfaces.
+- Increases line-height for report paragraphs and list items.
+- Adds vertical spacing between adjacent paragraphs.
+- Adds extra spacing between dense ledger rows/cards.
+- Adds more padding inside dense bordered long-form analysis rows.
+
+## Scope
+
+CSS/readability only. No report content, evaluation logic, scoring, database, download/export behavior, Narrative Synthesis generation, Revise, TrustedPath, Storygate, or Agent Readiness runtime changes.
+
+## Acceptance Criteria
+
+- Evaluation report paragraphs have more breathing room.
+- Dense long-form Criterion Analysis / ledger rows are easier to scan.
+- Report content is unchanged.
+- Report page can become longer vertically in exchange for better readability.
+- Dashboard/evaluation shell remains visually stable.
+
+## Notes
+
+This is intentionally a presentation-layer change. It does not attempt to rewrite or split generated report prose; it improves readability for the existing renderer. I could not run the app locally from the connector environment; CI/preview should validate build and visual behavior.

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,37 @@
   opacity: 1;
 }
 
+/* === Evaluation report paragraph rhythm ===
+ *
+ * Long-form reports contain dense rationale/evidence prose. Preserve the same
+ * text, but give adjacent paragraphs, ledger rows, and list items more vertical
+ * rhythm so author-facing reports read like editorial analysis instead of a
+ * compressed database dump.
+ */
+.min-h-screen.bg-gray-50 section p {
+  line-height: 1.75;
+}
+
+.min-h-screen.bg-gray-50 section p + p {
+  margin-top: 0.55rem;
+}
+
+.min-h-screen.bg-gray-50 section li {
+  line-height: 1.7;
+}
+
+.min-h-screen.bg-gray-50 section .rounded.border.border-gray-200.p-3.text-sm {
+  padding: 1rem;
+}
+
+.min-h-screen.bg-gray-50 section .rounded.border.border-gray-200.p-3.text-sm p + p {
+  margin-top: 0.65rem;
+}
+
+.min-h-screen.bg-gray-50 section .space-y-2 > .rounded.border.border-gray-200.p-3.text-sm + .rounded.border.border-gray-200.p-3.text-sm {
+  margin-top: 1rem;
+}
+
 /* === User evaluation dashboard === */
 
 .rg-dash-page {


### PR DESCRIPTION
## Summary

Improves readability on evaluation report pages by adding more paragraph rhythm and vertical spacing inside report cards and long-form ledger rows.

## Why

The current report view compresses dense editorial analysis into visually packed blocks. The content is valuable, but the paragraphs read like a database dump. This PR keeps the same report content while making it easier for authors to read long analysis sections.

## Changes

- Adds report-specific paragraph rhythm in `app/globals.css` for evaluation/report surfaces.
- Increases line-height for report paragraphs and list items.
- Adds vertical spacing between adjacent paragraphs.
- Adds extra spacing between dense ledger rows/cards.
- Adds more padding inside dense bordered long-form analysis rows.

## Scope

CSS/readability only. No report content, evaluation logic, scoring, database, download/export behavior, Narrative Synthesis generation, Revise, TrustedPath, Storygate, or Agent Readiness runtime changes.

## Acceptance Criteria

- Evaluation report paragraphs have more breathing room.
- Dense long-form Criterion Analysis / ledger rows are easier to scan.
- Report content is unchanged.
- Report page can become longer vertically in exchange for better readability.
- Dashboard/evaluation shell remains visually stable.

## Notes

This is intentionally a presentation-layer change. It does not attempt to rewrite or split generated report prose; it improves readability for the existing renderer. I could not run the app locally from the connector environment; CI/preview should validate build and visual behavior.