### PR TITLE
Refine Evaluate page with Saved Upload Paste tabs

### DIFF
--- a/.github/pr-bodies/PR-707.md
+++ b/.github/pr-bodies/PR-707.md
@@ -1,0 +1,44 @@
+## Summary
+
+Refines the Evaluate submission workbench into a clearer three-path flow: **Saved Document**, **Upload File**, and **Paste Text**.
+
+## Why
+
+The Evaluate page had the right ingredients, but the source-selection experience still blended saved documents, upload controls, and pasted text into one busy surface. This PR makes the user choose one clear source before beginning evaluation, which better matches the premium editorial-submission experience.
+
+## Changes
+
+- Adds a tabbed source selector with three options:
+  - Saved Document
+  - Upload File
+  - Paste Text
+- Shows only the active source-input surface at one time.
+- Adds a Selected Writing summary card that confirms what will be evaluated.
+- Keeps the existing Estimated Mode card and word-count-based mode guidance.
+- Moves upload into its own focused file-upload panel.
+- Keeps saved-document selection separate from pasted text.
+- Keeps pasted text as a direct evaluation source without replacing saved dashboard manuscripts.
+- Keeps dangerous/permanent delete behavior out of the primary submission flow.
+- Preserves the premium CTA: `Begin Editorial Evaluation`.
+
+## Scope
+
+Evaluate-page client UX only.
+
+No backend job creation changes, no manuscript upload API changes, no database schema changes, no evaluation pipeline changes, no scoring changes, no report changes, no dashboard changes, no Revise/TrustedPath/Storygate/Agent Readiness runtime changes.
+
+## Acceptance Criteria
+
+- `/evaluate` presents Saved Document / Upload File / Paste Text source tabs.
+- Only one input method is visible at a time.
+- Selecting a saved document clears pasted text.
+- Pasting text clears saved-document selection.
+- Uploading a file saves/selects the uploaded manuscript and shows it as the selected source.
+- Selected Writing summary clearly states what will be evaluated.
+- Estimated Mode still updates from the selected/uploaded/pasted word count.
+- CTA remains `Begin Editorial Evaluation`.
+- User-facing permanent delete controls are not shown in the main submission path.
+
+## Notes
+
+This is a UX refinement over the existing Evaluate form. It does not change the `/api/jobs` payload contract or the `/api/manuscripts` upload path.

--- a/.github/pr-bodies/evaluate-submission-tabs.md
+++ b/.github/pr-bodies/evaluate-submission-tabs.md
@@ -1,0 +1,44 @@
+## Summary
+
+Refines the Evaluate submission workbench into a clearer three-path flow: **Saved Document**, **Upload File**, and **Paste Text**.
+
+## Why
+
+The Evaluate page had the right ingredients, but the source-selection experience still blended saved documents, upload controls, and pasted text into one busy surface. This PR makes the user choose one clear source before beginning evaluation, which better matches the premium editorial-submission experience.
+
+## Changes
+
+- Adds a tabbed source selector with three options:
+  - Saved Document
+  - Upload File
+  - Paste Text
+- Shows only the active source-input surface at one time.
+- Adds a Selected Writing summary card that confirms what will be evaluated.
+- Keeps the existing Estimated Mode card and word-count-based mode guidance.
+- Moves upload into its own focused file-upload panel.
+- Keeps saved-document selection separate from pasted text.
+- Keeps pasted text as a direct evaluation source without replacing saved dashboard manuscripts.
+- Keeps dangerous/permanent delete behavior out of the primary submission flow.
+- Preserves the premium CTA: `Begin Editorial Evaluation`.
+
+## Scope
+
+Evaluate-page client UX only.
+
+No backend job creation changes, no manuscript upload API changes, no database schema changes, no evaluation pipeline changes, no scoring changes, no report changes, no dashboard changes, no Revise/TrustedPath/Storygate/Agent Readiness runtime changes.
+
+## Acceptance Criteria
+
+- `/evaluate` presents Saved Document / Upload File / Paste Text source tabs.
+- Only one input method is visible at a time.
+- Selecting a saved document clears pasted text.
+- Pasting text clears saved-document selection.
+- Uploading a file saves/selects the uploaded manuscript and shows it as the selected source.
+- Selected Writing summary clearly states what will be evaluated.
+- Estimated Mode still updates from the selected/uploaded/pasted word count.
+- CTA remains `Begin Editorial Evaluation`.
+- User-facing permanent delete controls are not shown in the main submission path.
+
+## Notes
+
+This is a UX refinement over the existing Evaluate form. It does not change the `/api/jobs` payload contract or the `/api/manuscripts` upload path.

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -2,6 +2,24 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
+const INPUT_METHODS = [
+  {
+    id: "saved",
+    label: "Saved Document",
+    description: "Choose from manuscripts already in your workspace.",
+  },
+  {
+    id: "upload",
+    label: "Upload File",
+    description: "Import a new DOCX or TXT file and select it for evaluation.",
+  },
+  {
+    id: "paste",
+    label: "Paste Text",
+    description: "Paste a scene, chapter, excerpt, or manuscript directly.",
+  },
+];
+
 function getEvaluationMode(wordCount) {
   if (!wordCount) {
     return {
@@ -26,6 +44,37 @@ function getEvaluationMode(wordCount) {
   };
 }
 
+function formatWordCount(value) {
+  return Number(value || 0).toLocaleString();
+}
+
+function getSubmissionSourceSummary({ activeInputMethod, selectedDashboardManuscript, manuscriptText, wordCount }) {
+  if (selectedDashboardManuscript) {
+    return {
+      label: activeInputMethod === "upload" ? "Uploaded file selected" : "Saved document selected",
+      title: selectedDashboardManuscript.title || "Untitled Manuscript",
+      meta: `${formatWordCount(selectedDashboardManuscript.word_count)} words · ${selectedDashboardManuscript.source ?? "saved manuscript"}`,
+      body: "This saved manuscript will be evaluated. Pasted text is ignored while a saved/uploaded manuscript is selected.",
+    };
+  }
+
+  if (manuscriptText.trim()) {
+    return {
+      label: "Pasted text selected",
+      title: "Manual text submission",
+      meta: `${formatWordCount(wordCount)} words · pasted text`,
+      body: "This pasted text will be evaluated directly. It will not replace saved manuscripts in your dashboard.",
+    };
+  }
+
+  return {
+    label: "No writing selected",
+    title: "Choose saved, upload, or paste",
+    meta: "0 words detected",
+    body: "Select one source before beginning evaluation.",
+  };
+}
+
 /**
  * Track A: Evaluation Entry
  * Single UI entry point to create evaluate_full jobs via POST /api/jobs
@@ -34,6 +83,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const fileInputRef = useRef(null);
   const uploadInputRef = useRef(null);
 
+  const [activeInputMethod, setActiveInputMethod] = useState("saved");
   const [manuscriptText, setManuscriptText] = useState("");
   const [projectTitle, setProjectTitle] = useState("");
   const [selectedManuscriptId, setSelectedManuscriptId] = useState(null);
@@ -57,6 +107,12 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
 
   const activeWordCount = selectedDashboardManuscript?.word_count ?? wordCount;
   const evaluationMode = getEvaluationMode(activeWordCount);
+  const submissionSourceSummary = getSubmissionSourceSummary({
+    activeInputMethod,
+    selectedDashboardManuscript,
+    manuscriptText,
+    wordCount,
+  });
 
   const visibleDashboardManuscripts = useMemo(
     () => dashboardManuscripts.filter((doc) => !hiddenManuscriptIds.includes(doc.id)),
@@ -140,6 +196,20 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     };
   }, []);
 
+  const handleInputMethodChange = (methodId) => {
+    setActiveInputMethod(methodId);
+    setError(null);
+
+    if (methodId === "paste") {
+      setSelectedManuscriptId(null);
+      return;
+    }
+
+    if (methodId === "saved" || methodId === "upload") {
+      setManuscriptText("");
+    }
+  };
+
   const handleUploadFile = async (file) => {
     if (!file) return;
     setIsUploading(true);
@@ -165,6 +235,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
         setSelectedManuscriptId(data.manuscript.id);
         setHiddenManuscriptIds((prev) => prev.filter((id) => id !== data.manuscript.id));
         setManuscriptText("");
+        setActiveInputMethod("upload");
       }
     } catch (err) {
       setError(err.message || "Upload failed");
@@ -176,6 +247,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const toggleManuscriptSelection = (manuscriptId) => {
     setSelectedManuscriptId((current) => (current === manuscriptId ? null : manuscriptId));
     setManuscriptText("");
+    setActiveInputMethod("saved");
   };
 
   const triggerDashboardUpload = () => uploadInputRef.current?.click();
@@ -246,130 +318,34 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
           <p className="font-rg-mono text-xs uppercase tracking-[0.22em] text-rg-gold">Submission workbench</p>
           <h2 className="mt-3 font-rg-serif text-4xl font-semibold tracking-tight text-stone-950 md:text-5xl">Choose your writing</h2>
           <p className="mx-auto mt-3 max-w-3xl text-stone-600">
-            Select a saved manuscript, upload a file, or paste text. RevisionGrade will route the submission into the correct evaluation depth based on length and complexity.
+            Select one clear source: use a saved manuscript, upload a new file, or paste text. RevisionGrade will estimate the evaluation depth before submission.
           </p>
         </div>
 
         <form onSubmit={handleSubmit}>
+          <div className="mb-6 grid gap-3 md:grid-cols-3">
+            {INPUT_METHODS.map((method) => {
+              const isActive = activeInputMethod === method.id;
+              return (
+                <button
+                  key={method.id}
+                  type="button"
+                  onClick={() => handleInputMethodChange(method.id)}
+                  className={`rounded-2xl border p-4 text-left transition ${
+                    isActive ? "border-rg-gold bg-[#FBFAF7] shadow-sm" : "border-stone-200 bg-white hover:bg-stone-50"
+                  }`}
+                  aria-pressed={isActive}
+                >
+                  <span className="font-rg-mono text-[0.65rem] uppercase tracking-[0.16em] text-rg-gold">Step 1</span>
+                  <span className="mt-2 block font-rg-serif text-xl text-stone-950">{method.label}</span>
+                  <span className="mt-1 block text-xs leading-5 text-stone-600">{method.description}</span>
+                </button>
+              );
+            })}
+          </div>
+
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
             <section className="space-y-5 lg:col-span-2">
-              <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-4">
-                <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                  <div>
-                    <h3 className="font-rg-serif text-2xl text-stone-950">Saved manuscripts</h3>
-                    <p className="mt-1 text-sm text-stone-600">Choose one saved manuscript, or upload a new file below.</p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={triggerDashboardUpload}
-                      disabled={isUploading || isSubmitting}
-                      className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
-                    >
-                      {isUploading ? "Uploading..." : "Upload New Document"}
-                    </button>
-                    {hiddenManuscriptIds.length > 0 && (
-                      <button
-                        type="button"
-                        onClick={restoreAllInThisWindow}
-                        disabled={isUploading || isSubmitting}
-                        className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
-                      >
-                        Restore hidden
-                      </button>
-                    )}
-                  </div>
-                </div>
-
-                <input
-                  ref={uploadInputRef}
-                  type="file"
-                  accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleUploadFile(file);
-                    e.target.value = "";
-                  }}
-                />
-
-                <div className="mb-3 max-h-[28rem] min-h-[12rem] space-y-2 overflow-y-auto pr-1">
-                  {isLoadingDashboard ? (
-                    <div className="text-sm text-stone-500">Loading saved manuscripts...</div>
-                  ) : visibleDashboardManuscripts.length === 0 ? (
-                    <div className="rounded-xl border border-stone-200 bg-white p-5 text-sm text-stone-500">No saved manuscripts found yet.</div>
-                  ) : (
-                    visibleDashboardManuscripts.map((doc) => (
-                      <div
-                        key={doc.id}
-                        role="button"
-                        tabIndex={0}
-                        onClick={(event) => {
-                          if (event.target.closest("button") || event.target.closest("input")) return;
-                          toggleManuscriptSelection(doc.id);
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            toggleManuscriptSelection(doc.id);
-                          }
-                        }}
-                        className={`cursor-pointer rounded-xl border p-3 ${
-                          selectedManuscriptId === doc.id ? "border-rg-gold bg-white shadow-sm" : "border-stone-200 bg-white/80"
-                        }`}
-                      >
-                        <div className="flex items-start gap-3">
-                          <input
-                            type="radio"
-                            name="dashboard-manuscript"
-                            checked={selectedManuscriptId === doc.id}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              if (selectedManuscriptId === doc.id) {
-                                event.preventDefault();
-                                toggleManuscriptSelection(doc.id);
-                              }
-                            }}
-                            onChange={() => {
-                              if (selectedManuscriptId !== doc.id) toggleManuscriptSelection(doc.id);
-                            }}
-                            className="mt-1"
-                          />
-                          <div className="min-w-0 flex-1">
-                            <div className="font-medium text-sm text-stone-950">{doc.title || "Untitled Manuscript"}</div>
-                            <div className="text-xs text-stone-500">{doc.word_count ?? 0} words • {doc.source ?? "unknown"}</div>
-                          </div>
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              hideManuscriptHere(doc.id);
-                            }}
-                            className="rounded-md border border-stone-200 bg-stone-50 px-3 py-1.5 text-xs font-medium text-stone-600 hover:bg-stone-100"
-                          >
-                            Hide
-                          </button>
-                        </div>
-                      </div>
-                    ))
-                  )}
-                </div>
-
-                {visibleDashboardManuscripts.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={clearThisWindow}
-                    disabled={isUploading || isSubmitting}
-                    className="rounded-md border border-stone-200 bg-white px-3 py-2 text-xs font-medium text-stone-600 hover:bg-stone-50 disabled:opacity-60"
-                  >
-                    Hide all from this window
-                  </button>
-                )}
-              </div>
-
-              <div className="text-center font-rg-mono text-xs uppercase tracking-[0.18em] text-stone-400">OR PASTE NEW TEXT</div>
-
               <div>
                 <label htmlFor="project-title" className="mb-2 block text-sm font-medium text-stone-700">
                   Project Title (optional)
@@ -385,46 +361,195 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                 />
               </div>
 
-              <div>
-                <div className="mb-2 flex items-center justify-between">
-                  <label htmlFor="manuscript-text" className="text-sm font-medium text-stone-700">
-                    Paste a paragraph, scene, chapter, excerpt, or full manuscript here
-                  </label>
-                  <button
-                    type="button"
-                    onClick={triggerInlineUpload}
-                    disabled={isUploading || isSubmitting}
-                    className="rounded-md border border-stone-200 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
-                  >
-                    Upload File
-                  </button>
+              {activeInputMethod === "saved" && (
+                <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-4">
+                  <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <h3 className="font-rg-serif text-2xl text-stone-950">Saved documents</h3>
+                      <p className="mt-1 text-sm text-stone-600">Choose one manuscript from your workspace.</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleInputMethodChange("upload")}
+                        disabled={isUploading || isSubmitting}
+                        className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
+                      >
+                        Upload instead
+                      </button>
+                      {hiddenManuscriptIds.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={restoreAllInThisWindow}
+                          disabled={isUploading || isSubmitting}
+                          className="rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50 disabled:opacity-60"
+                        >
+                          Restore hidden
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="mb-3 max-h-[26rem] min-h-[12rem] space-y-2 overflow-y-auto pr-1">
+                    {isLoadingDashboard ? (
+                      <div className="text-sm text-stone-500">Loading saved manuscripts...</div>
+                    ) : visibleDashboardManuscripts.length === 0 ? (
+                      <div className="rounded-xl border border-stone-200 bg-white p-5 text-sm text-stone-500">
+                        No saved manuscripts found yet. Use the Upload File tab to add one, or paste text directly.
+                      </div>
+                    ) : (
+                      visibleDashboardManuscripts.map((doc) => (
+                        <div
+                          key={doc.id}
+                          role="button"
+                          tabIndex={0}
+                          onClick={(event) => {
+                            if (event.target.closest("button") || event.target.closest("input")) return;
+                            toggleManuscriptSelection(doc.id);
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              toggleManuscriptSelection(doc.id);
+                            }
+                          }}
+                          className={`cursor-pointer rounded-xl border p-3 ${
+                            selectedManuscriptId === doc.id ? "border-rg-gold bg-white shadow-sm" : "border-stone-200 bg-white/80"
+                          }`}
+                        >
+                          <div className="flex items-start gap-3">
+                            <input
+                              type="radio"
+                              name="dashboard-manuscript"
+                              checked={selectedManuscriptId === doc.id}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                if (selectedManuscriptId === doc.id) {
+                                  event.preventDefault();
+                                  toggleManuscriptSelection(doc.id);
+                                }
+                              }}
+                              onChange={() => {
+                                if (selectedManuscriptId !== doc.id) toggleManuscriptSelection(doc.id);
+                              }}
+                              className="mt-1"
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="font-medium text-sm text-stone-950">{doc.title || "Untitled Manuscript"}</div>
+                              <div className="text-xs text-stone-500">{formatWordCount(doc.word_count)} words · {doc.source ?? "saved manuscript"}</div>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                hideManuscriptHere(doc.id);
+                              }}
+                              className="rounded-md border border-stone-200 bg-stone-50 px-3 py-1.5 text-xs font-medium text-stone-600 hover:bg-stone-100"
+                            >
+                              Hide
+                            </button>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  {visibleDashboardManuscripts.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={clearThisWindow}
+                      disabled={isUploading || isSubmitting}
+                      className="rounded-md border border-stone-200 bg-white px-3 py-2 text-xs font-medium text-stone-600 hover:bg-stone-50 disabled:opacity-60"
+                    >
+                      Hide all from this window
+                    </button>
+                  )}
                 </div>
-                <textarea
-                  id="manuscript-text"
-                  value={manuscriptText}
-                  onChange={(e) => {
-                    setManuscriptText(e.target.value);
-                    if (e.target.value.trim().length > 0) setSelectedManuscriptId(null);
-                  }}
-                  placeholder="Formatting is preserved where supported..."
-                  rows={12}
-                  className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-950"
-                  disabled={isSubmitting}
-                />
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-                  className="hidden"
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file) void handleUploadFile(file);
-                    e.target.value = "";
-                  }}
-                />
-                <p className="mt-2 text-xs text-stone-500">Current pasted word count: {wordCount}</p>
-                <p className="text-xs text-stone-500">Paste up to 150k words or upload files up to 250k words.</p>
-              </div>
+              )}
+
+              {activeInputMethod === "upload" && (
+                <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-6">
+                  <p className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold">Upload file</p>
+                  <h3 className="mt-2 font-rg-serif text-3xl text-stone-950">Upload a manuscript file</h3>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-stone-600">
+                    Upload a DOCX or TXT file. RevisionGrade saves it to your workspace, selects it for this evaluation, and preserves the original file text as the evaluation source.
+                  </p>
+                  <div className="mt-5 rounded-2xl border border-dashed border-stone-300 bg-white p-8 text-center">
+                    <button
+                      type="button"
+                      onClick={triggerDashboardUpload}
+                      disabled={isUploading || isSubmitting}
+                      className="rounded-xl bg-rg-gold px-5 py-3 font-rg-mono text-xs font-semibold uppercase tracking-[0.16em] text-stone-950 shadow-sm hover:opacity-90 disabled:opacity-60"
+                    >
+                      {isUploading ? "Uploading..." : "Choose File"}
+                    </button>
+                    <p className="mt-3 text-xs text-stone-500">Supported uploads: DOCX and TXT. Files may be up to 250k words.</p>
+                  </div>
+                  {selectedDashboardManuscript && (
+                    <button
+                      type="button"
+                      onClick={() => handleInputMethodChange("saved")}
+                      className="mt-4 rounded-md border border-stone-300 bg-white px-3 py-2 text-xs font-medium text-stone-700 hover:bg-stone-50"
+                    >
+                      View in saved documents
+                    </button>
+                  )}
+                </div>
+              )}
+
+              {activeInputMethod === "paste" && (
+                <div className="rounded-2xl border border-stone-200 bg-[#FBFAF7] p-4">
+                  <div className="mb-2 flex items-center justify-between">
+                    <label htmlFor="manuscript-text" className="font-rg-serif text-2xl text-stone-950">
+                      Paste text
+                    </label>
+                  </div>
+                  <p className="mb-3 text-sm leading-6 text-stone-600">
+                    Paste a paragraph, scene, chapter, excerpt, or full manuscript. This path creates an evaluation from pasted text without changing saved dashboard manuscripts.
+                  </p>
+                  <textarea
+                    id="manuscript-text"
+                    value={manuscriptText}
+                    onChange={(e) => {
+                      setManuscriptText(e.target.value);
+                      if (e.target.value.trim().length > 0) {
+                        setSelectedManuscriptId(null);
+                        setActiveInputMethod("paste");
+                      }
+                    }}
+                    placeholder="Formatting is preserved where supported..."
+                    rows={14}
+                    className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-sm text-stone-950"
+                    disabled={isSubmitting}
+                  />
+                  <p className="mt-2 text-xs text-stone-500">Current pasted word count: {formatWordCount(wordCount)}</p>
+                  <p className="text-xs text-stone-500">Paste up to 150k words.</p>
+                </div>
+              )}
+
+              <input
+                ref={uploadInputRef}
+                type="file"
+                accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void handleUploadFile(file);
+                  e.target.value = "";
+                }}
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".txt,.docx,text/plain,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void handleUploadFile(file);
+                  e.target.value = "";
+                }}
+              />
 
               <div className="rounded-xl border border-stone-200 p-4">
                 <label className="mb-2 block text-sm font-medium text-stone-700">English Variant</label>
@@ -441,11 +566,19 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
 
             <aside className="space-y-4">
               <div className="rounded-2xl border border-rg-gold/30 bg-[#FBFAF7] p-5">
+                <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.16em] text-rg-gold">Selected writing</p>
+                <h4 className="mt-2 font-rg-serif text-2xl text-stone-950">{submissionSourceSummary.title}</h4>
+                <p className="mt-2 text-xs font-semibold uppercase tracking-[0.12em] text-stone-500">{submissionSourceSummary.label}</p>
+                <p className="mt-2 text-sm font-medium text-stone-700">{submissionSourceSummary.meta}</p>
+                <p className="mt-2 text-xs leading-5 text-stone-600">{submissionSourceSummary.body}</p>
+              </div>
+
+              <div className="rounded-2xl border border-rg-gold/30 bg-[#FBFAF7] p-5">
                 <p className="font-rg-mono text-[0.65rem] uppercase tracking-[0.16em] text-rg-gold">Estimated Mode</p>
                 <h4 className="mt-2 font-rg-serif text-2xl text-stone-950">{evaluationMode.label}</h4>
                 <p className="mt-2 text-sm font-medium text-stone-700">{evaluationMode.summary}</p>
                 <p className="mt-2 text-xs leading-5 text-stone-600">{evaluationMode.detail}</p>
-                <p className="mt-4 text-xs text-stone-500">Detected/selected words: {activeWordCount || 0}</p>
+                <p className="mt-4 text-xs text-stone-500">Detected/selected words: {formatWordCount(activeWordCount)}</p>
               </div>
               <div className="rounded-2xl border border-stone-200 bg-white p-5">
                 <h4 className="font-rg-serif text-2xl text-stone-950">How evaluation works</h4>


### PR DESCRIPTION
## Summary

Refines the Evaluate submission workbench into a clearer three-path flow: **Saved Document**, **Upload File**, and **Paste Text**.

## Why

The Evaluate page had the right ingredients, but the source-selection experience still blended saved documents, upload controls, and pasted text into one busy surface. This PR makes the user choose one clear source before beginning evaluation, which better matches the premium editorial-submission experience.

## Changes

- Adds a tabbed source selector with three options:
  - Saved Document
  - Upload File
  - Paste Text
- Shows only the active source-input surface at one time.
- Adds a Selected Writing summary card that confirms what will be evaluated.
- Keeps the existing Estimated Mode card and word-count-based mode guidance.
- Moves upload into its own focused file-upload panel.
- Keeps saved-document selection separate from pasted text.
- Keeps pasted text as a direct evaluation source without replacing saved dashboard manuscripts.
- Keeps dangerous/permanent delete behavior out of the primary submission flow.
- Preserves the premium CTA: `Begin Editorial Evaluation`.

## Scope

Evaluate-page client UX only.

No backend job creation changes, no manuscript upload API changes, no database schema changes, no evaluation pipeline changes, no scoring changes, no report changes, no dashboard changes, no Revise/TrustedPath/Storygate/Agent Readiness runtime changes.

## Acceptance Criteria

- `/evaluate` presents Saved Document / Upload File / Paste Text source tabs.
- Only one input method is visible at a time.
- Selecting a saved document clears pasted text.
- Pasting text clears saved-document selection.
- Uploading a file saves/selects the uploaded manuscript and shows it as the selected source.
- Selected Writing summary clearly states what will be evaluated.
- Estimated Mode still updates from the selected/uploaded/pasted word count.
- CTA remains `Begin Editorial Evaluation`.
- User-facing permanent delete controls are not shown in the main submission path.

## Notes

This is a UX refinement over the existing Evaluate form. It does not change the `/api/jobs` payload contract or the `/api/manuscripts` upload path.