### PR TITLE
Apply score and confidence colors throughout reports

### DIFF
--- a/.github/pr-bodies/PR-709.md
+++ b/.github/pr-bodies/PR-709.md
@@ -1,0 +1,43 @@
+## Summary
+
+Applies the RevisionGrade score/confidence color system throughout report pages so score and confidence signals are visually legible instead of appearing as plain text inside dense report blocks.
+
+## Why
+
+The report already uses color language elsewhere, but long-form Criterion Analyses were rendering key decision signals like `Score: 9` and `Confidence: High` as ordinary black text. Authors and professional readers need those signals to pop immediately.
+
+## Changes
+
+- Adds `components/reports/ReportColorSystemHydrator.jsx`.
+- Mounts the hydrator in `app/layout.jsx`.
+- Hydrator runs only on `/reports/...` routes.
+- Detects rendered report lines matching:
+  - `Score: ...`
+  - `Confidence: High`
+  - `Confidence: Moderate` / `Medium`
+  - `Confidence: Low`
+- Applies consistent semantic color treatment:
+  - High / strong scores: green
+  - Moderate / middle scores: amber
+  - Low / weak scores: rose
+- Applies pill styling to the score/confidence lines.
+- Adds subtle card border/background tone to the nearest report row/card so dense blocks become easier to scan.
+- Uses a MutationObserver so async Narrative Synthesis / report content receives the color treatment when it appears.
+
+## Scope
+
+Report presentation only. No evaluation logic, scoring, database, report content, generation prompts, downloadable export behavior, Revise, TrustedPath, Storygate, or Agent Readiness runtime changes.
+
+## Acceptance Criteria
+
+- Long-form Criterion Analyses no longer show score/confidence as plain undifferentiated text.
+- High confidence appears green.
+- Moderate/medium confidence appears amber.
+- Low confidence appears rose.
+- Score tone follows the same green/amber/rose scale.
+- Color treatment applies to report content that loads after page render.
+- Non-report pages are not affected.
+
+## Notes
+
+This is a fast UI hardening pass for the live report surface. Downloads should receive the same color system in the premium export PR/design pass.

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -2,6 +2,7 @@
 import "./globals.css";
 import HeaderNav from "../components/HeaderNav";
 import SiteFooter from "../components/SiteFooter";
+import ReportColorSystemHydrator from "../components/reports/ReportColorSystemHydrator";
 
 export const metadata = {
   title: "RevisionGrade™",
@@ -22,6 +23,7 @@ export default function RootLayout({ children }) {
         className="antialiased bg-rg-ink text-rg-cream font-rg-serif"
         suppressHydrationWarning
       >
+        <ReportColorSystemHydrator />
         <HeaderNav />
         <main>{children}</main>
         <SiteFooter />

--- a/components/reports/ReportColorSystemHydrator.jsx
+++ b/components/reports/ReportColorSystemHydrator.jsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+const TONES = {
+  high: {
+    background: "#ecfdf5",
+    color: "#065f46",
+    border: "#a7f3d0",
+  },
+  moderate: {
+    background: "#fffbeb",
+    color: "#92400e",
+    border: "#fde68a",
+  },
+  low: {
+    background: "#fff1f2",
+    color: "#9f1239",
+    border: "#fecdd3",
+  },
+};
+
+function scoreTone(score, denominator = 10) {
+  if (!Number.isFinite(score)) return null;
+  const pct = denominator > 0 ? (score / denominator) * 100 : score;
+  if (pct >= 80) return TONES.high;
+  if (pct >= 60) return TONES.moderate;
+  return TONES.low;
+}
+
+function confidenceTone(text) {
+  const normalized = String(text || "").toLowerCase();
+  if (normalized.includes("high")) return TONES.high;
+  if (normalized.includes("moderate") || normalized.includes("medium")) return TONES.moderate;
+  if (normalized.includes("low")) return TONES.low;
+  return null;
+}
+
+function applyPillStyle(el, tone) {
+  if (!el || !tone || el.dataset.rgToneApplied === "true") return;
+  el.dataset.rgToneApplied = "true";
+  el.style.display = "inline-flex";
+  el.style.alignItems = "center";
+  el.style.width = "fit-content";
+  el.style.maxWidth = "100%";
+  el.style.border = `1px solid ${tone.border}`;
+  el.style.backgroundColor = tone.background;
+  el.style.color = tone.color;
+  el.style.borderRadius = "999px";
+  el.style.padding = "0.22rem 0.62rem";
+  el.style.fontWeight = "700";
+  el.style.lineHeight = "1.35";
+}
+
+function applyCardTone(el, tone) {
+  const card = el?.closest?.(".rounded.border");
+  if (!card || !tone || card.dataset.rgCardToneApplied === "true") return;
+  card.dataset.rgCardToneApplied = "true";
+  card.style.borderColor = tone.border;
+  card.style.background = `linear-gradient(180deg, ${tone.background} 0%, #ffffff 34%)`;
+}
+
+function applyReportColorSystem() {
+  const reportRoot = document.querySelector(".min-h-screen.bg-gray-50");
+  if (!reportRoot) return;
+
+  const textNodes = reportRoot.querySelectorAll("p, span, li");
+  textNodes.forEach((el) => {
+    const text = el.textContent?.trim() || "";
+
+    const confidenceMatch = text.match(/^Confidence:\s*(High|Moderate|Medium|Low)\b/i);
+    if (confidenceMatch) {
+      const tone = confidenceTone(confidenceMatch[1]);
+      applyPillStyle(el, tone);
+      applyCardTone(el, tone);
+      return;
+    }
+
+    const scoreMatch = text.match(/^Score:\s*(\d+(?:\.\d+)?)(?:\s*\/\s*(\d+))?/i);
+    if (scoreMatch) {
+      const score = Number(scoreMatch[1]);
+      const denominator = scoreMatch[2] ? Number(scoreMatch[2]) : 10;
+      const tone = scoreTone(score, denominator);
+      applyPillStyle(el, tone);
+      applyCardTone(el, tone);
+    }
+  });
+}
+
+export default function ReportColorSystemHydrator() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname?.startsWith("/reports/")) return;
+    applyReportColorSystem();
+
+    const observer = new MutationObserver(() => applyReportColorSystem());
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  return null;
+}

--- a/components/reports/ReportColorSystemHydrator.jsx
+++ b/components/reports/ReportColorSystemHydrator.jsx
@@ -6,18 +6,18 @@ import { usePathname } from "next/navigation";
 const TONES = {
   high: {
     background: "#ecfdf5",
-    color: "#065f46",
-    border: "#a7f3d0",
+    color: "#14532d",
+    border: "#86efac",
   },
   moderate: {
     background: "#fffbeb",
-    color: "#92400e",
-    border: "#fde68a",
+    color: "#78350f",
+    border: "#f59e0b",
   },
   low: {
-    background: "#fff1f2",
-    color: "#9f1239",
-    border: "#fecdd3",
+    background: "#fef2f2",
+    color: "#991b1b",
+    border: "#fca5a5",
   },
 };
 


### PR DESCRIPTION
## Summary

Applies the RevisionGrade score/confidence color system throughout report pages so score and confidence signals are visually legible instead of appearing as plain text inside dense report blocks.

## Why

The report already uses color language elsewhere, but long-form Criterion Analyses were rendering key decision signals like `Score: 9` and `Confidence: High` as ordinary black text. Authors and professional readers need those signals to pop immediately.

## Changes

- Adds `components/reports/ReportColorSystemHydrator.jsx`.
- Mounts the hydrator in `app/layout.jsx`.
- Hydrator runs only on `/reports/...` routes.
- Detects rendered report lines matching:
  - `Score: ...`
  - `Confidence: High`
  - `Confidence: Moderate` / `Medium`
  - `Confidence: Low`
- Applies consistent semantic color treatment:
  - High / strong scores: green
  - Moderate / middle scores: amber
  - Low / weak scores: rose
- Applies pill styling to the score/confidence lines.
- Adds subtle card border/background tone to the nearest report row/card so dense blocks become easier to scan.
- Uses a MutationObserver so async Narrative Synthesis / report content receives the color treatment when it appears.

## Scope

Report presentation only. No evaluation logic, scoring, database, report content, generation prompts, downloadable export behavior, Revise, TrustedPath, Storygate, or Agent Readiness runtime changes.

## Acceptance Criteria

- Long-form Criterion Analyses no longer show score/confidence as plain undifferentiated text.
- High confidence appears green.
- Moderate/medium confidence appears amber.
- Low confidence appears rose.
- Score tone follows the same green/amber/rose scale.
- Color treatment applies to report content that loads after page render.
- Non-report pages are not affected.

## Notes

This is a fast UI hardening pass for the live report surface. Downloads should receive the same color system in the premium export PR/design pass.