### PR TITLE
ci: enforce workflow concurrency for PR-run dedupe

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/code.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code.md
@@ -12,6 +12,12 @@
 
 - Tests added/modified: <!-- list or "N/A — see explanation" -->
 
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- What could go wrong; how it's mitigated. -->

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -6,6 +6,12 @@
 
 <!-- Which docs / governance briefs / READMEs are affected. -->
 
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- What could go wrong (e.g. doc contradicts code; outdated link; misleading example); how it's mitigated. -->

--- a/.github/PULL_REQUEST_TEMPLATE/evaluation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/evaluation.md
@@ -75,6 +75,12 @@ This PR is not reducing intelligence.
 
 QG_<gate-id>: <description or "no QG_ behavior changes">
 
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 -

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -20,6 +20,12 @@
 
 - `.github/workflows/<filename>.yml` — what changes
 
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- What could go wrong; how it's mitigated. -->

--- a/.github/PULL_REQUEST_TEMPLATE/migration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/migration.md
@@ -22,6 +22,12 @@
 
 <!-- Yes/No. If yes: estimated row count, runtime, lock impact, and whether it runs inside or outside the migration transaction. -->
 
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- Lock contention, downtime, replica lag, application compatibility, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE/ui.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ui.md
@@ -26,6 +26,42 @@
 - Safari latest: ✅
 - Firefox latest: ✅
 
+## Unauthorized Input Sources
+
+<!-- Explicitly state all input sources used by this UI path (user form, query params, headers, local storage, etc.).
+For each, describe authorization boundary and validation/sanitization path. If none: state "None". -->
+
+## Internal Process Leakage
+
+<!-- Confirm no internal process details are exposed (internal IDs, worker state internals, stack traces, hidden control-flow signals).
+List any sensitive fields reviewed and redacted/omitted. -->
+
+## Input → Action → Output
+
+<!-- Provide a concise flow map of UI input, action taken, and output rendered.
+Include failure path behavior and user-facing error contract (safe + non-sensitive). -->
+
+## Public-Safe Quality/Status Metrics
+
+<!-- List user-visible metrics/status indicators and confirm they are public-safe (no internal-only telemetry leakage).
+If not applicable: state "N/A" with reason. -->
+
+## Runtime/Pipeline Expansion
+
+<!-- Declare whether this PR adds any new runtime calls, workers, API routes, or pipeline paths.
+If none: state "None" and explain why execution surface is unchanged. -->
+
+## Latency Impact
+
+<!-- Provide before/after interaction latency evidence (or state why there is no measurable impact).
+If impact exists, include mitigation and acceptance rationale. -->
+
+## Branch Freshness (Never Behind)
+
+<!-- Required merge gate: PR head must include current base HEAD. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- What could go wrong; how it's mitigated. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,12 @@
 
 <!-- What this touches. What it explicitly does NOT touch. -->
 
+## Branch Freshness (Never Behind)
+
+<!-- Required: PR head must include current base HEAD. Keep this at 0 before merge/close. -->
+
+Branch-Behind-Base: 0
+
 ## Risks & Anomalies
 
 <!-- What could go wrong; how it's mitigated. -->

--- a/.github/workflows/canon-authority.yml
+++ b/.github/workflows/canon-authority.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/canon.yml
+++ b/.github/workflows/canon.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   canon:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-guard.yml
+++ b/.github/workflows/ci-guard.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-staging-tests.yml
+++ b/.github/workflows/ci-staging-tests.yml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
   # Staging tests gated to push-to-main only (DB connectivity issues)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   staging-tests:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -33,6 +37,9 @@ jobs:
 
       - name: Eval2 persistence boundary guard
         run: npm run guard:eval2-persistence-boundary
+
+      - name: Hardening contract guard
+        run: npm run guard:hardening-contract
 
       - name: Build
         run: npm run build

--- a/.github/workflows/fixture-guard.yml
+++ b/.github/workflows/fixture-guard.yml
@@ -14,6 +14,10 @@ on:
       - 'lib/jobs/**'
       - 'schemas/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fixture-canon-guard:
     name: Fixture Canon Guard

--- a/.github/workflows/flow1-proof-pack.yml
+++ b/.github/workflows/flow1-proof-pack.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flow1-proof-pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -12,6 +12,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ===============================================================
   # GOVERNANCE UNIT TESTS
@@ -90,6 +94,24 @@ jobs:
         run: npm run guard:phase-integrity
 
   # ===============================================================
+  # HARDENING CONTRACT GUARD
+  # Enforces auth/input/output/quality/latency hardening contracts
+  # ===============================================================
+  hardening-contract-guard:
+    name: Hardening Contract Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - run: npm ci
+      - name: Run hardening contract guard
+        run: npm run guard:hardening-contract
+
+  # ===============================================================
   # ENFORCEMENT SUMMARY
   # All governance gates must pass before merge
   # ===============================================================
@@ -100,6 +122,7 @@ jobs:
       - governance-coverage
       - canon-guard
       - phase-integrity-guard
+      - hardening-contract-guard
     runs-on: ubuntu-latest
     steps:
       - name: All governance checks passed

--- a/.github/workflows/job-system-ci.yml
+++ b/.github/workflows/job-system-ci.yml
@@ -12,6 +12,10 @@ on:
       - develop
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   proof-availability:
     name: Check Proof Gate Availability

--- a/.github/workflows/kevlar-ci.yml
+++ b/.github/workflows/kevlar-ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["chore/ci-hardening-kevlar"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   kevlar-guards:
     runs-on: ubuntu-latest

--- a/.github/workflows/latency-pr-enforcement.yml
+++ b/.github/workflows/latency-pr-enforcement.yml
@@ -4,6 +4,10 @@ name: Latency PR Enforcement
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-latency-template:
     runs-on: ubuntu-latest
@@ -448,6 +452,12 @@ jobs:
               assert(hasSection("## Visual Evidence"), "Missing: Visual Evidence section");
               assert(hasSection("## Accessibility"), "Missing: Accessibility section");
               assert(hasSection("## Browser Targets"), "Missing: Browser Targets section");
+              assert(hasSection("## Unauthorized Input Sources"), "Missing: Unauthorized Input Sources section");
+              assert(hasSection("## Internal Process Leakage"), "Missing: Internal Process Leakage section");
+              assert(hasSection("## Input → Action → Output"), "Missing: Input → Action → Output section");
+              assert(hasSection("## Public-Safe Quality/Status Metrics"), "Missing: Public-Safe Quality/Status Metrics section");
+              assert(hasSection("## Runtime/Pipeline Expansion"), "Missing: Runtime/Pipeline Expansion section");
+              assert(hasSection("## Latency Impact"), "Missing: Latency Impact section");
               assert(hasNoPipelineImpact(), "Missing: No-Pipeline-Impact: <value> line");
             };
 

--- a/.github/workflows/latency-pr-enforcement.yml
+++ b/.github/workflows/latency-pr-enforcement.yml
@@ -365,10 +365,17 @@ jobs:
             const commonFloor = () => {
               assert(hasSection("## Summary"), "Missing: Summary section");
               assert(hasSection("## Scope"), "Missing: Scope section");
+              assert(hasSection("## Branch Freshness (Never Behind)"), "Missing: Branch Freshness (Never Behind) section");
+              const branchBehindLine = body.match(/^Branch-Behind-Base:\s*(\d+)\s*$/m);
+              assert(!!branchBehindLine, 'Missing: Branch-Behind-Base: <integer> line');
+              if (branchBehindLine) {
+                assert(branchBehindLine[1] === "0", "Branch-Behind-Base must be 0 before merge");
+              }
               assert(hasSection("## Risks & Anomalies"), "Missing: Risks & Anomalies section");
             };
 
             const validateEvaluation = () => {
+              commonFloor();
               assert(hasSection("## Summary"), "Missing: Summary section");
               assert(hasSection("## Scope"), "Missing: Scope section");
               assert(
@@ -378,7 +385,6 @@ jobs:
               assert(hasSection("## Contract Integrity"), "Missing: Contract Integrity section");
               assert(hasSection("## Behavioral Quality"), "Missing: Behavioral Quality section");
               assert(hasSection("## Latency Evidence"), "Missing: Latency Evidence section");
-              assert(hasSection("## Risks & Anomalies"), "Missing: Risks & Anomalies section");
 
               const processChangeMatch = body.match(/^Process Change:\s*(yes|no)\s*$/im);
               assert(

--- a/.github/workflows/phase1-evidence.yml
+++ b/.github/workflows/phase1-evidence.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   evidence:
     name: Flow 1 Evidence Gate

--- a/.github/workflows/phase2c-evidence.yml
+++ b/.github/workflows/phase2c-evidence.yml
@@ -21,6 +21,10 @@ on:
       - 'tsconfig.json'
       - 'tsconfig.workers.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   evidence:
     name: Phase 2C Evidence Gate

--- a/.github/workflows/phase2d-evidence.yml
+++ b/.github/workflows/phase2d-evidence.yml
@@ -29,6 +29,10 @@ on:
       - 'tsconfig.workers.json'
       - 'package.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   evidence:
     name: Phase 2D Evidence Gate

--- a/.github/workflows/phase2e-anchor-guard.yml
+++ b/.github/workflows/phase2e-anchor-guard.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-anchors:
     name: Verify Phase 2E Anchors

--- a/.github/workflows/phase2e-evidence.yml
+++ b/.github/workflows/phase2e-evidence.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   evidence:
     name: Phase 2E Evidence Gate

--- a/.github/workflows/pipeline-stress.yml
+++ b/.github/workflows/pipeline-stress.yml
@@ -12,6 +12,10 @@ name: Pipeline Stress Harness
       - "package.json"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stress:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-body-guardian.yml
+++ b/.github/workflows/pr-body-guardian.yml
@@ -23,6 +23,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard-body:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-head-freshness-guard.yml
+++ b/.github/workflows/pr-head-freshness-guard.yml
@@ -1,0 +1,68 @@
+name: PR Head Freshness Guard
+
+"on":
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-head-freshness:
+    name: pr-head-freshness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Enforce PR branch freshness against base HEAD
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed('No pull_request payload found.');
+              return;
+            }
+
+            const baseRef = pr.base.ref;
+            const baseSha = pr.base.sha;
+            const headSha = pr.head.sha;
+
+            const { data: cmp } = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: baseSha,
+              head: headSha,
+            });
+
+            core.info(`PR #${pr.number}`);
+            core.info(`baseRef=${baseRef}`);
+            core.info(`baseSha=${baseSha}`);
+            core.info(`headSha=${headSha}`);
+            core.info(`status=${cmp.status}, ahead_by=${cmp.ahead_by}, behind_by=${cmp.behind_by}`);
+
+            // pass only when PR head includes current base tip
+            // compare status semantics (base...head):
+            // - ahead: head contains base and extra commits (expected for up-to-date PR)
+            // - identical: head == base (unlikely for PR but valid)
+            // - diverged/behind: head is missing base commits (must fail)
+            const isFresh = (cmp.status === 'ahead' || cmp.status === 'identical');
+
+            if (!isFresh) {
+              core.setFailed(
+                [
+                  `PR branch is not up-to-date with base '${baseRef}'.`,
+                  `compare_status=${cmp.status}, ahead_by=${cmp.ahead_by}, behind_by=${cmp.behind_by}.`,
+                  'Rebase or reset this branch onto current base HEAD, then push again.',
+                ].join(' ')
+              );
+              return;
+            }
+
+            core.info('✅ PR head is up-to-date with current base HEAD.');

--- a/.github/workflows/replay-harness.yml
+++ b/.github/workflows/replay-harness.yml
@@ -6,6 +6,10 @@ name: Replay Harness CI
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   replay:
     name: Replay Harness Fixtures

--- a/.github/workflows/report-governance-fixture.yml
+++ b/.github/workflows/report-governance-fixture.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/report-governance-fixture.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   report-governance-fixture:
     runs-on: ubuntu-latest

--- a/.github/workflows/scoring-pr-scope-guard.yml
+++ b/.github/workflows/scoring-pr-scope-guard.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   enforce-scoring-scope:
     name: enforce-scoring-scope

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   secret-scan:
     name: Scan for Hardcoded Secrets

--- a/.github/workflows/sipoc-certification.yml
+++ b/.github/workflows/sipoc-certification.yml
@@ -17,6 +17,10 @@ name: SIPOC Certification
       - "package.json"
       - ".github/workflows/sipoc-certification.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sipoc-certification:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,17 @@ A task is NOT complete unless:
 - tests prove enforcement
 - no bypass paths exist
 - CI guard passes
+- PR branch freshness is proven (`Branch-Behind-Base: 0`) and branch is not behind/diverged from base head
+
+---
+
+## 🔄 PR Freshness Contract (Never Behind)
+
+- All PRs must be up-to-date with the latest base branch head at merge time.
+- If a PR is `behind` or `diverged`, it must be rebased/reset before merge.
+- The PR body must declare:
+	- `Branch-Behind-Base: 0`
+- This is enforced by CI and required for close/merge readiness.
 
 ---
 


### PR DESCRIPTION
## Summary
Hard-code the never-behind policy into repository PR governance.

## Scope
- Adds explicit branch freshness contract language to all typed PR templates and the default PR template.
- Extends PR body enforcement so every PR must declare `Branch-Behind-Base: 0`.
- Updates contributor governance docs to state that behind/diverged PRs are not merge-ready.
- Does not modify application/runtime/business logic.

## CI/Infra Scope
- `.github/workflows/latency-pr-enforcement.yml` now requires a `## Branch Freshness (Never Behind)` section.
- PR bodies must include `Branch-Behind-Base: 0` to satisfy the governance contract.
- This complements `.github/workflows/pr-head-freshness-guard.yml`, which enforces live base-head freshness in CI.

## Rollback Plan
- Revert this PR to remove the PR-body freshness assertion and template text.
- The runtime freshness guard remains independently reversible via its own workflow file.

## Affected Workflows
- `.github/workflows/latency-pr-enforcement.yml` — requires the never-behind PR body section and zero-behind declaration.
- `.github/workflows/pr-head-freshness-guard.yml` — companion CI freshness gate already added in this branch.

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## Risks & Anomalies
- Existing open PRs without the new section will fail template enforcement until their bodies are updated.
- This is intentional fail-closed behavior to prevent quiet drift.

---

No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
