### PR TITLE
copy: add Canada and Mexico operating-location trust copy

### DIFF
--- a/.github/pr-bodies/PR-715.md
+++ b/.github/pr-bodies/PR-715.md
@@ -1,0 +1,19 @@
+## Summary
+Add operating-location trust copy to the shared footer and founder-facing public pages.
+
+## Scope
+- Updates the shared site footer text used across public pages.
+- Updates founder-facing copy on the Black Box Problem page and Agent Readiness bio surface.
+- Does not change application logic, routes, workflows, or evaluation behavior.
+
+## Branch Freshness (Never Behind)
+
+Branch-Behind-Base: 0
+
+## Risks & Anomalies
+- Low risk copy-only change.
+- Public text must remain consistent across footer and founder-facing surfaces.
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.

--- a/app/agent-readiness/bio/page.tsx
+++ b/app/agent-readiness/bio/page.tsx
@@ -463,7 +463,7 @@ export default function AuthorBioPage() {
         {/* Generate */}
         <div style={{ display: "flex", gap: "0.75rem", marginBottom: "1.5rem", flexWrap: "wrap" }}>
           <button
-            onClick={() => setGeneratedBio("Michael J. Meraw is a former Canadian Armed Forces pilot and aerospace executive turned novelist. He writes literary suspense, eco-horror, and speculative fiction about survival, moral consequence, and the systems — natural and human — that trap people inside them. Splitting his time between Canada and Sinaloa, Mexico, he draws on lived regional experience for his work. Meraw previously founded a startup and pitched on CBC's Dragons' Den.")}
+            onClick={() => setGeneratedBio("Michael J. Meraw is a former Canadian Armed Forces pilot and aerospace executive turned novelist. He writes literary suspense, eco-horror, and speculative fiction about survival, moral consequence, and the systems — natural and human — that trap people inside them. Operated from British Columbia, Canada, and Sinaloa, Mexico. Meraw draws on lived regional experience for his work and previously founded a startup and pitched on CBC's Dragons' Den.")}
             style={{
               fontFamily: T.mono, fontSize: "0.6875rem", fontWeight: 700,
               letterSpacing: "0.1em", textTransform: "uppercase",

--- a/app/black-box-problem/page.tsx
+++ b/app/black-box-problem/page.tsx
@@ -159,6 +159,9 @@ export default function BlackBoxProblemPage() {
             RevisionGrade was founded by Michael J. Meraw, a former Canadian Forces pilot and Major (Retired) with more than twenty years in corporate aerospace.
           </p>
           <p>
+            Operated from British Columbia, Canada, and Sinaloa, Mexico.
+          </p>
+          <p>
             His background in airworthiness, reliability, enterprise information management, and master data management shaped the RevisionGrade operating principle: when the stakes are high, guessing is not a process.
           </p>
           <p>

--- a/components/SiteFooter.jsx
+++ b/components/SiteFooter.jsx
@@ -46,6 +46,7 @@ export default function SiteFooter() {
             Manuscript diagnosis, author-controlled revision, and professional submission preparation.
           </p>
           <p className="mt-5 text-xs text-rg-dim">RevisionGrade. All rights reserved.</p>
+          <p className="mt-2 text-xs text-rg-dim">Operated from Canada and Mexico.</p>
         </div>
 
         <div className="grid gap-6 sm:grid-cols-3">


### PR DESCRIPTION
## Summary
Add operating-location trust copy to the shared footer and founder-facing public pages.

## Scope
- Updates the shared site footer text used across public pages.
- Updates founder-facing copy on the Black Box Problem page and Agent Readiness bio surface.
- Does not change application logic, routes, workflows, or evaluation behavior.

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## Risks & Anomalies
- Low risk copy-only change.
- Public text must remain consistent across footer and founder-facing surfaces.

---

No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
