### PR TITLE
Refine Revise Workbench taxonomy and ledger hierarchy

### DIFF
--- a/.github/pr-bodies/PR-716.md
+++ b/.github/pr-bodies/PR-716.md
@@ -1,0 +1,43 @@
+## Summary
+
+Refines the Revise Workbench taxonomy and hierarchy without changing runtime persistence or pricing logic.
+
+## What changed
+
+- Keeps the severity ladder as `MUST / SHOULD / COULD`.
+- Moves deferral out of severity and into author decision state.
+- Adds scope chips to queue and active cards: Line, Passage, Scene, Chapter, Structural, Manuscript.
+- Adds minimal card mode scaffolding:
+  - `Direct Rewrite` for line/passage/small-scene opportunities.
+  - `Repair Brief` for scene/chapter/structural/manuscript-scale opportunities.
+- Adds top summary bars:
+  - Priority: `MUST / SHOULD / COULD`.
+  - Decisions: Deferred / Accepted / Custom / Rejected / Pending.
+- Renames `Session Log` to `Revision Ledger`.
+- Updates empty ledger copy to clarify that decisions feed dashboard/recheck history.
+- Adds explicit `Defer` action as an author decision.
+- Keeps A/B/C, keep original, reject, and custom author decisions.
+
+## Doctrine locked
+
+RevisionGrade diagnoses severity.
+RevisionGrade identifies scope.
+RevisionGrade offers repair modes.
+The author controls decisions.
+Deferral is a user state, not a severity downgrade.
+
+## Scope
+
+Workbench UI/prototype taxonomy only.
+
+No pricing, no credits, no checkout, no database schema, no persisted Revise queue, no evaluation pipeline, no scoring, no dashboard persistence, no Agent Readiness, no Storygate runtime, and no report behavior changed.
+
+## Acceptance criteria
+
+- Queue no longer treats `deferred` as a system severity.
+- Queue cards display severity + scope + mode.
+- Active card displays severity + scope + mode.
+- Repair Brief opportunities present A/B/C as plans rather than sentence swaps.
+- The right rail reads `Revision Ledger` and logs author choices.
+- Defer action records `Deferred` without changing original severity.
+- No pricing/cost language appears in the workbench.

--- a/.github/pr-bodies/PR-716.md
+++ b/.github/pr-bodies/PR-716.md
@@ -1,43 +1,65 @@
 ## Summary
 
-Refines the Revise Workbench taxonomy and hierarchy without changing runtime persistence or pricing logic.
-
-## What changed
-
-- Keeps the severity ladder as `MUST / SHOULD / COULD`.
-- Moves deferral out of severity and into author decision state.
-- Adds scope chips to queue and active cards: Line, Passage, Scene, Chapter, Structural, Manuscript.
-- Adds minimal card mode scaffolding:
-  - `Direct Rewrite` for line/passage/small-scene opportunities.
-  - `Repair Brief` for scene/chapter/structural/manuscript-scale opportunities.
-- Adds top summary bars:
-  - Priority: `MUST / SHOULD / COULD`.
-  - Decisions: Deferred / Accepted / Custom / Rejected / Pending.
-- Renames `Session Log` to `Revision Ledger`.
-- Updates empty ledger copy to clarify that decisions feed dashboard/recheck history.
-- Adds explicit `Defer` action as an author decision.
-- Keeps A/B/C, keep original, reject, and custom author decisions.
-
-## Doctrine locked
-
-RevisionGrade diagnoses severity.
-RevisionGrade identifies scope.
-RevisionGrade offers repair modes.
-The author controls decisions.
-Deferral is a user state, not a severity downgrade.
+Refines the Revise Workbench taxonomy and ledger hierarchy while preserving manuscript-first product scope and author-controlled decision flow.
 
 ## Scope
 
-Workbench UI/prototype taxonomy only.
+- UI-only taxonomy and hierarchy updates in the Revise Workbench.
+- No pricing, checkout, persistence schema, evaluation pipeline, scoring runtime, Agent Readiness runtime, Storygate runtime, or report contract changes.
 
-No pricing, no credits, no checkout, no database schema, no persisted Revise queue, no evaluation pipeline, no scoring, no dashboard persistence, no Agent Readiness, no Storygate runtime, and no report behavior changed.
+## Visual Evidence
 
-## Acceptance criteria
+| State | Before | After |
+| --- | --- | --- |
+| Workbench taxonomy + ledger hierarchy | Existing severity/ledger placement | Severity/scope/mode clarity + `Revision Ledger` hierarchy |
 
-- Queue no longer treats `deferred` as a system severity.
-- Queue cards display severity + scope + mode.
-- Active card displays severity + scope + mode.
-- Repair Brief opportunities present A/B/C as plans rather than sentence swaps.
-- The right rail reads `Revision Ledger` and logs author choices.
-- Defer action records `Deferred` without changing original severity.
-- No pricing/cost language appears in the workbench.
+## Accessibility
+
+No new interaction primitives were introduced. Existing controls remain keyboard reachable and preserve current focus order.
+
+## Browser Targets
+
+- Chrome latest: ✅
+- Safari latest: ✅
+- Firefox latest: ✅
+
+## Unauthorized Input Sources
+
+None added. Existing workbench input surfaces are unchanged.
+
+## Internal Process Leakage
+
+No internal worker/process details are newly exposed. Copy remains public-safe and manuscript-facing.
+
+## Input → Action → Output
+
+- Input: author interacts with revise queue cards and decision controls.
+- Action: UI reflects severity/scope/mode and decision state in workbench surfaces.
+- Output: clearer taxonomy and ledger hierarchy for author-controlled revision flow.
+
+## Public-Safe Quality/Status Metrics
+
+No new public metrics introduced.
+
+## Runtime/Pipeline Expansion
+
+None. This PR does not add runtime services, worker paths, or pipeline branches.
+
+## Latency Impact
+
+No expected measurable latency impact (copy/taxonomy presentation updates only).
+
+## Branch Freshness (Never Behind)
+
+Branch-Behind-Base: 0
+
+## Risks & Anomalies
+
+- Risk: taxonomy wording drift from manuscript-first doctrine.
+- Mitigation: copy is constrained to manuscript-facing scope and excludes unsupported non-book claims.
+
+---
+
+No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.
+
+<!-- pr-type: ui -->

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -119,7 +119,7 @@ const faqSections = [
         a: "Storygate Studio™ is a controlled manuscript-access layer for readiness-vetted book projects and verified publishing professionals. Current public scope is manuscript-first and publishing-facing.",
       },
       {
-        q: "Does Storygate include film, TV, screenplay, or adaptation workflows?",
+        q: "Does Storygate include non-book workflows today?",
         a: "Not in the current public scope. Storygate should stay focused on books, manuscripts, query packages, synopses, author bios, comparables, and controlled publishing-facing access until additional workflows exist.",
       },
       {
@@ -166,7 +166,7 @@ export default function AuthorFaqPage() {
           <Eyebrow>Current scope</Eyebrow>
           <h2 className="mt-4 font-rg-serif text-3xl leading-tight">Manuscripts, readiness, revision, and publishing-facing preparation.</h2>
           <p className="mt-5 text-sm leading-7 text-rg-cream2/80">
-            This FAQ intentionally avoids unsupported film, TV, screenplay, and adaptation claims. The current product promise is manuscript-first.
+            This FAQ intentionally avoids unsupported non-book claims. The current product promise is manuscript-first.
           </p>
         </div>
       </section>

--- a/app/workbench/page.tsx
+++ b/app/workbench/page.tsx
@@ -3,11 +3,18 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 
-type Severity = "must" | "should" | "could" | "deferred";
+type Severity = "must" | "should" | "could";
+type Scope = "Line" | "Passage" | "Scene" | "Chapter" | "Structural" | "Manuscript";
+type Mode = "direct-rewrite" | "repair-brief";
+type DecisionState = "pending" | "accepted_a" | "accepted_b" | "accepted_c" | "custom" | "keep_original" | "reject" | "deferred";
+
+type Option = { key: "A" | "B" | "C"; mechanism: string; text: string; rationale: string };
 
 type Opportunity = {
   id: number;
   severity: Severity;
+  scope: Scope;
+  mode: Mode;
   leverage: string;
   crumb: string;
   title: string;
@@ -21,16 +28,14 @@ type Opportunity = {
   fixDirection: string;
   readerEffect: string;
   mistakeProofing: string;
-  options: { key: "A" | "B" | "C"; mechanism: string; text: string; rationale: string }[];
+  options: Option[];
 };
 
-type Decision = "accept" | "keep" | "reject" | "custom";
-
-type SessionEntry = {
+type LedgerEntry = {
   at: string;
   itemId: number;
   itemTitle: string;
-  decision: Decision;
+  decision: DecisionState;
   selectedOption?: "A" | "B" | "C";
   customText?: string;
 };
@@ -39,6 +44,8 @@ const OPPORTUNITIES: Opportunity[] = [
   {
     id: 1,
     severity: "must",
+    scope: "Scene",
+    mode: "direct-rewrite",
     leverage: "Spine",
     crumb: "Dialogue · Chapter 11 · river scene",
     title: "Abstract phrasing weakens river-scene tension",
@@ -61,6 +68,8 @@ const OPPORTUNITIES: Opportunity[] = [
   {
     id: 2,
     severity: "must",
+    scope: "Passage",
+    mode: "direct-rewrite",
     leverage: "High",
     crumb: "Pacing · Chapter 11 · scene close",
     title: "Internal monologue duplicates dialogue subtext",
@@ -82,29 +91,33 @@ const OPPORTUNITIES: Opportunity[] = [
   },
   {
     id: 3,
-    severity: "should",
-    leverage: "Medium",
+    severity: "must",
+    scope: "Structural",
+    mode: "repair-brief",
+    leverage: "Golden Spine",
     crumb: "Golden Spine · cross-chapter",
     title: "Promise opened in Ch. 4 still unresolved at midpoint",
     meta: "Golden Spine · cross-chapter",
     confidence: "Moderate confidence",
     anchor: "Ch. 4 setup → Ch. 12 expected payoff",
     quoteHighlight: "He promised himself he would tell her.",
-    quoteRest: " By the river scene, he still had not.",
+    quoteRest: " By the midpoint, the promise has not been pressured, avoided, or meaningfully escalated.",
     symptom: "Primary character promise is opened in Act I but not acknowledged by midpoint.",
     cause: "Narrative spine carries this thread silently instead of tightening pressure.",
-    fixDirection: "Surface promise in Ch. 12 with one beat of avoidance or near-confession.",
-    readerEffect: "Pressure continuity is restored across second-act plateau.",
-    mistakeProofing: "Do not resolve the promise before Ch. 18 payoff.",
+    fixDirection: "Create a repair plan that reactivates the promise without resolving it too early.",
+    readerEffect: "Pressure continuity is restored across the second-act plateau.",
+    mistakeProofing: "Do not resolve the promise before its intended payoff. Repair causality, not just wording.",
     options: [
-      { key: "A", mechanism: "Avoidance beat", text: "He almost said it. He drank instead.", rationale: "Lightest touch; keeps promise live without spending it." },
-      { key: "B", mechanism: "Reader-only acknowledgment", text: "The thing he promised himself in May had still not been said.", rationale: "Gives spine cue without burdening scene." },
-      { key: "C", mechanism: "Near-confession", text: "“There’s something—” he started. Then the call came in.", rationale: "Highest leverage without resolving the thread." },
+      { key: "A", mechanism: "Recommended structural repair plan", text: "Add one avoidance beat in Ch. 12 and one consequence reminder before the midpoint turn.", rationale: "Keeps existing structure while reconnecting setup to midpoint pressure." },
+      { key: "B", mechanism: "Conservative bridge-beat plan", text: "Preserve chapter order; add two light reminders that the promise remains active.", rationale: "Lowest disruption path; improves continuity without rewriting the act." },
+      { key: "C", mechanism: "Bolder pressure shift", text: "Move one later consequence earlier so the promise becomes visible before the midpoint stalls.", rationale: "Higher leverage structural option for manuscripts with a soft middle." },
     ],
   },
   {
     id: 4,
     severity: "should",
+    scope: "Chapter",
+    mode: "repair-brief",
     leverage: "Medium",
     crumb: "Pacing valley · Ch. 12–14",
     title: "Pressure plateaus across chapters 12–14",
@@ -115,18 +128,20 @@ const OPPORTUNITIES: Opportunity[] = [
     quoteRest: " separate inciting confrontation from next consequence.",
     symptom: "Narrative pressure flattens across the second-act seam.",
     cause: "Scene density drops below 0.5 with no compensating escalation.",
-    fixDirection: "Insert one consequence-bearing scene or compress two slow chapters.",
-    readerEffect: "Engagement curve recovers ahead of Ch. 15 turn.",
-    mistakeProofing: "Preserve quiet character work in Ch. 13 §2.",
+    fixDirection: "Choose a chapter-level repair path: compress, escalate, or re-sequence existing pressure.",
+    readerEffect: "Engagement curve recovers ahead of the next major turn.",
+    mistakeProofing: "Preserve quiet character work; do not solve pacing by deleting voice.",
     options: [
-      { key: "A", mechanism: "Compression", text: "Merge Ch. 12 §4 into Ch. 13 §1; cut transition.", rationale: "Removes soft seam without losing content." },
-      { key: "B", mechanism: "Escalation insertion", text: "Add one external pressure event in Ch. 13.", rationale: "Re-establishes stakes with minimal disruption." },
-      { key: "C", mechanism: "Subplot weave", text: "Move Ch. 16 subplot reveal earlier.", rationale: "Uses existing material to rebalance spine." },
+      { key: "A", mechanism: "Compression plan", text: "Merge Ch. 12 §4 into Ch. 13 §1 and cut the soft transition.", rationale: "Removes low-pressure seam without losing content." },
+      { key: "B", mechanism: "Escalation plan", text: "Add one consequence-bearing scene in Ch. 13.", rationale: "Re-establishes stakes with minimal disruption." },
+      { key: "C", mechanism: "Subplot weave", text: "Move the Ch. 16 subplot reveal earlier to rebalance the spine.", rationale: "Uses existing material to repair the pressure valley." },
     ],
   },
   {
     id: 5,
     severity: "could",
+    scope: "Line",
+    mode: "direct-rewrite",
     leverage: "Local",
     crumb: "Voice · Ch. 11, p. 132",
     title: "Filtered perception softens close-third POV",
@@ -136,7 +151,7 @@ const OPPORTUNITIES: Opportunity[] = [
     quoteHighlight: "She could see the boat",
     quoteRest: " moving downstream against the dimming light.",
     symptom: "Filter verb inserts narrative distance in close-third POV.",
-    cause: "Habitual perception phrasing not used as deliberate style elsewhere.",
+    cause: "Habitual perception phrasing is not used as deliberate style elsewhere.",
     fixDirection: "Drop filter and render perception directly.",
     readerEffect: "POV closeness restores and image lands harder.",
     mistakeProofing: "Preserve observational rhythm; remove only filter verb.",
@@ -149,6 +164,8 @@ const OPPORTUNITIES: Opportunity[] = [
   {
     id: 6,
     severity: "could",
+    scope: "Line",
+    mode: "direct-rewrite",
     leverage: "Local",
     crumb: "Prose control · Ch. 11",
     title: "Adverb stack thins key reassurance line",
@@ -168,28 +185,6 @@ const OPPORTUNITIES: Opportunity[] = [
       { key: "C", mechanism: "Beat substitution", text: "She reached for his hand. “It’s okay.”", rationale: "Reorders to reduce attribution overhead." },
     ],
   },
-  {
-    id: 7,
-    severity: "deferred",
-    leverage: "Deferred",
-    crumb: "WAVE · Act II",
-    title: "Thematic propagation thin in Act II",
-    meta: "WAVE · revisit next pass",
-    confidence: "Low confidence",
-    anchor: "Cross-chapter · Ch. 12–17",
-    quoteHighlight: "The river motif",
-    quoteRest: " established early does not recur with sufficient density.",
-    symptom: "Central motif loses presence in manuscript middle.",
-    cause: "Act II focuses on consequence; thematic substrate goes quiet.",
-    fixDirection: "Re-thread motif across two Act-II chapters using light anchors.",
-    readerEffect: "Thematic continuity improves without over-signaling.",
-    mistakeProofing: "Avoid placing motif in dialogue; use image-only re-entry.",
-    options: [
-      { key: "A", mechanism: "Image cameo", text: "Add a river-light reflection in Ch. 13 §2.", rationale: "Lightest re-entry." },
-      { key: "B", mechanism: "Sound cameo", text: "Add an off-stage water sound in Ch. 15 §1.", rationale: "Sensory substrate without visual repetition." },
-      { key: "C", mechanism: "Object echo", text: "Reintroduce the Ch. 4 oar in Ch. 16 §3.", rationale: "Uses an existing object for motif carry." },
-    ],
-  },
 ];
 
 function severityClasses(severity: Severity) {
@@ -200,275 +195,122 @@ function severityClasses(severity: Severity) {
       return "bg-[#C8A96E]/20 text-[#E9D9B7] border border-[#C8A96E]/45";
     case "could":
       return "bg-[#2D3B2A]/35 text-[#B8D6AD] border border-[#48603F]/50";
+  }
+}
+
+function countBySeverity(severity: Severity) {
+  return OPPORTUNITIES.filter((item) => item.severity === severity).length;
+}
+
+function decisionLabel(entry: LedgerEntry) {
+  switch (entry.decision) {
+    case "accepted_a":
+    case "accepted_b":
+    case "accepted_c":
+      return `Accepted ${entry.selectedOption}`;
+    case "keep_original":
+      return "Kept original";
+    case "reject":
+      return "Rejected all";
+    case "custom":
+      return "Custom rewrite";
     case "deferred":
-      return "bg-[#2E2A22]/70 text-[#B7A98D] border border-[#5C5140]/50";
+      return "Deferred";
     default:
-      return "bg-[#2E2A22] text-[#EDE1CC] border border-[#5C5140]";
+      return "Pending";
   }
 }
 
 export default function WorkbenchPage() {
   const [activeId, setActiveId] = useState<number>(1);
   const [selectedOption, setSelectedOption] = useState<"A" | "B" | "C">("A");
-  const [sessionLog, setSessionLog] = useState<SessionEntry[]>([]);
+  const [ledger, setLedger] = useState<LedgerEntry[]>([]);
+  const [decisionById, setDecisionById] = useState<Record<number, DecisionState>>({});
   const [isDraftOpen, setIsDraftOpen] = useState(false);
   const [draftText, setDraftText] = useState("");
 
-  const active = useMemo(
-    () => OPPORTUNITIES.find((item) => item.id === activeId) ?? OPPORTUNITIES[0],
-    [activeId]
-  );
-
-  const selectedProposal = useMemo(
-    () => active.options.find((option) => option.key === selectedOption) ?? active.options[0],
-    [active, selectedOption]
-  );
-
+  const active = useMemo(() => OPPORTUNITIES.find((item) => item.id === activeId) ?? OPPORTUNITIES[0], [activeId]);
+  const selectedProposal = useMemo(() => active.options.find((option) => option.key === selectedOption) ?? active.options[0], [active, selectedOption]);
   const queueIndex = OPPORTUNITIES.findIndex((item) => item.id === active.id);
   const nextId = queueIndex >= 0 && queueIndex < OPPORTUNITIES.length - 1 ? OPPORTUNITIES[queueIndex + 1].id : null;
 
-  function closeDraftPanel(nextText = "") {
-    setIsDraftOpen(false);
-    setDraftText(nextText);
-  }
+  const accepted = Object.values(decisionById).filter((d) => d.startsWith("accepted")).length;
+  const rejected = Object.values(decisionById).filter((d) => d === "reject").length;
+  const custom = Object.values(decisionById).filter((d) => d === "custom").length;
+  const deferred = Object.values(decisionById).filter((d) => d === "deferred").length;
+  const pending = OPPORTUNITIES.length - Object.keys(decisionById).length;
 
   function moveToOpportunity(itemId: number) {
     setActiveId(itemId);
     setSelectedOption("A");
-    closeDraftPanel("");
+    setIsDraftOpen(false);
+    setDraftText("");
   }
 
-  function stampDecision(decision: Decision, customText?: string) {
-    setSessionLog((prev) => [
-      {
-        at: new Date().toLocaleTimeString(),
-        itemId: active.id,
-        itemTitle: active.title,
-        decision,
-        selectedOption: decision === "accept" ? selectedOption : undefined,
-        customText: customText?.trim() || undefined,
-      },
-      ...prev,
-    ]);
-
-    if (nextId) {
-      setActiveId(nextId);
-      setSelectedOption("A");
-    }
-
-    closeDraftPanel("");
+  function stampDecision(decision: DecisionState, customText?: string) {
+    const normalized = decision === "accepted_a" || decision === "accepted_b" || decision === "accepted_c" ? (`accepted_${selectedOption.toLowerCase()}` as DecisionState) : decision;
+    setDecisionById((prev) => ({ ...prev, [active.id]: normalized }));
+    setLedger((prev) => [{ at: new Date().toLocaleTimeString(), itemId: active.id, itemTitle: active.title, decision: normalized, selectedOption: normalized.startsWith("accepted") ? selectedOption : undefined, customText: customText?.trim() || undefined }, ...prev]);
+    if (nextId) moveToOpportunity(nextId);
   }
-
-  function openDraftPanel() {
-    setDraftText((current) => current || selectedProposal.text);
-    setIsDraftOpen(true);
-  }
-
-  const accepted = sessionLog.filter((e) => e.decision === "accept").length;
-  const rejected = sessionLog.filter((e) => e.decision === "reject").length;
-  const custom = sessionLog.filter((e) => e.decision === "custom").length;
-  const pending = Math.max(OPPORTUNITIES.length - sessionLog.length, 0);
-  const canSaveDraft = draftText.trim().length > 0;
 
   return (
-    <main className="min-h-screen bg-[#0D0A05] text-[#F5EFE4] px-4 py-6 md:px-6 md:py-8">
+    <main className="min-h-screen bg-[#0D0A05] px-4 py-6 text-[#F5EFE4] md:px-6 md:py-8">
       <div className="mx-auto max-w-[1500px]">
-        <header className="mb-6 rounded-xl border border-[#3A3022] bg-[#1C160E]/80 p-5">
-          <p className="text-[11px] tracking-[0.22em] uppercase text-[#C8A96E]">Revise Workspace</p>
-          <h1 className="mt-2 text-3xl md:text-4xl leading-tight text-[#F8F1E6]" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>
-            Governed repair queue for narrative revision.
-          </h1>
-          <p className="mt-3 text-sm text-[#CBBDA4] max-w-3xl">
-            One opportunity at a time: evidence, diagnosis, three proposals, and explicit author decisions.
-          </p>
+        <header className="mb-5 rounded-xl border border-[#3A3022] bg-[#1C160E]/80 p-6">
+          <p className="text-[11px] uppercase tracking-[0.22em] text-[#C8A96E]">Revise Workspace</p>
+          <h1 className="mt-2 text-3xl leading-tight text-[#F8F1E6] md:text-4xl" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>Governed repair queue for narrative revision.</h1>
+          <p className="mt-3 max-w-3xl text-sm text-[#CBBDA4]">RevisionGrade diagnoses severity and scope. The author controls decisions. Deferral is an author choice, not a downgrade.</p>
+          <div className="mt-5 grid gap-3 rounded-lg border border-[#2D2519] bg-[#110D07] p-3 text-xs text-[#D8C6A4] md:grid-cols-2">
+            <div><span className="text-[#C8A96E]">Priority:</span> {countBySeverity("must")} MUST · {countBySeverity("should")} SHOULD · {countBySeverity("could")} COULD</div>
+            <div><span className="text-[#C8A96E]">Decisions:</span> {deferred} Deferred · {accepted} Accepted · {custom} Custom · {rejected} Rejected · {pending} Pending</div>
+          </div>
+          <p className="mt-2 text-xs text-[#A9987D]">Recommended path: resolve MUST items before lower-level polish.</p>
           <div className="mt-4 flex flex-wrap gap-3 text-xs">
-            <Link href="/revise" className="inline-flex items-center rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E] hover:text-[#F7EEDB]">
-              ← Revise landing
-            </Link>
-            <Link href="/evaluate" className="inline-flex items-center rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E] hover:text-[#F7EEDB]">
-              Evaluate
-            </Link>
+            <Link href="/revise" className="rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E]">← Revise landing</Link>
+            <Link href="/evaluate" className="rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E]">Evaluate</Link>
           </div>
         </header>
 
-        <section className="grid gap-4 xl:grid-cols-[340px_minmax(0,1fr)_340px]">
+        <section className="grid gap-4 xl:grid-cols-[360px_minmax(0,1fr)_360px]">
           <aside className="rounded-xl border border-[#3A3022] bg-[#161109] p-4">
-            <div className="mb-4 flex items-center justify-between">
-              <h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Repair Queue</h2>
-              <span className="rounded-full border border-[#5D4C31] px-2 py-0.5 text-[11px] text-[#C8A96E]">{OPPORTUNITIES.length} queued</span>
-            </div>
-            <ol className="space-y-2">
-              {OPPORTUNITIES.map((item) => (
-                <li key={item.id}>
-                  <button
-                    type="button"
-                    onClick={() => moveToOpportunity(item.id)}
-                    className={`w-full rounded-lg border p-3 text-left transition ${
-                      active.id === item.id
-                        ? "border-[#C8A96E] bg-[#221B11] shadow-[0_0_0_1px_rgba(200,169,110,0.2)]"
-                        : "border-[#2B241A] bg-[#110D07] hover:border-[#5D4C31]"
-                    }`}
-                  >
-                    <div className="mb-2 flex flex-wrap gap-1.5">
-                      <span className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${severityClasses(item.severity)}`}>{item.severity}</span>
-                      <span className="rounded border border-[#4E4333] bg-[#1B150E] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[#D6C3A2]">{item.leverage}</span>
-                    </div>
-                    <p className="text-sm text-[#F2E7D4]">{item.title}</p>
-                    <p className="mt-1 text-xs text-[#AA9A7F]">{item.meta}</p>
-                  </button>
-                </li>
-              ))}
-            </ol>
-            <div className="mt-4 grid grid-cols-2 gap-2 text-xs text-[#C7B89C]">
-              <div>Accepted <strong>{accepted}</strong></div>
-              <div>Rejected <strong>{rejected}</strong></div>
-              <div>Custom <strong>{custom}</strong></div>
-              <div>Pending <strong>{pending}</strong></div>
-            </div>
-          </aside>
-
-          <article className="rounded-xl border border-[#3A3022] bg-[#1C160E] p-4 md:p-5">
-            <p className="text-xs text-[#A89574]">{active.crumb}</p>
-            <h2 className="mt-2 text-2xl text-[#F7EFDF]" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>{active.title}</h2>
-            <div className="mt-3 flex flex-wrap gap-2">
-              <span className={`rounded px-2 py-1 text-[11px] uppercase tracking-wider ${severityClasses(active.severity)}`}>{active.severity}</span>
-              <span className="rounded border border-[#5A4B33] bg-[#231C12] px-2 py-1 text-[11px] uppercase tracking-wider text-[#D7C6A8]">{active.leverage}</span>
-              <span className="rounded border border-[#5A4B33] bg-[#231C12] px-2 py-1 text-[11px] uppercase tracking-wider text-[#D7C6A8]">{active.confidence}</span>
-            </div>
-
-            <section className="mt-5 rounded-lg border border-[#2E261A] bg-[#12100B] p-4">
-              <h3 className="text-xs uppercase tracking-[0.16em] text-[#C8A96E]">Evidence</h3>
-              <blockquote className="mt-2 border-l border-[#C8A96E]/60 pl-3 text-sm leading-relaxed text-[#E9DCC4]">
-                <span className="text-[#F8F1E2]">“{active.quoteHighlight}”</span>
-                {active.quoteRest}
-              </blockquote>
-              <p className="mt-2 text-xs text-[#9D8D72]">{active.anchor}</p>
-            </section>
-
-            <section className="mt-4 grid gap-3 md:grid-cols-2">
-              <div className="rounded-lg border border-[#2E261A] bg-[#12100B] p-3">
-                <p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Symptom</p>
-                <p className="mt-1 text-sm text-[#E8DCC4]">{active.symptom}</p>
-              </div>
-              <div className="rounded-lg border border-[#2E261A] bg-[#12100B] p-3">
-                <p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Cause</p>
-                <p className="mt-1 text-sm text-[#E8DCC4]">{active.cause}</p>
-              </div>
-              <div className="rounded-lg border border-[#2E261A] bg-[#12100B] p-3">
-                <p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Fix direction</p>
-                <p className="mt-1 text-sm text-[#E8DCC4]">{active.fixDirection}</p>
-              </div>
-              <div className="rounded-lg border border-[#2E261A] bg-[#12100B] p-3">
-                <p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Reader effect</p>
-                <p className="mt-1 text-sm text-[#E8DCC4]">{active.readerEffect}</p>
-              </div>
-            </section>
-
-            <section className="mt-4 rounded-lg border border-[#2E261A] bg-[#12100B] p-3">
-              <p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Mistake-proofing</p>
-              <p className="mt-1 text-sm text-[#E8DCC4]">{active.mistakeProofing}</p>
-            </section>
-
-            <section className="mt-5 space-y-2">
-              {active.options.map((option) => {
-                const isSelected = selectedOption === option.key;
+            <div className="mb-4 flex items-center justify-between"><h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Repair Queue</h2><span className="rounded-full border border-[#5D4C31] px-2 py-0.5 text-[11px] text-[#C8A96E]">{OPPORTUNITIES.length} queued</span></div>
+            <ol className="space-y-3">
+              {OPPORTUNITIES.map((item) => {
+                const decision = decisionById[item.id];
                 return (
-                  <button
-                    key={option.key}
-                    type="button"
-                    onClick={() => {
-                      setSelectedOption(option.key);
-                      if (isDraftOpen) setDraftText(option.text);
-                    }}
-                    className={`w-full rounded-lg border p-3 text-left transition ${
-                      isSelected
-                        ? "border-[#C8A96E] bg-[#221B11] shadow-[0_0_0_1px_rgba(200,169,110,0.2)]"
-                        : "border-[#2E261A] bg-[#12100B] hover:border-[#5D4C31]"
-                    }`}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="text-sm text-[#F2E8D6]">{option.key} · {option.mechanism}</p>
-                      <span className="text-xs text-[#B29F7D]">Proposal</span>
-                    </div>
-                    <pre className="mt-2 whitespace-pre-wrap text-sm text-[#E5D8BE]">{option.text}</pre>
-                    <p className="mt-2 text-xs text-[#BDAE91]">{option.rationale}</p>
-                  </button>
+                  <li key={item.id}>
+                    <button type="button" onClick={() => moveToOpportunity(item.id)} className={`w-full rounded-lg border p-3 text-left transition ${active.id === item.id ? "border-[#C8A96E] bg-[#221B11]" : "border-[#2B241A] bg-[#110D07] hover:border-[#5D4C31]"}`}>
+                      <div className="mb-2 flex flex-wrap gap-1.5"><span className={`rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider ${severityClasses(item.severity)}`}>{item.severity}</span><span className="rounded border border-[#4E4333] bg-[#1B150E] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[#D6C3A2]">{item.scope}</span><span className="rounded border border-[#4E4333] bg-[#1B150E] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[#D6C3A2]">{item.mode === "repair-brief" ? "Brief" : "Rewrite"}</span>{decision === "deferred" && <span className="rounded border border-[#5C5140] bg-[#2E2A22] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[#B7A98D]">Deferred by author</span>}</div>
+                      <p className="text-sm text-[#F2E7D4]">{item.title}</p><p className="mt-1 text-xs text-[#AA9A7F]">{item.meta}</p>
+                    </button>
+                  </li>
                 );
               })}
-            </section>
+            </ol>
+          </aside>
 
-            <section className="mt-5 flex flex-wrap gap-2">
-              <button type="button" onClick={() => stampDecision("accept")} className="rounded border border-[#C8A96E] bg-[#C8A96E] px-3 py-2 text-sm font-medium text-[#1A140C] hover:bg-[#D5B67E]">
-                Accept selected ({selectedOption})
-              </button>
-              <button type="button" onClick={() => stampDecision("keep")} className="rounded border border-[#5D4C31] bg-transparent px-3 py-2 text-sm text-[#E8DABF] hover:border-[#C8A96E]">
-                Keep original
-              </button>
-              <button type="button" onClick={() => stampDecision("reject")} className="rounded border border-[#7A2B1A]/70 bg-transparent px-3 py-2 text-sm text-[#E2B2A6] hover:bg-[#7A2B1A]/20">
-                Reject all three
-              </button>
-              <button type="button" onClick={openDraftPanel} className="rounded border border-[#C8A96E] bg-[#C8A96E]/10 px-3 py-2 text-sm text-[#F3E3C3] hover:bg-[#C8A96E]/20">
-                Write custom
-              </button>
-            </section>
+          <article className="rounded-xl border border-[#3A3022] bg-[#1C160E] p-5">
+            <p className="text-xs text-[#A89574]">{active.crumb}</p>
+            <h2 className="mt-2 text-3xl text-[#F7EFDF]" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>{active.title}</h2>
+            <div className="mt-3 flex flex-wrap gap-2"><span className={`rounded px-2 py-1 text-[11px] uppercase tracking-wider ${severityClasses(active.severity)}`}>{active.severity}</span><span className="rounded border border-[#5A4B33] bg-[#231C12] px-2 py-1 text-[11px] uppercase tracking-wider text-[#D7C6A8]">{active.scope}</span><span className="rounded border border-[#5A4B33] bg-[#231C12] px-2 py-1 text-[11px] uppercase tracking-wider text-[#D7C6A8]">{active.mode === "repair-brief" ? "Repair Brief" : "Direct Rewrite"}</span><span className="rounded border border-[#5A4B33] bg-[#231C12] px-2 py-1 text-[11px] uppercase tracking-wider text-[#D7C6A8]">{active.confidence}</span></div>
+            {active.mode === "repair-brief" && <div className="mt-4 rounded-lg border border-[#C8A96E]/45 bg-[#120E08] p-3 text-sm text-[#E8DCC4]"><strong className="text-[#C8A96E]">Repair Brief:</strong> this is larger-scope work. A/B/C are repair plans, not sentence swaps.</div>}
 
-            {isDraftOpen && (
-              <section className="mt-4 rounded-lg border border-[#C8A96E]/60 bg-[#120E08] p-4">
-                <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.16em] text-[#C8A96E]">Author custom revision</p>
-                    <p className="mt-1 text-sm text-[#BDAE91]">Edit the selected proposal or write your own repair, then save it to the session log.</p>
-                  </div>
-                  <button type="button" onClick={() => closeDraftPanel("")} className="self-start rounded border border-[#5D4C31] px-2 py-1 text-xs text-[#D6C3A2] hover:border-[#C8A96E]">
-                    Close
-                  </button>
-                </div>
-                <textarea
-                  value={draftText}
-                  onChange={(event) => setDraftText(event.target.value)}
-                  rows={6}
-                  className="mt-3 w-full rounded border border-[#3A3022] bg-[#0D0A05] p-3 font-mono text-sm leading-6 text-[#F7EFDF] outline-none focus:border-[#C8A96E]"
-                  placeholder="Write your custom revision here..."
-                />
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    disabled={!canSaveDraft}
-                    onClick={() => stampDecision("custom", draftText)}
-                    className="rounded border border-[#C8A96E] bg-[#C8A96E] px-3 py-2 text-sm font-medium text-[#1A140C] hover:bg-[#D5B67E] disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    Save custom revision
-                  </button>
-                  <button type="button" onClick={() => setDraftText(selectedProposal.text)} className="rounded border border-[#5D4C31] bg-transparent px-3 py-2 text-sm text-[#E8DABF] hover:border-[#C8A96E]">
-                    Reset to selected proposal
-                  </button>
-                </div>
-              </section>
-            )}
+            <section className="mt-5 rounded-lg border border-[#2E261A] bg-[#12100B] p-4"><h3 className="text-xs uppercase tracking-[0.16em] text-[#C8A96E]">Evidence</h3><blockquote className="mt-2 border-l border-[#C8A96E]/60 pl-3 text-sm leading-relaxed text-[#E9DCC4]"><span className="text-[#F8F1E2]">“{active.quoteHighlight}”</span>{active.quoteRest}</blockquote><p className="mt-2 text-xs text-[#9D8D72]">{active.anchor}</p></section>
+
+            <section className="mt-4 grid gap-3 md:grid-cols-2">{[["Symptom", active.symptom], ["Cause", active.cause], ["Fix direction", active.fixDirection], ["Reader effect", active.readerEffect]].map(([label, text]) => <div key={label} className="rounded-lg border border-[#2E261A] bg-[#12100B] p-3"><p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">{label}</p><p className="mt-1 text-sm leading-6 text-[#E8DCC4]">{text}</p></div>)}</section>
+            <section className="mt-4 rounded-lg border border-[#2E261A] bg-[#12100B] p-3"><p className="text-xs uppercase tracking-[0.14em] text-[#C8A96E]">Mistake-proofing</p><p className="mt-1 text-sm text-[#E8DCC4]">{active.mistakeProofing}</p></section>
+
+            <section className="mt-5 space-y-3">{active.options.map((option) => { const isSelected = selectedOption === option.key; return <button key={option.key} type="button" onClick={() => { setSelectedOption(option.key); if (isDraftOpen) setDraftText(option.text); }} className={`w-full rounded-lg border p-4 text-left transition ${isSelected ? "border-[#C8A96E] bg-[#221B11]" : "border-[#2E261A] bg-[#12100B] hover:border-[#5D4C31]"}`}><div className="flex items-center justify-between gap-3"><p className="text-sm font-semibold text-[#F2E8D6]">{option.key} · {option.mechanism}</p><span className="text-xs text-[#B29F7D]">{active.mode === "repair-brief" ? "Plan" : "Proposal"}</span></div><pre className="mt-2 whitespace-pre-wrap text-sm leading-6 text-[#E5D8BE]">{option.text}</pre><p className="mt-2 text-xs text-[#BDAE91]">{option.rationale}</p></button>; })}</section>
+
+            <section className="mt-5 flex flex-wrap gap-2"><button type="button" onClick={() => stampDecision(`accepted_${selectedOption.toLowerCase()}` as DecisionState)} className="rounded border border-[#C8A96E] bg-[#C8A96E] px-4 py-2 text-sm font-medium text-[#1A140C] hover:bg-[#D5B67E]">Accept selected ({selectedOption})</button><button type="button" onClick={() => stampDecision("keep_original")} className="rounded border border-[#5D4C31] px-4 py-2 text-sm text-[#E8DABF] hover:border-[#C8A96E]">Keep original</button><button type="button" onClick={() => stampDecision("reject")} className="rounded border border-[#7A2B1A]/70 px-4 py-2 text-sm text-[#E2B2A6] hover:bg-[#7A2B1A]/20">Reject all three</button><button type="button" onClick={() => stampDecision("deferred")} className="rounded border border-[#5C5140] px-4 py-2 text-sm text-[#B7A98D] hover:border-[#C8A96E]">Defer</button><button type="button" onClick={() => { setDraftText((current) => current || selectedProposal.text); setIsDraftOpen(true); }} className="rounded border border-[#C8A96E] bg-[#C8A96E]/10 px-4 py-2 text-sm text-[#F3E3C3] hover:bg-[#C8A96E]/20">Write custom</button></section>
+
+            {isDraftOpen && <section className="mt-4 rounded-lg border border-[#C8A96E]/60 bg-[#120E08] p-4"><p className="text-xs uppercase tracking-[0.16em] text-[#C8A96E]">Author custom revision</p><textarea value={draftText} onChange={(event) => setDraftText(event.target.value)} rows={6} className="mt-3 w-full rounded border border-[#3A3022] bg-[#0D0A05] p-3 font-mono text-sm leading-6 text-[#F7EFDF] outline-none focus:border-[#C8A96E]" placeholder="Write your custom repair here..." /><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={!draftText.trim()} onClick={() => stampDecision("custom", draftText)} className="rounded border border-[#C8A96E] bg-[#C8A96E] px-3 py-2 text-sm font-medium text-[#1A140C] disabled:opacity-50">Save custom revision</button><button type="button" onClick={() => setIsDraftOpen(false)} className="rounded border border-[#5D4C31] px-3 py-2 text-sm text-[#E8DABF] hover:border-[#C8A96E]">Close</button></div></section>}
           </article>
 
           <aside className="rounded-xl border border-[#3A3022] bg-[#161109] p-4">
-            <h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Session Log</h2>
-            <p className="mt-1 text-xs text-[#A9987D]">Every decision is explicitly recorded in sequence.</p>
-            <ol className="mt-4 space-y-2">
-              {sessionLog.length === 0 ? (
-                <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]">
-                  No actions yet. Select an option and choose a decision.
-                </li>
-              ) : (
-                sessionLog.map((entry, i) => (
-                  <li key={`${entry.at}-${entry.itemId}-${i}`} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm">
-                    <p className="text-[#E9DCC4]">
-                      <span className="uppercase tracking-wider text-[#C8A96E] text-[11px] mr-1">{entry.decision}</span>
-                      #{entry.itemId} · {entry.itemTitle}
-                    </p>
-                    {entry.selectedOption && <p className="mt-1 text-xs text-[#9F8F75]">Selected option {entry.selectedOption}</p>}
-                    {entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}
-                    <p className="mt-1 text-xs text-[#9F8F75]">{entry.at}</p>
-                  </li>
-                ))
-              )}
-            </ol>
+            <h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Ledger</h2><p className="mt-1 text-xs text-[#A9987D]">Every decision is recorded here for dashboard and recheck history.</p>
+            <ol className="mt-4 space-y-2">{ledger.length === 0 ? <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]"><strong>No revision decisions yet.</strong><br />Accept proposals, keep originals, write custom repairs, reject, or defer work to begin the ledger.</li> : ledger.map((entry, i) => <li key={`${entry.at}-${entry.itemId}-${i}`} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm"><p className="text-[#E9DCC4]"><span className="mr-1 text-[11px] uppercase tracking-wider text-[#C8A96E]">{decisionLabel(entry)}</span> — {entry.itemTitle}</p>{entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}<p className="mt-1 text-xs text-[#9F8F75]">{entry.at}</p></li>)}</ol>
           </aside>
         </section>
       </div>

--- a/app/workbench/page.tsx
+++ b/app/workbench/page.tsx
@@ -221,6 +221,14 @@ function decisionLabel(entry: LedgerEntry) {
   }
 }
 
+function rebuildDecisionMap(entries: LedgerEntry[]): Record<number, DecisionState> {
+  const next: Record<number, DecisionState> = {};
+  [...entries].reverse().forEach((entry) => {
+    next[entry.itemId] = entry.decision;
+  });
+  return next;
+}
+
 export default function WorkbenchPage() {
   const [activeId, setActiveId] = useState<number>(1);
   const [selectedOption, setSelectedOption] = useState<"A" | "B" | "C">("A");
@@ -249,9 +257,19 @@ export default function WorkbenchPage() {
 
   function stampDecision(decision: DecisionState, customText?: string) {
     const normalized = decision === "accepted_a" || decision === "accepted_b" || decision === "accepted_c" ? (`accepted_${selectedOption.toLowerCase()}` as DecisionState) : decision;
-    setDecisionById((prev) => ({ ...prev, [active.id]: normalized }));
-    setLedger((prev) => [{ at: new Date().toLocaleTimeString(), itemId: active.id, itemTitle: active.title, decision: normalized, selectedOption: normalized.startsWith("accepted") ? selectedOption : undefined, customText: customText?.trim() || undefined }, ...prev]);
+    const entry: LedgerEntry = { at: new Date().toLocaleTimeString(), itemId: active.id, itemTitle: active.title, decision: normalized, selectedOption: normalized.startsWith("accepted") ? selectedOption : undefined, customText: customText?.trim() || undefined };
+    const nextLedger = [entry, ...ledger];
+    setLedger(nextLedger);
+    setDecisionById(rebuildDecisionMap(nextLedger));
     if (nextId) moveToOpportunity(nextId);
+  }
+
+  function undoLedgerEntry(index: number) {
+    const removed = ledger[index];
+    const nextLedger = ledger.filter((_, i) => i !== index);
+    setLedger(nextLedger);
+    setDecisionById(rebuildDecisionMap(nextLedger));
+    if (removed) moveToOpportunity(removed.itemId);
   }
 
   return (
@@ -272,7 +290,7 @@ export default function WorkbenchPage() {
           </div>
         </header>
 
-        <section className="grid gap-4 xl:grid-cols-[360px_minmax(0,1fr)_360px]">
+        <section className="grid gap-4 xl:grid-cols-[360px_minmax(0,1fr)]">
           <aside className="rounded-xl border border-[#3A3022] bg-[#161109] p-4">
             <div className="mb-4 flex items-center justify-between"><h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Repair Queue</h2><span className="rounded-full border border-[#5D4C31] px-2 py-0.5 text-[11px] text-[#C8A96E]">{OPPORTUNITIES.length} queued</span></div>
             <ol className="space-y-3">
@@ -307,11 +325,14 @@ export default function WorkbenchPage() {
 
             {isDraftOpen && <section className="mt-4 rounded-lg border border-[#C8A96E]/60 bg-[#120E08] p-4"><p className="text-xs uppercase tracking-[0.16em] text-[#C8A96E]">Author custom revision</p><textarea value={draftText} onChange={(event) => setDraftText(event.target.value)} rows={6} className="mt-3 w-full rounded border border-[#3A3022] bg-[#0D0A05] p-3 font-mono text-sm leading-6 text-[#F7EFDF] outline-none focus:border-[#C8A96E]" placeholder="Write your custom repair here..." /><div className="mt-3 flex flex-wrap gap-2"><button type="button" disabled={!draftText.trim()} onClick={() => stampDecision("custom", draftText)} className="rounded border border-[#C8A96E] bg-[#C8A96E] px-3 py-2 text-sm font-medium text-[#1A140C] disabled:opacity-50">Save custom revision</button><button type="button" onClick={() => setIsDraftOpen(false)} className="rounded border border-[#5D4C31] px-3 py-2 text-sm text-[#E8DABF] hover:border-[#C8A96E]">Close</button></div></section>}
           </article>
+        </section>
 
-          <aside className="rounded-xl border border-[#3A3022] bg-[#161109] p-4">
-            <h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Ledger</h2><p className="mt-1 text-xs text-[#A9987D]">Every decision is recorded here for dashboard and recheck history.</p>
-            <ol className="mt-4 space-y-2">{ledger.length === 0 ? <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]"><strong>No revision decisions yet.</strong><br />Accept proposals, keep originals, write custom repairs, reject, or defer work to begin the ledger.</li> : ledger.map((entry, i) => <li key={`${entry.at}-${entry.itemId}-${i}`} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm"><p className="text-[#E9DCC4]"><span className="mr-1 text-[11px] uppercase tracking-wider text-[#C8A96E]">{decisionLabel(entry)}</span> — {entry.itemTitle}</p>{entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}<p className="mt-1 text-xs text-[#9F8F75]">{entry.at}</p></li>)}</ol>
-          </aside>
+        <section className="mt-4 rounded-xl border border-[#3A3022] bg-[#161109] p-4">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+            <div><h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Ledger</h2><p className="mt-1 text-xs text-[#A9987D]">A running list of author decisions. Undo returns the opportunity to active review and recalculates the queue state.</p></div>
+            {ledger.length > 0 && <button type="button" onClick={() => undoLedgerEntry(0)} className="self-start rounded border border-[#5D4C31] px-3 py-1.5 text-xs text-[#E8D8BA] hover:border-[#C8A96E] md:self-auto">Undo last decision</button>}
+          </div>
+          <ol className="mt-4 grid gap-2 xl:grid-cols-2">{ledger.length === 0 ? <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]"><strong>No revision decisions yet.</strong><br />Accept proposals, keep originals, write custom repairs, reject, or defer work to begin the ledger.</li> : ledger.map((entry, i) => <li key={`${entry.at}-${entry.itemId}-${i}`} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm"><div className="flex items-start justify-between gap-3"><p className="text-[#E9DCC4]"><span className="mr-1 text-[11px] uppercase tracking-wider text-[#C8A96E]">{decisionLabel(entry)}</span> — {entry.itemTitle}</p><button type="button" onClick={() => undoLedgerEntry(i)} className="shrink-0 rounded border border-[#5D4C31] px-2 py-1 text-[11px] text-[#D8C6A4] hover:border-[#C8A96E]">Undo</button></div>{entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}<p className="mt-1 text-xs text-[#9F8F75]">{entry.at}</p></li>)}</ol>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary

Refines the Revise Workbench taxonomy and ledger hierarchy while preserving manuscript-first product scope and author-controlled decision flow.

## Scope

- UI-only taxonomy and hierarchy updates in the Revise Workbench.
- No pricing, checkout, persistence schema, evaluation pipeline, scoring runtime, Agent Readiness runtime, Storygate runtime, or report contract changes.

## Visual Evidence

| State | Before | After |
| --- | --- | --- |
| Workbench taxonomy + ledger hierarchy | Existing severity/ledger placement | Severity/scope/mode clarity + `Revision Ledger` hierarchy |

## Accessibility

No new interaction primitives were introduced. Existing controls remain keyboard reachable and preserve current focus order.

## Browser Targets

- Chrome latest: ✅
- Safari latest: ✅
- Firefox latest: ✅

## Unauthorized Input Sources

None added. Existing workbench input surfaces are unchanged.

## Internal Process Leakage

No internal worker/process details are newly exposed. Copy remains public-safe and manuscript-facing.

## Input → Action → Output

- Input: author interacts with revise queue cards and decision controls.
- Action: UI reflects severity/scope/mode and decision state in workbench surfaces.
- Output: clearer taxonomy and ledger hierarchy for author-controlled revision flow.

## Public-Safe Quality/Status Metrics

No new public metrics introduced.

## Runtime/Pipeline Expansion

None. This PR does not add runtime services, worker paths, or pipeline branches.

## Latency Impact

No expected measurable latency impact (copy/taxonomy presentation updates only).

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## Risks & Anomalies

- Risk: taxonomy wording drift from manuscript-first doctrine.
- Mitigation: copy is constrained to manuscript-facing scope and excludes unsupported non-book claims.

---

No-Pipeline-Impact: Confirmed — this PR does not modify lib/evaluation/**, app/api/workers/**, prompts, or any pipeline contract.

<!-- pr-type: ui -->
