### PR TITLE
Operationalize Revise queue builder from evaluation artifacts

### DIFF
--- a/.github/pr-bodies/PR-720.md
+++ b/.github/pr-bodies/PR-720.md
@@ -1,0 +1,83 @@
+## Summary
+
+Operationalizes the first backend layer for the Revise queue builder.
+
+This PR makes the revision engine build a broader diagnostic finding set before proposal synthesis by combining:
+
+- existing evaluation-derived findings;
+- deep revision guidance mined from evaluation artifacts;
+- baseline manuscript discovery findings.
+
+## Why
+
+The Revise queue cannot depend only on top-level `quick_wins`, `strategic_revisions`, `criteria[].recommendations`, or `suggestions`.
+
+A report like Dracula may have empty top-level quick wins/strategic revisions while still containing substantial revision material deeper in the artifact, including per-criterion revision queues, revision notes, revision priorities, synthesis guidance, structural notes, and revision plans.
+
+## What changed
+
+- Adds `lib/revision/deepRevisionExtraction.ts`.
+  - Recursively walks evaluation artifacts.
+  - Extracts keys such as `revision_queue`, `revision_plan`, `revision_note`, `revision_priority`, `repair_queue`, `repair_plan`, `revision_guidance`, `revise_queue`, and `revise_plan`.
+  - Normalizes extracted guidance into `CreateDiagnosticFindingInput` records.
+
+- Adds `lib/revision/baselineManuscriptDiscovery.ts`.
+  - Adds safe baseline manuscript discovery for local opportunities.
+  - Currently covers long paragraph pressure and long sentence load.
+  - Caps discovered findings at 400.
+  - Uses `baseline_manuscript_discovery:*` finding types so this is clearly not WAVE/Golden Spine output.
+
+- Adds `lib/revision/operationalQueueBuilder.ts`.
+  - Orchestrates evaluation-derived findings, deep revision extraction, and baseline manuscript discovery.
+  - Deduplicates against existing diagnostic findings.
+  - Returns the complete finding list for the evaluation run.
+
+- Updates `lib/revision/engine.ts`.
+  - Replaces the direct `createDiagnosticFindingsForEvaluationRun(...)` call with `ensureOperationalRevisionFindings(...)` before proposal synthesis.
+  - Preserves existing revision session and finalize behavior.
+
+## Product doctrine
+
+Evaluation creates diagnostic raw material.
+Revise converts that material into actionable RevisionOpportunity cards.
+The evaluation report is the seed; the Revise queue is the operational repair landscape.
+
+Revise should not re-run the evaluation pipeline just to build the queue.
+
+## Dracula acceptance case
+
+Dracula should not return an empty Revise queue just because top-level Quick Wins and Strategic Revisions are empty.
+
+This PR makes the queue builder mine deeper revision guidance from evaluation artifacts so Dracula-style reports can still produce SHOULD/COULD opportunities from revision queues, revision plans, revision notes, and synthesis guidance.
+
+## WAVE boundary
+
+This PR does not claim Dracula had WAVE applied.
+
+Baseline manuscript discovery is explicitly named `baseline_manuscript_discovery` and is not WAVE, Golden Spine, Story Ledger, or long-form multi-layer logic.
+
+WAVE/Golden Spine Revise should only activate when those artifacts actually exist.
+
+## Scope
+
+Backend queue-builder layer only.
+
+No UI wiring to `/workbench` yet.
+No persisted author decision ledger changes.
+No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, dashboard charts, Agent Readiness, or Storygate runtime changes.
+
+## Next PR after this
+
+Wire `/workbench?manuscriptId=...&evaluationJobId=...` to load real revision session findings/proposals and replace hardcoded prototype cards.
+
+## Acceptance criteria
+
+- Revision engine still starts from a completed evaluation run.
+- Queue building reuses existing evaluation artifacts.
+- Deep revision guidance can be extracted even when top-level quick wins are empty.
+- Baseline manuscript discovery can add local opportunities beyond the report seed.
+- First proposal synthesis receives the expanded diagnostic finding set.
+- No evaluation pipeline rerun is introduced.
+- No WAVE/Golden Spine claims are made unless the source artifact provides those outputs.
+
+<!-- pr-type: backend -->

--- a/lib/revision/baselineManuscriptDiscovery.ts
+++ b/lib/revision/baselineManuscriptDiscovery.ts
@@ -1,0 +1,142 @@
+import { getVersionById } from "@/lib/manuscripts/versions";
+import type { CreateDiagnosticFindingInput } from "./types";
+
+const DISCOVERY_PREFIX = "baseline_manuscript_discovery";
+const MAX_DISCOVERY_FINDINGS = 400;
+
+type LocatedText = {
+  text: string;
+  paragraphIndex: number;
+  sentenceIndex?: number | null;
+};
+
+function wordCount(text: string): number {
+  const trimmed = text.trim();
+  return trimmed ? trimmed.split(/\s+/).length : 0;
+}
+
+function compact(text: string, max = 240): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  return clean.length <= max ? clean : `${clean.slice(0, max - 1).trim()}…`;
+}
+
+function splitParagraphs(rawText: string): LocatedText[] {
+  return rawText
+    .split(/\n{2,}/g)
+    .map((text, index) => ({ text: text.trim(), paragraphIndex: index + 1 }))
+    .filter((item) => item.text.length > 0);
+}
+
+function splitSentences(paragraph: LocatedText): LocatedText[] {
+  return paragraph.text
+    .split(/(?<=[.!?])\s+/g)
+    .map((text, index) => ({
+      text: text.trim(),
+      paragraphIndex: paragraph.paragraphIndex,
+      sentenceIndex: index + 1,
+    }))
+    .filter((item) => item.text.length > 0);
+}
+
+function location(item: LocatedText): string {
+  return item.sentenceIndex
+    ? `paragraph:${item.paragraphIndex}:sentence:${item.sentenceIndex}`
+    : `paragraph:${item.paragraphIndex}`;
+}
+
+function makeFinding(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+  item: LocatedText,
+  criterionKey: string,
+  findingType: string,
+  severity: "low" | "medium" | "high",
+  diagnosis: string,
+  recommendation: string,
+): CreateDiagnosticFindingInput {
+  return {
+    evaluation_job_id: evaluationRunId,
+    manuscript_version_id: manuscriptVersionId,
+    artifact_id: null,
+    criterion_key: criterionKey,
+    finding_type: `${DISCOVERY_PREFIX}:${findingType}`,
+    severity,
+    confidence: null,
+    location_ref: location(item),
+    paragraph_index: item.paragraphIndex,
+    sentence_index: item.sentenceIndex ?? null,
+    original_text: item.text,
+    evidence_excerpt: compact(item.text),
+    diagnosis,
+    recommendation,
+    action_hint: "refine",
+  };
+}
+
+function signature(input: CreateDiagnosticFindingInput): string {
+  return [input.finding_type, input.location_ref, input.original_text]
+    .join("|")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+export function isBaselineDiscoveryFindingType(findingType?: string | null): boolean {
+  return Boolean(findingType?.startsWith(DISCOVERY_PREFIX));
+}
+
+export async function buildBaselineManuscriptDiscoveryFindings(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+): Promise<CreateDiagnosticFindingInput[]> {
+  const version = await getVersionById(manuscriptVersionId);
+  const text = typeof version?.raw_text === "string" ? version.raw_text : "";
+  if (!text.trim()) return [];
+
+  const paragraphs = splitParagraphs(text);
+  const sentences = paragraphs.flatMap(splitSentences);
+  const candidates: CreateDiagnosticFindingInput[] = [];
+
+  for (const paragraph of paragraphs) {
+    if (wordCount(paragraph.text) >= 190) {
+      candidates.push(
+        makeFinding(
+          evaluationRunId,
+          manuscriptVersionId,
+          paragraph,
+          "PACING",
+          "long_paragraph_pressure",
+          "medium",
+          "Long paragraph may dilute pacing or visual clarity for the reader.",
+          "Review this paragraph for possible split points, compression, or a stronger turn beat while preserving voice.",
+        ),
+      );
+    }
+  }
+
+  for (const sentence of sentences) {
+    if (wordCount(sentence.text) >= 45) {
+      candidates.push(
+        makeFinding(
+          evaluationRunId,
+          manuscriptVersionId,
+          sentence,
+          "PROSE_CONTROL",
+          "long_sentence_load",
+          "low",
+          "Long sentence may be carrying too many beats at once.",
+          "Review for possible compression, punctuation reshaping, or a cleaner beat break without flattening style.",
+        ),
+      );
+    }
+  }
+
+  const seen = new Set<string>();
+  return candidates
+    .filter((candidate) => {
+      const key = signature(candidate);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, MAX_DISCOVERY_FINDINGS);
+}

--- a/lib/revision/deepRevisionExtraction.ts
+++ b/lib/revision/deepRevisionExtraction.ts
@@ -1,0 +1,291 @@
+import type {
+  CreateDiagnosticFindingInput,
+  FindingActionHint,
+  ProposalSeverity,
+} from "./types";
+
+function firstNonEmptyString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function cleanSnippet(text: string | null | undefined): string {
+  if (!text) return "";
+  return String(text)
+    .replace(/^\s*\.\.\.\s*/g, "")
+    .replace(/\s*\.\.\.\s*$/g, "")
+    .replace(/^\s*\.\s*/g, "")
+    .replace(/\s*\.\s*$/g, "")
+    .trim();
+}
+
+function normalizeFindingType(raw: unknown): string {
+  const base = firstNonEmptyString(typeof raw === "string" ? raw : "", "revision_note");
+  return base.replace(/\s+/g, "_").toLowerCase();
+}
+
+function normalizeCriterionKey(raw: unknown): string {
+  const key = firstNonEmptyString(typeof raw === "string" ? raw : "", "GENERAL");
+  return key.replace(/\s+/g, "_").toUpperCase();
+}
+
+function normalizeDeepKey(raw: string): string {
+  return raw.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function isRevisionGuidanceKey(key: string): boolean {
+  const normalized = normalizeDeepKey(key);
+  return (
+    normalized === "revisionqueue" ||
+    normalized === "revisionplan" ||
+    normalized === "revisionnote" ||
+    normalized === "revisionnotes" ||
+    normalized === "revisionpriority" ||
+    normalized === "revisionpriorities" ||
+    normalized === "repairqueue" ||
+    normalized === "repairplan" ||
+    normalized === "repairnote" ||
+    normalized === "repairnotes" ||
+    normalized === "revisionguidance" ||
+    normalized === "revisequeue" ||
+    normalized === "reviseplan"
+  );
+}
+
+function splitRevisionGuidanceText(value: string): string[] {
+  const text = value.trim();
+  if (!text) return [];
+
+  const bullets = text
+    .split(/(?:^|\n|\s)(?:\d+\.|[-•])\s+/g)
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (bullets.length > 1) return bullets;
+
+  return text
+    .split(/;\s+(?=[A-Z0-9'“\"])/g)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function toSeverity(raw: unknown, scoreOverride?: unknown): ProposalSeverity {
+  if (typeof scoreOverride === "number" && Number.isFinite(scoreOverride)) {
+    if (scoreOverride <= 4) return "high";
+    if (scoreOverride <= 7) return "medium";
+    return "low";
+  }
+
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (["must", "high", "critical", "major", "blocker"].includes(v)) return "high";
+  if (["could", "low", "minor", "optional"].includes(v)) return "low";
+  return "medium";
+}
+
+function toActionHint(raw: unknown): FindingActionHint | null {
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (v === "preserve" || v === "refine" || v === "replace") return v;
+  if (v === "keep" || v === "none" || v === "no_change") return "preserve";
+  return null;
+}
+
+function toConfidence(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+type DeepRevisionItem = {
+  value: unknown;
+  path: string;
+  context: Record<string, unknown>;
+  sourceKey: string;
+};
+
+function objectContext(value: any): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+  return {
+    criterion: value.criterion ?? value.criterion_key ?? value.key,
+    title: value.title ?? value.name ?? value.layer ?? value.act ?? value.section,
+    summary: value.summary ?? value.function ?? value.status,
+    evidence: value.evidence ?? value.fit_evidence ?? value.gap_evidence,
+    score: value.score ?? value.score_0_10 ?? value.final_score_0_10,
+    confidence: value.confidence,
+    severity: value.severity ?? value.priority,
+  };
+}
+
+function collectDeepRevisionItems(
+  value: unknown,
+  path: string[] = [],
+  context: Record<string, unknown> = {},
+): DeepRevisionItem[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) =>
+      collectDeepRevisionItems(item, [...path, String(index)], context),
+    );
+  }
+
+  if (!value || typeof value !== "object") return [];
+
+  const node = value as Record<string, unknown>;
+  const nextContext = { ...context, ...objectContext(node) };
+  const items: DeepRevisionItem[] = [];
+
+  for (const [key, child] of Object.entries(node)) {
+    const childPath = [...path, key];
+
+    if (isRevisionGuidanceKey(key)) {
+      if (typeof child === "string") {
+        for (const text of splitRevisionGuidanceText(child)) {
+          items.push({ value: text, path: childPath.join("."), context: nextContext, sourceKey: key });
+        }
+      } else if (Array.isArray(child)) {
+        child.forEach((entry, index) => {
+          if (typeof entry === "string") {
+            for (const text of splitRevisionGuidanceText(entry)) {
+              items.push({ value: text, path: [...childPath, String(index)].join("."), context: nextContext, sourceKey: key });
+            }
+          } else {
+            items.push({ value: entry, path: [...childPath, String(index)].join("."), context: nextContext, sourceKey: key });
+          }
+        });
+      } else if (child && typeof child === "object") {
+        items.push({ value: child, path: childPath.join("."), context: nextContext, sourceKey: key });
+      }
+      continue;
+    }
+
+    items.push(...collectDeepRevisionItems(child, childPath, nextContext));
+  }
+
+  return items;
+}
+
+function sourceLabel(sourceKey: string): string {
+  const normalized = normalizeDeepKey(sourceKey);
+  if (normalized.includes("queue")) return "revision_queue";
+  if (normalized.includes("priority")) return "revision_priority";
+  if (normalized.includes("plan")) return "revision_plan";
+  if (normalized.includes("repair")) return "repair_guidance";
+  return "revision_note";
+}
+
+function buildFindingFromDeepRevisionItem(
+  evaluationRunId: string,
+  manuscriptVersionId: string | null,
+  artifactId: string,
+  item: DeepRevisionItem,
+  index: number,
+): CreateDiagnosticFindingInput | null {
+  const raw = item.value;
+  const rawObject = raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : null;
+
+  const recommendation = cleanSnippet(
+    typeof raw === "string"
+      ? raw
+      : firstNonEmptyString(
+          rawObject?.recommendation,
+          rawObject?.revision_note,
+          rawObject?.revisionNote,
+          rawObject?.revision_priority,
+          rawObject?.revisionPriority,
+          rawObject?.revision_plan,
+          rawObject?.revisionPlan,
+          rawObject?.repair_plan,
+          rawObject?.repairPlan,
+          rawObject?.action,
+          rawObject?.text,
+          rawObject?.value,
+        ),
+  );
+
+  if (!recommendation) return null;
+
+  const criterion = firstNonEmptyString(
+    rawObject?.criterion,
+    rawObject?.criterion_key,
+    rawObject?.key,
+    item.context.criterion,
+    item.context.title,
+    "GENERAL",
+  );
+
+  const diagnosis = firstNonEmptyString(
+    rawObject?.diagnosis,
+    rawObject?.issue,
+    rawObject?.problem,
+    rawObject?.title,
+    rawObject?.summary,
+    item.context.summary,
+    `Revision guidance from ${item.path}`,
+  );
+
+  const evidence = cleanSnippet(
+    firstNonEmptyString(
+      rawObject?.evidence_excerpt,
+      rawObject?.evidence_snippet,
+      rawObject?.evidence,
+      rawObject?.quote,
+      item.context.evidence,
+    ),
+  );
+
+  return {
+    evaluation_job_id: evaluationRunId,
+    manuscript_version_id: manuscriptVersionId,
+    artifact_id: artifactId,
+    criterion_key: normalizeCriterionKey(criterion),
+    wave_id: firstNonEmptyString(rawObject?.wave_id, rawObject?.waveId) || null,
+    finding_type: normalizeFindingType(sourceLabel(item.sourceKey)),
+    severity: toSeverity(rawObject?.severity ?? rawObject?.priority ?? item.context.severity, item.context.score),
+    confidence: toConfidence(rawObject?.confidence ?? item.context.confidence),
+    location_ref: firstNonEmptyString(rawObject?.location_ref, rawObject?.locationRef, item.path) || `revision_guidance:${index + 1}`,
+    original_text: evidence,
+    evidence_excerpt: evidence,
+    diagnosis,
+    recommendation,
+    action_hint: toActionHint(rawObject?.action_hint ?? rawObject?.action_type ?? rawObject?.action) ?? "refine",
+  };
+}
+
+export function buildDeepRevisionFindings(
+  evaluationRunId: string,
+  manuscriptVersionId: string | null,
+  artifactId: string,
+  payload: any,
+): CreateDiagnosticFindingInput[] {
+  const rawItems = collectDeepRevisionItems(payload);
+  const seen = new Set<string>();
+  const findings: CreateDiagnosticFindingInput[] = [];
+
+  rawItems.forEach((item, index) => {
+    const finding = buildFindingFromDeepRevisionItem(
+      evaluationRunId,
+      manuscriptVersionId,
+      artifactId,
+      item,
+      index,
+    );
+    if (!finding) return;
+
+    const signature = [finding.criterion_key, finding.finding_type, finding.location_ref, finding.recommendation]
+      .join("|")
+      .toLowerCase();
+    if (seen.has(signature)) return;
+    seen.add(signature);
+    findings.push(finding);
+  });
+
+  return findings;
+}

--- a/lib/revision/engine.ts
+++ b/lib/revision/engine.ts
@@ -238,3 +238,97 @@ export async function startRevisionEngine(
     actionable_findings_count: synthesisSummary.actionable_findings_count,
   };
 }
+
+export async function finalizeRevisionEngine(
+  revisionSessionId: string,
+): Promise<FinalizeRevisionEngineResult> {
+  const sessionBeforeFinalize = await getRevisionSessionById(revisionSessionId);
+
+  if (!sessionBeforeFinalize) {
+    throw new Error(
+      `finalizeRevisionEngine failed: revision session not found: ${revisionSessionId}`,
+    );
+  }
+
+  // MANDATORY: Check governance eligibility before finalizing refinement
+  // This gates access from the finalize API endpoint, preventing bypass
+  await checkRefinementEligibilityByEvaluationRun(
+    supabase,
+    sessionBeforeFinalize.evaluation_run_id,
+  );
+
+  const readySession = await ensureRevisionSessionReadyForFinalize(
+    sessionBeforeFinalize,
+  );
+
+  try {
+    const applyResult = await applyRevisionSession(revisionSessionId);
+
+    const revisionSession = await getRevisionSessionById(revisionSessionId);
+    if (!revisionSession) {
+      throw new Error(
+        `finalizeRevisionEngine failed: revision session not found after apply: ${revisionSessionId}`,
+      );
+    }
+
+    const sourceVersion = await supabase
+      .from("manuscript_versions")
+      .select("id, manuscript_id")
+      .eq("id", revisionSession.source_version_id)
+      .maybeSingle();
+
+    void logRevisionEvent({
+      revision_session_id: revisionSessionId,
+      manuscript_id: sourceVersion.data?.manuscript_id ?? null,
+      manuscript_version_id: revisionSession.source_version_id,
+      evaluation_run_id: revisionSession.evaluation_run_id,
+      event_type: "finalize",
+      event_code: "REVISION_SESSION_FINALIZED",
+      metadata: {
+        result_version_id: applyResult.result_version_id,
+        accepted_count: applyResult.accepted_count,
+        modified_count: applyResult.modified_count,
+      },
+    });
+
+    return {
+      revision_session: revisionSession,
+      apply_result: applyResult,
+    };
+  } catch (error) {
+    if (readySession && readySession.status !== "applied" && readySession.status !== "failed") {
+      try {
+        await transitionRevisionSessionState(revisionSessionId, {
+          nextStatus: "failed",
+          findings_count: readySession.findings_count,
+          actionable_findings_count: readySession.actionable_findings_count,
+          proposal_ready_actionable_findings_count:
+            readySession.proposal_ready_actionable_findings_count,
+          proposals_created_count: readySession.proposals_created_count,
+          failure_code: "REVISION_FINALIZE_FAILED",
+          failure_message: error instanceof Error ? error.message : String(error),
+        });
+      } catch (transitionError) {
+        console.error("Failed to persist revision session failure state", {
+          revisionSessionId,
+          error:
+            transitionError instanceof Error
+              ? transitionError.message
+              : String(transitionError),
+        });
+      }
+    }
+
+    void logRevisionEvent({
+      revision_session_id: revisionSessionId,
+      manuscript_version_id: readySession?.source_version_id ?? sessionBeforeFinalize?.source_version_id ?? null,
+      evaluation_run_id: readySession?.evaluation_run_id ?? sessionBeforeFinalize?.evaluation_run_id ?? null,
+      event_type: "finalize",
+      severity: "error",
+      event_code: "REVISION_SESSION_FINALIZE_FAILED",
+      message: error instanceof Error ? error.message : String(error),
+    });
+
+    throw error;
+  }
+}

--- a/lib/revision/engine.ts
+++ b/lib/revision/engine.ts
@@ -1,7 +1,7 @@
 import { getSupabaseAdminClient } from "@/lib/supabase";
 import { applyRevisionSession } from "./apply";
 import { logRevisionEvent } from "./logRevisionEvent";
-import { createDiagnosticFindingsForEvaluationRun } from "./normalizeFindings";
+import { ensureOperationalRevisionFindings } from "./operationalQueueBuilder";
 import {
   createProposalsForSessionFromFindings,
   getFindingsSynthesisSummary,
@@ -154,7 +154,7 @@ export async function startRevisionEngine(
 
   // `failed` is a terminal state with no valid outbound transitions; create a fresh session.
   if (existing && existing.status !== "failed") {
-    await createDiagnosticFindingsForEvaluationRun(
+    await ensureOperationalRevisionFindings(
       input.evaluation_run_id,
       existing.source_version_id,
     );
@@ -206,7 +206,7 @@ export async function startRevisionEngine(
     event_code: "REVISION_SESSION_CREATED",
   });
 
-  await createDiagnosticFindingsForEvaluationRun(
+  await ensureOperationalRevisionFindings(
     input.evaluation_run_id,
     sourceVersionId,
   );
@@ -237,98 +237,4 @@ export async function startRevisionEngine(
     findings_count: synthesisSummary.findings_count,
     actionable_findings_count: synthesisSummary.actionable_findings_count,
   };
-}
-
-export async function finalizeRevisionEngine(
-  revisionSessionId: string,
-): Promise<FinalizeRevisionEngineResult> {
-  const sessionBeforeFinalize = await getRevisionSessionById(revisionSessionId);
-  
-  if (!sessionBeforeFinalize) {
-    throw new Error(
-      `finalizeRevisionEngine failed: revision session not found: ${revisionSessionId}`,
-    );
-  }
-
-  // MANDATORY: Check governance eligibility before finalizing refinement
-  // This gates access from the finalize API endpoint, preventing bypass
-  await checkRefinementEligibilityByEvaluationRun(
-    supabase,
-    sessionBeforeFinalize.evaluation_run_id,
-  );
-
-  const readySession = await ensureRevisionSessionReadyForFinalize(
-    sessionBeforeFinalize,
-  );
-
-  try {
-    const applyResult = await applyRevisionSession(revisionSessionId);
-
-    const revisionSession = await getRevisionSessionById(revisionSessionId);
-    if (!revisionSession) {
-      throw new Error(
-        `finalizeRevisionEngine failed: revision session not found after apply: ${revisionSessionId}`,
-      );
-    }
-
-    const sourceVersion = await supabase
-      .from("manuscript_versions")
-      .select("id, manuscript_id")
-      .eq("id", revisionSession.source_version_id)
-      .maybeSingle();
-
-    void logRevisionEvent({
-      revision_session_id: revisionSessionId,
-      manuscript_id: sourceVersion.data?.manuscript_id ?? null,
-      manuscript_version_id: revisionSession.source_version_id,
-      evaluation_run_id: revisionSession.evaluation_run_id,
-      event_type: "finalize",
-      event_code: "REVISION_SESSION_FINALIZED",
-      metadata: {
-        result_version_id: applyResult.result_version_id,
-        accepted_count: applyResult.accepted_count,
-        modified_count: applyResult.modified_count,
-      },
-    });
-
-    return {
-      revision_session: revisionSession,
-      apply_result: applyResult,
-    };
-  } catch (error) {
-    if (readySession && readySession.status !== "applied" && readySession.status !== "failed") {
-      try {
-        await transitionRevisionSessionState(revisionSessionId, {
-          nextStatus: "failed",
-          findings_count: readySession.findings_count,
-          actionable_findings_count: readySession.actionable_findings_count,
-          proposal_ready_actionable_findings_count:
-            readySession.proposal_ready_actionable_findings_count,
-          proposals_created_count: readySession.proposals_created_count,
-          failure_code: "REVISION_FINALIZE_FAILED",
-          failure_message: error instanceof Error ? error.message : String(error),
-        });
-      } catch (transitionError) {
-        console.error("Failed to persist revision session failure state", {
-          revisionSessionId,
-          error:
-            transitionError instanceof Error
-              ? transitionError.message
-              : String(transitionError),
-        });
-      }
-    }
-
-    void logRevisionEvent({
-      revision_session_id: revisionSessionId,
-      manuscript_version_id: readySession?.source_version_id ?? sessionBeforeFinalize?.source_version_id ?? null,
-      evaluation_run_id: readySession?.evaluation_run_id ?? sessionBeforeFinalize?.evaluation_run_id ?? null,
-      event_type: "finalize",
-      severity: "error",
-      event_code: "REVISION_SESSION_FINALIZE_FAILED",
-      message: error instanceof Error ? error.message : String(error),
-    });
-
-    throw error;
-  }
 }

--- a/lib/revision/operationalQueueBuilder.ts
+++ b/lib/revision/operationalQueueBuilder.ts
@@ -1,0 +1,125 @@
+import { getSupabaseAdminClient } from "@/lib/supabase";
+import { buildBaselineManuscriptDiscoveryFindings, isBaselineDiscoveryFindingType } from "./baselineManuscriptDiscovery";
+import { buildDeepRevisionFindings } from "./deepRevisionExtraction";
+import {
+  bulkCreateDiagnosticFindings,
+  createDiagnosticFindingsForEvaluationRun,
+  listFindingsForEvaluationRun,
+} from "./normalizeFindings";
+import type { CreateDiagnosticFindingInput, DiagnosticFinding } from "./types";
+
+let _supabase: ReturnType<typeof getSupabaseAdminClient> | undefined;
+
+function getSupabase() {
+  if (_supabase === undefined) _supabase = getSupabaseAdminClient();
+  return _supabase;
+}
+
+const supabase = new Proxy({} as NonNullable<ReturnType<typeof getSupabaseAdminClient>>, {
+  get(_target, prop) {
+    const client = getSupabase();
+    if (!client) throw new Error(`[REVISION-QUEUE] Supabase unavailable - cannot access .${String(prop)}`);
+    return client[prop as keyof typeof client];
+  },
+});
+
+function signature(input: CreateDiagnosticFindingInput): string {
+  return [
+    input.criterion_key,
+    input.finding_type,
+    input.location_ref ?? "",
+    input.diagnosis,
+    input.recommendation ?? "",
+  ]
+    .join("|")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function existingSignature(finding: DiagnosticFinding): string {
+  return [
+    finding.criterion_key,
+    finding.finding_type,
+    finding.location_ref ?? "",
+    finding.diagnosis,
+    finding.recommendation ?? "",
+  ]
+    .join("|")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function hasDeepRevisionFinding(findings: DiagnosticFinding[]): boolean {
+  return findings.some((finding) =>
+    ["revision_queue", "revision_plan", "revision_priority", "revision_note", "repair_guidance"]
+      .some((prefix) => finding.finding_type?.startsWith(prefix)),
+  );
+}
+
+async function createDeepRevisionFindings(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+  existing: DiagnosticFinding[],
+): Promise<DiagnosticFinding[]> {
+  if (hasDeepRevisionFinding(existing)) return existing;
+
+  const { data, error } = await supabase
+    .from("evaluation_artifacts")
+    .select("id, artifact_type, content, created_at")
+    .eq("job_id", evaluationRunId)
+    .in("artifact_type", ["evaluation_result_v2", "evaluation_result_v1"])
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(`createDeepRevisionFindings failed: ${error.message}`);
+
+  const seen = new Set(existing.map(existingSignature));
+  const inputs: CreateDiagnosticFindingInput[] = [];
+
+  for (const row of data ?? []) {
+    const artifactId = typeof row.id === "string" ? row.id : null;
+    if (!artifactId) continue;
+
+    for (const input of buildDeepRevisionFindings(evaluationRunId, manuscriptVersionId, artifactId, row.content ?? {})) {
+      const key = signature(input);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      inputs.push(input);
+    }
+  }
+
+  if (inputs.length > 0) await bulkCreateDiagnosticFindings(inputs);
+  return listFindingsForEvaluationRun(evaluationRunId);
+}
+
+async function createBaselineDiscoveryFindings(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+  existing: DiagnosticFinding[],
+): Promise<DiagnosticFinding[]> {
+  if (existing.some((finding) => isBaselineDiscoveryFindingType(finding.finding_type))) return existing;
+
+  const discovered = await buildBaselineManuscriptDiscoveryFindings(evaluationRunId, manuscriptVersionId);
+  if (discovered.length === 0) return existing;
+
+  const seen = new Set(existing.map(existingSignature));
+  const deduped = discovered.filter((input) => {
+    const key = signature(input);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  if (deduped.length > 0) await bulkCreateDiagnosticFindings(deduped);
+  return listFindingsForEvaluationRun(evaluationRunId);
+}
+
+export async function ensureOperationalRevisionFindings(
+  evaluationRunId: string,
+  manuscriptVersionId: string,
+): Promise<DiagnosticFinding[]> {
+  await createDiagnosticFindingsForEvaluationRun(evaluationRunId, manuscriptVersionId);
+  let findings = await listFindingsForEvaluationRun(evaluationRunId);
+  findings = await createDeepRevisionFindings(evaluationRunId, manuscriptVersionId, findings);
+  findings = await createBaselineDiscoveryFindings(evaluationRunId, manuscriptVersionId, findings);
+  return findings;
+}


### PR DESCRIPTION
## Summary

Operationalizes the first backend layer for the Revise queue builder.

This PR makes the revision engine build a broader diagnostic finding set before proposal synthesis by combining:

- existing evaluation-derived findings;
- deep revision guidance mined from evaluation artifacts;
- baseline manuscript discovery findings.

## Why

The Revise queue cannot depend only on top-level `quick_wins`, `strategic_revisions`, `criteria[].recommendations`, or `suggestions`.

A report like Dracula may have empty top-level quick wins/strategic revisions while still containing substantial revision material deeper in the artifact, including per-criterion revision queues, revision notes, revision priorities, synthesis guidance, structural notes, and revision plans.

## What changed

- Adds `lib/revision/deepRevisionExtraction.ts`.
  - Recursively walks evaluation artifacts.
  - Extracts keys such as `revision_queue`, `revision_plan`, `revision_note`, `revision_priority`, `repair_queue`, `repair_plan`, `revision_guidance`, `revise_queue`, and `revise_plan`.
  - Normalizes extracted guidance into `CreateDiagnosticFindingInput` records.

- Adds `lib/revision/baselineManuscriptDiscovery.ts`.
  - Adds safe baseline manuscript discovery for local opportunities.
  - Currently covers long paragraph pressure and long sentence load.
  - Caps discovered findings at 400.
  - Uses `baseline_manuscript_discovery:*` finding types so this is clearly not WAVE/Golden Spine output.

- Adds `lib/revision/operationalQueueBuilder.ts`.
  - Orchestrates evaluation-derived findings, deep revision extraction, and baseline manuscript discovery.
  - Deduplicates against existing diagnostic findings.
  - Returns the complete finding list for the evaluation run.

- Updates `lib/revision/engine.ts`.
  - Replaces the direct `createDiagnosticFindingsForEvaluationRun(...)` call with `ensureOperationalRevisionFindings(...)` before proposal synthesis.
  - Preserves existing revision session and finalize behavior.

## Product doctrine

Evaluation creates diagnostic raw material.
Revise converts that material into actionable RevisionOpportunity cards.
The evaluation report is the seed; the Revise queue is the operational repair landscape.

Revise should not re-run the evaluation pipeline just to build the queue.

## Dracula acceptance case

Dracula should not return an empty Revise queue just because top-level Quick Wins and Strategic Revisions are empty.

This PR makes the queue builder mine deeper revision guidance from evaluation artifacts so Dracula-style reports can still produce SHOULD/COULD opportunities from revision queues, revision plans, revision notes, and synthesis guidance.

## WAVE boundary

This PR does not claim Dracula had WAVE applied.

Baseline manuscript discovery is explicitly named `baseline_manuscript_discovery` and is not WAVE, Golden Spine, Story Ledger, or long-form multi-layer logic.

WAVE/Golden Spine Revise should only activate when those artifacts actually exist.

## Scope

Backend queue-builder layer only.

No UI wiring to `/workbench` yet.
No persisted author decision ledger changes.
No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, dashboard charts, Agent Readiness, or Storygate runtime changes.

## Next PR after this

Wire `/workbench?manuscriptId=...&evaluationJobId=...` to load real revision session findings/proposals and replace hardcoded prototype cards.

## Acceptance criteria

- Revision engine still starts from a completed evaluation run.
- Queue building reuses existing evaluation artifacts.
- Deep revision guidance can be extracted even when top-level quick wins are empty.
- Baseline manuscript discovery can add local opportunities beyond the report seed.
- First proposal synthesis receives the expanded diagnostic finding set.
- No evaluation pipeline rerun is introduced.
- No WAVE/Golden Spine claims are made unless the source artifact provides those outputs.

<!-- pr-type: backend -->