### PR TITLE
Sync Revise ledger decisions across devices

### DIFF
--- a/.github/pr-bodies/PR-723.md
+++ b/.github/pr-bodies/PR-723.md
@@ -1,0 +1,77 @@
+## Summary
+
+Stacks on #722 and adds the server-synced Revision Ledger layer for cross-device history and dashboard analytics.
+
+This keeps the local-first/offline behavior from #722, but adds the server table/API needed for decisions made on one device to become available to another device after sync.
+
+## What changed
+
+- Adds `revision_ledger_decisions` migration.
+  - Stores one row per author decision.
+  - Captures manuscript, evaluation, opportunity, decision type, selected option, custom text, local id, and client timestamps.
+  - Adds indexes for user, manuscript, evaluation, opportunity, decision, and created time.
+  - Enables RLS with own-user select/insert/update policies.
+  - Adds unique `(user_id, evaluation_job_id, local_id)` for idempotent local-first sync.
+
+- Adds `lib/revision/ledger.ts`.
+  - Verifies the authenticated user owns the manuscript/evaluation.
+  - Validates decision payloads.
+  - Upserts pending local ledger entries into `revision_ledger_decisions`.
+  - Lists synced ledger entries for a manuscript/evaluation.
+
+- Adds `app/api/revision-ledger/route.ts`.
+  - `GET` loads server-synced ledger history.
+  - `POST` syncs pending local entries.
+
+- Updates `ReviseWorkbenchClient`.
+  - Loads server ledger entries when online.
+  - Merges server history with local cache.
+  - Syncs pending local decisions when online.
+  - Marks synced entries as `Synced` and failed entries as retryable.
+  - Keeps local/offline behavior intact.
+
+## Product doctrine
+
+The author should be able to work locally without losing decisions, but the server ledger becomes the cross-device source of truth after sync.
+
+Device behavior:
+
+- Laptop loads Revise online → queue/ledger cache locally.
+- Laptop goes offline → author can continue reviewing and deciding.
+- Decisions are marked Pending sync.
+- Connection returns → decisions sync to server.
+- Phone loads Revise online later → server ledger is available and cached locally on the phone.
+
+## Scope
+
+Server-side Revision Ledger decision persistence and client sync only.
+
+No dashboard chart consumption yet.
+No final manuscript patch/apply behavior changes.
+No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, Agent Readiness, or Storygate runtime changes.
+
+## Dependency
+
+This PR is stacked on #722 and should be reviewed/merged after #720, #721, and #722.
+
+## Next PR after this
+
+Feed synced `revision_ledger_decisions` into dashboard analytics:
+
+- accepted/rejected/custom/deferred counts;
+- decisions by MUST / SHOULD / COULD;
+- decisions by scope/category;
+- before/after recheck deltas;
+- TrustedPath/manual activity history.
+
+## Acceptance criteria
+
+- New ledger table exists with RLS and idempotent local id uniqueness.
+- API rejects missing manuscript/evaluation identifiers.
+- API verifies manuscript ownership before reading or writing decisions.
+- Local pending decisions sync when online.
+- Server ledger entries load into the workbench on another online device.
+- Offline local cache remains usable if network is unavailable.
+- Dashboard analytics can consume the server table in a later PR.
+
+<!-- pr-type: migration -->

--- a/app/api/revision-ledger/route.ts
+++ b/app/api/revision-ledger/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import {
+  listRevisionLedgerDecisions,
+  syncRevisionLedgerDecisions,
+  type SyncRevisionLedgerEntryInput,
+} from "@/lib/revision/ledger";
+
+function badRequest(error: string) {
+  return NextResponse.json({ ok: false, error }, { status: 400 });
+}
+
+function serverError(error: unknown) {
+  return NextResponse.json(
+    { ok: false, error: error instanceof Error ? error.message : String(error) },
+    { status: 500 },
+  );
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const manuscriptId = url.searchParams.get("manuscriptId");
+    const evaluationJobId = url.searchParams.get("evaluationJobId");
+
+    if (!manuscriptId) return badRequest("Missing manuscriptId");
+    if (!evaluationJobId) return badRequest("Missing evaluationJobId");
+
+    const entries = await listRevisionLedgerDecisions({ manuscriptId, evaluationJobId });
+    return NextResponse.json({ ok: true, entries });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message === "Not authenticated" ? 401 : message.includes("not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const manuscriptId = body?.manuscriptId;
+    const evaluationJobId = body?.evaluationJobId;
+    const entries = body?.entries as SyncRevisionLedgerEntryInput[] | undefined;
+
+    if (!manuscriptId) return badRequest("Missing manuscriptId");
+    if (!evaluationJobId) return badRequest("Missing evaluationJobId");
+    if (!Array.isArray(entries)) return badRequest("Missing entries array");
+
+    const synced = await syncRevisionLedgerDecisions({ manuscriptId, evaluationJobId, entries });
+    return NextResponse.json({ ok: true, entries: synced });
+  } catch (error) {
+    return serverError(error);
+  }
+}

--- a/components/revision/ReviseWorkbenchClient.tsx
+++ b/components/revision/ReviseWorkbenchClient.tsx
@@ -9,13 +9,27 @@ type SyncStatus = "pending" | "synced" | "failed";
 
 type LedgerEntry = {
   localId: string;
+  serverId?: string;
   at: string;
+  createdAtIso: string;
   itemId: string;
   itemTitle: string;
   decision: DecisionState;
   selectedOption?: "A" | "B" | "C";
   customText?: string;
   syncStatus: SyncStatus;
+};
+
+type ServerLedgerEntry = {
+  id: string;
+  local_id: string;
+  opportunity_id: string;
+  opportunity_title: string;
+  decision: Exclude<DecisionState, "pending">;
+  selected_option: "A" | "B" | "C" | null;
+  custom_text: string | null;
+  client_created_at: string | null;
+  client_synced_at: string;
 };
 
 type LocalWorkbenchCache = {
@@ -106,6 +120,33 @@ function rebuildDecisionMap(entries: LedgerEntry[]): Record<string, DecisionStat
   return next;
 }
 
+function rowToLedgerEntry(row: ServerLedgerEntry): LedgerEntry {
+  const created = row.client_created_at ?? row.client_synced_at ?? new Date().toISOString();
+  return {
+    localId: row.local_id,
+    serverId: row.id,
+    at: new Date(created).toLocaleTimeString(),
+    createdAtIso: created,
+    itemId: row.opportunity_id,
+    itemTitle: row.opportunity_title,
+    decision: row.decision,
+    selectedOption: row.selected_option ?? undefined,
+    customText: row.custom_text ?? undefined,
+    syncStatus: "synced",
+  };
+}
+
+function mergeLedger(local: LedgerEntry[], remote: LedgerEntry[]) {
+  const byLocalId = new Map<string, LedgerEntry>();
+  [...remote, ...local].forEach((entry) => {
+    const existing = byLocalId.get(entry.localId);
+    if (!existing || existing.syncStatus !== "pending") {
+      byLocalId.set(entry.localId, entry);
+    }
+  });
+  return [...byLocalId.values()].sort((a, b) => b.createdAtIso.localeCompare(a.createdAtIso));
+}
+
 function EmptyWorkbench({ payload, cachedAt }: { payload: WorkbenchQueuePayload; cachedAt?: string | null }) {
   return (
     <main className="min-h-screen bg-[#0D0A05] px-4 py-6 text-[#F5EFE4] md:px-6 md:py-8">
@@ -127,6 +168,7 @@ export default function ReviseWorkbenchClient({ payload }: { payload: WorkbenchQ
   const [cachedPayload, setCachedPayload] = useState<WorkbenchQueuePayload | null>(null);
   const [cachedAt, setCachedAt] = useState<string | null>(null);
   const [isOnline, setIsOnline] = useState(true);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const effectivePayload = payload.ok && payload.opportunities.length > 0 ? payload : (cachedPayload ?? payload);
   const opportunities = effectivePayload.opportunities;
   const key = cacheKey(effectivePayload);
@@ -176,6 +218,95 @@ export default function ReviseWorkbenchClient({ payload }: { payload: WorkbenchQ
     setCachedAt(new Date().toISOString());
   }, [effectivePayload, key, ledger]);
 
+  useEffect(() => {
+    if (!isOnline || !effectivePayload.manuscriptId || !effectivePayload.evaluationJobId) return;
+    let cancelled = false;
+
+    async function loadServerLedger() {
+      try {
+        const params = new URLSearchParams({
+          manuscriptId: effectivePayload.manuscriptId ?? "",
+          evaluationJobId: effectivePayload.evaluationJobId ?? "",
+        });
+        const response = await fetch(`/api/revision-ledger?${params.toString()}`);
+        if (!response.ok) return;
+        const json = await response.json();
+        if (!json?.ok || !Array.isArray(json.entries) || cancelled) return;
+        const remote = (json.entries as ServerLedgerEntry[]).map(rowToLedgerEntry);
+        setLedger((current) => {
+          const merged = mergeLedger(current, remote);
+          setDecisionById(rebuildDecisionMap(merged));
+          saveLocalCache(key, effectivePayload, merged);
+          return merged;
+        });
+      } catch {
+        // Offline cache remains authoritative locally until sync succeeds.
+      }
+    }
+
+    void loadServerLedger();
+    return () => {
+      cancelled = true;
+    };
+  }, [effectivePayload, isOnline, key]);
+
+  useEffect(() => {
+    if (!isOnline || !effectivePayload.manuscriptId || !effectivePayload.evaluationJobId) return;
+    const pendingEntries = ledger.filter((entry) => entry.syncStatus !== "synced" && entry.decision !== "pending");
+    if (pendingEntries.length === 0) return;
+    let cancelled = false;
+
+    async function syncPending() {
+      try {
+        const response = await fetch("/api/revision-ledger", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            manuscriptId: effectivePayload.manuscriptId,
+            evaluationJobId: effectivePayload.evaluationJobId,
+            entries: pendingEntries.map((entry) => ({
+              localId: entry.localId,
+              opportunityId: entry.itemId,
+              opportunityTitle: entry.itemTitle,
+              decision: entry.decision,
+              selectedOption: entry.selectedOption ?? null,
+              customText: entry.customText ?? null,
+              clientCreatedAt: entry.createdAtIso,
+              metadata: { source: "workbench-local-first" },
+            })),
+          }),
+        });
+
+        const json = await response.json().catch(() => null);
+        if (!response.ok || !json?.ok || !Array.isArray(json.entries)) {
+          throw new Error(json?.error ?? "Ledger sync failed");
+        }
+
+        const syncedIds = new Map((json.entries as ServerLedgerEntry[]).map((row) => [row.local_id, row]));
+        if (cancelled) return;
+        setLedger((current) => {
+          const next = current.map((entry) => {
+            const row = syncedIds.get(entry.localId);
+            if (!row) return entry;
+            return { ...entry, serverId: row.id, syncStatus: "synced" as const };
+          });
+          saveLocalCache(key, effectivePayload, next);
+          return next;
+        });
+        setSyncMessage("Synced");
+      } catch (error) {
+        if (cancelled) return;
+        setLedger((current) => current.map((entry) => pendingEntries.some((p) => p.localId === entry.localId) ? { ...entry, syncStatus: "failed" as const } : entry));
+        setSyncMessage(error instanceof Error ? error.message : "Ledger sync failed");
+      }
+    }
+
+    void syncPending();
+    return () => {
+      cancelled = true;
+    };
+  }, [effectivePayload, isOnline, key, ledger]);
+
   const active = useMemo(() => opportunities.find((item) => item.id === activeId) ?? opportunities[0], [activeId, opportunities]);
   const selectedProposal = useMemo(() => active?.options.find((option) => option.key === selectedOption) ?? active?.options[0], [active, selectedOption]);
   const queueIndex = opportunities.findIndex((item) => item.id === active?.id);
@@ -201,9 +332,11 @@ export default function ReviseWorkbenchClient({ payload }: { payload: WorkbenchQ
 
   function stampDecision(decision: DecisionState, customText?: string) {
     const normalized = decision === "accepted_a" || decision === "accepted_b" || decision === "accepted_c" ? (`accepted_${selectedOption.toLowerCase()}` as DecisionState) : decision;
+    const createdAtIso = new Date().toISOString();
     const entry: LedgerEntry = {
       localId: localId(),
-      at: new Date().toLocaleTimeString(),
+      at: new Date(createdAtIso).toLocaleTimeString(),
+      createdAtIso,
       itemId: active.id,
       itemTitle: active.title,
       decision: normalized,
@@ -237,7 +370,9 @@ export default function ReviseWorkbenchClient({ payload }: { payload: WorkbenchQ
           <div className="mt-4 flex flex-wrap gap-2 text-xs">
             <span className={`rounded border px-2 py-1 ${isOnline ? "border-[#48603F] text-[#B8D6AD]" : "border-[#7A2B1A]/70 text-[#E9B19F]"}`}>{isOnline ? "Online" : "Offline"}</span>
             <span className="rounded border border-[#5D4C31] px-2 py-1 text-[#D8C6A4]">Local cache active</span>
+            <span className="rounded border border-[#5D4C31] px-2 py-1 text-[#D8C6A4]">Server ledger enabled</span>
             {pendingSync > 0 && <span className="rounded border border-[#C8A96E]/45 px-2 py-1 text-[#E9D9B7]">{pendingSync} pending sync</span>}
+            {syncMessage && <span className="rounded border border-[#5D4C31] px-2 py-1 text-[#A9987D]">{syncMessage}</span>}
             {cachedAt && <span className="rounded border border-[#5D4C31] px-2 py-1 text-[#A9987D]">Cached {new Date(cachedAt).toLocaleString()}</span>}
           </div>
           <div className="mt-5 grid gap-3 rounded-lg border border-[#2D2519] bg-[#110D07] p-3 text-xs text-[#D8C6A4] md:grid-cols-2">
@@ -279,8 +414,8 @@ export default function ReviseWorkbenchClient({ payload }: { payload: WorkbenchQ
         </section>
 
         <section className="mt-4 rounded-xl border border-[#3A3022] bg-[#161109] p-4">
-          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between"><div><h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Ledger</h2><p className="mt-1 text-xs text-[#A9987D]">A running list of author decisions. Queue and ledger are cached locally for offline review. Pending decisions sync when the server endpoint lands.</p></div>{ledger.length > 0 && <button type="button" onClick={() => undoLedgerEntry(0)} className="self-start rounded border border-[#5D4C31] px-3 py-1.5 text-xs text-[#E8D8BA] hover:border-[#C8A96E] md:self-auto">Undo last decision</button>}</div>
-          <ol className="mt-4 grid gap-2 xl:grid-cols-2">{ledger.length === 0 ? <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]"><strong>No revision decisions yet.</strong><br />Accept proposals, keep originals, write custom repairs, reject, or defer work to begin the ledger.</li> : ledger.map((entry, i) => <li key={entry.localId} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm"><div className="flex items-start justify-between gap-3"><p className="text-[#E9DCC4]"><span className="mr-1 text-[11px] uppercase tracking-wider text-[#C8A96E]">{decisionLabel(entry)}</span> — {entry.itemTitle}</p><button type="button" onClick={() => undoLedgerEntry(i)} className="shrink-0 rounded border border-[#5D4C31] px-2 py-1 text-[11px] text-[#D8C6A4] hover:border-[#C8A96E]">Undo</button></div>{entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}<p className="mt-1 text-xs text-[#9F8F75]">{entry.at} · {entry.syncStatus === "synced" ? "Synced" : "Pending sync"}</p></li>)}</ol>
+          <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between"><div><h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Ledger</h2><p className="mt-1 text-xs text-[#A9987D]">A running list of author decisions. Queue and ledger are cached locally for offline review and synced to the server for cross-device history.</p></div>{ledger.length > 0 && <button type="button" onClick={() => undoLedgerEntry(0)} className="self-start rounded border border-[#5D4C31] px-3 py-1.5 text-xs text-[#E8D8BA] hover:border-[#C8A96E] md:self-auto">Undo last decision</button>}</div>
+          <ol className="mt-4 grid gap-2 xl:grid-cols-2">{ledger.length === 0 ? <li className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm text-[#B3A185]"><strong>No revision decisions yet.</strong><br />Accept proposals, keep originals, write custom repairs, reject, or defer work to begin the ledger.</li> : ledger.map((entry, i) => <li key={entry.localId} className="rounded-lg border border-[#2D2519] bg-[#120E08] p-3 text-sm"><div className="flex items-start justify-between gap-3"><p className="text-[#E9DCC4]"><span className="mr-1 text-[11px] uppercase tracking-wider text-[#C8A96E]">{decisionLabel(entry)}</span> — {entry.itemTitle}</p><button type="button" onClick={() => undoLedgerEntry(i)} className="shrink-0 rounded border border-[#5D4C31] px-2 py-1 text-[11px] text-[#D8C6A4] hover:border-[#C8A96E]">Undo</button></div>{entry.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{entry.customText}</pre>}<p className="mt-1 text-xs text-[#9F8F75]">{entry.at} · {entry.syncStatus === "synced" ? "Synced" : entry.syncStatus === "failed" ? "Sync failed — will retry" : "Pending sync"}</p></li>)}</ol>
         </section>
       </div>
     </main>

--- a/lib/revision/ledger.ts
+++ b/lib/revision/ledger.ts
@@ -1,0 +1,170 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+
+export type RevisionLedgerDecision =
+  | "accepted_a"
+  | "accepted_b"
+  | "accepted_c"
+  | "custom"
+  | "keep_original"
+  | "reject"
+  | "deferred";
+
+export type SyncRevisionLedgerEntryInput = {
+  localId: string;
+  opportunityId: string;
+  opportunityTitle: string;
+  decision: RevisionLedgerDecision;
+  selectedOption?: "A" | "B" | "C" | null;
+  customText?: string | null;
+  clientCreatedAt?: string | null;
+  isUndo?: boolean;
+  undoneLocalId?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type SyncRevisionLedgerInput = {
+  manuscriptId: string | number;
+  evaluationJobId: string;
+  entries: SyncRevisionLedgerEntryInput[];
+};
+
+export type SyncedRevisionLedgerRow = {
+  id: string;
+  local_id: string;
+  opportunity_id: string;
+  opportunity_title: string;
+  decision: RevisionLedgerDecision;
+  selected_option: "A" | "B" | "C" | null;
+  custom_text: string | null;
+  client_created_at: string | null;
+  client_synced_at: string;
+  is_undo: boolean;
+  undone_local_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+const DECISIONS = new Set<RevisionLedgerDecision>([
+  "accepted_a",
+  "accepted_b",
+  "accepted_c",
+  "custom",
+  "keep_original",
+  "reject",
+  "deferred",
+]);
+
+function isUuid(value: string | null | undefined): boolean {
+  return Boolean(value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value));
+}
+
+function normalizeDecision(value: unknown): RevisionLedgerDecision | null {
+  if (typeof value !== "string") return null;
+  return DECISIONS.has(value as RevisionLedgerDecision) ? (value as RevisionLedgerDecision) : null;
+}
+
+function normalizeOption(value: unknown): "A" | "B" | "C" | null {
+  return value === "A" || value === "B" || value === "C" ? value : null;
+}
+
+async function assertOwnedEvaluation(input: { manuscriptId: string | number; evaluationJobId: string }) {
+  const user = await getAuthenticatedUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const manuscriptId = Number(input.manuscriptId);
+  if (!Number.isInteger(manuscriptId)) throw new Error("Invalid manuscript id");
+
+  const supabase = createAdminClient();
+
+  const { data: manuscript, error: manuscriptError } = await supabase
+    .from("manuscripts")
+    .select("id, title, user_id")
+    .eq("id", manuscriptId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (manuscriptError) throw new Error(manuscriptError.message);
+  if (!manuscript) throw new Error("Manuscript not found in your workspace");
+
+  const { data: job, error: jobError } = await supabase
+    .from("evaluation_jobs")
+    .select("id, manuscript_id, status")
+    .eq("id", input.evaluationJobId)
+    .eq("manuscript_id", manuscriptId)
+    .maybeSingle();
+
+  if (jobError) throw new Error(jobError.message);
+  if (!job) throw new Error("Evaluation job not found for this manuscript");
+
+  return { supabase, userId: user.id, manuscriptId };
+}
+
+function validateEntry(entry: SyncRevisionLedgerEntryInput): SyncRevisionLedgerEntryInput {
+  if (!entry || typeof entry !== "object") throw new Error("Invalid ledger entry");
+  if (typeof entry.localId !== "string" || entry.localId.trim().length === 0) {
+    throw new Error("Ledger entry missing localId");
+  }
+  if (typeof entry.opportunityId !== "string" || entry.opportunityId.trim().length === 0) {
+    throw new Error("Ledger entry missing opportunityId");
+  }
+  if (typeof entry.opportunityTitle !== "string" || entry.opportunityTitle.trim().length === 0) {
+    throw new Error("Ledger entry missing opportunityTitle");
+  }
+  const decision = normalizeDecision(entry.decision);
+  if (!decision) throw new Error(`Invalid ledger decision: ${String(entry.decision)}`);
+  return { ...entry, decision, selectedOption: normalizeOption(entry.selectedOption) };
+}
+
+export async function syncRevisionLedgerDecisions(input: SyncRevisionLedgerInput): Promise<SyncedRevisionLedgerRow[]> {
+  const { supabase, userId, manuscriptId } = await assertOwnedEvaluation(input);
+  const entries = Array.isArray(input.entries) ? input.entries.map(validateEntry) : [];
+  if (entries.length === 0) return [];
+
+  const rows = entries.map((entry) => ({
+    user_id: userId,
+    manuscript_id: manuscriptId,
+    evaluation_job_id: input.evaluationJobId,
+    finding_id: isUuid(entry.opportunityId) ? entry.opportunityId : null,
+    opportunity_id: entry.opportunityId,
+    opportunity_title: entry.opportunityTitle,
+    decision: entry.decision,
+    selected_option: entry.selectedOption ?? null,
+    custom_text: entry.customText ?? null,
+    local_id: entry.localId,
+    client_created_at: entry.clientCreatedAt ?? null,
+    client_synced_at: new Date().toISOString(),
+    is_undo: Boolean(entry.isUndo),
+    undone_local_id: entry.undoneLocalId ?? null,
+    metadata: entry.metadata ?? {},
+    updated_at: new Date().toISOString(),
+  }));
+
+  const { data, error } = await supabase
+    .from("revision_ledger_decisions")
+    .upsert(rows, { onConflict: "user_id,evaluation_job_id,local_id" })
+    .select("id, local_id, opportunity_id, opportunity_title, decision, selected_option, custom_text, client_created_at, client_synced_at, is_undo, undone_local_id, metadata, created_at, updated_at")
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as SyncedRevisionLedgerRow[];
+}
+
+export async function listRevisionLedgerDecisions(input: {
+  manuscriptId: string | number;
+  evaluationJobId: string;
+}): Promise<SyncedRevisionLedgerRow[]> {
+  const { supabase, userId, manuscriptId } = await assertOwnedEvaluation(input);
+
+  const { data, error } = await supabase
+    .from("revision_ledger_decisions")
+    .select("id, local_id, opportunity_id, opportunity_title, decision, selected_option, custom_text, client_created_at, client_synced_at, is_undo, undone_local_id, metadata, created_at, updated_at")
+    .eq("user_id", userId)
+    .eq("manuscript_id", manuscriptId)
+    .eq("evaluation_job_id", input.evaluationJobId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as SyncedRevisionLedgerRow[];
+}

--- a/supabase/migrations/20260526170000_add_revision_ledger_decisions.sql
+++ b/supabase/migrations/20260526170000_add_revision_ledger_decisions.sql
@@ -1,0 +1,67 @@
+-- Server-synced Revision Ledger decisions
+-- Local-first workbench decisions sync here for cross-device history and dashboard analytics.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.revision_ledger_decisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  manuscript_id bigint NOT NULL REFERENCES public.manuscripts(id) ON DELETE CASCADE,
+  evaluation_job_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  finding_id uuid,
+  opportunity_id text NOT NULL,
+  opportunity_title text NOT NULL,
+  decision text NOT NULL CHECK (decision IN ('accepted_a', 'accepted_b', 'accepted_c', 'custom', 'keep_original', 'reject', 'deferred')),
+  selected_option text CHECK (selected_option IN ('A', 'B', 'C')),
+  custom_text text,
+  local_id text NOT NULL,
+  client_created_at timestamptz,
+  client_synced_at timestamptz NOT NULL DEFAULT now(),
+  is_undo boolean NOT NULL DEFAULT false,
+  undone_local_id text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, evaluation_job_id, local_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_user_id
+  ON public.revision_ledger_decisions(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_manuscript_id
+  ON public.revision_ledger_decisions(manuscript_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_evaluation_job_id
+  ON public.revision_ledger_decisions(evaluation_job_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_opportunity_id
+  ON public.revision_ledger_decisions(opportunity_id);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_decision
+  ON public.revision_ledger_decisions(decision);
+
+CREATE INDEX IF NOT EXISTS idx_revision_ledger_decisions_created_at
+  ON public.revision_ledger_decisions(created_at DESC);
+
+ALTER TABLE public.revision_ledger_decisions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS revision_ledger_decisions_select_own ON public.revision_ledger_decisions;
+CREATE POLICY revision_ledger_decisions_select_own
+  ON public.revision_ledger_decisions
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS revision_ledger_decisions_insert_own ON public.revision_ledger_decisions;
+CREATE POLICY revision_ledger_decisions_insert_own
+  ON public.revision_ledger_decisions
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS revision_ledger_decisions_update_own ON public.revision_ledger_decisions;
+CREATE POLICY revision_ledger_decisions_update_own
+  ON public.revision_ledger_decisions
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Stacks on #722 and adds the server-synced Revision Ledger layer for cross-device history and dashboard analytics.

This keeps the local-first/offline behavior from #722, but adds the server table/API needed for decisions made on one device to become available to another device after sync.

## What changed

- Adds `revision_ledger_decisions` migration.
  - Stores one row per author decision.
  - Captures manuscript, evaluation, opportunity, decision type, selected option, custom text, local id, and client timestamps.
  - Adds indexes for user, manuscript, evaluation, opportunity, decision, and created time.
  - Enables RLS with own-user select/insert/update policies.
  - Adds unique `(user_id, evaluation_job_id, local_id)` for idempotent local-first sync.

- Adds `lib/revision/ledger.ts`.
  - Verifies the authenticated user owns the manuscript/evaluation.
  - Validates decision payloads.
  - Upserts pending local ledger entries into `revision_ledger_decisions`.
  - Lists synced ledger entries for a manuscript/evaluation.

- Adds `app/api/revision-ledger/route.ts`.
  - `GET` loads server-synced ledger history.
  - `POST` syncs pending local entries.

- Updates `ReviseWorkbenchClient`.
  - Loads server ledger entries when online.
  - Merges server history with local cache.
  - Syncs pending local decisions when online.
  - Marks synced entries as `Synced` and failed entries as retryable.
  - Keeps local/offline behavior intact.

## Product doctrine

The author should be able to work locally without losing decisions, but the server ledger becomes the cross-device source of truth after sync.

Device behavior:

- Laptop loads Revise online → queue/ledger cache locally.
- Laptop goes offline → author can continue reviewing and deciding.
- Decisions are marked Pending sync.
- Connection returns → decisions sync to server.
- Phone loads Revise online later → server ledger is available and cached locally on the phone.

## Scope

Server-side Revision Ledger decision persistence and client sync only.

No dashboard chart consumption yet.
No final manuscript patch/apply behavior changes.
No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, Agent Readiness, or Storygate runtime changes.

## Dependency

This PR is stacked on #722 and should be reviewed/merged after #720, #721, and #722.

## Next PR after this

Feed synced `revision_ledger_decisions` into dashboard analytics:

- accepted/rejected/custom/deferred counts;
- decisions by MUST / SHOULD / COULD;
- decisions by scope/category;
- before/after recheck deltas;
- TrustedPath/manual activity history.

## Acceptance criteria

- New ledger table exists with RLS and idempotent local id uniqueness.
- API rejects missing manuscript/evaluation identifiers.
- API verifies manuscript ownership before reading or writing decisions.
- Local pending decisions sync when online.
- Server ledger entries load into the workbench on another online device.
- Offline local cache remains usable if network is unavailable.
- Dashboard analytics can consume the server table in a later PR.

<!-- pr-type: migration -->