### PR TITLE
Feed Revise ledger decisions into dashboard analytics

### DIFF
--- a/.github/pr-bodies/PR-724.md
+++ b/.github/pr-bodies/PR-724.md
@@ -1,0 +1,83 @@
+## Summary
+
+Adds real Revise analytics to the author dashboard using the server-synced `revision_ledger_decisions` table and `diagnostic_findings` queue data.
+
+This turns the dashboard Revise section from a placeholder into a progress surface that reflects synced author decisions.
+
+## What changed
+
+- Updates `getDashboardEvaluations(...)` to also return `reviseAnalytics`.
+- Computes Revise analytics from:
+  - `diagnostic_findings` for total opportunities, MUST / SHOULD / COULD, and scope counts;
+  - `revision_ledger_decisions` for accepted/custom/kept/rejected/deferred author decisions and activity over time.
+- Passes `reviseAnalytics` into `AuthorProgressLedger`.
+- Updates the Dashboard hero copy to say Revise decisions are now tracked.
+- Replaces the old placeholder Revise Analytics card with real dashboard data:
+  - total opportunities;
+  - decided vs pending;
+  - MUST / SHOULD / COULD counts;
+  - decision state bars;
+  - revision scope bars;
+  - synced ledger activity chart.
+
+## Product doctrine
+
+Dashboard progress should be included with paid audits and should prove movement over time.
+
+The dashboard now tracks:
+
+- evaluation history;
+- score movement;
+- Revise decision activity;
+- pending repair work;
+- recheck readiness path.
+
+No improvement claim is made until the manuscript is re-evaluated.
+
+## Unauthorized Input Sources
+
+None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, `diagnostic_findings`, and `revision_ledger_decisions` through existing server-side dashboard access paths.
+
+## Internal Process Leakage
+
+No internal process, raw traces, worker IDs, pipeline diagnostics, or private job internals are surfaced. The UI shows public-safe author-facing aggregates only.
+
+## Input → Action → Output
+
+Input: user-owned evaluation jobs, diagnostic findings, and synced Revision Ledger decisions.
+
+Action: aggregate counts by decision state, priority, scope, and activity date.
+
+Output: dashboard cards and bars showing Revise progress and pending work.
+
+## Public-Safe Quality/Status Metrics
+
+Metrics are author-facing and safe: accepted/custom/kept/rejected/deferred counts, MUST/SHOULD/COULD counts, scope counts, and activity totals. No hidden model, provider, latency, token, or worker metrics are exposed.
+
+## Runtime/Pipeline Expansion
+
+No evaluation, revision, scoring, OpenAI, Perplexity, worker, queue, or pipeline runtime is expanded. This PR adds read-only dashboard aggregation over existing persisted tables.
+
+## Latency Impact
+
+Low. Adds two dashboard read queries for existing dashboard-owned data: `diagnostic_findings` and `revision_ledger_decisions`, scoped to the visible evaluation jobs. No background jobs or model calls are added.
+
+## Scope
+
+Dashboard analytics only.
+
+No Revise queue generation changes.
+No Revise decision write-path changes.
+No offline cache changes.
+No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, Agent Readiness, or Storygate runtime changes.
+
+## Acceptance criteria
+
+- Dashboard still loads evaluation rows.
+- Dashboard receives `reviseAnalytics` from the server.
+- Revise Analytics card shows real totals when diagnostic findings or ledger decisions exist.
+- Empty state remains clear when no revision decisions exist.
+- No improvement claim appears without re-evaluation.
+- Metrics remain user-facing and do not leak internal process details.
+
+<!-- pr-type: ui -->

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import {
 export const dynamic = 'force-dynamic'
 
 export default async function DashboardPage() {
-  const { rows, error } = await getDashboardEvaluations({ limit: 15 })
+  const { rows, reviseAnalytics, error } = await getDashboardEvaluations({ limit: 15 })
 
   if (error) {
     return (
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="rg-dash-page">
-      <AuthorProgressLedger rows={rows} kpis={kpis} />
+      <AuthorProgressLedger rows={rows} kpis={kpis} reviseAnalytics={reviseAnalytics} />
       <p className="rg-dash-footnote">
         Submission readiness indicates a manuscript has reached a RevisionGrade quality
         threshold associated with stronger submission potential. It is a curation

--- a/components/dashboard/AuthorProgressLedger.jsx
+++ b/components/dashboard/AuthorProgressLedger.jsx
@@ -25,7 +25,17 @@ function trend(rows, latest) {
     .slice(-6)
 }
 
-export default function AuthorProgressLedger({ rows, kpis }) {
+function barWidth(value, total) {
+  if (!total) return '0%'
+  return `${Math.max(4, Math.min(100, (value / total) * 100))}%`
+}
+
+function activityLabel(value) {
+  const date = new Date(`${value}T00:00:00Z`)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+export default function AuthorProgressLedger({ rows, kpis, reviseAnalytics }) {
   const latest = rows[0]
   const prior = rows.find((r) => r.manuscriptId === latest.manuscriptId && r.id !== latest.id)
   const overallDelta = typeof latest.overallScore === 'number' && typeof prior?.overallScore === 'number' ? latest.overallScore - prior.overallScore : null
@@ -33,6 +43,17 @@ export default function AuthorProgressLedger({ rows, kpis }) {
   const topScore = Math.max(latest.overallScore ?? 0, latest.readinessScore ?? 0)
   const points = trend(rows, latest)
   const canPackage = latest.status !== 'running' && latest.status !== 'failed'
+  const revise = reviseAnalytics ?? {
+    totalOpportunities: 0,
+    totalDecisions: 0,
+    uniqueDecidedOpportunities: 0,
+    decisions: { accepted: 0, custom: 0, keptOriginal: 0, rejected: 0, deferred: 0 },
+    priorities: { must: 0, should: 0, could: 0, decided: 0, pending: 0 },
+    scopes: { Line: 0, Passage: 0, Scene: 0, Chapter: 0, Structural: 0, Manuscript: 0 },
+    activity: [],
+  }
+  const decisionTotal = revise.uniqueDecidedOpportunities || 0
+  const scopeTotal = Object.values(revise.scopes).reduce((sum, n) => sum + n, 0)
 
   return (
     <div className="space-y-6">
@@ -41,7 +62,7 @@ export default function AuthorProgressLedger({ rows, kpis }) {
         <div className="mt-4 grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
           <div>
             <h1 className="max-w-4xl text-4xl font-bold leading-tight md:text-5xl">Track the path from evaluation to readiness.</h1>
-            <p className="mt-4 max-w-3xl text-base leading-8 text-neutral-600">Your dashboard is included with paid audits. It shows evaluation history, score movement, current readiness, and the Revise analytics that will activate once repair data is persisted.</p>
+            <p className="mt-4 max-w-3xl text-base leading-8 text-neutral-600">Your dashboard is included with paid audits. It shows evaluation history, score movement, current readiness, Revise decisions, and the recheck trail that proves whether the manuscript moved.</p>
           </div>
           <div className="grid gap-2 min-w-56">
             <Link href={latest.reportHref} className="rounded-full bg-neutral-950 px-5 py-3 text-center text-sm font-bold text-white">Open latest report</Link>
@@ -55,8 +76,8 @@ export default function AuthorProgressLedger({ rows, kpis }) {
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {[
           ['Latest overall', kpis.latestOverall.value, overallDelta == null ? 'Awaiting comparison' : `${overallDelta >= 0 ? '+' : ''}${overallDelta.toFixed(1)} vs prior`],
-          ['Market readiness', kpis.latestReadiness.value, 'Threshold is 8.0'],
-          ['Best score', kpis.bestScore.value, kpis.bestScore.delta],
+          ['Market readiness', kpis.latestReadiness.value, readinessDelta == null ? 'Threshold is 8.0' : `${readinessDelta >= 0 ? '+' : ''}${readinessDelta.toFixed(1)} readiness delta`],
+          ['Revise decisions', String(revise.uniqueDecidedOpportunities), `${revise.priorities.pending} opportunities pending`],
           ['Ready for review', kpis.curationReady.value, 'Latest works at or above 8.0'],
         ].map(([label, value, note]) => (
           <article key={label} className="rounded-2xl border border-neutral-300 bg-white p-5 text-neutral-950">
@@ -100,13 +121,47 @@ export default function AuthorProgressLedger({ rows, kpis }) {
             {points.map((row) => <div key={row.id} className="flex flex-1 flex-col items-center gap-2"><div className="flex h-44 items-end gap-1"><i className="w-3 rounded-t bg-neutral-800" style={{ height: pct(row.overallScore) }} /><i className="w-3 rounded-t bg-amber-600" style={{ height: pct(row.readinessScore) }} /></div><strong className="text-sm">{fmt(row.readinessScore)}</strong><small className="text-xs text-neutral-500">{d(row.createdAt)}</small></div>)}
           </div>
         </article>
-        <article className="rounded-3xl border border-dashed border-neutral-300 bg-neutral-50 p-6 text-neutral-950">
-          <h2 className="text-2xl font-bold">Revise Analytics</h2>
-          <p className="mt-2 text-sm leading-6 text-neutral-600">Next phase: surface MUST / SHOULD / COULD opportunities, repair scope, decision history, and issue-type trends after Revise data is persisted.</p>
-          <div className="mt-6 grid gap-3 sm:grid-cols-3">
-            {['MUST', 'SHOULD', 'COULD'].map((label) => <div key={label} className="rounded-2xl border border-neutral-300 bg-white p-4"><p className="text-xs font-bold uppercase tracking-wide text-neutral-500">{label}</p><p className="mt-2 text-sm text-neutral-600">Pending Revise queue data</p></div>)}
-          </div>
-          <p className="mt-5 text-sm text-neutral-500">No improvement claim appears until the manuscript is revised and re-evaluated.</p>
+
+        <article className="rounded-3xl border border-neutral-300 bg-white p-6 text-neutral-950">
+          <div className="flex items-start justify-between gap-4"><div><h2 className="text-2xl font-bold">Revise Analytics</h2><p className="mt-2 text-sm leading-6 text-neutral-600">Synced from the Revision Ledger. These show author decisions and pending repair work; improvement is confirmed only after re-evaluation.</p></div><span className="rounded-full border border-neutral-300 px-3 py-1 text-xs font-bold uppercase tracking-wide">{revise.totalOpportunities} opportunities</span></div>
+          {revise.totalOpportunities === 0 ? (
+            <div className="mt-6 rounded-2xl border border-dashed border-neutral-300 bg-neutral-50 p-5 text-sm leading-6 text-neutral-600">No revision decisions yet. Open the Revise Workbench to begin building your manuscript progress history.</div>
+          ) : (
+            <div className="mt-6 space-y-6">
+              <div className="grid gap-3 sm:grid-cols-3">
+                {[
+                  ['MUST', revise.priorities.must, 'Readiness blockers'],
+                  ['SHOULD', revise.priorities.should, 'High-value repairs'],
+                  ['COULD', revise.priorities.could, 'Optional refinements'],
+                ].map(([label, value, note]) => <div key={label} className="rounded-2xl border border-neutral-300 bg-neutral-50 p-4"><p className="text-xs font-bold uppercase tracking-wide text-neutral-500">{label}</p><p className="mt-2 text-3xl font-bold">{value}</p><p className="mt-1 text-xs text-neutral-600">{note}</p></div>)}
+              </div>
+
+              <div className="rounded-2xl border border-neutral-300 bg-neutral-50 p-4">
+                <div className="flex items-center justify-between gap-3"><p className="text-xs font-bold uppercase tracking-[0.18em] text-neutral-500">Decision state</p><strong className="text-sm">{revise.uniqueDecidedOpportunities}/{revise.totalOpportunities} decided</strong></div>
+                <div className="mt-4 space-y-3">
+                  {[
+                    ['Accepted', revise.decisions.accepted],
+                    ['Custom', revise.decisions.custom],
+                    ['Kept original', revise.decisions.keptOriginal],
+                    ['Rejected', revise.decisions.rejected],
+                    ['Deferred', revise.decisions.deferred],
+                  ].map(([label, value]) => <div key={label} className="grid grid-cols-[110px_1fr_44px] items-center gap-3"><span className="text-sm text-neutral-600">{label}</span><div className="h-3 overflow-hidden rounded-full bg-white"><i className="block h-full rounded-full bg-neutral-900" style={{ width: barWidth(value, decisionTotal) }} /></div><strong className="text-right text-sm">{value}</strong></div>)}
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-neutral-300 bg-neutral-50 p-4">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-neutral-500">Revision scope</p>
+                <div className="mt-4 space-y-3">
+                  {Object.entries(revise.scopes).map(([label, value]) => <div key={label} className="grid grid-cols-[90px_1fr_44px] items-center gap-3"><span className="text-sm text-neutral-600">{label}</span><div className="h-3 overflow-hidden rounded-full bg-white"><i className="block h-full rounded-full bg-amber-600" style={{ width: barWidth(value, scopeTotal) }} /></div><strong className="text-right text-sm">{value}</strong></div>)}
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-neutral-300 bg-neutral-50 p-4">
+                <p className="text-xs font-bold uppercase tracking-[0.18em] text-neutral-500">Revision activity</p>
+                {revise.activity.length === 0 ? <p className="mt-3 text-sm text-neutral-600">No synced ledger activity yet.</p> : <div className="mt-4 flex h-28 items-end gap-2">{revise.activity.map((point) => <div key={point.date} className="flex flex-1 flex-col items-center gap-2"><i className="w-full rounded-t bg-neutral-900" style={{ height: barWidth(point.count, Math.max(...revise.activity.map((p) => p.count))) }} /><small className="text-[10px] text-neutral-500">{activityLabel(point.date)}</small></div>)}</div>}
+              </div>
+            </div>
+          )}
         </article>
       </section>
     </div>

--- a/lib/dashboard/getDashboardEvaluations.ts
+++ b/lib/dashboard/getDashboardEvaluations.ts
@@ -37,12 +37,91 @@ export type DashboardKpis = {
   curationReady: DashboardKpi
 }
 
+export type ReviseDecisionBucket = {
+  accepted: number
+  custom: number
+  keptOriginal: number
+  rejected: number
+  deferred: number
+}
+
+export type RevisePriorityBucket = {
+  must: number
+  should: number
+  could: number
+  decided: number
+  pending: number
+}
+
+export type ReviseScopeBucket = {
+  Line: number
+  Passage: number
+  Scene: number
+  Chapter: number
+  Structural: number
+  Manuscript: number
+}
+
+export type ReviseActivityPoint = {
+  date: string
+  count: number
+}
+
+export type DashboardReviseAnalytics = {
+  totalOpportunities: number
+  totalDecisions: number
+  uniqueDecidedOpportunities: number
+  decisions: ReviseDecisionBucket
+  priorities: RevisePriorityBucket
+  scopes: ReviseScopeBucket
+  activity: ReviseActivityPoint[]
+  latestEvaluationJobId: string | null
+}
+
+const emptyDecisionBucket = (): ReviseDecisionBucket => ({
+  accepted: 0,
+  custom: 0,
+  keptOriginal: 0,
+  rejected: 0,
+  deferred: 0,
+})
+
+const emptyPriorityBucket = (): RevisePriorityBucket => ({
+  must: 0,
+  should: 0,
+  could: 0,
+  decided: 0,
+  pending: 0,
+})
+
+const emptyScopeBucket = (): ReviseScopeBucket => ({
+  Line: 0,
+  Passage: 0,
+  Scene: 0,
+  Chapter: 0,
+  Structural: 0,
+  Manuscript: 0,
+})
+
+export function emptyReviseAnalytics(): DashboardReviseAnalytics {
+  return {
+    totalOpportunities: 0,
+    totalDecisions: 0,
+    uniqueDecidedOpportunities: 0,
+    decisions: emptyDecisionBucket(),
+    priorities: emptyPriorityBucket(),
+    scopes: emptyScopeBucket(),
+    activity: [],
+    latestEvaluationJobId: null,
+  }
+}
+
 export async function getDashboardEvaluations(
   _opts: { limit?: number } = {},
-): Promise<{ rows: DashboardEvaluationRow[]; error: Error | null }> {
+): Promise<{ rows: DashboardEvaluationRow[]; reviseAnalytics: DashboardReviseAnalytics; error: Error | null }> {
   try {
     const user = await getAuthenticatedUser()
-    if (!user) return { rows: [], error: null }
+    if (!user) return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: null }
 
     const supabase = createAdminClient()
     const limit = _opts.limit ?? 15
@@ -54,11 +133,11 @@ export async function getDashboardEvaluations(
       .eq('user_id', user.id)
 
     if (manuscriptsError) {
-      return { rows: [], error: new Error(manuscriptsError.message) }
+      return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: new Error(manuscriptsError.message) }
     }
 
     if (!manuscripts || manuscripts.length === 0) {
-      return { rows: [], error: null }
+      return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: null }
     }
 
     const titleById = new Map<number, string>()
@@ -76,11 +155,12 @@ export async function getDashboardEvaluations(
       .limit(limit)
 
     if (jobsError) {
-      return { rows: [], error: new Error(jobsError.message) }
+      return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: new Error(jobsError.message) }
     }
 
-    if (!jobs || jobs.length === 0) return { rows: [], error: null }
+    if (!jobs || jobs.length === 0) return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: null }
 
+    const jobIds = (jobs as Array<{ id: string }>).map((j) => j.id)
     const completedJobIds = (jobs as Array<{ id: string; status: string }>)
       .filter((j) => j.status === 'complete')
       .map((j) => j.id)
@@ -141,10 +221,166 @@ export async function getDashboardEvaluations(
       })
     }
 
-    return { rows, error: null }
+    const reviseAnalytics = await computeReviseAnalyticsForDashboard({
+      supabase,
+      userId: user.id,
+      jobIds,
+      latestEvaluationJobId: rows[0]?.jobId ?? null,
+    })
+
+    return { rows, reviseAnalytics, error: null }
   } catch (err) {
-    return { rows: [], error: err instanceof Error ? err : new Error(String(err)) }
+    return { rows: [], reviseAnalytics: emptyReviseAnalytics(), error: err instanceof Error ? err : new Error(String(err)) }
   }
+}
+
+async function computeReviseAnalyticsForDashboard({
+  supabase,
+  userId,
+  jobIds,
+  latestEvaluationJobId,
+}: {
+  supabase: ReturnType<typeof createAdminClient>
+  userId: string
+  jobIds: string[]
+  latestEvaluationJobId: string | null
+}): Promise<DashboardReviseAnalytics> {
+  if (jobIds.length === 0) return emptyReviseAnalytics()
+
+  const { data: findings, error: findingsError } = await supabase
+    .from('diagnostic_findings')
+    .select('id, evaluation_job_id, criterion_key, finding_type, severity, location_ref, diagnosis, recommendation, evidence_excerpt, original_text')
+    .in('evaluation_job_id', jobIds)
+
+  if (findingsError) {
+    return { ...emptyReviseAnalytics(), latestEvaluationJobId }
+  }
+
+  const findingRows = (findings ?? []) as Array<{
+    id: string
+    evaluation_job_id: string
+    criterion_key: string | null
+    finding_type: string | null
+    severity: string | null
+    location_ref: string | null
+    diagnosis: string | null
+    recommendation: string | null
+    evidence_excerpt: string | null
+    original_text: string | null
+  }>
+
+  const findingById = new Map(findingRows.map((f) => [f.id, f]))
+  const priority = emptyPriorityBucket()
+  const scopes = emptyScopeBucket()
+
+  for (const finding of findingRows) {
+    const severity = severityToPriority(finding.severity)
+    priority[severity] += 1
+    scopes[inferScope(finding)] += 1
+  }
+
+  const { data: ledger, error: ledgerError } = await supabase
+    .from('revision_ledger_decisions')
+    .select('evaluation_job_id, opportunity_id, opportunity_title, decision, selected_option, created_at')
+    .eq('user_id', userId)
+    .in('evaluation_job_id', jobIds)
+    .eq('is_undo', false)
+    .order('created_at', { ascending: true })
+
+  if (ledgerError) {
+    return {
+      ...emptyReviseAnalytics(),
+      totalOpportunities: findingRows.length,
+      priorities: { ...priority, pending: findingRows.length },
+      scopes,
+      latestEvaluationJobId,
+    }
+  }
+
+  const ledgerRows = (ledger ?? []) as Array<{
+    evaluation_job_id: string
+    opportunity_id: string
+    opportunity_title: string | null
+    decision: string
+    selected_option: string | null
+    created_at: string
+  }>
+
+  const latestByOpportunity = new Map<string, (typeof ledgerRows)[number]>()
+  const activityByDate = new Map<string, number>()
+
+  for (const row of ledgerRows) {
+    latestByOpportunity.set(`${row.evaluation_job_id}:${row.opportunity_id}`, row)
+    const day = formatDateKey(row.created_at)
+    activityByDate.set(day, (activityByDate.get(day) ?? 0) + 1)
+  }
+
+  const decisions = emptyDecisionBucket()
+  for (const row of latestByOpportunity.values()) {
+    if (row.decision === 'custom') decisions.custom += 1
+    else if (row.decision === 'keep_original') decisions.keptOriginal += 1
+    else if (row.decision === 'reject') decisions.rejected += 1
+    else if (row.decision === 'deferred') decisions.deferred += 1
+    else if (row.decision.startsWith('accepted_')) decisions.accepted += 1
+  }
+
+  priority.decided = latestByOpportunity.size
+  priority.pending = Math.max(0, findingRows.length - latestByOpportunity.size)
+
+  return {
+    totalOpportunities: findingRows.length,
+    totalDecisions: ledgerRows.length,
+    uniqueDecidedOpportunities: latestByOpportunity.size,
+    decisions,
+    priorities: priority,
+    scopes,
+    activity: [...activityByDate.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .slice(-14)
+      .map(([date, count]) => ({ date, count })),
+    latestEvaluationJobId,
+  }
+}
+
+function severityToPriority(severity: string | null | undefined): 'must' | 'should' | 'could' {
+  if (severity === 'high') return 'must'
+  if (severity === 'medium') return 'should'
+  return 'could'
+}
+
+function inferScope(finding: {
+  criterion_key?: string | null
+  finding_type?: string | null
+  location_ref?: string | null
+  diagnosis?: string | null
+  recommendation?: string | null
+  evidence_excerpt?: string | null
+  original_text?: string | null
+}): keyof ReviseScopeBucket {
+  const haystack = [
+    finding.criterion_key,
+    finding.finding_type,
+    finding.location_ref,
+    finding.diagnosis,
+    finding.recommendation,
+    finding.evidence_excerpt,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  if (haystack.includes('manuscript') || haystack.includes('whole book')) return 'Manuscript'
+  if (haystack.includes('structural') || haystack.includes('spine') || haystack.includes('closure') || haystack.includes('midpoint') || haystack.includes('arc')) return 'Structural'
+  if (haystack.includes('chapter') || haystack.includes('ch.')) return 'Chapter'
+  if (haystack.includes('scene') || haystack.includes('dialogue') || haystack.includes('pacing') || haystack.includes('character')) return 'Scene'
+  if ((finding.original_text ?? finding.evidence_excerpt ?? '').length > 220) return 'Passage'
+  return 'Line'
+}
+
+function formatDateKey(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown'
+  return date.toISOString().slice(0, 10)
 }
 
 export function statusFromScores(


### PR DESCRIPTION
## Summary

Adds real Revise analytics to the author dashboard using the server-synced `revision_ledger_decisions` table and `diagnostic_findings` queue data.

This turns the dashboard Revise section from a placeholder into a progress surface that reflects synced author decisions.

## What changed

- Updates `getDashboardEvaluations(...)` to also return `reviseAnalytics`.
- Computes Revise analytics from:
  - `diagnostic_findings` for total opportunities, MUST / SHOULD / COULD, and scope counts;
  - `revision_ledger_decisions` for accepted/custom/kept/rejected/deferred author decisions and activity over time.
- Passes `reviseAnalytics` into `AuthorProgressLedger`.
- Updates the Dashboard hero copy to say Revise decisions are now tracked.
- Replaces the old placeholder Revise Analytics card with real dashboard data:
  - total opportunities;
  - decided vs pending;
  - MUST / SHOULD / COULD counts;
  - decision state bars;
  - revision scope bars;
  - synced ledger activity chart.

## Product doctrine

Dashboard progress should be included with paid audits and should prove movement over time.

The dashboard now tracks:

- evaluation history;
- score movement;
- Revise decision activity;
- pending repair work;
- recheck readiness path.

No improvement claim is made until the manuscript is re-evaluated.

## Unauthorized Input Sources

None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, `diagnostic_findings`, and `revision_ledger_decisions` through existing server-side dashboard access paths.

## Internal Process Leakage

No internal process, raw traces, worker IDs, pipeline diagnostics, or private job internals are surfaced. The UI shows public-safe author-facing aggregates only.

## Input → Action → Output

Input: user-owned evaluation jobs, diagnostic findings, and synced Revision Ledger decisions.

Action: aggregate counts by decision state, priority, scope, and activity date.

Output: dashboard cards and bars showing Revise progress and pending work.

## Public-Safe Quality/Status Metrics

Metrics are author-facing and safe: accepted/custom/kept/rejected/deferred counts, MUST/SHOULD/COULD counts, scope counts, and activity totals. No hidden model, provider, latency, token, or worker metrics are exposed.

## Runtime/Pipeline Expansion

No evaluation, revision, scoring, OpenAI, Perplexity, worker, queue, or pipeline runtime is expanded. This PR adds read-only dashboard aggregation over existing persisted tables.

## Latency Impact

Low. Adds two dashboard read queries for existing dashboard-owned data: `diagnostic_findings` and `revision_ledger_decisions`, scoped to the visible evaluation jobs. No background jobs or model calls are added.

## Scope

Dashboard analytics only.

No Revise queue generation changes.
No Revise decision write-path changes.
No offline cache changes.
No pricing, credits, checkout, scoring, evaluation pipeline, report rendering, Agent Readiness, or Storygate runtime changes.

## Acceptance criteria

- Dashboard still loads evaluation rows.
- Dashboard receives `reviseAnalytics` from the server.
- Revise Analytics card shows real totals when diagnostic findings or ledger decisions exist.
- Empty state remains clear when no revision decisions exist.
- No improvement claim appears without re-evaluation.
- Metrics remain user-facing and do not leak internal process details.

<!-- pr-type: ui -->