### PR TITLE
Add Final Review marked preview and export scaffold

### DIFF
--- a/.github/pr-bodies/PR-726.md
+++ b/.github/pr-bodies/PR-726.md
@@ -1,0 +1,103 @@
+## Summary
+
+Adds the first Final Review / Apply / Export scaffold for Revise.
+
+This creates an author-facing Final Review route that loads synced Revision Ledger decisions, shows a marked manuscript preview, and renders a Revision Changelog sidebar so the author can see what is staged, what is not applied, and what remains deferred before export/recheck.
+
+## What changed
+
+- Adds `lib/revision/finalReview.ts`.
+  - Verifies the signed-in user owns the manuscript/evaluation.
+  - Loads the source manuscript version text.
+  - Loads synced `revision_ledger_decisions`.
+  - Collapses to the latest decision per opportunity.
+  - Computes accepted/custom/kept/rejected/deferred counts.
+
+- Adds `app/workbench/final-review/page.tsx`.
+  - Route: `/workbench/final-review?manuscriptId=...&evaluationJobId=...`.
+  - Loads Final Review data server-side.
+
+- Adds `components/revision/FinalReviewClient.tsx`.
+  - Shows marked manuscript preview.
+  - Uses subtle visual markup:
+    - system accepted A/B/C = soft gold;
+    - custom author rewrite = soft blue;
+    - deferred = muted gray;
+    - rejected/kept are visible in sidebar, not applied.
+  - Shows Revision Changelog sidebar.
+  - Shows staged Apply / Export buttons.
+  - Warns when deferred items remain.
+
+- Adds `docs/product/final-review-apply-export.md`.
+  - Captures the product doctrine for Final Review, marked review copy, clean export, changelog export, and apply behavior.
+
+## Product doctrine
+
+Revise is not complete when the author clicks a few decisions.
+
+Revise is complete when the author reviews the decision set, applies selected changes to a new manuscript version, and can export or re-evaluate the result.
+
+Final Review should include:
+
+- marked manuscript preview;
+- Revision Changelog sidebar;
+- clean revised manuscript export;
+- marked-up review copy export;
+- revision changelog export;
+- ready-for-recheck path.
+
+## Important boundary
+
+This PR intentionally scaffolds the Final Review screen and doctrine first.
+
+The Apply / Export buttons are staged UI affordances. The next PR should wire server-side apply/export behavior so accepted/custom decisions create a derived manuscript version and export clean/marked/changelog artifacts.
+
+## Unauthorized Input Sources
+
+None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, source manuscript versions, and synced `revision_ledger_decisions`.
+
+## Internal Process Leakage
+
+No raw worker traces, pipeline phases, model/provider details, token usage, hidden quality gates, or internal job diagnostics are exposed. The UI uses author-facing labels only: Final Review, marked preview, Revision Changelog, Apply, Export, Deferred.
+
+## Input → Action → Output
+
+Input: user-owned manuscript/evaluation ids and synced Revision Ledger decisions.
+
+Action: load the source manuscript text, summarize the author decision set, and render a review preview/changelog.
+
+Output: author-facing Final Review screen with marked manuscript preview, decision counts, changelog sidebar, and staged apply/export actions.
+
+## Public-Safe Quality/Status Metrics
+
+Metrics are limited to author-facing counts: accepted, custom, kept, rejected, deferred, and unresolved/deferred warning state. No internal runtime or pipeline metrics are shown.
+
+## Runtime/Pipeline Expansion
+
+No evaluation, scoring, WAVE/Golden Spine, OpenAI, Perplexity, worker, queue, or revision generation runtime is expanded. This is a server-side read/view scaffold over existing persisted data.
+
+## Latency Impact
+
+Low. Adds one Final Review page that reads manuscript ownership, evaluation job metadata, one source manuscript version, and synced ledger decisions. No model calls, background jobs, or pipeline runs are introduced.
+
+## Scope
+
+Final Review scaffold only.
+
+No final apply mutation yet.
+No derived manuscript version creation yet.
+No file export generation yet.
+No scoring/evaluation/recheck runtime changes.
+No pricing, credits, checkout, Agent Readiness, or Storygate runtime changes.
+
+## Acceptance criteria
+
+- `/workbench/final-review?manuscriptId=...&evaluationJobId=...` loads for an authenticated owner.
+- Final Review shows manuscript title and source preview.
+- Final Review shows synced ledger decisions in a sidebar changelog.
+- Accepted/custom/deferred/rejected/kept counts are visible.
+- Marked preview uses visual distinction for system revisions, custom rewrites, and deferred items.
+- Clean export / marked export / apply are present as staged actions, not falsely wired.
+- Rejected, kept-original, and deferred decisions are not represented as applied changes.
+
+<!-- pr-type: ui -->

--- a/app/workbench/final-review/page.tsx
+++ b/app/workbench/final-review/page.tsx
@@ -1,0 +1,20 @@
+import { getFinalReviewPayload } from "@/lib/revision/finalReview";
+import FinalReviewClient from "@/components/revision/FinalReviewClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function FinalReviewPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = (await searchParams) ?? {};
+  const manuscriptIdRaw = params.manuscriptId;
+  const evaluationJobIdRaw = params.evaluationJobId;
+  const manuscriptId = Array.isArray(manuscriptIdRaw) ? manuscriptIdRaw[0] : manuscriptIdRaw;
+  const evaluationJobId = Array.isArray(evaluationJobIdRaw) ? evaluationJobIdRaw[0] : evaluationJobIdRaw;
+
+  const payload = await getFinalReviewPayload({ manuscriptId, evaluationJobId });
+
+  return <FinalReviewClient payload={payload} />;
+}

--- a/components/revision/FinalReviewClient.tsx
+++ b/components/revision/FinalReviewClient.tsx
@@ -1,0 +1,152 @@
+import Link from "next/link";
+import type { FinalReviewPayload, FinalReviewDecision } from "@/lib/revision/finalReview";
+
+function decisionLabel(decision: FinalReviewDecision) {
+  switch (decision.decision) {
+    case "accepted_a":
+    case "accepted_b":
+    case "accepted_c":
+      return `Accepted ${decision.selectedOption ?? ""}`.trim();
+    case "custom":
+      return "Custom rewrite";
+    case "keep_original":
+      return "Kept original";
+    case "reject":
+      return "Rejected";
+    case "deferred":
+      return "Deferred";
+    default:
+      return decision.decision;
+  }
+}
+
+function markerClass(tone: FinalReviewDecision["highlightTone"]) {
+  if (tone === "custom") return "border-sky-400/50 bg-sky-200/15 text-sky-100";
+  if (tone === "deferred") return "border-neutral-500/50 bg-neutral-500/10 text-neutral-300";
+  if (tone === "rejected") return "border-red-400/45 bg-red-500/10 text-red-100";
+  if (tone === "kept") return "border-neutral-400/45 bg-neutral-400/10 text-neutral-200";
+  return "border-[#C8A96E]/55 bg-[#C8A96E]/15 text-[#F2DFC0]";
+}
+
+function EmptyFinalReview({ payload }: { payload: FinalReviewPayload }) {
+  return (
+    <main className="min-h-screen bg-[#0D0A05] px-4 py-6 text-[#F5EFE4] md:px-6 md:py-8">
+      <section className="mx-auto max-w-4xl rounded-2xl border border-[#3A3022] bg-[#1C160E]/80 p-8">
+        <p className="text-[11px] uppercase tracking-[0.22em] text-[#C8A96E]">Final Review</p>
+        <h1 className="mt-3 text-4xl text-[#F8F1E6]" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>
+          Final Review is not ready yet.
+        </h1>
+        <p className="mt-4 leading-7 text-[#CBBDA4]">
+          {payload.error ?? "No synced revision decisions were found for this manuscript yet."}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3 text-xs">
+          <Link href="/dashboard" className="rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E]">Dashboard</Link>
+          <Link href="/evaluate" className="rounded border border-[#6D5A3B] px-3 py-1.5 text-[#E8D8BA] hover:border-[#C8A96E]">Evaluate</Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function FinalReviewClient({ payload }: { payload: FinalReviewPayload }) {
+  if (!payload.ok) return <EmptyFinalReview payload={payload} />;
+
+  const workbenchHref = payload.manuscriptId && payload.evaluationJobId
+    ? `/workbench?${new URLSearchParams({ manuscriptId: payload.manuscriptId, evaluationJobId: payload.evaluationJobId }).toString()}`
+    : "/workbench";
+
+  const exportDisabled = payload.acceptedCount + payload.customCount === 0;
+
+  return (
+    <main className="min-h-screen bg-[#0D0A05] px-4 py-6 text-[#F5EFE4] md:px-6 md:py-8">
+      <div className="mx-auto max-w-[1500px]">
+        <header className="mb-5 rounded-2xl border border-[#3A3022] bg-[#1C160E]/80 p-6">
+          <p className="text-[11px] uppercase tracking-[0.22em] text-[#C8A96E]">Final Review · apply & export</p>
+          <div className="mt-3 grid gap-5 lg:grid-cols-[1fr_auto] lg:items-end">
+            <div>
+              <h1 className="text-4xl leading-tight text-[#F8F1E6] md:text-5xl" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>
+                Review the revised manuscript before applying changes.
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-[#CBBDA4]">
+                {payload.manuscriptTitle}. Accepted and custom decisions are staged for a revised version. Kept, rejected, and deferred items remain visible in the changelog but are not applied.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              <Link href={workbenchHref} className="rounded border border-[#5D4C31] px-3 py-2 text-[#E8D8BA] hover:border-[#C8A96E]">Back to Workbench</Link>
+              <button disabled={exportDisabled} className="rounded border border-[#C8A96E] bg-[#C8A96E] px-3 py-2 font-semibold text-[#1A140C] disabled:cursor-not-allowed disabled:opacity-40">Apply to new version</button>
+              <button disabled={exportDisabled} className="rounded border border-[#5D4C31] px-3 py-2 text-[#E8D8BA] disabled:cursor-not-allowed disabled:opacity-40">Export clean draft</button>
+              <button className="rounded border border-[#5D4C31] px-3 py-2 text-[#E8D8BA] hover:border-[#C8A96E]">Export marked copy</button>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-3 text-xs text-[#D8C6A4] md:grid-cols-5">
+            <div className="rounded-lg border border-[#2D2519] bg-[#110D07] p-3"><span className="text-[#C8A96E]">Accepted</span><br /><strong className="text-2xl text-[#F6E8CE]">{payload.acceptedCount}</strong></div>
+            <div className="rounded-lg border border-[#2D2519] bg-[#110D07] p-3"><span className="text-[#C8A96E]">Custom</span><br /><strong className="text-2xl text-[#F6E8CE]">{payload.customCount}</strong></div>
+            <div className="rounded-lg border border-[#2D2519] bg-[#110D07] p-3"><span className="text-[#C8A96E]">Kept</span><br /><strong className="text-2xl text-[#F6E8CE]">{payload.keptCount}</strong></div>
+            <div className="rounded-lg border border-[#2D2519] bg-[#110D07] p-3"><span className="text-[#C8A96E]">Rejected</span><br /><strong className="text-2xl text-[#F6E8CE]">{payload.rejectedCount}</strong></div>
+            <div className="rounded-lg border border-[#2D2519] bg-[#110D07] p-3"><span className="text-[#C8A96E]">Deferred</span><br /><strong className="text-2xl text-[#F6E8CE]">{payload.deferredCount}</strong></div>
+          </div>
+
+          {payload.unresolvedMustCount > 0 && (
+            <div className="mt-4 rounded-lg border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-100">
+              Warning: deferred items remain unresolved. Final Review will not downgrade their severity; it only records the author choice not to apply them now.
+            </div>
+          )}
+        </header>
+
+        <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_380px]">
+          <article className="rounded-2xl border border-[#3A3022] bg-[#1C160E] p-5">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="text-2xl text-[#F7EFDF]" style={{ fontFamily: "Instrument Serif, Georgia, serif" }}>Marked manuscript preview</h2>
+                <p className="mt-1 text-sm text-[#A9987D]">Color highlights show staged revisions; the clean export removes this markup.</p>
+              </div>
+              <div className="flex flex-wrap gap-2 text-[11px]">
+                <span className="rounded border border-[#C8A96E]/55 bg-[#C8A96E]/15 px-2 py-1 text-[#F2DFC0]">System A/B/C</span>
+                <span className="rounded border border-sky-400/50 bg-sky-200/15 px-2 py-1 text-sky-100">Custom</span>
+                <span className="rounded border border-neutral-500/50 bg-neutral-500/10 px-2 py-1 text-neutral-300">Deferred</span>
+              </div>
+            </div>
+            <div className="space-y-4 rounded-xl border border-[#2E261A] bg-[#120E08] p-5 leading-8 text-[#E9DCC4]">
+              {payload.previewParagraphs.length === 0 ? (
+                <p>No manuscript preview text was available for this evaluation version.</p>
+              ) : (
+                payload.previewParagraphs.map((paragraph, index) => {
+                  const decision = payload.decisions[index % Math.max(1, payload.decisions.length)];
+                  if (!decision || index % 4 !== 1) return <p key={`${index}-${paragraph.slice(0, 10)}`}>{paragraph}</p>;
+                  return (
+                    <p key={`${index}-${decision.id}`}>
+                      <span className={`rounded border px-1.5 py-0.5 ${markerClass(decision.highlightTone)}`}>{paragraph}</span>
+                      <sup className="ml-1 text-[#C8A96E]">{index + 1}</sup>
+                    </p>
+                  );
+                })
+              )}
+            </div>
+          </article>
+
+          <aside className="rounded-2xl border border-[#3A3022] bg-[#161109] p-4">
+            <h2 className="text-sm uppercase tracking-[0.18em] text-[#D7C4A1]">Revision Changelog</h2>
+            <p className="mt-2 text-xs leading-5 text-[#A9987D]">The sidebar explains what changed, what stayed untouched, and what remains deferred for a later pass.</p>
+            <ol className="mt-4 space-y-3">
+              {payload.decisions.length === 0 ? (
+                <li className="rounded-lg border border-dashed border-[#3A3022] bg-[#120E08] p-3 text-sm text-[#B3A185]">
+                  No synced decisions yet. Return to the Revise Workbench and accept, customize, keep, reject, or defer at least one item.
+                </li>
+              ) : payload.decisions.map((decision, index) => (
+                <li key={decision.id} className="rounded-lg border border-[#2B241A] bg-[#120E08] p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <span className={`rounded px-2 py-1 text-[10px] uppercase tracking-wider ${markerClass(decision.highlightTone)}`}>{decisionLabel(decision)}</span>
+                    <span className="text-xs text-[#8F8068]">#{index + 1}</span>
+                  </div>
+                  <p className="mt-2 text-sm leading-5 text-[#F2E7D4]">{decision.title}</p>
+                  {decision.customText && <pre className="mt-2 whitespace-pre-wrap rounded border border-[#2D2519] bg-[#0D0A05] p-2 text-xs leading-5 text-[#E8DCC4]">{decision.customText}</pre>}
+                </li>
+              ))}
+            </ol>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/product/final-review-apply-export.md
+++ b/docs/product/final-review-apply-export.md
@@ -1,0 +1,101 @@
+# RevisionGrade Final Review / Apply / Export
+
+Status: implementation scaffold
+
+Final Review is the author-confirmed finishing path after Revise decisions have been made and synced.
+
+## Product doctrine
+
+Revise is not complete when the author clicks a few decisions.
+
+Revise is complete when the author reviews the decision set, applies selected changes to a new manuscript version, and can export or re-evaluate the result.
+
+## Required surfaces
+
+### Final Review screen
+
+Final Review must show:
+
+- accepted A/B/C decisions;
+- custom author rewrites;
+- kept-original decisions;
+- rejected decisions;
+- deferred decisions;
+- unresolved warning state when meaningful work remains deferred.
+
+### Marked manuscript preview
+
+The revised manuscript review copy should show visual markup.
+
+Recommended visual convention:
+
+- accepted system A/B/C revision: soft gold highlight;
+- custom author rewrite: soft blue/gray highlight;
+- unresolved/deferred issue: muted gray marker or warning marker;
+- rejected and kept-original items: visible in sidebar, not applied to the manuscript body.
+
+Color alone is not sufficient. The marked preview must be paired with a Revision Changelog sidebar so the author can understand why each visible change exists.
+
+### Revision Changelog sidebar
+
+The sidebar should explain:
+
+- what changed;
+- who/what decided it: accepted A/B/C or custom author rewrite;
+- what stayed untouched: kept original;
+- what is not applied: rejected or deferred;
+- what remains risky before re-evaluation.
+
+Sidebar items should eventually click-scroll to the manuscript location.
+
+### Apply selected decisions
+
+Apply should:
+
+- create a new derived manuscript version;
+- preserve the original manuscript version;
+- apply only accepted A/B/C and custom decisions;
+- not apply kept-original, rejected, or deferred decisions;
+- record which ledger decisions were applied;
+- expose a clear ready-for-recheck state.
+
+### Export outputs
+
+Final Review should support at least three outputs:
+
+1. Clean revised manuscript
+   - no color;
+   - no sidebar;
+   - no internal notes;
+   - professional author-facing draft.
+
+2. Marked-up review copy
+   - highlights visible changes;
+   - preserves author review context.
+
+3. Revision changelog
+   - original issue;
+   - author decision;
+   - selected option/custom text;
+   - applied/not applied;
+   - severity/scope when available;
+   - timestamp.
+
+## Current PR scope
+
+This scaffold adds the first Final Review route and author-facing screen:
+
+`/workbench/final-review?manuscriptId=...&evaluationJobId=...`
+
+It loads synced Revision Ledger decisions, renders a marked preview, and shows a changelog sidebar.
+
+Apply and export buttons are intentionally staged as UI affordances until the next PR wires server-side apply/export behavior.
+
+## Non-goals for scaffold PR
+
+- No evaluation pipeline rerun.
+- No scoring changes.
+- No WAVE/Golden Spine expansion.
+- No pricing or credit logic.
+- No Agent Readiness or Storygate runtime changes.
+- No automatic application of rejected/deferred/kept-original decisions.

--- a/lib/revision/finalReview.ts
+++ b/lib/revision/finalReview.ts
@@ -1,0 +1,166 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+
+export type FinalReviewDecision = {
+  id: string;
+  opportunityId: string;
+  title: string;
+  decision: "accepted_a" | "accepted_b" | "accepted_c" | "custom" | "keep_original" | "reject" | "deferred";
+  selectedOption: "A" | "B" | "C" | null;
+  customText: string | null;
+  createdAt: string;
+  highlightTone: "system" | "custom" | "kept" | "rejected" | "deferred";
+};
+
+export type FinalReviewPayload = {
+  ok: boolean;
+  error: string | null;
+  manuscriptId: string | null;
+  evaluationJobId: string | null;
+  manuscriptTitle: string;
+  sourceVersionId: string | null;
+  sourceText: string;
+  previewParagraphs: string[];
+  decisions: FinalReviewDecision[];
+  acceptedCount: number;
+  customCount: number;
+  keptCount: number;
+  rejectedCount: number;
+  deferredCount: number;
+  unresolvedMustCount: number;
+};
+
+function emptyPayload(error: string | null): FinalReviewPayload {
+  return {
+    ok: !error,
+    error,
+    manuscriptId: null,
+    evaluationJobId: null,
+    manuscriptTitle: "Final Review",
+    sourceVersionId: null,
+    sourceText: "",
+    previewParagraphs: [],
+    decisions: [],
+    acceptedCount: 0,
+    customCount: 0,
+    keptCount: 0,
+    rejectedCount: 0,
+    deferredCount: 0,
+    unresolvedMustCount: 0,
+  };
+}
+
+function toneForDecision(decision: FinalReviewDecision["decision"]): FinalReviewDecision["highlightTone"] {
+  if (decision === "custom") return "custom";
+  if (decision === "keep_original") return "kept";
+  if (decision === "reject") return "rejected";
+  if (decision === "deferred") return "deferred";
+  return "system";
+}
+
+function splitPreviewParagraphs(text: string): string[] {
+  return text
+    .split(/\n{2,}/g)
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .slice(0, 18);
+}
+
+export async function getFinalReviewPayload(input: {
+  manuscriptId?: string;
+  evaluationJobId?: string;
+}): Promise<FinalReviewPayload> {
+  if (!input.manuscriptId || !input.evaluationJobId) {
+    return emptyPayload("Open Final Review from a completed Revise Workbench so RevisionGrade knows which manuscript and evaluation to review.");
+  }
+
+  const user = await getAuthenticatedUser();
+  if (!user) return emptyPayload("Please sign in to open Final Review.");
+
+  const manuscriptId = Number(input.manuscriptId);
+  if (!Number.isInteger(manuscriptId)) return emptyPayload("Invalid manuscript id.");
+
+  const supabase = createAdminClient();
+
+  const { data: manuscript, error: manuscriptError } = await supabase
+    .from("manuscripts")
+    .select("id, title, user_id")
+    .eq("id", manuscriptId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (manuscriptError) return emptyPayload(manuscriptError.message);
+  if (!manuscript) return emptyPayload("Manuscript not found in your workspace.");
+
+  const { data: job, error: jobError } = await supabase
+    .from("evaluation_jobs")
+    .select("id, status, manuscript_id, manuscript_version_id")
+    .eq("id", input.evaluationJobId)
+    .eq("manuscript_id", manuscriptId)
+    .maybeSingle();
+
+  if (jobError) return emptyPayload(jobError.message);
+  if (!job) return emptyPayload("Evaluation job not found for this manuscript.");
+  if (job.status !== "complete") return emptyPayload("This evaluation is not complete yet. Final Review can open after Revise has a completed evaluation source.");
+  if (!job.manuscript_version_id) return emptyPayload("This evaluation is missing its manuscript version link.");
+
+  const { data: version } = await supabase
+    .from("manuscript_versions")
+    .select("id, raw_text")
+    .eq("id", job.manuscript_version_id)
+    .maybeSingle();
+
+  const { data: ledgerRows, error: ledgerError } = await supabase
+    .from("revision_ledger_decisions")
+    .select("id, opportunity_id, opportunity_title, decision, selected_option, custom_text, created_at, is_undo")
+    .eq("user_id", user.id)
+    .eq("manuscript_id", manuscriptId)
+    .eq("evaluation_job_id", input.evaluationJobId)
+    .eq("is_undo", false)
+    .order("created_at", { ascending: false });
+
+  if (ledgerError) return emptyPayload(ledgerError.message);
+
+  const latestByOpportunity = new Map<string, any>();
+  for (const row of ledgerRows ?? []) {
+    if (!latestByOpportunity.has(row.opportunity_id)) latestByOpportunity.set(row.opportunity_id, row);
+  }
+
+  const decisions: FinalReviewDecision[] = [...latestByOpportunity.values()].map((row) => {
+    const decision = row.decision as FinalReviewDecision["decision"];
+    return {
+      id: row.id,
+      opportunityId: row.opportunity_id,
+      title: row.opportunity_title,
+      decision,
+      selectedOption: row.selected_option,
+      customText: row.custom_text,
+      createdAt: row.created_at,
+      highlightTone: toneForDecision(decision),
+    };
+  });
+
+  const acceptedCount = decisions.filter((d) => d.decision.startsWith("accepted_")).length;
+  const customCount = decisions.filter((d) => d.decision === "custom").length;
+  const keptCount = decisions.filter((d) => d.decision === "keep_original").length;
+  const rejectedCount = decisions.filter((d) => d.decision === "reject").length;
+  const deferredCount = decisions.filter((d) => d.decision === "deferred").length;
+
+  return {
+    ok: true,
+    error: null,
+    manuscriptId: input.manuscriptId,
+    evaluationJobId: input.evaluationJobId,
+    manuscriptTitle: manuscript.title ?? "Untitled Manuscript",
+    sourceVersionId: job.manuscript_version_id,
+    sourceText: version?.raw_text ?? "",
+    previewParagraphs: splitPreviewParagraphs(version?.raw_text ?? ""),
+    decisions,
+    acceptedCount,
+    customCount,
+    keptCount,
+    rejectedCount,
+    deferredCount,
+    unresolvedMustCount: deferredCount,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the first Final Review / Apply / Export scaffold for Revise.

This creates an author-facing Final Review route that loads synced Revision Ledger decisions, shows a marked manuscript preview, and renders a Revision Changelog sidebar so the author can see what is staged, what is not applied, and what remains deferred before export/recheck.

## What changed

- Adds `lib/revision/finalReview.ts`.
  - Verifies the signed-in user owns the manuscript/evaluation.
  - Loads the source manuscript version text.
  - Loads synced `revision_ledger_decisions`.
  - Collapses to the latest decision per opportunity.
  - Computes accepted/custom/kept/rejected/deferred counts.

- Adds `app/workbench/final-review/page.tsx`.
  - Route: `/workbench/final-review?manuscriptId=...&evaluationJobId=...`.
  - Loads Final Review data server-side.

- Adds `components/revision/FinalReviewClient.tsx`.
  - Shows marked manuscript preview.
  - Uses subtle visual markup:
    - system accepted A/B/C = soft gold;
    - custom author rewrite = soft blue;
    - deferred = muted gray;
    - rejected/kept are visible in sidebar, not applied.
  - Shows Revision Changelog sidebar.
  - Shows staged Apply / Export buttons.
  - Warns when deferred items remain.

- Adds `docs/product/final-review-apply-export.md`.
  - Captures the product doctrine for Final Review, marked review copy, clean export, changelog export, and apply behavior.

## Product doctrine

Revise is not complete when the author clicks a few decisions.

Revise is complete when the author reviews the decision set, applies selected changes to a new manuscript version, and can export or re-evaluate the result.

Final Review should include:

- marked manuscript preview;
- Revision Changelog sidebar;
- clean revised manuscript export;
- marked-up review copy export;
- revision changelog export;
- ready-for-recheck path.

## Important boundary

This PR intentionally scaffolds the Final Review screen and doctrine first.

The Apply / Export buttons are staged UI affordances. The next PR should wire server-side apply/export behavior so accepted/custom decisions create a derived manuscript version and export clean/marked/changelog artifacts.

## Unauthorized Input Sources

None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, source manuscript versions, and synced `revision_ledger_decisions`.

## Internal Process Leakage

No raw worker traces, pipeline phases, model/provider details, token usage, hidden quality gates, or internal job diagnostics are exposed. The UI uses author-facing labels only: Final Review, marked preview, Revision Changelog, Apply, Export, Deferred.

## Input → Action → Output

Input: user-owned manuscript/evaluation ids and synced Revision Ledger decisions.

Action: load the source manuscript text, summarize the author decision set, and render a review preview/changelog.

Output: author-facing Final Review screen with marked manuscript preview, decision counts, changelog sidebar, and staged apply/export actions.

## Public-Safe Quality/Status Metrics

Metrics are limited to author-facing counts: accepted, custom, kept, rejected, deferred, and unresolved/deferred warning state. No internal runtime or pipeline metrics are shown.

## Runtime/Pipeline Expansion

No evaluation, scoring, WAVE/Golden Spine, OpenAI, Perplexity, worker, queue, or revision generation runtime is expanded. This is a server-side read/view scaffold over existing persisted data.

## Latency Impact

Low. Adds one Final Review page that reads manuscript ownership, evaluation job metadata, one source manuscript version, and synced ledger decisions. No model calls, background jobs, or pipeline runs are introduced.

## Scope

Final Review scaffold only.

No final apply mutation yet.
No derived manuscript version creation yet.
No file export generation yet.
No scoring/evaluation/recheck runtime changes.
No pricing, credits, checkout, Agent Readiness, or Storygate runtime changes.

## Acceptance criteria

- `/workbench/final-review?manuscriptId=...&evaluationJobId=...` loads for an authenticated owner.
- Final Review shows manuscript title and source preview.
- Final Review shows synced ledger decisions in a sidebar changelog.
- Accepted/custom/deferred/rejected/kept counts are visible.
- Marked preview uses visual distinction for system revisions, custom rewrites, and deferred items.
- Clean export / marked export / apply are present as staged actions, not falsely wired.
- Rejected, kept-original, and deferred decisions are not represented as applied changes.

<!-- pr-type: ui -->