### PR TITLE
Add Final Review apply and export runtime

### DIFF
--- a/.github/pr-bodies/PR-727.md
+++ b/.github/pr-bodies/PR-727.md
@@ -1,0 +1,116 @@
+## Summary
+
+Adds the server-side Final Review apply/export runtime behind the scaffold from #726.
+
+This PR introduces the persistence and API layer needed to apply author-confirmed Revise decisions safely, export clean/marked/changelog review artifacts, and record every apply/export attempt.
+
+## What changed
+
+- Adds migration `20260526183000_add_final_review_apply_export_runtime.sql`.
+  - Adds ledger snapshot fields to `revision_ledger_decisions`:
+    - `selected_text`
+    - `source_excerpt`
+    - `source_location`
+  - Adds `final_review_apply_runs` to record apply/export attempts.
+  - Adds indexes and RLS policies for own-user access.
+
+- Updates `lib/revision/ledger.ts`.
+  - Accepts and returns selected text/source excerpt/source location snapshots.
+  - Persists selected replacement text for accepted/custom decisions when available.
+
+- Adds `lib/revision/finalReviewRuntime.ts`.
+  - Verifies manuscript/evaluation ownership.
+  - Loads the source manuscript version.
+  - Loads latest synced ledger decisions.
+  - Applies only accepted/custom decisions with exact source/replacement snapshots.
+  - Blocks apply when snapshots are missing or source text no longer matches.
+  - Creates a derived manuscript version only when safe.
+  - Builds clean, marked, and changelog TXT exports.
+  - Records apply/export runs.
+
+- Adds `POST /api/final-review/apply`.
+  - Attempts to create a new derived manuscript version from accepted/custom decisions.
+  - Returns a conflict when the apply operation is blocked for safety.
+
+- Adds `GET /api/final-review/export`.
+  - Supports `format=clean`, `format=marked`, and `format=changelog`.
+  - Returns TXT attachments.
+
+- Adds `docs/product/final-review-runtime.md`.
+  - Documents runtime safety doctrine and the next UI wiring step.
+
+## Product doctrine
+
+Final Review must never invent manuscript changes.
+
+A decision can only be applied when the ledger stores enough information to make the change safely:
+
+- exact source excerpt;
+- exact selected replacement text or custom rewrite;
+- source manuscript version ownership verified server-side.
+
+If those snapshots are missing or no longer match the source manuscript version, Apply blocks and records why. This protects author trust and prevents fabricated revisions.
+
+## Important boundary
+
+This PR creates the runtime endpoints and persistence foundation. It does **not** fully wire the Final Review UI buttons yet.
+
+The next PR should wire:
+
+- Workbench decision snapshot capture;
+- Final Review Apply button;
+- clean export link;
+- marked export link;
+- changelog export link;
+- apply result / blocked reason UI.
+
+## Unauthorized Input Sources
+
+None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, manuscript versions, and synced `revision_ledger_decisions`. No external services, model calls, browser tools, or new unauthenticated inputs are introduced.
+
+## Internal Process Leakage
+
+No worker traces, pipeline phases, model/provider details, token usage, hidden quality gates, or internal job diagnostics are surfaced. User-facing errors are limited to safe apply/export states such as missing snapshots, ownership/auth failures, and source mismatch.
+
+## Input → Action → Output
+
+Input: authenticated `manuscriptId`, `evaluationJobId`, source manuscript version, and synced ledger decisions with snapshots.
+
+Action: verify ownership; load source text; build changelog/exports; attempt exact source-to-replacement application; record apply/export run.
+
+Output: JSON apply result or TXT attachment, plus `final_review_apply_runs` audit record.
+
+## Public-Safe Quality/Status Metrics
+
+Metrics/statuses are public-safe author-facing values only: `blocked`, `applied`, `exported`, applied/skipped decision ids, export kind, and blocked reason. No runtime, model, provider, latency, token, or worker metrics are exposed.
+
+## Runtime/Pipeline Expansion
+
+No evaluation, scoring, WAVE/Golden Spine, OpenAI, Perplexity, revision generation, worker, queue, or background pipeline runtime is expanded. This PR adds server-side apply/export endpoints over existing persisted data only.
+
+## Latency Impact
+
+Low. Runtime work is limited to ownership checks, one source manuscript version read, one ledger read, string replacement over the manuscript text, one apply/export run insert, and optional derived version creation. No model calls or background jobs are added.
+
+## Scope
+
+Runtime foundation only.
+
+No Final Review UI button wiring yet.
+No Workbench snapshot-capture UI change yet.
+No DOCX/PDF export yet.
+No model-generated repair application.
+No scoring/evaluation/recheck runtime changes.
+No pricing, credits, checkout, Agent Readiness, or Storygate runtime changes.
+
+## Acceptance criteria
+
+- Migration adds ledger snapshot fields and `final_review_apply_runs`.
+- Ledger sync can persist selected/source snapshots when provided.
+- Apply endpoint blocks if accepted/custom decisions lack safe source/replacement snapshots.
+- Apply endpoint creates a derived manuscript version only when all applicable decisions can be applied safely.
+- Export endpoint supports clean, marked, and changelog TXT outputs.
+- Apply/export attempts are recorded in `final_review_apply_runs`.
+- Rejected, kept-original, and deferred decisions are not applied.
+
+<!-- pr-type: backend -->

--- a/app/api/final-review/apply/route.ts
+++ b/app/api/final-review/apply/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { applyFinalReviewDecisions } from "@/lib/revision/finalReviewRuntime";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const manuscriptId = body?.manuscriptId;
+    const evaluationJobId = body?.evaluationJobId;
+
+    if (!manuscriptId) return NextResponse.json({ ok: false, error: "Missing manuscriptId" }, { status: 400 });
+    if (!evaluationJobId) return NextResponse.json({ ok: false, error: "Missing evaluationJobId" }, { status: 400 });
+
+    const result = await applyFinalReviewDecisions({ manuscriptId, evaluationJobId });
+    return NextResponse.json(result, { status: result.ok ? 200 : 409 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message === "Not authenticated" ? 401 : message.includes("not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/app/api/final-review/export/route.ts
+++ b/app/api/final-review/export/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { buildFinalReviewExport, type FinalReviewExportFormat } from "@/lib/revision/finalReviewRuntime";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function isFormat(value: string | null): value is FinalReviewExportFormat {
+  return value === "clean" || value === "marked" || value === "changelog";
+}
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const manuscriptId = url.searchParams.get("manuscriptId");
+    const evaluationJobId = url.searchParams.get("evaluationJobId");
+    const format = url.searchParams.get("format");
+
+    if (!manuscriptId) return NextResponse.json({ ok: false, error: "Missing manuscriptId" }, { status: 400 });
+    if (!evaluationJobId) return NextResponse.json({ ok: false, error: "Missing evaluationJobId" }, { status: 400 });
+    if (!isFormat(format)) return NextResponse.json({ ok: false, error: "Invalid or missing format" }, { status: 400 });
+
+    const exportResult = await buildFinalReviewExport({ manuscriptId, evaluationJobId, format });
+    return new NextResponse(exportResult.content, {
+      headers: {
+        "Content-Type": exportResult.contentType,
+        "Content-Disposition": `attachment; filename="${exportResult.filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message === "Not authenticated" ? 401 : message.includes("not found") ? 404 : 500;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/docs/product/final-review-runtime.md
+++ b/docs/product/final-review-runtime.md
@@ -1,0 +1,42 @@
+# Final Review Apply / Export Runtime
+
+Status: runtime foundation
+
+This layer adds the server-side apply/export path behind Final Review.
+
+## What the runtime can do
+
+- Export a clean TXT draft.
+- Export a marked TXT review copy.
+- Export a TXT revision changelog.
+- Attempt to apply accepted/custom decisions into a new derived manuscript version.
+- Record apply/export attempts in `final_review_apply_runs`.
+
+## Safety rule
+
+Final Review may not silently invent manuscript changes.
+
+A decision can only be applied when the ledger stores enough information to make the change safely:
+
+- `source_excerpt`: the exact text to replace in the source manuscript version;
+- `selected_text`: the accepted A/B/C replacement text, or the custom author rewrite;
+- source version ownership and manuscript ownership verified server-side.
+
+If a decision does not have a source/replacement snapshot, Apply blocks and records the blocked attempt. This protects author trust and prevents accidental or fabricated revisions.
+
+## Export behavior
+
+- Changelog export always works from synced ledger data.
+- Marked review export includes the source manuscript plus changelog.
+- Clean export applies only decisions with valid source/replacement snapshots. If snapshots are missing, it exports source text with a notice rather than pretending the manuscript was revised.
+
+## Next UI step
+
+The workbench should persist decision snapshots when the author clicks Accept A/B/C or Custom:
+
+- selected option text;
+- source excerpt/evidence anchor;
+- source location;
+- option label and mechanism metadata.
+
+Once that lands, Apply can create a derived manuscript version reliably for accepted/custom decisions.

--- a/lib/revision/finalReviewRuntime.ts
+++ b/lib/revision/finalReviewRuntime.ts
@@ -1,0 +1,282 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+import { createDerivedVersion } from "@/lib/manuscripts/versions";
+
+export type FinalReviewExportFormat = "clean" | "marked" | "changelog";
+
+export type FinalReviewRuntimeInput = {
+  manuscriptId: string | number;
+  evaluationJobId: string;
+};
+
+type RuntimeContext = {
+  supabase: ReturnType<typeof createAdminClient>;
+  userId: string;
+  manuscriptId: number;
+  manuscriptTitle: string;
+  evaluationJobId: string;
+  sourceVersionId: string;
+  sourceText: string;
+  decisions: RuntimeDecision[];
+};
+
+type RuntimeDecision = {
+  id: string;
+  opportunity_id: string;
+  opportunity_title: string;
+  decision: string;
+  selected_option: string | null;
+  custom_text: string | null;
+  selected_text: string | null;
+  source_excerpt: string | null;
+  source_location: string | null;
+  created_at: string;
+};
+
+const APPLICABLE = new Set(["accepted_a", "accepted_b", "accepted_c", "custom"]);
+
+function safeFilename(title: string, suffix: string, ext: string): string {
+  const base = title.replace(/[^a-z0-9]+/gi, "-").toLowerCase().replace(/^-|-$/g, "").slice(0, 50) || "manuscript";
+  return `revisiongrade-${base}-${suffix}.${ext}`;
+}
+
+async function loadRuntimeContext(input: FinalReviewRuntimeInput): Promise<RuntimeContext> {
+  const user = await getAuthenticatedUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const manuscriptId = Number(input.manuscriptId);
+  if (!Number.isInteger(manuscriptId)) throw new Error("Invalid manuscript id");
+
+  const supabase = createAdminClient();
+
+  const { data: manuscript, error: manuscriptError } = await supabase
+    .from("manuscripts")
+    .select("id, title, user_id")
+    .eq("id", manuscriptId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (manuscriptError) throw new Error(manuscriptError.message);
+  if (!manuscript) throw new Error("Manuscript not found in your workspace");
+
+  const { data: job, error: jobError } = await supabase
+    .from("evaluation_jobs")
+    .select("id, status, manuscript_id, manuscript_version_id")
+    .eq("id", input.evaluationJobId)
+    .eq("manuscript_id", manuscriptId)
+    .maybeSingle();
+
+  if (jobError) throw new Error(jobError.message);
+  if (!job) throw new Error("Evaluation job not found for this manuscript");
+  if (job.status !== "complete") throw new Error("Evaluation must be complete before Final Review can apply or export.");
+  if (!job.manuscript_version_id) throw new Error("Evaluation is missing source manuscript version.");
+
+  const { data: version, error: versionError } = await supabase
+    .from("manuscript_versions")
+    .select("id, raw_text")
+    .eq("id", job.manuscript_version_id)
+    .maybeSingle();
+
+  if (versionError) throw new Error(versionError.message);
+  if (!version) throw new Error("Source manuscript version not found.");
+
+  const { data: rows, error: ledgerError } = await supabase
+    .from("revision_ledger_decisions")
+    .select("id, opportunity_id, opportunity_title, decision, selected_option, custom_text, selected_text, source_excerpt, source_location, created_at")
+    .eq("user_id", user.id)
+    .eq("manuscript_id", manuscriptId)
+    .eq("evaluation_job_id", input.evaluationJobId)
+    .eq("is_undo", false)
+    .order("created_at", { ascending: false });
+
+  if (ledgerError) throw new Error(ledgerError.message);
+
+  const latestByOpportunity = new Map<string, RuntimeDecision>();
+  for (const row of (rows ?? []) as RuntimeDecision[]) {
+    if (!latestByOpportunity.has(row.opportunity_id)) latestByOpportunity.set(row.opportunity_id, row);
+  }
+
+  return {
+    supabase,
+    userId: user.id,
+    manuscriptId,
+    manuscriptTitle: manuscript.title ?? "Untitled Manuscript",
+    evaluationJobId: String(input.evaluationJobId),
+    sourceVersionId: job.manuscript_version_id,
+    sourceText: version.raw_text ?? "",
+    decisions: [...latestByOpportunity.values()],
+  };
+}
+
+function applicableDecisions(decisions: RuntimeDecision[]): RuntimeDecision[] {
+  return decisions.filter((d) => APPLICABLE.has(d.decision));
+}
+
+function buildChangelog(ctx: RuntimeContext): string {
+  const lines = [
+    `RevisionGrade Final Review Changelog`,
+    `Manuscript: ${ctx.manuscriptTitle}`,
+    `Evaluation Job: ${ctx.evaluationJobId}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+  ];
+
+  if (ctx.decisions.length === 0) {
+    lines.push("No synced revision decisions were found.");
+    return lines.join("\n");
+  }
+
+  for (const decision of ctx.decisions) {
+    lines.push(`- ${decision.decision.toUpperCase()} — ${decision.opportunity_title}`);
+    if (decision.selected_option) lines.push(`  Option: ${decision.selected_option}`);
+    if (decision.source_location) lines.push(`  Location: ${decision.source_location}`);
+    if (decision.source_excerpt) lines.push(`  Source: ${decision.source_excerpt}`);
+    if (decision.selected_text) lines.push(`  Selected text: ${decision.selected_text}`);
+    if (decision.custom_text) lines.push(`  Custom text: ${decision.custom_text}`);
+    lines.push(`  Created: ${decision.created_at}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function buildMarkedText(ctx: RuntimeContext): string {
+  const lines = [
+    `RevisionGrade Marked Review Copy`,
+    `Manuscript: ${ctx.manuscriptTitle}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    ctx.sourceText,
+    "",
+    "--- Revision Changelog ---",
+    buildChangelog(ctx),
+  ];
+  return lines.join("\n");
+}
+
+function applyTextSnapshots(ctx: RuntimeContext): { text: string; applied: RuntimeDecision[]; blocked: string[] } {
+  let text = ctx.sourceText;
+  const applied: RuntimeDecision[] = [];
+  const blocked: string[] = [];
+
+  for (const decision of applicableDecisions(ctx.decisions)) {
+    const replacement = decision.decision === "custom" ? decision.custom_text : decision.selected_text;
+    const source = decision.source_excerpt;
+
+    if (!replacement || !source) {
+      blocked.push(`${decision.opportunity_title}: missing source excerpt or selected replacement text.`);
+      continue;
+    }
+
+    if (!text.includes(source)) {
+      blocked.push(`${decision.opportunity_title}: source excerpt no longer matches source manuscript version.`);
+      continue;
+    }
+
+    text = text.replace(source, replacement);
+    applied.push(decision);
+  }
+
+  return { text, applied, blocked };
+}
+
+async function recordRun(
+  ctx: RuntimeContext,
+  input: {
+    status: "blocked" | "applied" | "exported";
+    mode: "apply" | "export_clean" | "export_marked" | "export_changelog";
+    revisedVersionId?: string | null;
+    appliedDecisionIds?: string[];
+    skippedDecisionIds?: string[];
+    blockedReason?: string | null;
+    exportFormat?: string | null;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  await ctx.supabase.from("final_review_apply_runs").insert({
+    user_id: ctx.userId,
+    manuscript_id: ctx.manuscriptId,
+    evaluation_job_id: ctx.evaluationJobId,
+    source_version_id: ctx.sourceVersionId,
+    revised_version_id: input.revisedVersionId ?? null,
+    status: input.status,
+    mode: input.mode,
+    applied_decision_ids: input.appliedDecisionIds ?? [],
+    skipped_decision_ids: input.skippedDecisionIds ?? [],
+    blocked_reason: input.blockedReason ?? null,
+    export_format: input.exportFormat ?? null,
+    metadata: input.metadata ?? {},
+  });
+}
+
+export async function applyFinalReviewDecisions(input: FinalReviewRuntimeInput) {
+  const ctx = await loadRuntimeContext(input);
+  const result = applyTextSnapshots(ctx);
+
+  if (result.applied.length === 0 || result.blocked.length > 0) {
+    await recordRun(ctx, {
+      status: "blocked",
+      mode: "apply",
+      skippedDecisionIds: applicableDecisions(ctx.decisions).map((d) => d.id),
+      blockedReason: result.blocked.join(" | ") || "No applicable accepted/custom decisions with persisted text snapshots.",
+      metadata: { blocked: result.blocked },
+    });
+    return { ok: false, error: result.blocked.join("\n") || "No applicable accepted/custom decisions with persisted text snapshots." };
+  }
+
+  const version = await createDerivedVersion({
+    manuscript_id: ctx.manuscriptId,
+    source_version_id: ctx.sourceVersionId,
+    raw_text: result.text,
+    created_by: ctx.userId,
+  });
+
+  await recordRun(ctx, {
+    status: "applied",
+    mode: "apply",
+    revisedVersionId: version.id,
+    appliedDecisionIds: result.applied.map((d) => d.id),
+    skippedDecisionIds: ctx.decisions.filter((d) => !APPLICABLE.has(d.decision)).map((d) => d.id),
+    metadata: { applied_count: result.applied.length },
+  });
+
+  return { ok: true, revisedVersionId: version.id, appliedCount: result.applied.length };
+}
+
+export async function buildFinalReviewExport(input: FinalReviewRuntimeInput & { format: FinalReviewExportFormat }) {
+  const ctx = await loadRuntimeContext(input);
+  const applied = applyTextSnapshots(ctx);
+  const format = input.format;
+  let content = "";
+  let suffix = "";
+
+  if (format === "changelog") {
+    content = buildChangelog(ctx);
+    suffix = "changelog";
+  } else if (format === "marked") {
+    content = buildMarkedText(ctx);
+    suffix = "marked-review-copy";
+  } else {
+    if (applied.blocked.length > 0) {
+      content = `${ctx.sourceText}\n\n--- RevisionGrade Clean Draft Notice ---\nClean export could not apply all decisions because some accepted/custom decisions are missing source/replacement snapshots. Exported source text unchanged.\n\n${applied.blocked.join("\n")}`;
+    } else {
+      content = applied.text;
+    }
+    suffix = "clean-draft";
+  }
+
+  await recordRun(ctx, {
+    status: "exported",
+    mode: format === "clean" ? "export_clean" : format === "marked" ? "export_marked" : "export_changelog",
+    appliedDecisionIds: applied.applied.map((d) => d.id),
+    skippedDecisionIds: ctx.decisions.filter((d) => !APPLICABLE.has(d.decision)).map((d) => d.id),
+    exportFormat: "txt",
+    metadata: { export_kind: format, blocked: applied.blocked },
+  });
+
+  return {
+    content,
+    filename: safeFilename(ctx.manuscriptTitle, suffix, "txt"),
+    contentType: "text/plain; charset=utf-8",
+  };
+}

--- a/lib/revision/ledger.ts
+++ b/lib/revision/ledger.ts
@@ -17,6 +17,9 @@ export type SyncRevisionLedgerEntryInput = {
   decision: RevisionLedgerDecision;
   selectedOption?: "A" | "B" | "C" | null;
   customText?: string | null;
+  selectedText?: string | null;
+  sourceExcerpt?: string | null;
+  sourceLocation?: string | null;
   clientCreatedAt?: string | null;
   isUndo?: boolean;
   undoneLocalId?: string | null;
@@ -37,6 +40,9 @@ export type SyncedRevisionLedgerRow = {
   decision: RevisionLedgerDecision;
   selected_option: "A" | "B" | "C" | null;
   custom_text: string | null;
+  selected_text: string | null;
+  source_excerpt: string | null;
+  source_location: string | null;
   client_created_at: string | null;
   client_synced_at: string;
   is_undo: boolean;
@@ -56,6 +62,9 @@ const DECISIONS = new Set<RevisionLedgerDecision>([
   "deferred",
 ]);
 
+const LEDGER_SELECT =
+  "id, local_id, opportunity_id, opportunity_title, decision, selected_option, custom_text, selected_text, source_excerpt, source_location, client_created_at, client_synced_at, is_undo, undone_local_id, metadata, created_at, updated_at";
+
 function isUuid(value: string | null | undefined): boolean {
   return Boolean(value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value));
 }
@@ -67,6 +76,10 @@ function normalizeDecision(value: unknown): RevisionLedgerDecision | null {
 
 function normalizeOption(value: unknown): "A" | "B" | "C" | null {
   return value === "A" || value === "B" || value === "C" ? value : null;
+}
+
+function normalizeText(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
 async function assertOwnedEvaluation(input: { manuscriptId: string | number; evaluationJobId: string }) {
@@ -114,7 +127,16 @@ function validateEntry(entry: SyncRevisionLedgerEntryInput): SyncRevisionLedgerE
   }
   const decision = normalizeDecision(entry.decision);
   if (!decision) throw new Error(`Invalid ledger decision: ${String(entry.decision)}`);
-  return { ...entry, decision, selectedOption: normalizeOption(entry.selectedOption) };
+
+  return {
+    ...entry,
+    decision,
+    selectedOption: normalizeOption(entry.selectedOption),
+    customText: normalizeText(entry.customText),
+    selectedText: normalizeText(entry.selectedText),
+    sourceExcerpt: normalizeText(entry.sourceExcerpt),
+    sourceLocation: normalizeText(entry.sourceLocation),
+  };
 }
 
 export async function syncRevisionLedgerDecisions(input: SyncRevisionLedgerInput): Promise<SyncedRevisionLedgerRow[]> {
@@ -132,6 +154,9 @@ export async function syncRevisionLedgerDecisions(input: SyncRevisionLedgerInput
     decision: entry.decision,
     selected_option: entry.selectedOption ?? null,
     custom_text: entry.customText ?? null,
+    selected_text: entry.selectedText ?? entry.customText ?? null,
+    source_excerpt: entry.sourceExcerpt ?? null,
+    source_location: entry.sourceLocation ?? null,
     local_id: entry.localId,
     client_created_at: entry.clientCreatedAt ?? null,
     client_synced_at: new Date().toISOString(),
@@ -144,7 +169,7 @@ export async function syncRevisionLedgerDecisions(input: SyncRevisionLedgerInput
   const { data, error } = await supabase
     .from("revision_ledger_decisions")
     .upsert(rows, { onConflict: "user_id,evaluation_job_id,local_id" })
-    .select("id, local_id, opportunity_id, opportunity_title, decision, selected_option, custom_text, client_created_at, client_synced_at, is_undo, undone_local_id, metadata, created_at, updated_at")
+    .select(LEDGER_SELECT)
     .order("created_at", { ascending: true });
 
   if (error) throw new Error(error.message);
@@ -159,7 +184,7 @@ export async function listRevisionLedgerDecisions(input: {
 
   const { data, error } = await supabase
     .from("revision_ledger_decisions")
-    .select("id, local_id, opportunity_id, opportunity_title, decision, selected_option, custom_text, client_created_at, client_synced_at, is_undo, undone_local_id, metadata, created_at, updated_at")
+    .select(LEDGER_SELECT)
     .eq("user_id", userId)
     .eq("manuscript_id", manuscriptId)
     .eq("evaluation_job_id", input.evaluationJobId)

--- a/supabase/migrations/20260526183000_add_final_review_apply_export_runtime.sql
+++ b/supabase/migrations/20260526183000_add_final_review_apply_export_runtime.sql
@@ -1,0 +1,55 @@
+-- Final Review apply/export runtime persistence.
+-- Adds payload snapshots to ledger decisions and records apply/export runs.
+
+BEGIN;
+
+ALTER TABLE public.revision_ledger_decisions
+  ADD COLUMN IF NOT EXISTS selected_text text,
+  ADD COLUMN IF NOT EXISTS source_excerpt text,
+  ADD COLUMN IF NOT EXISTS source_location text;
+
+CREATE TABLE IF NOT EXISTS public.final_review_apply_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  manuscript_id bigint NOT NULL REFERENCES public.manuscripts(id) ON DELETE CASCADE,
+  evaluation_job_id uuid NOT NULL REFERENCES public.evaluation_jobs(id) ON DELETE CASCADE,
+  source_version_id uuid NOT NULL REFERENCES public.manuscript_versions(id) ON DELETE CASCADE,
+  revised_version_id uuid REFERENCES public.manuscript_versions(id) ON DELETE SET NULL,
+  status text NOT NULL CHECK (status IN ('blocked', 'applied', 'exported')),
+  mode text NOT NULL CHECK (mode IN ('apply', 'export_clean', 'export_marked', 'export_changelog')),
+  applied_decision_ids uuid[] NOT NULL DEFAULT '{}'::uuid[],
+  skipped_decision_ids uuid[] NOT NULL DEFAULT '{}'::uuid[],
+  blocked_reason text,
+  export_format text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_final_review_apply_runs_user_id
+  ON public.final_review_apply_runs(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_final_review_apply_runs_manuscript_id
+  ON public.final_review_apply_runs(manuscript_id);
+
+CREATE INDEX IF NOT EXISTS idx_final_review_apply_runs_evaluation_job_id
+  ON public.final_review_apply_runs(evaluation_job_id);
+
+CREATE INDEX IF NOT EXISTS idx_final_review_apply_runs_created_at
+  ON public.final_review_apply_runs(created_at DESC);
+
+ALTER TABLE public.final_review_apply_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS final_review_apply_runs_select_own ON public.final_review_apply_runs;
+CREATE POLICY final_review_apply_runs_select_own
+  ON public.final_review_apply_runs
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS final_review_apply_runs_insert_own ON public.final_review_apply_runs;
+CREATE POLICY final_review_apply_runs_insert_own
+  ON public.final_review_apply_runs
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds the server-side Final Review apply/export runtime behind the scaffold from #726.

This PR introduces the persistence and API layer needed to apply author-confirmed Revise decisions safely, export clean/marked/changelog review artifacts, and record every apply/export attempt.

## What changed

- Adds migration `20260526183000_add_final_review_apply_export_runtime.sql`.
  - Adds ledger snapshot fields to `revision_ledger_decisions`:
    - `selected_text`
    - `source_excerpt`
    - `source_location`
  - Adds `final_review_apply_runs` to record apply/export attempts.
  - Adds indexes and RLS policies for own-user access.

- Updates `lib/revision/ledger.ts`.
  - Accepts and returns selected text/source excerpt/source location snapshots.
  - Persists selected replacement text for accepted/custom decisions when available.

- Adds `lib/revision/finalReviewRuntime.ts`.
  - Verifies manuscript/evaluation ownership.
  - Loads the source manuscript version.
  - Loads latest synced ledger decisions.
  - Applies only accepted/custom decisions with exact source/replacement snapshots.
  - Blocks apply when snapshots are missing or source text no longer matches.
  - Creates a derived manuscript version only when safe.
  - Builds clean, marked, and changelog TXT exports.
  - Records apply/export runs.

- Adds `POST /api/final-review/apply`.
  - Attempts to create a new derived manuscript version from accepted/custom decisions.
  - Returns a conflict when the apply operation is blocked for safety.

- Adds `GET /api/final-review/export`.
  - Supports `format=clean`, `format=marked`, and `format=changelog`.
  - Returns TXT attachments.

- Adds `docs/product/final-review-runtime.md`.
  - Documents runtime safety doctrine and the next UI wiring step.

## Product doctrine

Final Review must never invent manuscript changes.

A decision can only be applied when the ledger stores enough information to make the change safely:

- exact source excerpt;
- exact selected replacement text or custom rewrite;
- source manuscript version ownership verified server-side.

If those snapshots are missing or no longer match the source manuscript version, Apply blocks and records why. This protects author trust and prevents fabricated revisions.

## Important boundary

This PR creates the runtime endpoints and persistence foundation. It does **not** fully wire the Final Review UI buttons yet.

The next PR should wire:

- Workbench decision snapshot capture;
- Final Review Apply button;
- clean export link;
- marked export link;
- changelog export link;
- apply result / blocked reason UI.

## Unauthorized Input Sources

None. This PR reads only authenticated user-owned manuscripts, evaluation jobs, manuscript versions, and synced `revision_ledger_decisions`. No external services, model calls, browser tools, or new unauthenticated inputs are introduced.

## Internal Process Leakage

No worker traces, pipeline phases, model/provider details, token usage, hidden quality gates, or internal job diagnostics are surfaced. User-facing errors are limited to safe apply/export states such as missing snapshots, ownership/auth failures, and source mismatch.

## Input → Action → Output

Input: authenticated `manuscriptId`, `evaluationJobId`, source manuscript version, and synced ledger decisions with snapshots.

Action: verify ownership; load source text; build changelog/exports; attempt exact source-to-replacement application; record apply/export run.

Output: JSON apply result or TXT attachment, plus `final_review_apply_runs` audit record.

## Public-Safe Quality/Status Metrics

Metrics/statuses are public-safe author-facing values only: `blocked`, `applied`, `exported`, applied/skipped decision ids, export kind, and blocked reason. No runtime, model, provider, latency, token, or worker metrics are exposed.

## Runtime/Pipeline Expansion

No evaluation, scoring, WAVE/Golden Spine, OpenAI, Perplexity, revision generation, worker, queue, or background pipeline runtime is expanded. This PR adds server-side apply/export endpoints over existing persisted data only.

## Latency Impact

Low. Runtime work is limited to ownership checks, one source manuscript version read, one ledger read, string replacement over the manuscript text, one apply/export run insert, and optional derived version creation. No model calls or background jobs are added.

## Scope

Runtime foundation only.

No Final Review UI button wiring yet.
No Workbench snapshot-capture UI change yet.
No DOCX/PDF export yet.
No model-generated repair application.
No scoring/evaluation/recheck runtime changes.
No pricing, credits, checkout, Agent Readiness, or Storygate runtime changes.

## Acceptance criteria

- Migration adds ledger snapshot fields and `final_review_apply_runs`.
- Ledger sync can persist selected/source snapshots when provided.
- Apply endpoint blocks if accepted/custom decisions lack safe source/replacement snapshots.
- Apply endpoint creates a derived manuscript version only when all applicable decisions can be applied safely.
- Export endpoint supports clean, marked, and changelog TXT outputs.
- Apply/export attempts are recorded in `final_review_apply_runs`.
- Rejected, kept-original, and deferred decisions are not applied.

<!-- pr-type: backend -->