### PR TITLE
feat: add Phase v2 progress gate helpers

### DIFF
--- a/.github/pr-bodies/PR-738.md
+++ b/.github/pr-bodies/PR-738.md
@@ -1,0 +1,45 @@
+## Summary
+
+Implements the support-layer requested by #732.
+
+Adds pure helpers for Phase Architecture v2 gate validity:
+
+- `derivePass3aGateValidity(progress, artifacts)`
+- `deriveReviewGateReadiness(progress, artifacts)`
+- `assertPhase2Preconditions(progress, artifacts)`
+
+Adds unit coverage for the critical contract:
+
+- failed Pass 3A is never gate-valid
+- degraded Pass 3A is gate-valid only with structured proof
+- done Pass 3A requires `pass3_preflight_draft_v1` plus completion metadata
+- Review Gate requires Story Layer + quality report + Pass 3A gate validity
+- Phase 2 blocks missing/running/half-written/failed Pass 3A
+
+## Scope
+
+This PR is intentionally support-layer only.
+
+It does **not**:
+
+- split Track C runtime
+- alter scoring
+- alter synthesis
+- alter WAVE
+- rename Quality Gate
+- change processor/runtime behavior
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/gateValidity.ts`
+- `__tests__/evaluation/phaseV2GateValidity.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/phaseV2GateValidity.test.ts --runInBand
+```
+
+## Closes
+
+Closes #732

--- a/__tests__/evaluation/phaseV2GateValidity.test.ts
+++ b/__tests__/evaluation/phaseV2GateValidity.test.ts
@@ -1,0 +1,214 @@
+import {
+  assertPhase2Preconditions,
+  derivePass3aGateValidity,
+  deriveReviewGateReadiness,
+  type PhaseV2ArtifactSet,
+  type PhaseV2Progress,
+} from '../../lib/evaluation/phase-architecture-v2/gateValidity';
+
+const artifact = (id: string) => ({ artifact_id: id, source_hash: `sha256:${id}` });
+
+const storyArtifacts: PhaseV2ArtifactSet = {
+  pass1a_story_layer_v1: artifact('story-layer'),
+  ledger_quality_report_v1: artifact('quality-report'),
+};
+
+const doneProgress: PhaseV2Progress = {
+  pass3a_status: 'done',
+  pass3a_completed_at: '2026-05-26T00:00:00.000Z',
+};
+
+const doneArtifacts: PhaseV2ArtifactSet = {
+  ...storyArtifacts,
+  pass3_preflight_draft_v1: artifact('preflight'),
+};
+
+const degradedProgress: PhaseV2Progress = {
+  pass3a_status: 'degraded',
+  degraded_reason: 'PASS3A_REDUCE_TIMEOUT',
+  degraded_reason_codes: ['PASS3A_REDUCE_TIMEOUT'],
+  degraded_at: '2026-05-26T00:00:00.000Z',
+};
+
+describe('Phase Architecture v2 — Pass 3A gate validity', () => {
+  it('treats failed Pass 3A as gate-blocking, never gate-valid', () => {
+    const result = derivePass3aGateValidity({ pass3a_status: 'failed' }, doneArtifacts);
+
+    expect(result.ok).toBe(false);
+    expect(result.gate_validity).toBe('gate_blocking');
+    expect(result.code).toBe('PASS3A_FAILED_BLOCKING');
+  });
+
+  it('treats running/map_done/reduce_running as not-ready half-written states', () => {
+    for (const status of ['running', 'map_done', 'reduce_running'] as const) {
+      const result = derivePass3aGateValidity({ pass3a_status: status }, doneArtifacts);
+
+      expect(result.ok).toBe(false);
+      expect(result.gate_validity).toBe('not_ready');
+      expect(result.code).toBe('PASS3A_HALF_WRITTEN');
+    }
+  });
+
+  it('treats done without pass3_preflight_draft_v1 as gate-blocking', () => {
+    const result = derivePass3aGateValidity(doneProgress, storyArtifacts);
+
+    expect(result.ok).toBe(false);
+    expect(result.gate_validity).toBe('gate_blocking');
+    expect(result.code).toBe('PASS3A_ARTIFACT_MISSING');
+  });
+
+  it('treats done without completion metadata as gate-blocking', () => {
+    const result = derivePass3aGateValidity(
+      { pass3a_status: 'done' },
+      { pass3_preflight_draft_v1: artifact('preflight') },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.gate_validity).toBe('gate_blocking');
+    expect(result.code).toBe('PASS3A_COMPLETION_METADATA_MISSING');
+  });
+
+  it('treats done with valid artifact and completion metadata as gate-valid', () => {
+    const result = derivePass3aGateValidity(doneProgress, doneArtifacts);
+
+    expect(result.ok).toBe(true);
+    expect(result.gate_validity).toBe('gate_valid');
+    expect(result.code).toBe('PASS3A_DONE_GATE_VALID');
+  });
+
+  it('treats degraded without structured proof as gate-blocking', () => {
+    const result = derivePass3aGateValidity({ pass3a_status: 'degraded' }, {});
+
+    expect(result.ok).toBe(false);
+    expect(result.gate_validity).toBe('gate_blocking');
+    expect(result.code).toBe('PASS3A_DEGRADED_PROOF_MISSING');
+  });
+
+  it('treats degraded with structured proof as gate-valid', () => {
+    const result = derivePass3aGateValidity(degradedProgress, {});
+
+    expect(result.ok).toBe(true);
+    expect(result.gate_validity).toBe('gate_valid');
+    expect(result.code).toBe('PASS3A_DEGRADED_GATE_VALID');
+  });
+});
+
+describe('Phase Architecture v2 — derived Review Gate readiness', () => {
+  it('blocks Review Gate without pass1a_story_layer_v1', () => {
+    const result = deriveReviewGateReadiness(doneProgress, {
+      ledger_quality_report_v1: artifact('quality-report'),
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.review_gate_ready).toBe(false);
+    expect(result.code).toBe('REVIEW_GATE_STORY_LAYER_MISSING');
+  });
+
+  it('blocks Review Gate without ledger_quality_report_v1', () => {
+    const result = deriveReviewGateReadiness(doneProgress, {
+      pass1a_story_layer_v1: artifact('story-layer'),
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.review_gate_ready).toBe(false);
+    expect(result.code).toBe('REVIEW_GATE_QUALITY_REPORT_MISSING');
+  });
+
+  it('blocks Review Gate when Pass 3A is missing/running/half-written/failed', () => {
+    for (const status of ['not_started', 'running', 'map_done', 'reduce_running', 'failed'] as const) {
+      const result = deriveReviewGateReadiness(
+        { pass3a_status: status },
+        {
+          ...storyArtifacts,
+          pass3_preflight_draft_v1: artifact('preflight'),
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.review_gate_ready).toBe(false);
+    }
+  });
+
+  it('opens Review Gate when Story Layer, quality report, and done preflight are valid', () => {
+    const result = deriveReviewGateReadiness(doneProgress, doneArtifacts);
+
+    expect(result.ok).toBe(true);
+    expect(result.review_gate_ready).toBe(true);
+    expect(result.code).toBe('REVIEW_GATE_READY');
+  });
+
+  it('opens Review Gate when Story Layer, quality report, and degraded preflight proof are valid', () => {
+    const result = deriveReviewGateReadiness(degradedProgress, storyArtifacts);
+
+    expect(result.ok).toBe(true);
+    expect(result.review_gate_ready).toBe(true);
+    expect(result.code).toBe('REVIEW_GATE_READY');
+  });
+});
+
+describe('Phase Architecture v2 — Phase 2 preconditions', () => {
+  it('blocks Phase 2 without accepted_story_ledger_v1', () => {
+    const result = assertPhase2Preconditions(doneProgress, doneArtifacts);
+
+    expect(result.ok).toBe(false);
+    expect(result.gate_validity).toBe('gate_blocking');
+    expect(result.code).toBe('PHASE2_ACCEPTED_STORY_LEDGER_MISSING');
+  });
+
+  it('blocks Phase 2 when Pass 3A is missing/running/half-written/failed', () => {
+    for (const status of ['not_started', 'running', 'map_done', 'reduce_running', 'failed'] as const) {
+      const result = assertPhase2Preconditions(
+        { pass3a_status: status },
+        {
+          accepted_story_ledger_v1: artifact('accepted-ledger'),
+          pass3_preflight_draft_v1: artifact('preflight'),
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(['PASS3A_NOT_READY', 'PASS3A_HALF_WRITTEN', 'PASS3A_FAILED_BLOCKING']).toContain(result.code);
+    }
+  });
+
+  it('blocks Phase 2 when done lacks pass3_preflight_draft_v1', () => {
+    const result = assertPhase2Preconditions(doneProgress, {
+      accepted_story_ledger_v1: artifact('accepted-ledger'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_ARTIFACT_MISSING');
+  });
+
+  it('blocks Phase 2 when degraded lacks structured proof', () => {
+    const result = assertPhase2Preconditions(
+      { pass3a_status: 'degraded' },
+      { accepted_story_ledger_v1: artifact('accepted-ledger') },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_DEGRADED_PROOF_MISSING');
+  });
+
+  it('allows Phase 2 when accepted ledger and done preflight are valid', () => {
+    const result = assertPhase2Preconditions(doneProgress, {
+      accepted_story_ledger_v1: artifact('accepted-ledger'),
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.gate_validity).toBe('gate_valid');
+    expect(result.code).toBe('PHASE2_PRECONDITIONS_SATISFIED');
+  });
+
+  it('allows Phase 2 when accepted ledger and degraded preflight proof are valid', () => {
+    const result = assertPhase2Preconditions(degradedProgress, {
+      accepted_story_ledger_v1: artifact('accepted-ledger'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.gate_validity).toBe('gate_valid');
+    expect(result.code).toBe('PHASE2_PRECONDITIONS_SATISFIED');
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/gateValidity.ts
+++ b/lib/evaluation/phase-architecture-v2/gateValidity.ts
@@ -1,0 +1,230 @@
+export const PASS3A_STATUSES = [
+  'not_started',
+  'running',
+  'map_done',
+  'reduce_running',
+  'done',
+  'degraded',
+  'failed',
+] as const;
+
+export type Pass3AStatus = (typeof PASS3A_STATUSES)[number];
+
+export const PASS3A_GATE_VALIDITIES = [
+  'not_ready',
+  'gate_valid',
+  'gate_blocking',
+] as const;
+
+export type Pass3AGateValidity = (typeof PASS3A_GATE_VALIDITIES)[number];
+
+export type PhaseV2Progress = {
+  phase0_status?: string;
+  chunk_manifest_status?: string;
+  phase1a_status?: string;
+
+  pass3a_status?: Pass3AStatus;
+  pass3a_gate_validity?: Pass3AGateValidity;
+  pass3a_map_status?: 'not_started' | 'running' | 'done' | 'failed';
+  pass3a_reduce_status?: 'not_started' | 'running' | 'done' | 'failed' | 'skipped';
+
+  pass3a_artifact_id?: string;
+  pass3a_completed_at?: string;
+
+  degraded_reason?: string;
+  degraded_reason_codes?: string[];
+  degraded_at?: string;
+
+  failed_reason?: string;
+  failed_at?: string;
+
+  review_gate_ready?: boolean;
+};
+
+export type ArtifactRef = {
+  artifact_id?: string | null;
+  source_hash?: string | null;
+};
+
+export type PhaseV2ArtifactSet = {
+  pass1a_story_layer_v1?: ArtifactRef | null;
+  ledger_quality_report_v1?: ArtifactRef | null;
+  pass3_preflight_draft_v1?: ArtifactRef | null;
+  accepted_story_ledger_v1?: ArtifactRef | null;
+};
+
+export type GateDecision = {
+  ok: boolean;
+  gate_validity: Pass3AGateValidity;
+  reason: string;
+  code: string;
+};
+
+export type ReviewGateDecision = GateDecision & {
+  review_gate_ready: boolean;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasArtifactRef(ref: ArtifactRef | null | undefined): ref is Required<ArtifactRef> {
+  return isNonEmptyString(ref?.artifact_id) && isNonEmptyString(ref?.source_hash);
+}
+
+function hasStructuredDegradationProof(progress: PhaseV2Progress): boolean {
+  return (
+    isNonEmptyString(progress.degraded_reason) &&
+    Array.isArray(progress.degraded_reason_codes) &&
+    progress.degraded_reason_codes.some(isNonEmptyString) &&
+    isNonEmptyString(progress.degraded_at)
+  );
+}
+
+export function derivePass3aGateValidity(
+  progress: PhaseV2Progress = {},
+  artifacts: PhaseV2ArtifactSet = {},
+): GateDecision {
+  const status = progress.pass3a_status ?? 'not_started';
+
+  switch (status) {
+    case 'done': {
+      if (!hasArtifactRef(artifacts.pass3_preflight_draft_v1)) {
+        return {
+          ok: false,
+          gate_validity: 'gate_blocking',
+          reason: 'Pass 3A status is done but pass3_preflight_draft_v1 is missing or malformed.',
+          code: 'PASS3A_ARTIFACT_MISSING',
+        };
+      }
+
+      if (!isNonEmptyString(progress.pass3a_completed_at)) {
+        return {
+          ok: false,
+          gate_validity: 'gate_blocking',
+          reason: 'Pass 3A status is done but completion metadata is missing.',
+          code: 'PASS3A_COMPLETION_METADATA_MISSING',
+        };
+      }
+
+      return {
+        ok: true,
+        gate_validity: 'gate_valid',
+        reason: 'Pass 3A completed with a valid preflight artifact.',
+        code: 'PASS3A_DONE_GATE_VALID',
+      };
+    }
+
+    case 'degraded': {
+      if (!hasStructuredDegradationProof(progress)) {
+        return {
+          ok: false,
+          gate_validity: 'gate_blocking',
+          reason: 'Pass 3A status is degraded but structured degradation proof is missing.',
+          code: 'PASS3A_DEGRADED_PROOF_MISSING',
+        };
+      }
+
+      return {
+        ok: true,
+        gate_validity: 'gate_valid',
+        reason: 'Pass 3A degraded with structured proof.',
+        code: 'PASS3A_DEGRADED_GATE_VALID',
+      };
+    }
+
+    case 'failed':
+      return {
+        ok: false,
+        gate_validity: 'gate_blocking',
+        reason: 'Pass 3A failed and requires retry or operator intervention.',
+        code: 'PASS3A_FAILED_BLOCKING',
+      };
+
+    case 'running':
+    case 'map_done':
+    case 'reduce_running':
+      return {
+        ok: false,
+        gate_validity: 'not_ready',
+        reason: `Pass 3A is not terminal yet: ${status}.`,
+        code: 'PASS3A_HALF_WRITTEN',
+      };
+
+    case 'not_started':
+    default:
+      return {
+        ok: false,
+        gate_validity: 'not_ready',
+        reason: 'Pass 3A has not started.',
+        code: 'PASS3A_NOT_READY',
+      };
+  }
+}
+
+export function deriveReviewGateReadiness(
+  progress: PhaseV2Progress = {},
+  artifacts: PhaseV2ArtifactSet = {},
+): ReviewGateDecision {
+  if (!hasArtifactRef(artifacts.pass1a_story_layer_v1)) {
+    return {
+      ok: false,
+      review_gate_ready: false,
+      gate_validity: 'gate_blocking',
+      reason: 'pass1a_story_layer_v1 is required before Review Gate.',
+      code: 'REVIEW_GATE_STORY_LAYER_MISSING',
+    };
+  }
+
+  if (!hasArtifactRef(artifacts.ledger_quality_report_v1)) {
+    return {
+      ok: false,
+      review_gate_ready: false,
+      gate_validity: 'gate_blocking',
+      reason: 'ledger_quality_report_v1 is required before Review Gate.',
+      code: 'REVIEW_GATE_QUALITY_REPORT_MISSING',
+    };
+  }
+
+  const pass3aDecision = derivePass3aGateValidity(progress, artifacts);
+  if (!pass3aDecision.ok) {
+    return {
+      ...pass3aDecision,
+      review_gate_ready: false,
+    };
+  }
+
+  return {
+    ok: true,
+    review_gate_ready: true,
+    gate_validity: 'gate_valid',
+    reason: 'Review Gate is ready: Story Layer, quality report, and Pass 3A are gate-valid.',
+    code: 'REVIEW_GATE_READY',
+  };
+}
+
+export function assertPhase2Preconditions(
+  progress: PhaseV2Progress = {},
+  artifacts: PhaseV2ArtifactSet = {},
+): GateDecision {
+  if (!hasArtifactRef(artifacts.accepted_story_ledger_v1)) {
+    return {
+      ok: false,
+      gate_validity: 'gate_blocking',
+      reason: 'accepted_story_ledger_v1 is required before Phase 2.',
+      code: 'PHASE2_ACCEPTED_STORY_LEDGER_MISSING',
+    };
+  }
+
+  const pass3aDecision = derivePass3aGateValidity(progress, artifacts);
+  if (!pass3aDecision.ok) {
+    return pass3aDecision;
+  }
+
+  return {
+    ok: true,
+    gate_validity: 'gate_valid',
+    reason: 'Phase 2 preconditions satisfied.',
+    code: 'PHASE2_PRECONDITIONS_SATISFIED',
+  };
+}


### PR DESCRIPTION
## Summary

Implements the support-layer requested by #732.

Adds pure helpers for Phase Architecture v2 gate validity:

- `derivePass3aGateValidity(progress, artifacts)`
- `deriveReviewGateReadiness(progress, artifacts)`
- `assertPhase2Preconditions(progress, artifacts)`

Adds unit coverage for the critical contract:

- failed Pass 3A is never gate-valid
- degraded Pass 3A is gate-valid only with structured proof
- done Pass 3A requires `pass3_preflight_draft_v1` plus completion metadata
- Review Gate requires Story Layer + quality report + Pass 3A gate validity
- Phase 2 blocks missing/running/half-written/failed Pass 3A

## Scope

This PR is intentionally support-layer only.

It does **not**:

- split Track C runtime
- alter scoring
- alter synthesis
- alter WAVE
- rename Quality Gate
- change processor/runtime behavior

## Files

- `lib/evaluation/phase-architecture-v2/gateValidity.ts`
- `__tests__/evaluation/phaseV2GateValidity.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/phaseV2GateValidity.test.ts --runInBand
```

## Closes

Closes #732