### PR TITLE
feat: harden Review Gate handoff with Pass 3A readiness

### DIFF
--- a/.github/pr-bodies/PR-739.md
+++ b/.github/pr-bodies/PR-739.md
@@ -1,0 +1,43 @@
+## Summary
+
+Implements the next surgical layer for #733 as a stacked follow-up to #738.
+
+Adds a pure Review Gate handoff helper that can only produce a reviewable `review_gate` handoff when all Phase Architecture v2 conditions are satisfied:
+
+- `pass1a_story_layer_v1` exists
+- `ledger_quality_report_v1` exists
+- Pass 3A is terminal-and-gate-valid
+
+Adds tests proving Review Gate handoff blocks when Pass 3A is missing, running, half-written, failed, done-without-artifact, or degraded-without-proof.
+
+## Scope
+
+This PR is still intentionally narrow.
+
+It does **not**:
+
+- extract Track C runtime
+- alter scoring
+- alter synthesis
+- alter WAVE
+- rename Quality Gate
+- modify processor runtime behavior directly
+
+## Depends on
+
+- #738
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/reviewGateHandoff.ts`
+- `__tests__/evaluation/reviewGate.phaseV2Handoff.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/reviewGate.phaseV2Handoff.test.ts --runInBand
+```
+
+## Closes
+
+Closes #733

--- a/__tests__/evaluation/reviewGate.phaseV2Handoff.test.ts
+++ b/__tests__/evaluation/reviewGate.phaseV2Handoff.test.ts
@@ -1,0 +1,128 @@
+import { buildReviewGateHandoff } from '../../lib/evaluation/phase-architecture-v2/reviewGateHandoff';
+import type { PhaseV2ArtifactSet, PhaseV2Progress } from '../../lib/evaluation/phase-architecture-v2/gateValidity';
+
+const artifact = (id: string) => ({ artifact_id: id, source_hash: `sha256:${id}` });
+
+const storyArtifacts: PhaseV2ArtifactSet = {
+  pass1a_story_layer_v1: artifact('story-layer'),
+  ledger_quality_report_v1: artifact('quality-report'),
+};
+
+const doneProgress: PhaseV2Progress = {
+  pass3a_status: 'done',
+  pass3a_completed_at: '2026-05-26T00:00:00.000Z',
+};
+
+const doneArtifacts: PhaseV2ArtifactSet = {
+  ...storyArtifacts,
+  pass3_preflight_draft_v1: artifact('preflight'),
+};
+
+const degradedProgress: PhaseV2Progress = {
+  pass3a_status: 'degraded',
+  degraded_reason: 'PASS3A_REDUCE_TIMEOUT',
+  degraded_reason_codes: ['PASS3A_REDUCE_TIMEOUT'],
+  degraded_at: '2026-05-26T00:00:00.000Z',
+};
+
+describe('Phase Architecture v2 — Review Gate handoff helper', () => {
+  it('builds a queued review_gate handoff only when Story Layer, quality report, and done Pass 3A are valid', () => {
+    const result = buildReviewGateHandoff(doneProgress, doneArtifacts);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected Review Gate handoff to be ready');
+
+    expect(result.handoff.status).toBe('queued');
+    expect(result.handoff.phase).toBe('review_gate');
+    expect(result.handoff.phase_status).toBe('awaiting_approval');
+    expect(result.handoff.progress.review_gate_ready).toBe(true);
+    expect(result.handoff.progress.gate_ready_status).toBe('reviewable');
+    expect(result.handoff.progress.story_layer_artifact_id).toBe('story-layer');
+    expect(result.handoff.progress.quality_report_artifact_id).toBe('quality-report');
+    expect(result.handoff.progress.pass3a_status).toBe('done');
+    expect(result.handoff.progress.pass3a_artifact_id).toBe('preflight');
+  });
+
+  it('builds a queued review_gate handoff when Pass 3A is degraded with structured proof', () => {
+    const result = buildReviewGateHandoff(degradedProgress, storyArtifacts);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected degraded Pass 3A to be gate-valid');
+
+    expect(result.handoff.status).toBe('queued');
+    expect(result.handoff.phase).toBe('review_gate');
+    expect(result.handoff.progress.review_gate_ready).toBe(true);
+    expect(result.handoff.progress.pass3a_status).toBe('degraded');
+    expect(result.handoff.progress.pass3a_degraded_reason).toBe('PASS3A_REDUCE_TIMEOUT');
+    expect(result.handoff.progress.pass3a_artifact_id).toBeUndefined();
+  });
+
+  it('blocks handoff without pass1a_story_layer_v1', () => {
+    const result = buildReviewGateHandoff(doneProgress, {
+      ledger_quality_report_v1: artifact('quality-report'),
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected Review Gate handoff to block');
+
+    expect(result.blocked.status).toBe('blocked');
+    expect(result.blocked.progress.review_gate_ready).toBe(false);
+    expect(result.blocked.progress.gate_ready_status).toBe('blocked');
+    expect(result.blocked.progress.block_code).toBe('REVIEW_GATE_STORY_LAYER_MISSING');
+  });
+
+  it('blocks handoff without ledger_quality_report_v1', () => {
+    const result = buildReviewGateHandoff(doneProgress, {
+      pass1a_story_layer_v1: artifact('story-layer'),
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected Review Gate handoff to block');
+
+    expect(result.blocked.progress.review_gate_ready).toBe(false);
+    expect(result.blocked.progress.block_code).toBe('REVIEW_GATE_QUALITY_REPORT_MISSING');
+  });
+
+  it('blocks handoff when Pass 3A is missing/running/half-written/failed', () => {
+    for (const status of ['not_started', 'running', 'map_done', 'reduce_running', 'failed'] as const) {
+      const result = buildReviewGateHandoff(
+        { pass3a_status: status },
+        {
+          ...storyArtifacts,
+          pass3_preflight_draft_v1: artifact('preflight'),
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error(`Expected ${status} Pass 3A to block`);
+
+      expect(result.blocked.progress.review_gate_ready).toBe(false);
+      expect(result.blocked.progress.pass3a_status).toBe(status);
+      expect(['PASS3A_NOT_READY', 'PASS3A_HALF_WRITTEN', 'PASS3A_FAILED_BLOCKING']).toContain(
+        result.blocked.progress.block_code,
+      );
+    }
+  });
+
+  it('blocks handoff when done Pass 3A lacks pass3_preflight_draft_v1', () => {
+    const result = buildReviewGateHandoff(doneProgress, storyArtifacts);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected missing preflight artifact to block');
+
+    expect(result.blocked.progress.block_code).toBe('PASS3A_ARTIFACT_MISSING');
+    expect(result.blocked.progress.hard_fail_present).toBe(true);
+  });
+
+  it('blocks handoff when degraded Pass 3A lacks structured proof', () => {
+    const result = buildReviewGateHandoff({ pass3a_status: 'degraded' }, storyArtifacts);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected degraded without proof to block');
+
+    expect(result.blocked.progress.block_code).toBe('PASS3A_DEGRADED_PROOF_MISSING');
+    expect(result.blocked.progress.hard_fail_present).toBe(true);
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/reviewGateHandoff.ts
+++ b/lib/evaluation/phase-architecture-v2/reviewGateHandoff.ts
@@ -1,0 +1,108 @@
+import {
+  deriveReviewGateReadiness,
+  type PhaseV2ArtifactSet,
+  type PhaseV2Progress,
+  type ReviewGateDecision,
+} from './gateValidity';
+
+export type ReviewGateHandoff = {
+  status: 'queued';
+  phase: 'review_gate';
+  phase_status: 'awaiting_approval';
+  progress: {
+    phase: 'phase_1a';
+    phase_status: 'awaiting_approval';
+    message: string;
+    gate_ready_status: 'reviewable';
+    review_gate_ready: true;
+    hard_fail_present: false;
+    story_layer_artifact_id: string;
+    quality_report_artifact_id: string;
+    pass3a_gate_validity: 'gate_valid';
+    pass3a_status: 'done' | 'degraded';
+    pass3a_artifact_id?: string;
+    pass3a_degraded_reason?: string;
+  };
+};
+
+export type ReviewGateBlocked = {
+  status: 'blocked';
+  review_gate_ready: false;
+  decision: ReviewGateDecision;
+  progress: {
+    phase: 'phase_1a';
+    phase_status: 'blocked';
+    message: string;
+    gate_ready_status: 'blocked';
+    review_gate_ready: false;
+    hard_fail_present: boolean;
+    block_code: string;
+    block_reason: string;
+    pass3a_gate_validity: ReviewGateDecision['gate_validity'];
+    pass3a_status?: PhaseV2Progress['pass3a_status'];
+  };
+};
+
+export type ReviewGateHandoffResult =
+  | { ok: true; handoff: ReviewGateHandoff; decision: ReviewGateDecision }
+  | { ok: false; blocked: ReviewGateBlocked };
+
+function artifactId(ref: { artifact_id?: string | null } | null | undefined): string {
+  return ref?.artifact_id ?? '';
+}
+
+export function buildReviewGateHandoff(
+  progress: PhaseV2Progress = {},
+  artifacts: PhaseV2ArtifactSet = {},
+): ReviewGateHandoffResult {
+  const decision = deriveReviewGateReadiness(progress, artifacts);
+
+  if (!decision.ok) {
+    return {
+      ok: false,
+      blocked: {
+        status: 'blocked',
+        review_gate_ready: false,
+        decision,
+        progress: {
+          phase: 'phase_1a',
+          phase_status: 'blocked',
+          message: `Review Gate blocked: ${decision.reason}`,
+          gate_ready_status: 'blocked',
+          review_gate_ready: false,
+          hard_fail_present: decision.gate_validity === 'gate_blocking',
+          block_code: decision.code,
+          block_reason: decision.reason,
+          pass3a_gate_validity: decision.gate_validity,
+          pass3a_status: progress.pass3a_status,
+        },
+      },
+    };
+  }
+
+  const pass3aStatus = progress.pass3a_status === 'degraded' ? 'degraded' : 'done';
+
+  return {
+    ok: true,
+    decision,
+    handoff: {
+      status: 'queued',
+      phase: 'review_gate',
+      phase_status: 'awaiting_approval',
+      progress: {
+        phase: 'phase_1a',
+        phase_status: 'awaiting_approval',
+        message: 'Phase 1A complete — Story Layer, quality report, and Pass 3A preflight are ready for Review Gate',
+        gate_ready_status: 'reviewable',
+        review_gate_ready: true,
+        hard_fail_present: false,
+        story_layer_artifact_id: artifactId(artifacts.pass1a_story_layer_v1),
+        quality_report_artifact_id: artifactId(artifacts.ledger_quality_report_v1),
+        pass3a_gate_validity: 'gate_valid',
+        pass3a_status: pass3aStatus,
+        pass3a_artifact_id: artifactId(artifacts.pass3_preflight_draft_v1) || undefined,
+        pass3a_degraded_reason: pass3aStatus === 'degraded' ? progress.degraded_reason : undefined,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements the next surgical layer for #733 as a stacked follow-up to #738.

Adds a pure Review Gate handoff helper that can only produce a reviewable `review_gate` handoff when all Phase Architecture v2 conditions are satisfied:

- `pass1a_story_layer_v1` exists
- `ledger_quality_report_v1` exists
- Pass 3A is terminal-and-gate-valid

Adds tests proving Review Gate handoff blocks when Pass 3A is missing, running, half-written, failed, done-without-artifact, or degraded-without-proof.

## Scope

This PR is still intentionally narrow.

It does **not**:

- extract Track C runtime
- alter scoring
- alter synthesis
- alter WAVE
- rename Quality Gate
- modify processor runtime behavior directly

## Depends on

- #738

## Files

- `lib/evaluation/phase-architecture-v2/reviewGateHandoff.ts`
- `__tests__/evaluation/reviewGate.phaseV2Handoff.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/reviewGate.phaseV2Handoff.test.ts --runInBand
```

## Closes

Closes #733