### PR TITLE
feat: add Phase 2 Pass 3A guard helper

### DIFF
--- a/.github/pr-bodies/PR-740.md
+++ b/.github/pr-bodies/PR-740.md
@@ -1,0 +1,58 @@
+## Summary
+
+Implements the next support-layer for #734.
+
+Adds a pure Phase 2 guard helper:
+
+- `guardPhase2Start(progress, artifacts)`
+
+The helper wraps the Phase v2 preconditions and returns a runtime-friendly result with a progress patch:
+
+- `phase2_preflight_gate='passed' | 'blocked'`
+- explicit block/pass code
+- explicit reason
+- Pass 3A gate validity
+
+## What it proves
+
+Phase 2 is blocked unless:
+
+- `accepted_story_ledger_v1` exists
+- Pass 3A is terminal-and-gate-valid
+
+Blocked states include:
+
+- missing Pass 3A
+- running/map_done/reduce_running Pass 3A
+- failed Pass 3A
+- done without `pass3_preflight_draft_v1`
+- done without completion metadata
+- degraded without structured proof
+
+## Scope
+
+This PR is intentionally support-layer only.
+
+It does **not**:
+
+- wire the guard into processor runtime yet
+- extract Track C runtime
+- alter scoring
+- alter synthesis
+- alter WAVE
+- rename Quality Gate
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/phase2Guard.ts`
+- `__tests__/evaluation/phase2.phaseV2Guard.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/phase2.phaseV2Guard.test.ts --runInBand
+```
+
+## Closes
+
+Closes #734

--- a/__tests__/evaluation/phase2.phaseV2Guard.test.ts
+++ b/__tests__/evaluation/phase2.phaseV2Guard.test.ts
@@ -1,0 +1,105 @@
+import { guardPhase2Start } from '../../lib/evaluation/phase-architecture-v2/phase2Guard';
+import type { PhaseV2ArtifactSet, PhaseV2Progress } from '../../lib/evaluation/phase-architecture-v2/gateValidity';
+
+const artifact = (id: string) => ({ artifact_id: id, source_hash: `sha256:${id}` });
+
+const acceptedArtifacts: PhaseV2ArtifactSet = {
+  accepted_story_ledger_v1: artifact('accepted-ledger'),
+};
+
+const doneProgress: PhaseV2Progress = {
+  pass3a_status: 'done',
+  pass3a_completed_at: '2026-05-26T00:00:00.000Z',
+};
+
+const degradedProgress: PhaseV2Progress = {
+  pass3a_status: 'degraded',
+  degraded_reason: 'PASS3A_REDUCE_TIMEOUT',
+  degraded_reason_codes: ['PASS3A_REDUCE_TIMEOUT'],
+  degraded_at: '2026-05-26T00:00:00.000Z',
+};
+
+describe('Phase Architecture v2 — Phase 2 guard helper', () => {
+  it('blocks Phase 2 without accepted_story_ledger_v1', () => {
+    const result = guardPhase2Start(doneProgress, {
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.can_start_phase2).toBe(false);
+    expect(result.progress_patch.phase2_preflight_gate).toBe('blocked');
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('PHASE2_ACCEPTED_STORY_LEDGER_MISSING');
+  });
+
+  it('blocks Phase 2 for missing/running/half-written/failed Pass 3A', () => {
+    for (const status of ['not_started', 'running', 'map_done', 'reduce_running', 'failed'] as const) {
+      const result = guardPhase2Start(
+        { pass3a_status: status },
+        {
+          ...acceptedArtifacts,
+          pass3_preflight_draft_v1: artifact('preflight'),
+        },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.can_start_phase2).toBe(false);
+      expect(result.progress_patch.phase2_preflight_gate).toBe('blocked');
+      expect(['PASS3A_NOT_READY', 'PASS3A_HALF_WRITTEN', 'PASS3A_FAILED_BLOCKING']).toContain(
+        result.progress_patch.phase2_preflight_gate_code,
+      );
+    }
+  });
+
+  it('blocks Phase 2 when done lacks pass3_preflight_draft_v1', () => {
+    const result = guardPhase2Start(doneProgress, acceptedArtifacts);
+
+    expect(result.ok).toBe(false);
+    expect(result.can_start_phase2).toBe(false);
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('PASS3A_ARTIFACT_MISSING');
+    expect(result.progress_patch.pass3a_gate_validity).toBe('gate_blocking');
+  });
+
+  it('blocks Phase 2 when done lacks completion metadata', () => {
+    const result = guardPhase2Start(
+      { pass3a_status: 'done' },
+      {
+        ...acceptedArtifacts,
+        pass3_preflight_draft_v1: artifact('preflight'),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.can_start_phase2).toBe(false);
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('PASS3A_COMPLETION_METADATA_MISSING');
+  });
+
+  it('blocks Phase 2 when degraded lacks structured proof', () => {
+    const result = guardPhase2Start({ pass3a_status: 'degraded' }, acceptedArtifacts);
+
+    expect(result.ok).toBe(false);
+    expect(result.can_start_phase2).toBe(false);
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('PASS3A_DEGRADED_PROOF_MISSING');
+  });
+
+  it('allows Phase 2 when accepted ledger and done preflight are valid', () => {
+    const result = guardPhase2Start(doneProgress, {
+      ...acceptedArtifacts,
+      pass3_preflight_draft_v1: artifact('preflight'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.can_start_phase2).toBe(true);
+    expect(result.progress_patch.phase2_preflight_gate).toBe('passed');
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('PHASE2_PRECONDITIONS_SATISFIED');
+    expect(result.progress_patch.pass3a_gate_validity).toBe('gate_valid');
+  });
+
+  it('allows Phase 2 when accepted ledger and degraded preflight proof are valid', () => {
+    const result = guardPhase2Start(degradedProgress, acceptedArtifacts);
+
+    expect(result.ok).toBe(true);
+    expect(result.can_start_phase2).toBe(true);
+    expect(result.progress_patch.phase2_preflight_gate).toBe('passed');
+    expect(result.progress_patch.pass3a_gate_validity).toBe('gate_valid');
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/phase2Guard.ts
+++ b/lib/evaluation/phase-architecture-v2/phase2Guard.ts
@@ -1,0 +1,69 @@
+import {
+  assertPhase2Preconditions,
+  type GateDecision,
+  type PhaseV2ArtifactSet,
+  type PhaseV2Progress,
+} from './gateValidity';
+
+export type Phase2GuardResult =
+  | {
+      ok: true;
+      can_start_phase2: true;
+      decision: GateDecision;
+      progress_patch: {
+        phase2_preflight_gate: 'passed';
+        phase2_preflight_gate_code: 'PHASE2_PRECONDITIONS_SATISFIED';
+        phase2_preflight_gate_reason: string;
+        pass3a_gate_validity: 'gate_valid';
+      };
+    }
+  | {
+      ok: false;
+      can_start_phase2: false;
+      decision: GateDecision;
+      progress_patch: {
+        phase2_preflight_gate: 'blocked';
+        phase2_preflight_gate_code: string;
+        phase2_preflight_gate_reason: string;
+        pass3a_gate_validity: GateDecision['gate_validity'];
+      };
+    };
+
+/**
+ * Phase Architecture v2 Phase 2 entry guard.
+ *
+ * This helper is intentionally pure. Runtime callers can use it before moving a
+ * job into Phase 2 without importing scoring, synthesis, worker, or WAVE logic.
+ */
+export function guardPhase2Start(
+  progress: PhaseV2Progress = {},
+  artifacts: PhaseV2ArtifactSet = {},
+): Phase2GuardResult {
+  const decision = assertPhase2Preconditions(progress, artifacts);
+
+  if (!decision.ok) {
+    return {
+      ok: false,
+      can_start_phase2: false,
+      decision,
+      progress_patch: {
+        phase2_preflight_gate: 'blocked',
+        phase2_preflight_gate_code: decision.code,
+        phase2_preflight_gate_reason: decision.reason,
+        pass3a_gate_validity: decision.gate_validity,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    can_start_phase2: true,
+    decision,
+    progress_patch: {
+      phase2_preflight_gate: 'passed',
+      phase2_preflight_gate_code: 'PHASE2_PRECONDITIONS_SATISFIED',
+      phase2_preflight_gate_reason: decision.reason,
+      pass3a_gate_validity: 'gate_valid',
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements the next support-layer for #734.

Adds a pure Phase 2 guard helper:

- `guardPhase2Start(progress, artifacts)`

The helper wraps the Phase v2 preconditions and returns a runtime-friendly result with a progress patch:

- `phase2_preflight_gate='passed' | 'blocked'`
- explicit block/pass code
- explicit reason
- Pass 3A gate validity

## What it proves

Phase 2 is blocked unless:

- `accepted_story_ledger_v1` exists
- Pass 3A is terminal-and-gate-valid

Blocked states include:

- missing Pass 3A
- running/map_done/reduce_running Pass 3A
- failed Pass 3A
- done without `pass3_preflight_draft_v1`
- done without completion metadata
- degraded without structured proof

## Scope

This PR is intentionally support-layer only.

It does **not**:

- wire the guard into processor runtime yet
- extract Track C runtime
- alter scoring
- alter synthesis
- alter WAVE
- rename Quality Gate

## Files

- `lib/evaluation/phase-architecture-v2/phase2Guard.ts`
- `__tests__/evaluation/phase2.phaseV2Guard.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/phase2.phaseV2Guard.test.ts --runInBand
```

## Closes

Closes #734