### PR TITLE
feat: add Phase v2 progress labels

### DIFF
--- a/.github/pr-bodies/PR-741.md
+++ b/.github/pr-bodies/PR-741.md
@@ -1,0 +1,48 @@
+## Summary
+
+Adds canonical Phase Architecture v2 labels/constants for #736.
+
+This gives UI, logs, telemetry, and progress components a single import target instead of hand-typed labels.
+
+## Adds
+
+- `PHASE_V2_PROGRESS_LADDER`
+- `PHASE_V2_RUNTIME_LABELS`
+- `PHASE_V2_LOG_EVENTS`
+- `PHASE_V2_NAMING_RULES`
+
+## What this protects
+
+- Pass 3A is not Phase 0.
+- Phase 1A Story Layer is distinct from Pass 3A MAP/REDUCE.
+- Quality Gate is distinct from WAVE Revision.
+- Failed Pass 3A is visibly blocking.
+- Degraded Pass 3A is visibly degraded, not complete.
+
+## Scope
+
+This is constants/tests only.
+
+It does **not**:
+
+- change UI rendering yet
+- change logs yet
+- alter runtime behavior
+- alter scoring
+- alter synthesis
+- alter WAVE
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/progressLabels.ts`
+- `__tests__/evaluation/phaseV2ProgressLabels.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/phaseV2ProgressLabels.test.ts --runInBand
+```
+
+## Related
+
+Part of #736

--- a/__tests__/evaluation/phaseV2ProgressLabels.test.ts
+++ b/__tests__/evaluation/phaseV2ProgressLabels.test.ts
@@ -1,0 +1,51 @@
+import {
+  PHASE_V2_LOG_EVENTS,
+  PHASE_V2_NAMING_RULES,
+  PHASE_V2_PROGRESS_LADDER,
+  PHASE_V2_RUNTIME_LABELS,
+} from '../../lib/evaluation/phase-architecture-v2/progressLabels';
+
+describe('Phase Architecture v2 — progress labels and naming rules', () => {
+  it('contains the canonical progress ladder percentages', () => {
+    expect(PHASE_V2_PROGRESS_LADDER).toEqual([
+      { key: 'queued', label: 'Queued', percent: 2 },
+      { key: 'phase_0_calibrating', label: 'Phase 0 calibrating', percent: 5 },
+      { key: 'chunk_routing', label: 'Chunk routing / manuscript prep', percent: 10 },
+      { key: 'parallel_reading', label: 'Phase 1A + Preflight reading in parallel', percentRange: [15, 40] },
+      { key: 'reduce_and_assembly', label: '3A REDUCE + Story Layer assembly', percentRange: [42, 47] },
+      { key: 'review_gate', label: 'Review Gate', percent: 50 },
+      { key: 'phase_2_criteria', label: 'Phase 2 criteria analysis', percentRange: [60, 75] },
+      { key: 'phase_3b_synthesis', label: 'Phase 3B synthesis', percentRange: [80, 92] },
+      { key: 'dream_longform', label: 'DREAM longform', percentRange: [95, 99] },
+      { key: 'complete', label: 'Complete', percent: 100 },
+    ]);
+  });
+
+  it('distinguishes Phase 1A Story Layer from Pass 3A MAP/REDUCE labels', () => {
+    expect(PHASE_V2_RUNTIME_LABELS.phase1aStoryLayerReading).toBe('Phase 1A Story Layer reading');
+    expect(PHASE_V2_RUNTIME_LABELS.pass3aMapReading).toBe('Pass 3A MAP reading');
+    expect(PHASE_V2_RUNTIME_LABELS.pass3aReduce).toBe('Pass 3A REDUCE');
+  });
+
+  it('keeps Quality Gate and WAVE Revision separate', () => {
+    expect(PHASE_V2_RUNTIME_LABELS.qualityGate).toBe('Quality Gate');
+    expect(PHASE_V2_RUNTIME_LABELS.waveRevision).toBe('WAVE Revision');
+    expect(PHASE_V2_RUNTIME_LABELS.qualityGate).not.toBe(PHASE_V2_RUNTIME_LABELS.waveRevision);
+  });
+
+  it('declares explicit lifecycle log event names', () => {
+    expect(PHASE_V2_LOG_EVENTS.pass3aMapStarted).toBe('pass3a_map_started');
+    expect(PHASE_V2_LOG_EVENTS.pass3aReduceCompleted).toBe('pass3a_reduce_completed');
+    expect(PHASE_V2_LOG_EVENTS.reviewGateBlocked).toBe('review_gate_blocked');
+    expect(PHASE_V2_LOG_EVENTS.phase2Blocked).toBe('phase2_blocked');
+    expect(PHASE_V2_LOG_EVENTS.qualityGateStarted).toBe('quality_gate_started');
+    expect(PHASE_V2_LOG_EVENTS.waveRevisionStarted).toBe('wave_revision_started');
+  });
+
+  it('captures the hard naming rules', () => {
+    expect(PHASE_V2_NAMING_RULES).toContain('Pass 3A is never Phase 0.');
+    expect(PHASE_V2_NAMING_RULES).toContain('Quality Gate is never WAVE.');
+    expect(PHASE_V2_NAMING_RULES).toContain('Failed Pass 3A must be visibly blocking.');
+    expect(PHASE_V2_NAMING_RULES).toContain('Degraded Pass 3A must be visibly degraded, not complete.');
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/progressLabels.ts
+++ b/lib/evaluation/phase-architecture-v2/progressLabels.ts
@@ -1,0 +1,64 @@
+export const PHASE_V2_PROGRESS_LADDER = [
+  { key: 'queued', label: 'Queued', percent: 2 },
+  { key: 'phase_0_calibrating', label: 'Phase 0 calibrating', percent: 5 },
+  { key: 'chunk_routing', label: 'Chunk routing / manuscript prep', percent: 10 },
+  { key: 'parallel_reading', label: 'Phase 1A + Preflight reading in parallel', percentRange: [15, 40] as const },
+  { key: 'reduce_and_assembly', label: '3A REDUCE + Story Layer assembly', percentRange: [42, 47] as const },
+  { key: 'review_gate', label: 'Review Gate', percent: 50 },
+  { key: 'phase_2_criteria', label: 'Phase 2 criteria analysis', percentRange: [60, 75] as const },
+  { key: 'phase_3b_synthesis', label: 'Phase 3B synthesis', percentRange: [80, 92] as const },
+  { key: 'dream_longform', label: 'DREAM longform', percentRange: [95, 99] as const },
+  { key: 'complete', label: 'Complete', percent: 100 },
+] as const;
+
+export type PhaseV2ProgressLadderKey = (typeof PHASE_V2_PROGRESS_LADDER)[number]['key'];
+
+export const PHASE_V2_RUNTIME_LABELS = {
+  queued: 'Queued',
+  phase0Calibrating: 'Phase 0 calibrating',
+  chunkRouting: 'Chunk routing / manuscript prep',
+  phase1aStoryLayerReading: 'Phase 1A Story Layer reading',
+  pass3aMapReading: 'Pass 3A MAP reading',
+  pass3aReduce: 'Pass 3A REDUCE',
+  reviewGate: 'Review Gate',
+  phase2CriteriaAnalysis: 'Phase 2 Criteria Analysis',
+  phase3bSynthesis: 'Phase 3B Synthesis',
+  qualityGate: 'Quality Gate',
+  waveRevision: 'WAVE Revision',
+  dreamLongform: 'DREAM longform',
+  complete: 'Complete',
+} as const;
+
+export type PhaseV2RuntimeLabelKey = keyof typeof PHASE_V2_RUNTIME_LABELS;
+
+export const PHASE_V2_LOG_EVENTS = {
+  phase0Started: 'phase0_started',
+  phase0Completed: 'phase0_completed',
+  chunkRoutingManifestReady: 'chunk_routing_manifest_ready',
+  phase1aStoryLayerStarted: 'phase1a_story_layer_started',
+  phase1aStoryLayerCompleted: 'phase1a_story_layer_completed',
+  pass3aMapStarted: 'pass3a_map_started',
+  pass3aMapCompleted: 'pass3a_map_completed',
+  pass3aReduceStarted: 'pass3a_reduce_started',
+  pass3aReduceCompleted: 'pass3a_reduce_completed',
+  pass3aDegraded: 'pass3a_degraded',
+  pass3aFailed: 'pass3a_failed',
+  reviewGateReady: 'review_gate_ready',
+  reviewGateBlocked: 'review_gate_blocked',
+  phase2Started: 'phase2_started',
+  phase2Blocked: 'phase2_blocked',
+  phase3bStarted: 'phase3b_started',
+  qualityGateStarted: 'quality_gate_started',
+  waveRevisionStarted: 'wave_revision_started',
+} as const;
+
+export type PhaseV2LogEventKey = keyof typeof PHASE_V2_LOG_EVENTS;
+
+export const PHASE_V2_NAMING_RULES = [
+  'Pass 3A is never Phase 0.',
+  'Pass 3A is never hidden inside generic Phase 1A labels once Track C is split.',
+  'Quality Gate is never WAVE.',
+  'WAVE is never Pass 4 unless a full repo-wide rename retires old Pass 4 Quality Gate usage.',
+  'Failed Pass 3A must be visibly blocking.',
+  'Degraded Pass 3A must be visibly degraded, not complete.',
+] as const;


### PR DESCRIPTION
## Summary

Adds canonical Phase Architecture v2 labels/constants for #736.

This gives UI, logs, telemetry, and progress components a single import target instead of hand-typed labels.

## Adds

- `PHASE_V2_PROGRESS_LADDER`
- `PHASE_V2_RUNTIME_LABELS`
- `PHASE_V2_LOG_EVENTS`
- `PHASE_V2_NAMING_RULES`

## What this protects

- Pass 3A is not Phase 0.
- Phase 1A Story Layer is distinct from Pass 3A MAP/REDUCE.
- Quality Gate is distinct from WAVE Revision.
- Failed Pass 3A is visibly blocking.
- Degraded Pass 3A is visibly degraded, not complete.

## Scope

This is constants/tests only.

It does **not**:

- change UI rendering yet
- change logs yet
- alter runtime behavior
- alter scoring
- alter synthesis
- alter WAVE

## Files

- `lib/evaluation/phase-architecture-v2/progressLabels.ts`
- `__tests__/evaluation/phaseV2ProgressLabels.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/phaseV2ProgressLabels.test.ts --runInBand
```

## Related

Part of #736