### PR TITLE
feat: add WAVE revision proof contract

### DIFF
--- a/.github/pr-bodies/PR-743.md
+++ b/.github/pr-bodies/PR-743.md
@@ -1,0 +1,50 @@
+## Summary
+
+Adds a Phase Architecture v2 proof helper for WAVE Revision.
+
+This does not run WAVE and does not change WAVE runtime behavior. It validates whether the post-evaluation WAVE phase produced an explicit proof state and keeps naming separate:
+
+- Quality Gate = deterministic validation
+- WAVE Revision = post-evaluation revision planning
+
+## Adds
+
+- `deriveWaveRevisionProof(plan, runRecord)`
+- Tests for complete, skipped, timeout, failed, missing, and status-mismatch proof states
+
+## What this protects
+
+- WAVE must not silently no-op.
+- Complete WAVE proof requires modules, revision session, and passed WAVE gate metadata.
+- Skipped WAVE proof requires reason codes and failed WAVE gate result.
+- Timeout is explicit/retryable but not a successful proof.
+- Failed WAVE is blocking.
+- WAVE is not Quality Gate.
+
+## Scope
+
+This is proof-contract only.
+
+It does **not**:
+
+- wire WAVE into processor runtime
+- change WAVE eligibility
+- change WAVE execution
+- alter scoring
+- alter synthesis
+- rename Quality Gate
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/waveRevisionProof.ts`
+- `__tests__/evaluation/waveRevisionProof.phaseV2.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/waveRevisionProof.phaseV2.test.ts --runInBand
+```
+
+## Related
+
+Part of #737

--- a/__tests__/evaluation/waveRevisionProof.phaseV2.test.ts
+++ b/__tests__/evaluation/waveRevisionProof.phaseV2.test.ts
@@ -1,0 +1,129 @@
+import { deriveWaveRevisionProof } from '../../lib/evaluation/phase-architecture-v2/waveRevisionProof';
+import type { WaveRevisionPlanArtifact, WaveRunRecord } from '../../lib/evaluation/waveRevision';
+
+const generatedAt = '2026-05-26T00:00:00.000Z';
+
+function run(status: WaveRunRecord['status'], overrides: Partial<WaveRunRecord> = {}): WaveRunRecord {
+  return {
+    job_id: 'job-1',
+    status,
+    gate_result: { passed: status === 'complete', reasons: status === 'complete' ? [] : ['WORD_COUNT_BELOW_THRESHOLD'] },
+    duration_ms: 123,
+    generated_at: generatedAt,
+    ...overrides,
+  };
+}
+
+function plan(status: WaveRevisionPlanArtifact['status'], overrides: Partial<WaveRevisionPlanArtifact> = {}): WaveRevisionPlanArtifact {
+  return {
+    status,
+    generated_at: generatedAt,
+    ...overrides,
+  };
+}
+
+describe('Phase Architecture v2 — WAVE Revision proof', () => {
+  it('requires both plan and run metadata', () => {
+    const result = deriveWaveRevisionProof(null, null);
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('missing');
+    expect(result.code).toBe('WAVE_PROOF_MISSING');
+    expect(result.quality_gate_label).toBe('Quality Gate');
+    expect(result.wave_label).toBe('WAVE Revision');
+  });
+
+  it('fails when plan and run statuses disagree', () => {
+    const result = deriveWaveRevisionProof(plan('complete'), run('skipped'));
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('WAVE_PROOF_STATUS_MISMATCH');
+  });
+
+  it('accepts complete WAVE proof with modules, revision session, and passed gate', () => {
+    const result = deriveWaveRevisionProof(
+      plan('complete', {
+        modules_run: 3,
+        revision_session_id: 'session-1',
+      }),
+      run('complete', {
+        modules_run: 3,
+        gate_result: { passed: true, reasons: [] },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('complete');
+    expect(result.code).toBe('WAVE_REVISION_COMPLETE_PROOF_VALID');
+  });
+
+  it('rejects incomplete complete-WAVE proof', () => {
+    const result = deriveWaveRevisionProof(
+      plan('complete', {
+        modules_run: 3,
+      }),
+      run('complete', {
+        modules_run: 3,
+        gate_result: { passed: true, reasons: [] },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('WAVE_COMPLETE_PROOF_INCOMPLETE');
+  });
+
+  it('accepts skipped WAVE proof with reason codes and failed WAVE gate', () => {
+    const result = deriveWaveRevisionProof(
+      plan('skipped', {
+        reason: 'STRUCTURAL_FLOOR_NOT_MET',
+        reason_codes: ['WORD_COUNT_BELOW_THRESHOLD'],
+      }),
+      run('skipped', {
+        gate_result: { passed: false, reasons: ['WORD_COUNT_BELOW_THRESHOLD'] },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('skipped');
+    expect(result.code).toBe('WAVE_REVISION_SKIPPED_PROOF_VALID');
+  });
+
+  it('rejects skipped WAVE proof without reason codes', () => {
+    const result = deriveWaveRevisionProof(plan('skipped'), run('skipped'));
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('WAVE_SKIPPED_PROOF_INCOMPLETE');
+  });
+
+  it('treats retryable timeout as explicit but not successful proof', () => {
+    const result = deriveWaveRevisionProof(
+      plan('timeout', { retryable: true }),
+      run('timeout', { gate_result: { passed: true, reasons: [] } }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('timeout');
+    expect(result.code).toBe('WAVE_REVISION_TIMEOUT_RETRYABLE');
+  });
+
+  it('rejects timeout without retryable proof', () => {
+    const result = deriveWaveRevisionProof(plan('timeout'), run('timeout'));
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('WAVE_TIMEOUT_PROOF_INCOMPLETE');
+  });
+
+  it('treats failed WAVE as blocking and distinct from Quality Gate', () => {
+    const result = deriveWaveRevisionProof(
+      plan('failed', { reason: 'WAVE_EXECUTION_ERROR' }),
+      run('failed', { error: 'WAVE_EXECUTION_ERROR' }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('failed');
+    expect(result.code).toBe('WAVE_REVISION_FAILED_BLOCKING');
+    expect(result.quality_gate_label).toBe('Quality Gate');
+    expect(result.wave_label).toBe('WAVE Revision');
+    expect(result.quality_gate_label).not.toBe(result.wave_label);
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/waveRevisionProof.ts
+++ b/lib/evaluation/phase-architecture-v2/waveRevisionProof.ts
@@ -1,0 +1,142 @@
+import type { WaveRevisionPlanArtifact, WaveRunRecord } from '../waveRevision';
+
+export type WaveRevisionProofStatus =
+  | 'complete'
+  | 'skipped'
+  | 'timeout'
+  | 'failed'
+  | 'missing';
+
+export type WaveRevisionProofDecision = {
+  ok: boolean;
+  status: WaveRevisionProofStatus;
+  code: string;
+  reason: string;
+  quality_gate_label: 'Quality Gate';
+  wave_label: 'WAVE Revision';
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasReasonCodes(plan: WaveRevisionPlanArtifact): boolean {
+  return Array.isArray(plan.reason_codes) && plan.reason_codes.some(isNonEmptyString);
+}
+
+/**
+ * Phase Architecture v2 WAVE proof validator.
+ *
+ * This helper does not run WAVE. It validates whether the post-evaluation WAVE
+ * handoff produced an explicit proof state and keeps WAVE naming separate from
+ * deterministic Quality Gate naming.
+ */
+export function deriveWaveRevisionProof(
+  plan?: WaveRevisionPlanArtifact | null,
+  runRecord?: WaveRunRecord | null,
+): WaveRevisionProofDecision {
+  if (!plan || !runRecord) {
+    return {
+      ok: false,
+      status: 'missing',
+      code: 'WAVE_PROOF_MISSING',
+      reason: 'WAVE Revision proof requires both wave_revision_plan_v1 and wave run metadata.',
+      quality_gate_label: 'Quality Gate',
+      wave_label: 'WAVE Revision',
+    };
+  }
+
+  if (plan.status !== runRecord.status) {
+    return {
+      ok: false,
+      status: 'failed',
+      code: 'WAVE_PROOF_STATUS_MISMATCH',
+      reason: `WAVE plan status ${plan.status} does not match run status ${runRecord.status}.`,
+      quality_gate_label: 'Quality Gate',
+      wave_label: 'WAVE Revision',
+    };
+  }
+
+  switch (plan.status) {
+    case 'complete': {
+      const modulesRun = typeof plan.modules_run === 'number' && plan.modules_run > 0;
+      const runModulesRun = typeof runRecord.modules_run === 'number' && runRecord.modules_run > 0;
+      const hasRevisionSession = isNonEmptyString(plan.revision_session_id);
+
+      if (!modulesRun || !runModulesRun || !hasRevisionSession || !runRecord.gate_result.passed) {
+        return {
+          ok: false,
+          status: 'failed',
+          code: 'WAVE_COMPLETE_PROOF_INCOMPLETE',
+          reason: 'WAVE complete proof requires modules_run, revision_session_id, and passed WAVE gate metadata.',
+          quality_gate_label: 'Quality Gate',
+          wave_label: 'WAVE Revision',
+        };
+      }
+
+      return {
+        ok: true,
+        status: 'complete',
+        code: 'WAVE_REVISION_COMPLETE_PROOF_VALID',
+        reason: 'WAVE Revision completed with persisted plan and run metadata.',
+        quality_gate_label: 'Quality Gate',
+        wave_label: 'WAVE Revision',
+      };
+    }
+
+    case 'skipped': {
+      if (!hasReasonCodes(plan) || runRecord.gate_result.passed) {
+        return {
+          ok: false,
+          status: 'failed',
+          code: 'WAVE_SKIPPED_PROOF_INCOMPLETE',
+          reason: 'WAVE skipped proof requires reason_codes and a failed WAVE gate result.',
+          quality_gate_label: 'Quality Gate',
+          wave_label: 'WAVE Revision',
+        };
+      }
+
+      return {
+        ok: true,
+        status: 'skipped',
+        code: 'WAVE_REVISION_SKIPPED_PROOF_VALID',
+        reason: 'WAVE Revision was explicitly skipped with reason codes.',
+        quality_gate_label: 'Quality Gate',
+        wave_label: 'WAVE Revision',
+      };
+    }
+
+    case 'timeout': {
+      if (plan.retryable !== true) {
+        return {
+          ok: false,
+          status: 'failed',
+          code: 'WAVE_TIMEOUT_PROOF_INCOMPLETE',
+          reason: 'WAVE timeout proof requires retryable=true.',
+          quality_gate_label: 'Quality Gate',
+          wave_label: 'WAVE Revision',
+        };
+      }
+
+      return {
+        ok: false,
+        status: 'timeout',
+        code: 'WAVE_REVISION_TIMEOUT_RETRYABLE',
+        reason: 'WAVE Revision timed out and is retryable; this is explicit but not a successful proof.',
+        quality_gate_label: 'Quality Gate',
+        wave_label: 'WAVE Revision',
+      };
+    }
+
+    case 'failed':
+    default:
+      return {
+        ok: false,
+        status: 'failed',
+        code: 'WAVE_REVISION_FAILED_BLOCKING',
+        reason: plan.reason ?? runRecord.error ?? 'WAVE Revision failed.',
+        quality_gate_label: 'Quality Gate',
+        wave_label: 'WAVE Revision',
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Phase Architecture v2 proof helper for WAVE Revision.

This does not run WAVE and does not change WAVE runtime behavior. It validates whether the post-evaluation WAVE phase produced an explicit proof state and keeps naming separate:

- Quality Gate = deterministic validation
- WAVE Revision = post-evaluation revision planning

## Adds

- `deriveWaveRevisionProof(plan, runRecord)`
- Tests for complete, skipped, timeout, failed, missing, and status-mismatch proof states

## What this protects

- WAVE must not silently no-op.
- Complete WAVE proof requires modules, revision session, and passed WAVE gate metadata.
- Skipped WAVE proof requires reason codes and failed WAVE gate result.
- Timeout is explicit/retryable but not a successful proof.
- Failed WAVE is blocking.
- WAVE is not Quality Gate.

## Scope

This is proof-contract only.

It does **not**:

- wire WAVE into processor runtime
- change WAVE eligibility
- change WAVE execution
- alter scoring
- alter synthesis
- rename Quality Gate

## Files

- `lib/evaluation/phase-architecture-v2/waveRevisionProof.ts`
- `__tests__/evaluation/waveRevisionProof.phaseV2.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/waveRevisionProof.phaseV2.test.ts --runInBand
```

## Related

Part of #737