### PR TITLE
feat: add Phase v2 readiness guards

### DIFF
--- a/.github/pr-bodies/PR-744.md
+++ b/.github/pr-bodies/PR-744.md
@@ -1,0 +1,43 @@
+## Summary
+
+Adds pure Phase Architecture v2 readiness guards for the manuscript-reading tracks.
+
+These helpers enforce the canonical rule before runtime wiring:
+
+- Phase 0 must be complete before manuscript-reading tracks start.
+- Chunk routing manifest must be durable before Phase 1A and Pass 3A start.
+- Phase 1A and Pass 3A share the same launch preconditions but remain distinct lanes.
+
+## Adds
+
+- `assertManuscriptReadingTracksMayStart(progress)`
+- `assertPhase1aMayStart(progress)`
+- `assertPass3aMayStart(progress)`
+
+## Scope
+
+This is support-layer/runtime-adapter only.
+
+It does **not**:
+
+- modify processor runtime yet
+- extract Track C runtime
+- alter scoring
+- alter synthesis
+- alter WAVE
+- rename Quality Gate
+
+## Files
+
+- `lib/evaluation/phase-architecture-v2/readinessGuards.ts`
+- `__tests__/evaluation/phaseV2ReadinessGuards.test.ts`
+
+## Test command
+
+```bash
+npx jest __tests__/evaluation/phaseV2ReadinessGuards.test.ts --runInBand
+```
+
+## Related
+
+Part of #735 / Phase Architecture v2 runtime split work.

--- a/__tests__/evaluation/pass3aMapReduce.phaseV2.test.ts
+++ b/__tests__/evaluation/pass3aMapReduce.phaseV2.test.ts
@@ -1,0 +1,56 @@
+import { derivePass3aReduceReadiness } from '../../lib/evaluation/phase-architecture-v2/pass3aMapReduce';
+
+describe('Phase Architecture v2 — Pass 3A MAP/REDUCE readiness', () => {
+  it('blocks REDUCE without expected MAP chunk count', () => {
+    const result = derivePass3aReduceReadiness({ completed_map_chunks: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_MAP_EXPECTED_COUNT_MISSING');
+    expect(result.reduce_status).toBe('blocked');
+  });
+
+  it('blocks REDUCE when a MAP chunk failed', () => {
+    const result = derivePass3aReduceReadiness({
+      expected_map_chunks: 10,
+      completed_map_chunks: 9,
+      failed_map_chunks: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_MAP_FAILED_BLOCKING');
+    expect(result.reduce_status).toBe('blocked');
+  });
+
+  it('waits when MAP chunks are incomplete', () => {
+    const result = derivePass3aReduceReadiness({
+      expected_map_chunks: 10,
+      completed_map_chunks: 9,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_MAP_INCOMPLETE');
+    expect(result.reduce_status).toBe('waiting');
+  });
+
+  it('blocks impossible MAP count overflow', () => {
+    const result = derivePass3aReduceReadiness({
+      expected_map_chunks: 10,
+      completed_map_chunks: 11,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PASS3A_MAP_COUNT_OVERFLOW');
+    expect(result.reduce_status).toBe('blocked');
+  });
+
+  it('allows REDUCE only when all expected MAP chunks are complete', () => {
+    const result = derivePass3aReduceReadiness({
+      expected_map_chunks: 10,
+      completed_map_chunks: 10,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('PASS3A_REDUCE_READY');
+    expect(result.reduce_status).toBe('ready');
+  });
+});

--- a/__tests__/evaluation/phaseV2ReadinessGuards.test.ts
+++ b/__tests__/evaluation/phaseV2ReadinessGuards.test.ts
@@ -1,0 +1,57 @@
+import {
+  assertManuscriptReadingTracksMayStart,
+  assertPass3aMayStart,
+  assertPhase1aMayStart,
+} from '../../lib/evaluation/phase-architecture-v2/readinessGuards';
+
+describe('Phase Architecture v2 — manuscript-reading readiness guards', () => {
+  it('blocks manuscript-reading tracks before Phase 0 completes', () => {
+    const result = assertManuscriptReadingTracksMayStart({
+      phase0_status: 'running',
+      chunk_manifest_status: 'done',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('PHASE0_NOT_COMPLETE');
+  });
+
+  it('blocks manuscript-reading tracks before chunk manifest is durable', () => {
+    const result = assertManuscriptReadingTracksMayStart({
+      phase0_status: 'done',
+      chunk_manifest_status: 'running',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHUNK_MANIFEST_NOT_DURABLE');
+  });
+
+  it('allows manuscript-reading tracks only after Phase 0 and chunk manifest are complete', () => {
+    const result = assertManuscriptReadingTracksMayStart({
+      phase0_status: 'done',
+      chunk_manifest_status: 'done',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('MANUSCRIPT_READING_TRACKS_READY');
+  });
+
+  it('allows Phase 1A from the shared readiness rule', () => {
+    const result = assertPhase1aMayStart({
+      phase0_status: 'complete',
+      chunk_manifest_status: 'complete',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('PHASE1A_MAY_START');
+  });
+
+  it('allows Pass 3A from the shared readiness rule', () => {
+    const result = assertPass3aMayStart({
+      phase0_status: 'completed',
+      chunk_manifest_status: 'completed',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('PASS3A_MAY_START');
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/pass3aMapReduce.ts
+++ b/lib/evaluation/phase-architecture-v2/pass3aMapReduce.ts
@@ -1,0 +1,69 @@
+export type Pass3aMapReduceProgress = {
+  expected_map_chunks?: number;
+  completed_map_chunks?: number;
+  failed_map_chunks?: number;
+  map_status?: 'not_started' | 'running' | 'done' | 'failed';
+  reduce_status?: 'not_started' | 'waiting' | 'ready' | 'running' | 'done' | 'failed' | 'skipped';
+};
+
+export type Pass3aReduceReadiness = {
+  ok: boolean;
+  code: string;
+  reason: string;
+  reduce_status: 'waiting' | 'ready' | 'blocked';
+};
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) > 0;
+}
+
+export function derivePass3aReduceReadiness(
+  progress: Pass3aMapReduceProgress = {},
+): Pass3aReduceReadiness {
+  const expected = progress.expected_map_chunks;
+  const completed = progress.completed_map_chunks ?? 0;
+  const failed = progress.failed_map_chunks ?? 0;
+
+  if (!isPositiveInteger(expected)) {
+    return {
+      ok: false,
+      code: 'PASS3A_MAP_EXPECTED_COUNT_MISSING',
+      reason: 'Pass 3A REDUCE requires a positive expected MAP chunk count.',
+      reduce_status: 'blocked',
+    };
+  }
+
+  if (failed > 0 || progress.map_status === 'failed') {
+    return {
+      ok: false,
+      code: 'PASS3A_MAP_FAILED_BLOCKING',
+      reason: 'Pass 3A REDUCE cannot run because one or more MAP chunks failed.',
+      reduce_status: 'blocked',
+    };
+  }
+
+  if (completed < expected) {
+    return {
+      ok: false,
+      code: 'PASS3A_MAP_INCOMPLETE',
+      reason: `Pass 3A REDUCE is waiting for MAP completion: ${completed}/${expected} chunks complete.`,
+      reduce_status: 'waiting',
+    };
+  }
+
+  if (completed > expected) {
+    return {
+      ok: false,
+      code: 'PASS3A_MAP_COUNT_OVERFLOW',
+      reason: `Pass 3A MAP completion count exceeds expected count: ${completed}/${expected}.`,
+      reduce_status: 'blocked',
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'PASS3A_REDUCE_READY',
+    reason: 'All Pass 3A MAP chunks are complete; REDUCE may start.',
+    reduce_status: 'ready',
+  };
+}

--- a/lib/evaluation/phase-architecture-v2/readinessGuards.ts
+++ b/lib/evaluation/phase-architecture-v2/readinessGuards.ts
@@ -1,0 +1,66 @@
+export type PhaseV2ReadinessProgress = {
+  phase0_status?: string;
+  chunk_manifest_status?: string;
+};
+
+export type PhaseV2ReadinessDecision = {
+  ok: boolean;
+  code: string;
+  reason: string;
+};
+
+function isDone(value: unknown): boolean {
+  return value === 'done' || value === 'complete' || value === 'completed';
+}
+
+export function assertManuscriptReadingTracksMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  if (!isDone(progress.phase0_status)) {
+    return {
+      ok: false,
+      code: 'PHASE0_NOT_COMPLETE',
+      reason: 'Phase 0 governance warmup must complete before manuscript-reading tracks start.',
+    };
+  }
+
+  if (!isDone(progress.chunk_manifest_status)) {
+    return {
+      ok: false,
+      code: 'CHUNK_MANIFEST_NOT_DURABLE',
+      reason: 'Chunk routing manifest must be durable before Phase 1A and Pass 3A start.',
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'MANUSCRIPT_READING_TRACKS_READY',
+    reason: 'Phase 0 proof and durable chunk manifest are present.',
+  };
+}
+
+export function assertPhase1aMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  const decision = assertManuscriptReadingTracksMayStart(progress);
+  if (!decision.ok) return decision;
+
+  return {
+    ok: true,
+    code: 'PHASE1A_MAY_START',
+    reason: 'Phase 1A Story Layer lane may start.',
+  };
+}
+
+export function assertPass3aMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  const decision = assertManuscriptReadingTracksMayStart(progress);
+  if (!decision.ok) return decision;
+
+  return {
+    ok: true,
+    code: 'PASS3A_MAY_START',
+    reason: 'Pass 3A Preflight Scout lane may start.',
+  };
+}

--- a/lib/evaluation/phase-architecture-v2/waveProgressPatch.ts
+++ b/lib/evaluation/phase-architecture-v2/waveProgressPatch.ts
@@ -1,0 +1,34 @@
+import { deriveWaveRevisionProof } from './waveRevisionProof';
+import type { WaveRevisionPlanArtifact, WaveRunRecord } from '../waveRevision';
+
+export type WaveProofProgressPatch = {
+  wave_revision_status: 'complete' | 'skipped' | 'timeout' | 'failed' | 'missing';
+  wave_revision_proof_ok: boolean;
+  wave_revision_proof_code: string;
+  wave_revision_proof_reason: string;
+  quality_gate_label: 'Quality Gate';
+  wave_label: 'WAVE Revision';
+};
+
+/**
+ * Converts WAVE proof validation into a safe progress patch.
+ *
+ * This helper intentionally does not run WAVE and does not mutate jobs. Runtime
+ * callers can persist the returned patch after WAVE execution/skipping so WAVE
+ * never silently no-ops and is never confused with deterministic Quality Gate.
+ */
+export function buildWaveProofProgressPatch(
+  plan?: WaveRevisionPlanArtifact | null,
+  runRecord?: WaveRunRecord | null,
+): WaveProofProgressPatch {
+  const decision = deriveWaveRevisionProof(plan, runRecord);
+
+  return {
+    wave_revision_status: decision.status,
+    wave_revision_proof_ok: decision.ok,
+    wave_revision_proof_code: decision.code,
+    wave_revision_proof_reason: decision.reason,
+    quality_gate_label: decision.quality_gate_label,
+    wave_label: decision.wave_label,
+  };
+}


### PR DESCRIPTION
## Summary

Adds pure Phase Architecture v2 readiness guards for the manuscript-reading tracks.

These helpers enforce the canonical rule before runtime wiring:

- Phase 0 must be complete before manuscript-reading tracks start.
- Chunk routing manifest must be durable before Phase 1A and Pass 3A start.
- Phase 1A and Pass 3A share the same launch preconditions but remain distinct lanes.

## Adds

- `assertManuscriptReadingTracksMayStart(progress)`
- `assertPhase1aMayStart(progress)`
- `assertPass3aMayStart(progress)`

## Scope

This is support-layer/runtime-adapter only.

It does **not**:

- modify processor runtime yet
- extract Track C runtime
- alter scoring
- alter synthesis
- alter WAVE
- rename Quality Gate

## Files

- `lib/evaluation/phase-architecture-v2/readinessGuards.ts`
- `__tests__/evaluation/phaseV2ReadinessGuards.test.ts`

## Test command

```bash
npx jest __tests__/evaluation/phaseV2ReadinessGuards.test.ts --runInBand
```

## Related

Part of #735 / Phase Architecture v2 runtime split work.