### PR TITLE
Harden author-facing report rendering and export reliability

### DIFF
--- a/.github/pr-bodies/PR-794.md
+++ b/.github/pr-bodies/PR-794.md
@@ -1,24 +1,72 @@
 ## Summary
-- filter internal diagnostic/system-repair language from author-facing longform sections
-- renumber visible revision priorities after filtering so they are contiguous
-- replace semicolon-mashed evidence/action rendering with proper list blocks
-- remove silent PDF→TXT fallback on PDF export failure
-- return explicit `PDF_EXPORT_FAILED` error response when PDF generation fails
-- validate generated PDF header bytes (`%PDF`) before returning PDF download
+- Harden author-facing report/export rendering so internal diagnostic/system-repair text is not shown to authors.
+- Replace semicolon-mashed rendering with structured list output across page + TXT/PDF/DOCX paths.
+- Eliminate silent PDF→TXT success fallback and return explicit PDF failure response.
 
-## Files changed
-- `lib/evaluation/reportRenderSafety.ts`
-- `app/reports/[jobId]/page.tsx`
-- `app/api/reports/[jobId]/download/route.ts`
-- `components/reports/longform/LongformRevisionPlan.tsx`
-- `components/reports/longform/LongformRelationshipSpineLedger.tsx`
+## Scope
+- Renderer/export hygiene only (no pipeline phase-order changes).
+- Files in scope:
+	- `lib/evaluation/reportRenderSafety.ts`
+	- `app/reports/[jobId]/page.tsx`
+	- `app/api/reports/[jobId]/download/route.ts`
+	- `components/reports/longform/LongformRevisionPlan.tsx`
+	- `components/reports/longform/LongformRelationshipSpineLedger.tsx`
+	- `tests/lib/evaluation/reportRenderSafety.test.ts`
+
+## Branch Freshness (Never Behind)
+Branch-Behind-Base: 0
+
+## Evaluation Process Change Declaration
+Process Change: no
+
+## Contract Integrity
+- Canonical job status contract unchanged (`queued|running|complete|failed`).
+- No job-state transition semantics changed.
+- No new status/type identifiers introduced.
+
+## Behavioral Quality
+- `filterAuthorFacingTextList` removes internal diagnostics from author-facing output.
+- `getRenumberedAuthorFacingRevisionPlan` ensures contiguous visible priorities (`1..N`).
+- TXT export list blocks now sanitize each item via `cleanReportText(...)` after filtering.
+- PDF path now returns explicit `PDF_EXPORT_FAILED` on generation failure; no silent TXT masquerade.
+
+## Latency Evidence
+Selected pass:
+- [ ] Pass 1
+- [ ] Pass 2
+- [x] Pass 3
+
+Baseline (Pre-change)
+| Run | pass3_ms | total_ms | criteria_count_by_state | Notes |
+|---|---:|---:|---|---|
+| Run 1 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Renderer/export-only patch; no pipeline pass timing modified. |
+
+Post-change Runs
+| Run | pass3_ms | total_ms | criteria_count_by_state | Notes |
+|---|---:|---:|---|---|
+| Run 1 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Focused Jest suites passed; no pass-timing code touched. |
+| Run 2 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Export/report behavior verified by targeted tests + diagnostics. |
+
+Quality gate / anomaly disclosure:
+- No QG_ logic changed in this PR.
+- Quality Gate behavior is preserved; this PR improves author-facing hygiene without reducing intelligence.
+
+Final principle:
+- This change is not reducing intelligence; it only removes internal diagnostic leakage from author surfaces and tightens export correctness.
+
+## Risks & Anomalies
+- Risk: over-filtering valid advice if wording matches diagnostic patterns too broadly.
+- Mitigation: targeted helper tests validate retained manuscript-facing advice and removed internal/system strings.
 
 ## Validation
-- diagnostics check on touched files: no errors
-- branch contains commit: `2e1ccf7c`
+- Diagnostics: no errors in touched renderer/export/helper files.
+- Tests updated and passing:
+	- `tests/lib/evaluation/reportRenderSafety.test.ts`
+	- `tests/evaluation/pipeline/pass3b.revisionPlanGuardrail.test.ts`
+	- `tests/evaluation/pipeline/truthfulFallback.pass3b.test.ts`
 
 ## Acceptance criteria mapping
-- internal diagnostics removed from author-facing revision lists
-- revision priorities displayed as 1..N after filtering
-- criterion/revision text rendered as list items, not semicolon-mashed strings
-- PDF failures no longer return disguised TXT success payloads
+- Internal diagnostics removed from author-facing revision lists.
+- Visible priorities renumber contiguously after filtering.
+- Criterion evidence/revision actions render as lists (no semicolon-mashed blobs).
+- PDF failures return explicit error (`PDF_EXPORT_FAILED`) rather than TXT success fallback.

--- a/.github/pr-bodies/PR-794.md
+++ b/.github/pr-bodies/PR-794.md
@@ -1,0 +1,24 @@
+## Summary
+- filter internal diagnostic/system-repair language from author-facing longform sections
+- renumber visible revision priorities after filtering so they are contiguous
+- replace semicolon-mashed evidence/action rendering with proper list blocks
+- remove silent PDF→TXT fallback on PDF export failure
+- return explicit `PDF_EXPORT_FAILED` error response when PDF generation fails
+- validate generated PDF header bytes (`%PDF`) before returning PDF download
+
+## Files changed
+- `lib/evaluation/reportRenderSafety.ts`
+- `app/reports/[jobId]/page.tsx`
+- `app/api/reports/[jobId]/download/route.ts`
+- `components/reports/longform/LongformRevisionPlan.tsx`
+- `components/reports/longform/LongformRelationshipSpineLedger.tsx`
+
+## Validation
+- diagnostics check on touched files: no errors
+- branch contains commit: `2e1ccf7c`
+
+## Acceptance criteria mapping
+- internal diagnostics removed from author-facing revision lists
+- revision priorities displayed as 1..N after filtering
+- criterion/revision text rendered as list items, not semicolon-mashed strings
+- PDF failures no longer return disguised TXT success payloads

--- a/app/api/reports/[jobId]/download/route.ts
+++ b/app/api/reports/[jobId]/download/route.ts
@@ -8,6 +8,10 @@ import { isEvaluationResultV1, type EvaluationResultV1 } from '@/schemas/evaluat
 import { isEvaluationResultV2, type EvaluationResultV2 } from '@/schemas/evaluation-result-v2';
 import type { LongformDreamDocument } from '@/lib/evaluation/pipeline/runPass3bLongform';
 import {
+  filterAuthorFacingTextList,
+  getRenumberedAuthorFacingRevisionPlan,
+} from '@/lib/evaluation/reportRenderSafety';
+import {
   Document, Packer, Paragraph, TextRun, HeadingLevel,
   Table, TableRow, TableCell, WidthType, BorderStyle,
   AlignmentType, ShadingType, Header, Footer,
@@ -120,6 +124,20 @@ function opportunityRows(r: ExportRecommendation): Array<[string, string]> {
   return candidates.flatMap(([label, value]) => {
     if (typeof value !== 'string' || value.trim().length === 0) return [];
     return [[label, cleanReportText(value)] as [string, string]];
+  });
+}
+
+function pushTxtListBlock(lines: string[], label: string, values: unknown, options: { ordered?: boolean } = {}): void {
+  const cleaned = filterAuthorFacingTextList(values);
+  if (cleaned.length === 0) return;
+
+  lines.push(`  ${label}:`);
+  cleaned.forEach((item, idx) => {
+    if (options.ordered) {
+      lines.push(`    ${idx + 1}. ${item}`);
+      return;
+    }
+    lines.push(`    • ${item}`);
   });
 }
 
@@ -332,22 +350,23 @@ function appendDreamTxtSections(lines: string[], dream: LongformDreamDocument): 
     dream.criterion_analyses.forEach((a) => {
       push('');
       push(`${a.key} — ${a.score}/10 (${a.confidence} confidence)`);
-      if (Array.isArray(a.fit_evidence) && a.fit_evidence.length > 0) push(`  What is working: ${a.fit_evidence.map((item) => cleanReportText(item)).join('; ')}`);
-      if (Array.isArray(a.gap_evidence) && a.gap_evidence.length > 0) push(`  What weakens impact: ${a.gap_evidence.map((item) => cleanReportText(item)).join('; ')}`);
-      if (Array.isArray(a.revision_queue) && a.revision_queue.length > 0) push(`  Revision queue: ${a.revision_queue.map((item) => cleanReportText(item)).join('; ')}`);
+      pushTxtListBlock(lines, 'What is working', a.fit_evidence);
+      pushTxtListBlock(lines, 'What weakens impact', a.gap_evidence);
+      pushTxtListBlock(lines, 'Revision queue', a.revision_queue, { ordered: true });
     });
   }
 
-  if (Array.isArray(dream.revision_plan) && dream.revision_plan.length > 0) {
+  const revisionPlan = getRenumberedAuthorFacingRevisionPlan(dream.revision_plan);
+  if (revisionPlan.length > 0) {
     push('');
     push(sub);
     push('REVISION PLAN');
     push(sub);
-    dream.revision_plan.forEach((item) => {
+    revisionPlan.forEach((item) => {
       push('');
-      push(`Priority ${item.priority}: ${cleanReportText(item.title)}`);
+      push(`Priority ${item.displayPriority}: ${cleanReportText(item.title)}`);
       push(`  Goal: ${cleanReportText(item.goal)}`);
-      if (Array.isArray(item.actions) && item.actions.length > 0) push(`  Actions: ${item.actions.map((action) => cleanReportText(action)).join('; ')}`);
+      pushTxtListBlock(lines, 'Actions', item.actions, { ordered: true });
       if (item.acceptance_check) push(`  Acceptance check: ${cleanReportText(item.acceptance_check)}`);
     });
   }
@@ -774,12 +793,13 @@ async function buildPdfReport(result: ExportableResult, title: string | null, jo
         });
       }
 
-      if (Array.isArray(dream.revision_plan) && dream.revision_plan.length > 0) {
+      const revisionPlan = getRenumberedAuthorFacingRevisionPlan(dream.revision_plan);
+      if (revisionPlan.length > 0) {
         section('Revision Plan');
-        dream.revision_plan.forEach((item) => {
+        revisionPlan.forEach((item) => {
           ensureSpace(90);
           doc.font('Helvetica-Bold').fontSize(10.5).fillColor(RG.textPrimary).text(
-            toPdfSafeText(`Priority ${item.priority}: ${cleanReportText(item.title)}`),
+            toPdfSafeText(`Priority ${item.displayPriority}: ${cleanReportText(item.title)}`),
             { width: contentWidth },
           );
           paragraph(`Goal: ${cleanReportText(item.goal)}`);
@@ -1145,10 +1165,11 @@ async function buildDocx(result: ExportableResult, title: string | null, jobId: 
       });
     }
 
-    if (Array.isArray(dream.revision_plan) && dream.revision_plan.length > 0) {
+    const revisionPlan = getRenumberedAuthorFacingRevisionPlan(dream.revision_plan);
+    if (revisionPlan.length > 0) {
       children.push(brandHeading('Revision Plan', HeadingLevel.HEADING_3));
-      dream.revision_plan.forEach((item) => {
-        children.push(bodyPara(`Priority ${item.priority}: ${item.title}`, { bold: true }));
+      revisionPlan.forEach((item) => {
+        children.push(bodyPara(`Priority ${item.displayPriority}: ${item.title}`, { bold: true }));
         children.push(bodyPara(`Goal: ${item.goal}`, { size: 19, color: RG.textMuted }));
         if (Array.isArray(item.actions)) item.actions.forEach((action) => children.push(bulletPara(action)));
         if (item.acceptance_check) children.push(bodyPara(`Acceptance check: ${item.acceptance_check}`, { size: 19, color: RG.textMuted }));
@@ -1296,6 +1317,10 @@ export async function GET(
   if (format === 'pdf') {
     try {
       const buffer = await buildPdfReport(result, title, jobId, dream);
+      if (buffer.subarray(0, 4).toString('ascii') !== '%PDF') {
+        throw new Error('Generated artifact does not contain valid PDF header bytes');
+      }
+
       return new Response(new Uint8Array(buffer), {
         headers: {
           'Content-Type': 'application/pdf',
@@ -1310,16 +1335,13 @@ export async function GET(
         stack: err instanceof Error ? err.stack : undefined,
       });
 
-      const body = buildTxtReport(result, title, jobId, dream);
-      return new Response(body, {
-        status: 200,
-        headers: {
-          'Content-Type': 'text/plain; charset=utf-8',
-          'Content-Disposition': `attachment; filename="${safeFilename(title, jobId, 'txt')}"`,
-          'Cache-Control': 'no-store',
-          'X-RevisionGrade-Export-Fallback': 'pdf-to-txt',
+      return NextResponse.json(
+        {
+          error: 'PDF export failed. Please retry or choose TXT/DOCX.',
+          code: 'PDF_EXPORT_FAILED',
         },
-      });
+        { status: 500 },
+      );
     }
   }
 

--- a/app/api/reports/[jobId]/download/route.ts
+++ b/app/api/reports/[jobId]/download/route.ts
@@ -128,7 +128,9 @@ function opportunityRows(r: ExportRecommendation): Array<[string, string]> {
 }
 
 function pushTxtListBlock(lines: string[], label: string, values: unknown, options: { ordered?: boolean } = {}): void {
-  const cleaned = filterAuthorFacingTextList(values);
+  const cleaned = filterAuthorFacingTextList(values)
+    .map((item) => cleanReportText(item, ''))
+    .filter((item) => item.length > 0);
   if (cleaned.length === 0) return;
 
   lines.push(`  ${label}:`);

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -25,6 +25,8 @@ import {
   getDisplayRecord,
   getDisplayDreamScore,
   getDisplayText,
+  filterAuthorFacingTextList,
+  getRenumberedAuthorFacingRevisionPlan,
   safeTruncateToWordBoundary,
 } from '@/lib/evaluation/reportRenderSafety';
 import { resolveReportTitle } from '@/lib/evaluation/reportTitle';
@@ -270,7 +272,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
   const dreamReaderFirstAct = getDisplayRecord(dreamReaderExperience?.first_act);
   const dreamReaderMiddle = getDisplayRecord(dreamReaderExperience?.middle);
   const dreamReaderFinalAct = getDisplayRecord(dreamReaderExperience?.final_act);
-  const dreamRevisionPlan = getDisplayObjectArray(dreamDoc?.revision_plan);
+  const dreamRevisionPlan = getRenumberedAuthorFacingRevisionPlan(dreamDoc?.revision_plan);
   const dreamReleasability = getDisplayObjectArray(dreamDoc?.releasability);
   const dreamAcceptanceChecks = getDisplayRecord(dreamDoc?.acceptance_checks);
   const dreamRequiredDetections = getDisplayDreamList(dreamAcceptanceChecks?.required_detection);
@@ -712,9 +714,50 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                           <p><span className="font-medium">Criterion:</span> {getDisplayText(analysis.key)}</p>
                           <p><span className="font-medium">Score:</span> {getDisplayText(analysis.score)}</p>
                           <p><span className="font-medium">Confidence:</span> {getDisplayText(analysis.confidence)}</p>
-                          <p><span className="font-medium">Fit evidence:</span> {getDisplayDreamList(analysis.fit_evidence).join("; ") || "—"}</p>
-                          <p><span className="font-medium">Gap evidence:</span> {getDisplayDreamList(analysis.gap_evidence).join("; ") || "—"}</p>
-                          <p><span className="font-medium">Revision queue:</span> {getDisplayDreamList(analysis.revision_queue).join("; ") || "—"}</p>
+
+                          {(() => {
+                            const fitEvidence = filterAuthorFacingTextList(analysis.fit_evidence);
+                            const gapEvidence = filterAuthorFacingTextList(analysis.gap_evidence);
+                            const revisionQueue = filterAuthorFacingTextList(analysis.revision_queue);
+
+                            return (
+                              <div className="mt-2 space-y-2">
+                                {fitEvidence.length > 0 && (
+                                  <div>
+                                    <p className="font-medium">Fit evidence:</p>
+                                    <ul className="list-disc list-inside space-y-0.5 text-gray-700">
+                                      {fitEvidence.map((entry, i) => (
+                                        <li key={i}>{entry}</li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                )}
+                                {gapEvidence.length > 0 && (
+                                  <div>
+                                    <p className="font-medium">Gap evidence:</p>
+                                    <ul className="list-disc list-inside space-y-0.5 text-gray-700">
+                                      {gapEvidence.map((entry, i) => (
+                                        <li key={i}>{entry}</li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                )}
+                                {revisionQueue.length > 0 && (
+                                  <div>
+                                    <p className="font-medium">Revision queue:</p>
+                                    <ol className="list-decimal list-inside space-y-0.5 text-gray-700">
+                                      {revisionQueue.map((entry, i) => (
+                                        <li key={i}>{entry}</li>
+                                      ))}
+                                    </ol>
+                                  </div>
+                                )}
+                                {fitEvidence.length === 0 && gapEvidence.length === 0 && revisionQueue.length === 0 && (
+                                  <p className="text-gray-700">—</p>
+                                )}
+                              </div>
+                            );
+                          })()}
                         </div>
                       ))}
                     </div>
@@ -818,10 +861,21 @@ export default async function ReportPage({ params }: { params: { jobId: string }
                     <div className="space-y-2">
                       {dreamRevisionPlan.map((planItem, idx) => (
                         <div key={idx} className="rounded border border-gray-200 p-3 text-sm">
-                          <p><span className="font-medium">Priority:</span> {getDisplayText(planItem.priority)}</p>
+                          <p><span className="font-medium">Priority:</span> {planItem.displayPriority}</p>
                           <p><span className="font-medium">Title:</span> {getDisplayText(planItem.title)}</p>
                           <p><span className="font-medium">Goal:</span> {getDisplayText(planItem.goal)}</p>
-                          <p><span className="font-medium">Actions:</span> {getDisplayDreamList(planItem.actions).join("; ") || "—"}</p>
+                          {planItem.actions.length > 0 ? (
+                            <div>
+                              <p><span className="font-medium">Actions:</span></p>
+                              <ol className="list-decimal list-inside space-y-0.5 text-gray-700 mt-1">
+                                {planItem.actions.map((action, actionIdx) => (
+                                  <li key={actionIdx}>{action}</li>
+                                ))}
+                              </ol>
+                            </div>
+                          ) : (
+                            <p><span className="font-medium">Actions:</span> —</p>
+                          )}
                           <p><span className="font-medium">Acceptance check:</span> {getDisplayText(planItem.acceptance_check)}</p>
                         </div>
                       ))}

--- a/components/reports/longform/LongformRelationshipSpineLedger.tsx
+++ b/components/reports/longform/LongformRelationshipSpineLedger.tsx
@@ -1,4 +1,5 @@
 import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
+import { getRenumberedAuthorFacingRevisionPlan } from "@/lib/evaluation/reportRenderSafety";
 
 type Props = { doc: LongformDreamDocument };
 
@@ -29,7 +30,7 @@ export default function LongformRelationshipSpineLedger({ doc }: Props) {
   );
 
   // Also pull from revision_plan items that target relationships
-  const relationshipRevisions = (doc.revision_plan ?? []).filter((p) =>
+  const relationshipRevisions = getRenumberedAuthorFacingRevisionPlan(doc.revision_plan).filter((p) =>
     /relation|spine|bond|companion|bridge|dyad|family|unit/i.test(p.title + " " + p.goal)
   );
 
@@ -108,7 +109,7 @@ export default function LongformRelationshipSpineLedger({ doc }: Props) {
             {relationshipRevisions.map((p, i) => (
               <div key={i} className="rounded-lg border border-indigo-100 bg-indigo-50 p-3 text-sm">
                 <p className="font-medium text-indigo-800 mb-0.5">
-                  #{p.priority} — {p.title}
+                  #{p.displayPriority} — {p.title}
                 </p>
                 <p className="text-xs text-indigo-700 mb-1">{p.goal}</p>
                 {p.actions?.length > 0 && (

--- a/components/reports/longform/LongformRevisionPlan.tsx
+++ b/components/reports/longform/LongformRevisionPlan.tsx
@@ -1,4 +1,5 @@
 import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
+import { getRenumberedAuthorFacingRevisionPlan } from "@/lib/evaluation/reportRenderSafety";
 
 type Props = { doc: LongformDreamDocument };
 
@@ -11,7 +12,7 @@ const PRIORITY_COLORS = [
 ];
 
 export default function LongformRevisionPlan({ doc }: Props) {
-  const plan = doc.revision_plan ?? [];
+  const plan = getRenumberedAuthorFacingRevisionPlan(doc.revision_plan);
   if (plan.length === 0) return null;
 
   return (
@@ -22,7 +23,7 @@ export default function LongformRevisionPlan({ doc }: Props) {
           <div key={i} className={`rounded-lg border-l-4 p-4 ${colorClass}`}>
             <div className="flex items-start gap-3">
               <span className="shrink-0 w-6 h-6 rounded-full bg-white border border-gray-300 flex items-center justify-center text-xs font-bold text-gray-700">
-                {item.priority}
+                {item.displayPriority}
               </span>
               <div className="flex-1 space-y-2">
                 <p className="font-semibold text-gray-800 text-sm">{item.title}</p>

--- a/lib/evaluation/reportRenderSafety.ts
+++ b/lib/evaluation/reportRenderSafety.ts
@@ -135,3 +135,75 @@ export function getDisplayDreamMarketField(
   const value = getDisplayText(marketShelf[field], "").trim();
   return value.length > 0 ? value : null;
 }
+
+const INTERNAL_DIAGNOSTIC_PATTERNS: RegExp[] = [
+  /source[-\s]?integrity/i,
+  /relationship\s+network\s+representation/i,
+  /threat\s*\/?\s*pressure/i,
+  /location\s*\/?\s*timeline/i,
+  /object\s*\/?\s*symbol/i,
+  /extraction\s+diagnostic/i,
+  /repair\s+relationship\s+network/i,
+  /layer\s+contamination/i,
+  /taxonomy\s+repair/i,
+  /no\s+qualifying\s+relationship\s+pairs/i,
+  /renderer\s+defect|schema\s+defect|ontology\s+repair/i,
+];
+
+export type AuthorFacingRevisionPlanItem = {
+  priority: number;
+  title: string;
+  goal: string;
+  actions: string[];
+  acceptance_check: string;
+};
+
+export function isInternalDiagnosticText(value: string): boolean {
+  const text = value.trim();
+  if (!text) return false;
+  return INTERNAL_DIAGNOSTIC_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function filterAuthorFacingTextList(value: unknown): string[] {
+  return getDisplayDreamList(value).filter((entry) => !isInternalDiagnosticText(entry));
+}
+
+export function getAuthorFacingRevisionPlan(value: unknown): AuthorFacingRevisionPlanItem[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => entry !== null)
+    .map((entry) => {
+      const rawPriority = entry.priority;
+      const priority = typeof rawPriority === "number" && Number.isFinite(rawPriority)
+        ? rawPriority
+        : Number.parseInt(getDisplayText(rawPriority, "0"), 10) || 0;
+
+      const title = getDisplayText(entry.title, "");
+      const goal = getDisplayText(entry.goal, "");
+      const actions = filterAuthorFacingTextList(entry.actions);
+      const acceptance_check = getDisplayText(entry.acceptance_check, "");
+
+      return {
+        priority,
+        title,
+        goal,
+        actions,
+        acceptance_check,
+      };
+    })
+    .filter((item) => {
+      const combined = [item.title, item.goal, item.acceptance_check, ...item.actions].join(" ");
+      return combined.trim().length > 0 && !isInternalDiagnosticText(combined);
+    });
+}
+
+export function getRenumberedAuthorFacingRevisionPlan(
+  value: unknown,
+): Array<AuthorFacingRevisionPlanItem & { displayPriority: number }> {
+  return getAuthorFacingRevisionPlan(value).map((item, idx) => ({
+    ...item,
+    displayPriority: idx + 1,
+  }));
+}

--- a/tests/lib/evaluation/reportRenderSafety.test.ts
+++ b/tests/lib/evaluation/reportRenderSafety.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  filterAuthorFacingTextList,
+  getRenumberedAuthorFacingRevisionPlan,
+} from '@/lib/evaluation/reportRenderSafety';
+
+describe('reportRenderSafety author-facing helpers', () => {
+  it('drops internal diagnostic strings from free text lists', () => {
+    const input = [
+      'Correct Source-Integrity and Extraction Semantics',
+      'Repair Relationship Network Representation',
+      'Reframe Threat / Pressure / Ending Taxonomy',
+      'Normalize Location / Timeline and Separate Diagnostics',
+      'Rewrite the midpoint exchange to force an irreversible choice.',
+      'Seed a callback line in the final act.',
+    ];
+
+    const filtered = filterAuthorFacingTextList(input);
+
+    expect(filtered).toEqual([
+      'Rewrite the midpoint exchange to force an irreversible choice.',
+      'Seed a callback line in the final act.',
+    ]);
+
+    const joined = filtered.join(' ');
+    expect(joined).not.toMatch(/source[-\s]?integrity/i);
+    expect(joined).not.toMatch(/relationship\s+network/i);
+    expect(joined).not.toMatch(/threat\s*\/?\s*pressure/i);
+    expect(joined).not.toMatch(/location\s*\/?\s*timeline/i);
+  });
+
+  it('strips internal actions but keeps valid manuscript priorities', () => {
+    const plan = [
+      {
+        priority: 1,
+        title: 'Correct Source-Integrity and Extraction Semantics',
+        goal: 'Repair diagnostics pipeline outputs.',
+        actions: ['Rebuild extractor status map'],
+        acceptance_check: 'Source integrity status no longer hard-fails.',
+      },
+      {
+        priority: 2,
+        title: 'Strengthen midpoint causality',
+        goal: 'Force consequential midpoint decision.',
+        actions: [
+          'Reframe Threat / Pressure / Ending Taxonomy',
+          'Normalize Location / Timeline and Separate Diagnostics',
+          'Rewrite chapter 12 ending to force a public choice.',
+          'Cut one repetitive setup beat in chapter 10.',
+        ],
+        acceptance_check: 'Midpoint introduces irreversible social consequence.',
+      },
+      {
+        priority: 3,
+        title: 'Sharpen final emotional aftercare',
+        goal: 'Separate plot closure from emotional closure.',
+        actions: [
+          'Add a final-scene callback that resolves emotional debt.',
+        ],
+        acceptance_check: 'Final act lands both plot and emotional aftercare.',
+      },
+    ];
+
+    const result = getRenumberedAuthorFacingRevisionPlan(plan);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe('Strengthen midpoint causality');
+    expect(result[1].title).toBe('Sharpen final emotional aftercare');
+
+    expect(result[0].actions).toEqual([
+      'Rewrite chapter 12 ending to force a public choice.',
+      'Cut one repetitive setup beat in chapter 10.',
+    ]);
+
+    expect(result[1].actions).toEqual([
+      'Add a final-scene callback that resolves emotional debt.',
+    ]);
+  });
+
+  it('renumbers display priorities contiguously after filtering', () => {
+    const plan = [
+      {
+        priority: 2,
+        title: 'Repair Relationship Network Representation',
+        goal: 'Internal diagnostic remediation',
+        actions: ['No qualifying relationship pairs found'],
+        acceptance_check: 'Diagnostics clean',
+      },
+      {
+        priority: 4,
+        title: 'Condense repetitive chapter transitions',
+        goal: 'Improve pace and consequence continuity.',
+        actions: ['Merge two transition scenes in Act II.'],
+        acceptance_check: 'Transitions preserve causality while reducing repetition.',
+      },
+      {
+        priority: 6,
+        title: 'Clarify symbol payoff',
+        goal: 'Make symbol lifecycle legible from setup to payoff.',
+        actions: ['Seed symbol transfer in chapter 3 and resolve in finale.'],
+        acceptance_check: 'Symbol appears, transfers, and resolves by ending.',
+      },
+    ];
+
+    const result = getRenumberedAuthorFacingRevisionPlan(plan);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((item) => item.displayPriority)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary
- Harden author-facing report/export rendering so internal diagnostic/system-repair text is not shown to authors.
- Replace semicolon-mashed rendering with structured list output across page + TXT/PDF/DOCX paths.
- Eliminate silent PDF→TXT success fallback and return explicit PDF failure response.

## Scope
- Renderer/export hygiene only (no pipeline phase-order changes).
- Files in scope:
	- `lib/evaluation/reportRenderSafety.ts`
	- `app/reports/[jobId]/page.tsx`
	- `app/api/reports/[jobId]/download/route.ts`
	- `components/reports/longform/LongformRevisionPlan.tsx`
	- `components/reports/longform/LongformRelationshipSpineLedger.tsx`
	- `tests/lib/evaluation/reportRenderSafety.test.ts`

## Branch Freshness (Never Behind)
Branch-Behind-Base: 0

## Evaluation Process Change Declaration
Process Change: no

## Contract Integrity
- Canonical job status contract unchanged (`queued|running|complete|failed`).
- No job-state transition semantics changed.
- No new status/type identifiers introduced.

## Behavioral Quality
- `filterAuthorFacingTextList` removes internal diagnostics from author-facing output.
- `getRenumberedAuthorFacingRevisionPlan` ensures contiguous visible priorities (`1..N`).
- TXT export list blocks now sanitize each item via `cleanReportText(...)` after filtering.
- PDF path now returns explicit `PDF_EXPORT_FAILED` on generation failure; no silent TXT masquerade.

## Latency Evidence
Selected pass:
- [ ] Pass 1
- [ ] Pass 2
- [x] Pass 3

Baseline (Pre-change)
| Run | pass3_ms | total_ms | criteria_count_by_state | Notes |
|---|---:|---:|---|---|
| Run 1 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Renderer/export-only patch; no pipeline pass timing modified. |

Post-change Runs
| Run | pass3_ms | total_ms | criteria_count_by_state | Notes |
|---|---:|---:|---|---|
| Run 1 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Focused Jest suites passed; no pass-timing code touched. |
| Run 2 | 0 (N/A for renderer-only change) | 0 (N/A) | N/A | Export/report behavior verified by targeted tests + diagnostics. |

Quality gate / anomaly disclosure:
- No QG_ logic changed in this PR.
- Quality Gate behavior is preserved; this PR improves author-facing hygiene without reducing intelligence.

Final principle:
- This change is not reducing intelligence; it only removes internal diagnostic leakage from author surfaces and tightens export correctness.

## Risks & Anomalies
- Risk: over-filtering valid advice if wording matches diagnostic patterns too broadly.
- Mitigation: targeted helper tests validate retained manuscript-facing advice and removed internal/system strings.

## Validation
- Diagnostics: no errors in touched renderer/export/helper files.
- Tests updated and passing:
	- `tests/lib/evaluation/reportRenderSafety.test.ts`
	- `tests/evaluation/pipeline/pass3b.revisionPlanGuardrail.test.ts`
	- `tests/evaluation/pipeline/truthfulFallback.pass3b.test.ts`

## Acceptance criteria mapping
- Internal diagnostics removed from author-facing revision lists.
- Visible priorities renumber contiguously after filtering.
- Criterion evidence/revision actions render as lists (no semicolon-mashed blobs).
- PDF failures return explicit error (`PDF_EXPORT_FAILED`) rather than TXT success fallback.