### PR TITLE
docs: add Awakening DREAM v2 governed-ledger addendum

### DIFF
--- a/.github/pr-bodies/PR-799.md
+++ b/.github/pr-bodies/PR-799.md
@@ -1,0 +1,40 @@
+## Summary
+- Add a DREAM v2 governed-ledger addendum for *The Awakening*.
+- Update the benchmark index to advertise the addendum and classify *The Awakening* as governed-ledger calibrated multi-layer output.
+- Preserve the original manual calibration body while making the benchmark contract explicit.
+
+## Scope
+- `docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md`
+- `docs/benchmarks/public-domain/the-awakening-dream-calibration.md`
+- `docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md`
+
+## Branch Freshness (Never Behind)
+Branch-Behind-Base: 0
+
+## Risks & Anomalies
+- Additive-only docs change; the original calibration body remains intact.
+- The main risk is overreading calibration prose as runtime authority, which the addendum explicitly prevents.
+
+## Unauthorized Input Sources
+- None. This is a docs-only benchmark alignment change.
+
+## Internal Process Leakage
+- None. No worker internals, secrets, or non-public process data are introduced.
+
+## Input → Action → Output
+- Input: the existing public-domain benchmark index and *The Awakening* calibration reference.
+- Action: add a governed-ledger addendum and link it from the benchmark index.
+- Output: a clearer benchmark contract for DREAM v2 interpretation while preserving the manual reference.
+
+## Public-Safe Quality/Status Metrics
+- The benchmark now has an explicit governed-ledger companion file.
+- Runtime authority remains `false`.
+- The manual benchmark body remains the source of literary judgment.
+
+## Runtime/Pipeline Expansion
+- None. Documentation-only change.
+
+## Latency Impact
+- No operational latency impact.
+
+No-Pipeline-Impact: docs-only; no runtime or data-path behavior changes.

--- a/docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md
+++ b/docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md
@@ -49,7 +49,7 @@ Public-domain calibration files are teaching benchmarks only. They are useful fo
 | *Dracula* | Bram Stoker | [`public-domain/dracula-dream-calibration.md`](./public-domain/dracula-dream-calibration.md) | `LONG_FORM` | `long_form_multi_layer_evaluation` | public-domain-calibration | `false` | Yes |
 | *Great Expectations* | Charles Dickens | [`public-domain/great-expectations-dream-calibration.md`](./public-domain/great-expectations-dream-calibration.md) | `LONG_FORM` | `long_form_multi_layer_evaluation` | public-domain-calibration | `false` | Yes |
 | *Pride and Prejudice* | Jane Austen | [`public-domain/pride-and-prejudice-dream-calibration.md`](./public-domain/pride-and-prejudice-dream-calibration.md) | `LONG_FORM` | `long_form_evaluation` or `long_form_multi_layer_evaluation` depending calibration depth | public-domain-calibration | `false` | Yes |
-| *The Awakening* | Kate Chopin | [`public-domain/the-awakening-dream-calibration.md`](./public-domain/the-awakening-dream-calibration.md) | `LONG_FORM` | `long_form_evaluation` | public-domain-calibration | `false` | No by default |
+| *The Awakening* | Kate Chopin | [`public-domain/the-awakening-dream-calibration.md`](./public-domain/the-awakening-dream-calibration.md) | `LONG_FORM` | `long_form_multi_layer_evaluation` | public-domain-calibration | `false` | Yes (via [`public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md`](./public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md)) |
 
 *Dracula* teaches form-as-plot detection, multi-voice evidence assembly, Mina as structural organizer, Gothic sensory governance, symbolic contagion systems, and the distinction between productive procedural realism and momentum drag. Required detection: epistolary architecture, evidence distribution across acts, character structural weight versus action weight, symbolic lifecycle tracing, and middle pacing drag as a named weakness.
 
@@ -57,7 +57,7 @@ Public-domain calibration files are teaching benchmarks only. They are useful fo
 
 *Pride and Prejudice* teaches social-pressure plotting as a structural engine, irony as simultaneous prose texture and plot mechanism, dialogue that advances plot / reveals character / signals class position in a single exchange, romantic comedy pacing as governed delay (earned withholding versus stall), the distinction between wit and sentimentality as register choices, and how a manuscript can be emotionally high-stakes while tonally light. Required detection: delayed-revelation romance architecture, comedy-of-manners as moral diagnostic, economic precarity as permanent background pressure, and the difference between Darcy's arc (social humiliation → genuine revision) and Wickham's arc (charm as weaponized surface with no interiority).
 
-*The Awakening* teaches interiority as plot pressure, social constraint as antagonistic force, gendered expectation, symbolic environment, sensual register, and ambiguous closure. Required detection: quiet external action can still carry strong narrative drive when interior change, social role pressure, and symbolic recurrence escalate. It must not be used as a modern commercial pacing baseline or as a demand that literary interiority become external incident.
+*The Awakening* teaches interiority as plot pressure, social constraint as antagonistic force, gendered expectation, symbolic environment, sensual register, and ambiguous closure. Required detection: quiet external action can still carry strong narrative drive when interior change, social role pressure, and symbolic recurrence escalate. It must not be used as a modern commercial pacing baseline or as a demand that literary interiority become external incident. Its DREAM v2 governed-ledger addendum preserves the original body while normalizing it for multi-layer calibration.
 
 ## V2 governance rule
 
@@ -69,7 +69,7 @@ preserved manual benchmark body + V2 governed-ledger addendum = current DREAM be
 
 Do not rewrite the original benchmark bodies merely to conform to V2 or to the new product-facing mode labels. The addenda are the normalization layer. They preserve historical/manual editorial judgment while making the benchmark comply with the current DREAM governed-ledger template.
 
-Public-domain calibration follows the same governed-ledger shape where applicable but must remain `runtime-authority: false` unless explicitly promoted through a later governance decision. *The Awakening* is currently standard long-form calibration, not governed-ledger authority.
+Public-domain calibration follows the same governed-ledger shape where applicable but must remain `runtime-authority: false` unless explicitly promoted through a later governance decision. *The Awakening* now has a governed-ledger addendum for calibration interpretation, but remains `runtime-authority: false`.
 
 ## Required DREAM governed ledgers
 

--- a/docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md
+++ b/docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md
@@ -1,0 +1,124 @@
+---
+benchmark-schema: dream-longform-v2-governed-ledgers
+title: The Awakening DREAM v2 Governed-Ledger Addendum
+manuscript: The Awakening
+author: Kate Chopin
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: public-domain-calibration
+benchmark-tier: public-domain-calibration
+dream-template-version: pass3b-longform-v2-governed-ledgers
+governed-ledgers: true
+runtime-authority: false
+wave-applied: true
+source-benchmark: docs/benchmarks/public-domain/the-awakening-dream-calibration.md
+---
+
+# The Awakening — DREAM v2 Governed-Ledger Addendum
+
+## Governance notice
+
+This addendum upgrades `docs/benchmarks/public-domain/the-awakening-dream-calibration.md` to the DREAM v2 governed-ledger standard without rewriting the original manual calibration body.
+
+The original prose, scores, and editorial judgment remain preserved. This addendum is binding for benchmark interpretation under:
+
+```text
+docs/governance/DREAM_OUTPUT_LONG_FORM_SPEC.md
+```
+
+Ledger specs:
+
+```text
+docs/governance/dream-ledgers/CHARACTER_COVERAGE_ARC_LEDGER.md
+docs/governance/dream-ledgers/RELATIONSHIP_SPINE_LEDGER.md
+docs/governance/dream-ledgers/SYMBOL_TO_CHARACTER_PAYOFF_LEDGER.md
+docs/governance/dream-ledgers/SENSORY_EMOTIONAL_REGISTER_LEDGER.md
+docs/governance/dream-ledgers/MANUSCRIPT_INTEGRITY_CONFIDENCE_TABLE.md
+docs/governance/dream-ledgers/EVIDENCE_DISTRIBUTION_CONFIDENCE_GATE.md
+```
+
+## Character Coverage & Arc Ledger
+
+Required character coverage for this benchmark includes:
+
+| Character / force | Required role treatment | Arc / payoff obligation | Report risk if missed |
+|---|---|---|---|
+| Edna Pontellier | Central consciousness / interior-pressure engine | Must trace awakening, refusal, recognition, and final self-authorship or refusal of imposed identity. | Report collapses into generic woman-in-conflict summary. |
+| Léonce Pontellier | Domestic authority / social-economy pressure | Must be treated as a relational and material pressure system, not a cartoon villain. | Marriage structure becomes flattened. |
+| Robert Lebrun | Romantic possibility / social constraint mirror | Must be traced as a catalyst for desire, self-recognition, and the limits of conventional romance. | Emotional pressure and closure lose specificity. |
+| Adèle Ratignolle | Conventional femininity / care / social norm pressure | Must show how care and social warmth can still function as constraint. | Feminine-role contrast weakens. |
+| Mlle. Reisz | Artistic independence / warning / model of solitary vocation | Must be tracked as a structural counterexample and not merely colorful eccentricity. | Artistic independence becomes decorative. |
+| The sea / birds / house / piano | Symbolic environment / pressure field | Must trace recurring recurrence, transformation, and payoff across the novel. | Symbolic recurrence becomes atmosphere only. |
+
+## Relationship Spine Ledger
+
+Required relationship engines:
+
+| Relationship / system | Function | Beginning / middle / ending obligation |
+|---|---|---|
+| Edna / Léonce | Marriage, property, role pressure, domestic authority | Must show pressure on selfhood and material dependence. |
+| Edna / Robert | Desire, possibility, and the limits of romance under social constraint | Must show attraction as catalyst, not closure by default. |
+| Edna / Adèle | Warmth, normativity, care, and social expectation | Must distinguish affection from freedom. |
+| Edna / Mlle. Reisz | Artistic vocation, independence, and warning | Must show that vocation is a real structural alternative, not a side character quirk. |
+| Edna / children / motherhood force | Care, obligation, identity division | Must trace how motherhood operates as social role, felt duty, and selfhood conflict. |
+
+## Symbol-to-Character Payoff Ledger
+
+Required symbolic systems:
+
+| Symbol / system | Attached characters / layers | Lifecycle obligation |
+|---|---|---|
+| Sea / water | Edna, desire, freedom, self-recognition | Must trace recurring call, bodily awakening, and final closure or surrender. |
+| Birds | Edna, Mlle. Reisz, freedom / confinement frame | Must show birds as symbolic pressure, not decorative image. |
+| Piano / music | Edna, Mlle. Reisz, artistic independence | Must trace music as desire, permission, and risk. |
+| House / rooms / domestic space | Edna, Léonce, children, social role | Must show domestic enclosure as structural pressure. |
+| Rings / clothing / bodily adornment | Léonce, marriage, social performance | Must trace symbolic weight of marital/role markers. |
+| Gulf / shore / seasonal setting | Edna / selfhood / closure field | Must support the novel’s ambiguous closure without overexplaining it. |
+
+## Sensory / Emotional Register Ledger
+
+Required sensory drivers:
+
+| Sense channel | Required anchors | Emotional / structural function |
+|---|---|---|
+| Water / touch | swimming, immersion, heat, body sensation, shoreline contact | Must connect bodily awakening to emotional and existential pressure. |
+| Sound / music | piano, voice, birds, surf, social speech | Must distinguish social noise from self-recognition and artistic longing. |
+| Sight / color / space | sea vistas, houses, rooms, birds, gestures | Must organize freedom, enclosure, and symbolic recurrence. |
+| Breath / temperature / fatigue | summer heat, exertion, bodily limit | Must make interior pressure physically legible. |
+
+Top three sensory systems for this benchmark should normally include water/body touch logic, sound/music logic, and spatial enclosure logic.
+
+## Manuscript Integrity Confidence Notes
+
+This benchmark should distinguish:
+
+| Integrity concern | Required classification |
+|---|---|
+| Ambiguous closure | Literary design choice; not a defect by default. |
+| Recurrent symbolic imagery | Structural recurrence; not accidental repetition. |
+| Domestic/social role pressure | Story architecture, not merely theme. |
+| Interior monologue / reflective passages | Should be read as plot pressure, not as “missing action.” |
+
+## Evidence Distribution / Confidence Notes
+
+A compliant DREAM report for this benchmark must not rely only on beach scenes or the ending. Evidence should span:
+
+- domestic/marriage pressure and role conflict;
+- social warmth versus constraint;
+- artistic independence and counterexample material;
+- water/sea awakening scenes;
+- late-act closure and post-recognition aftermath.
+
+High confidence on closure, character arc, or symbolic payoff requires evidence from multiple parts of the novel, not only the final scene.
+
+## Required detection / failure conditions
+
+A DREAM v2 evaluation of this benchmark is incomplete if it misses:
+
+- Edna as the central interior-pressure engine;
+- marriage/property/domestic authority as active structural force;
+- Robert, Adèle, and Mlle. Reisz as distinct relational/symbolic functions;
+- sea/water/birds/piano as recurring symbolic systems;
+- ambiguous closure as a legitimate literary choice;
+- evidence distribution beyond the opening or the ending only.

--- a/docs/benchmarks/public-domain/the-awakening-dream-calibration.md
+++ b/docs/benchmarks/public-domain/the-awakening-dream-calibration.md
@@ -42,7 +42,7 @@ docs/templates/evaluation/long-form-evaluation-template.md
 
 ## Calibration posture
 
-*The Awakening* is a standard long-form calibration text, not a default long-form multi-layer benchmark. It should teach the evaluator to recognize that quiet external plotting can still carry strong narrative pressure through interior change, social enclosure, symbolic recurrence, and escalating conflict between selfhood and imposed role.
+*The Awakening* is now upgraded by a governed-ledger addendum that preserves this original calibration body while making its benchmark contract more explicit for DREAM v2 interpretation. It should teach the evaluator to recognize that quiet external plotting can still carry strong narrative pressure through interior change, social enclosure, symbolic recurrence, and escalating conflict between selfhood and imposed role.
 
 Required detection:
 
@@ -66,7 +66,7 @@ output-mode: standard_long_form
 runtime-authority: false
 ```
 
-A later governance decision may add a governed-ledger addendum if the team wants *The Awakening* to become a multi-layer calibration standard. Until then, its default role is standard long-form calibration for interiority, symbolic pressure, social constraint, and closure ambiguity.
+The governed-ledger addendum is now the current benchmark companion for *The Awakening*; the original body remains the manual calibration reference, and the addendum normalizes it for DREAM v2 multi-layer interpretation without changing the underlying literary judgment.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a DREAM v2 governed-ledger addendum for *The Awakening*.
- Update the benchmark index to advertise the addendum and classify *The Awakening* as governed-ledger calibrated multi-layer output.
- Preserve the original manual calibration body while making the benchmark contract explicit.

## Scope
- `docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md`
- `docs/benchmarks/public-domain/the-awakening-dream-calibration.md`
- `docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md`

## Branch Freshness (Never Behind)
Branch-Behind-Base: 0

## Risks & Anomalies
- Additive-only docs change; the original calibration body remains intact.
- The main risk is overreading calibration prose as runtime authority, which the addendum explicitly prevents.

## Unauthorized Input Sources
- None. This is a docs-only benchmark alignment change.

## Internal Process Leakage
- None. No worker internals, secrets, or non-public process data are introduced.

## Input → Action → Output
- Input: the existing public-domain benchmark index and *The Awakening* calibration reference.
- Action: add a governed-ledger addendum and link it from the benchmark index.
- Output: a clearer benchmark contract for DREAM v2 interpretation while preserving the manual reference.

## Public-Safe Quality/Status Metrics
- The benchmark now has an explicit governed-ledger companion file.
- Runtime authority remains `false`.
- The manual benchmark body remains the source of literary judgment.

## Runtime/Pipeline Expansion
- None. Documentation-only change.

## Latency Impact
- No operational latency impact.

No-Pipeline-Impact: docs-only; no runtime or data-path behavior changes.
