### PR TITLE
fix(copy): PR0 — public phase-label wording cleanup

### DIFF
--- a/.github/pr-bodies/PR-815.md
+++ b/.github/pr-bodies/PR-815.md
@@ -1,0 +1,18 @@
+## Summary
+Public-facing evaluation labels were normalized to safer, customer-facing phrasing.
+
+## Scope
+- UI copy only
+- No logic or pipeline behavior changes
+
+## Changes
+- `components/evaluation-poller-display.ts`
+- `components/EvaluationPoller.tsx`
+- `components/evaluation/SynthesisPoller.tsx`
+- `app/evaluate/[jobId]/page.tsx`
+- `app/reports/[jobId]/page.tsx`
+- `components/ledger/StoryLedgerShell.tsx`
+- `tests/evaluation-poller-display.test.ts`
+
+## Validation
+- `npx jest --runInBand tests/evaluation-poller-display.test.ts` (pass)

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -620,7 +620,7 @@ export default async function EvaluationReportPage({
           aria-live="polite"
         >
           <p className="text-sm font-semibold" style={{ color: '#0E0E0E' }}>
-            ✓ Story Ledger approved — craft diagnosis is now running.
+            ✓ Story Ledger approved — building your report is now running.
           </p>
           <p className="mt-1 text-sm" style={{ color: '#7B7B7B' }}>
             {(() => {
@@ -962,15 +962,15 @@ export default async function EvaluationReportPage({
             </>
           )}
 
-          {/* ── Narrative Synthesis (long-form) ── */}
+          {/* ── Finalizing your report (long-form) ── */}
           {isLongForm && isComplete && (
             <section className="rounded-lg border border-indigo-100 bg-white p-6 mb-4">
               <div className="mb-5">
                 <h2 className="text-xl font-semibold text-gray-900 flex items-center gap-2">
-                  <span aria-hidden>📖</span> Narrative Synthesis
+                  <span aria-hidden>📖</span> Finalizing your report
                 </h2>
                 <p className="text-sm text-gray-700 mt-0.5">
-                  Holistic Craft Assessment — long-form synthesis report
+                  Holistic craft assessment — long-form report finalization
                 </p>
               </div>
 

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -607,11 +607,11 @@ export default async function ReportPage({ params }: { params: { jobId: string }
         </section>
         )}
 
-        {/* Narrative Synthesis (Pass 3b — async, long-form manuscripts only) */}
+        {/* Finalizing your report (Pass 3b — async, long-form manuscripts only) */}
         {isLongForm && (
           <section className="bg-white rounded-lg shadow-sm p-6 mb-6 border border-indigo-100">
             <h2 className="text-2xl font-semibold text-gray-900 mb-1 flex items-center gap-2">
-              <span aria-hidden>&#x1F4D6;</span> Narrative Synthesis
+              <span aria-hidden>&#x1F4D6;</span> Finalizing your report
               {!dreamDoc && (
                 <span className="ml-2 inline-flex items-center rounded-full bg-amber-100 text-amber-800 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold">
                   Part 2 generating…
@@ -620,7 +620,7 @@ export default async function ReportPage({ params }: { params: { jobId: string }
             </h2>
             <p className="text-sm text-gray-700 mb-4">
               {dreamDoc
-                ? "Holistic Craft Assessment — long-form synthesis report"
+                ? "Holistic craft assessment — long-form report finalization"
                 : "Part 1 of 2 ready — scroll up to review scores and revision plan while Part 2 generates below"}
             </p>
 

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -746,7 +746,7 @@ export function EvaluationPoller({
         {isInterimComplete && redirectOnComplete && !redirectedRef.current && (
           <div className="p-3 bg-blue-50 border border-blue-200 rounded">
             <p className="text-sm text-blue-800">
-              Diagnostic report ready. Narrative Synthesis is still generating — the full report will appear automatically when complete.
+              Diagnostic report ready. Finalizing your report is still generating — the full report will appear automatically when complete.
             </p>
             <button
               type="button"

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -63,11 +63,11 @@ export function getProgressDisplay(
 
     if (isLongForm && !hasSynthesis) {
       return {
-        label: "Craft diagnostics complete — Narrative Synthesis in progress\u2026",
+        label: "Building your report complete — Finalizing your report in progress\u2026",
         valueLabel: "92%",
         helperText:
           "Your 13-criteria diagnostic report is ready below. " +
-          "Narrative Synthesis is still generating and will appear when complete.",
+          "Finalizing your report is still generating and will appear when complete.",
         indeterminate: false,
         percentage: 92,
         color: "blue",
@@ -81,7 +81,7 @@ export function getProgressDisplay(
         : "Evaluation complete!",
       valueLabel: "100%",
       helperText: isLongForm
-        ? "Your full evaluation report, including Narrative Synthesis, is ready."
+        ? "Your full evaluation report is ready."
         : "Your evaluation report is ready.",
       indeterminate: false,
       percentage: 100,
@@ -109,9 +109,9 @@ export function getProgressDisplay(
 
   if (job.phase === 'phase_3' && job.status === 'queued') {
     return {
-      label: "Finalizing your evaluation...",
+      label: "Finalizing your report...",
       valueLabel: "86%",
-      helperText: "Almost done — preparing your detailed report.",
+      helperText: "Finalizing your report.",
       indeterminate: false,
       percentage: 86,
       color: "blue",
@@ -121,9 +121,9 @@ export function getProgressDisplay(
 
   if (job.phase === 'phase_2' && job.status === 'queued') {
     return {
-      label: "Analyzing your manuscript in depth...",
+      label: "Building your report...",
       valueLabel: "67%",
-      helperText: "Reading closely across all thirteen evaluation criteria.",
+      helperText: "Building your report across all thirteen evaluation criteria.",
       indeterminate: false,
       percentage: 67,
       color: "blue",
@@ -147,13 +147,13 @@ export function getProgressDisplay(
 
   if (job.phase === 'phase_0' && job.status === 'queued') {
     return {
-      label: "Getting ready...",
+      label: "Preparing your evaluation",
       valueLabel: "5%",
       percentage: 5,
       color: "blue",
       hardStop: false,
       indeterminate: false,
-      helperText: "Your manuscript has been received and your evaluation is starting.",
+      helperText: "Your manuscript has been received. Preparing your evaluation.",
     };
   }
 
@@ -173,9 +173,9 @@ export function getProgressDisplay(
 
   if (job.cross_check_status === "running" || job.cross_check_status === "queued") {
     return {
-      label: "Putting the finishing touches on your report...",
+      label: "Finalizing your report...",
       valueLabel: "97%",
-      helperText: "Your evaluation is nearly complete.",
+      helperText: "Finalizing your report.",
       indeterminate: false,
       percentage: 97,
       color: "blue",
@@ -186,9 +186,9 @@ export function getProgressDisplay(
   if (job.phase === "phase_3") {
     const pct = elapsedDrift(job.phase3_started_at, 86, 96, _now);
     return {
-      label: "Finalizing your evaluation...",
+      label: "Finalizing your report...",
       valueLabel: `${pct}%`,
-      helperText: "Almost done — preparing your detailed report.",
+      helperText: "Finalizing your report.",
       indeterminate: false,
       percentage: pct,
       color: "blue",
@@ -199,9 +199,9 @@ export function getProgressDisplay(
   if (job.phase === "phase_2") {
     const pct = elapsedDrift(job.phase2_started_at, 67, 82, _now);
     return {
-      label: "Analyzing your manuscript in depth...",
+      label: "Building your report...",
       valueLabel: `${pct}%`,
-      helperText: "Reading closely across all thirteen evaluation criteria.",
+      helperText: "Building your report across all thirteen evaluation criteria.",
       indeterminate: false,
       percentage: pct,
       color: "blue",
@@ -246,7 +246,7 @@ export function getProgressDisplay(
   if (job.phase === 'phase_0') {
     const pct = elapsedDrift(job.phase0_started_at, 5, 12, _now);
     return {
-      label: "Getting ready...",
+      label: "Preparing your evaluation",
       valueLabel: `${pct}%`,
       helperText: "Your manuscript has been received and your evaluation is starting.",
       indeterminate: false,

--- a/components/evaluation/SynthesisPoller.tsx
+++ b/components/evaluation/SynthesisPoller.tsx
@@ -201,10 +201,10 @@ export function SynthesisPoller({ jobId, wordCount, initialDreamDoc = null, onRe
         />
         <div>
           <p className="text-sm text-gray-700 font-medium">
-            Narrative Synthesis (Part 2 of 2) is generating automatically.
+            Finalizing your report (Part 2 of 2) is generating automatically.
           </p>
           <p className="text-sm text-gray-500 mt-0.5">
-            Your scores, criteria analyses, and revision plan are ready above. Narrative Synthesis will appear here in approximately {rangeLabel} minutes
+            Your scores, criteria analyses, and revision plan are ready above. Finalizing your report will appear here in approximately {rangeLabel} minutes
             {elapsedMin > 0 ? ` — ${elapsedMin} min elapsed` : ""}.
             This page will update automatically — no refresh needed.
           </p>

--- a/components/ledger/StoryLedgerShell.tsx
+++ b/components/ledger/StoryLedgerShell.tsx
@@ -411,7 +411,7 @@ const MODULES: { id: ModuleId; label: string; number: number; sublabel: string; 
   { id: "story_layer", number: 1, label: "Story Layer Map", sublabel: "Generated story facts", icon: "◈" },
   { id: "review_gate", number: 2, label: "Review Gate", sublabel: "Author approval", icon: "◎" },
   { id: "accepted_ledger", number: 3, label: "Accepted Ledger", sublabel: "Frozen canon", icon: "◆" },
-  { id: "wave_handoff", number: 4, label: "WAVE Handoff", sublabel: "13 criteria + repair", icon: "◇" },
+  { id: "wave_handoff", number: 4, label: "Preparing next-step guidance", sublabel: "13 criteria + repair", icon: "◇" },
 ];
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -1957,7 +1957,7 @@ function Module4WaveHandoff({ approved }: { approved: boolean }) {
     return (
       <Card>
         <Pill tone="neutral">Module 4 · Locked</Pill>
-        <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>WAVE Handoff</h2>
+        <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>Preparing next-step guidance</h2>
         <p style={{ margin: 0, ...T.body }}>
           The WAVE Revision System™ bridge unlocks only after the Story Ledger is
           accepted. The craft evaluation uses the accepted ledger as its sole
@@ -1982,7 +1982,7 @@ function Module4WaveHandoff({ approved }: { approved: boolean }) {
         >
           <div style={{ flex: 1 }}>
             <Pill tone="gold">Module 4 · Active</Pill>
-            <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>WAVE Handoff</h2>
+            <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>Preparing next-step guidance</h2>
             <p style={{ margin: 0, maxWidth: "58ch", ...T.bodyLg }}>
               The accepted story ledger is now the authorized narrative matrix. The
               craft evaluation will diagnose your manuscript across 13 criteria using

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -140,13 +140,13 @@ describe("getProgressDisplay: canonical state mapping", () => {
 
   // ── Phase 2 ───────────────────────────────────────────────────────────────
 
-  test("phase_2 -> analyzing manuscript in depth, 67%", () => {
+  test("phase_2 -> building your report, 67%", () => {
     const pd = getProgressDisplay({
       status: "running",
       phase: "phase_2",
       phase_status: "running",
     });
-    expect(pd!.label).toBe("Analyzing your manuscript in depth...");
+    expect(pd!.label).toBe("Building your report...");
     expect(pd!.percentage).toBe(67);
     expect(pd!.color).toBe("blue");
     expect(pd!.hardStop).toBe(false);
@@ -154,43 +154,43 @@ describe("getProgressDisplay: canonical state mapping", () => {
 
   // ── Phase 3 / synthesis ───────────────────────────────────────────────────
 
-  test("phase_3 -> Finalizing your evaluation, 86%", () => {
+  test("phase_3 -> finalizing your report, 86%", () => {
     const pd = getProgressDisplay({
       status: "running",
       phase: "phase_3",
     });
-    expect(pd!.label).toBe("Finalizing your evaluation...");
+    expect(pd!.label).toBe("Finalizing your report...");
     expect(pd!.percentage).toBe(86);
   });
 
   // ── Cross-check / Final QA ────────────────────────────────────────────────
 
-  test("cross_check_status=running -> finishing touches, 97%", () => {
+  test("cross_check_status=running -> finalizing report, 97%", () => {
     const pd = getProgressDisplay({
       status: "running",
       phase: "phase_2",
       phase_status: "complete",
       cross_check_status: "running",
     });
-    expect(pd!.label).toBe("Putting the finishing touches on your report...");
+    expect(pd!.label).toBe("Finalizing your report...");
     expect(pd!.percentage).toBe(97);
   });
 
-  test("cross_check_status=queued -> finishing touches, 97%", () => {
+  test("cross_check_status=queued -> finalizing report, 97%", () => {
     const pd = getProgressDisplay({
       status: "running",
       cross_check_status: "queued",
     });
-    expect(pd!.label).toBe("Putting the finishing touches on your report...");
+    expect(pd!.label).toBe("Finalizing your report...");
     expect(pd!.percentage).toBe(97);
   });
 
   // ── Unknown running state ─────────────────────────────────────────────────
 
-  test("running with no phase -> getting ready label, 5%", () => {
+  test("running with no phase -> preparing your evaluation label, 5%", () => {
     const pd = getProgressDisplay({ status: "running" });
     expect(pd).not.toBeNull();
-    expect(pd!.label).toBe("Getting ready...");
+    expect(pd!.label).toBe("Preparing your evaluation");
     expect(pd!.percentage).toBe(5);
   });
 });
@@ -293,7 +293,7 @@ describe("getStageLabelFromPhase: convenience wrapper", () => {
 
   test("phase_3 returns the finalizing label", () => {
     const label = getStageLabelFromPhase("phase_3", "running", null);
-    expect(label).toBe("Finalizing your evaluation...");
+    expect(label).toBe("Finalizing your report...");
   });
 
   test("null phase returns null (no jargon fallback)", () => {


### PR DESCRIPTION
## Summary
Public-facing evaluation labels were normalized to safer, customer-facing phrasing.

## Scope
- UI copy only
- No logic or pipeline behavior changes

## Changes
- `components/evaluation-poller-display.ts`
- `components/EvaluationPoller.tsx`
- `components/evaluation/SynthesisPoller.tsx`
- `app/evaluate/[jobId]/page.tsx`
- `app/reports/[jobId]/page.tsx`
- `components/ledger/StoryLedgerShell.tsx`
- `tests/evaluation-poller-display.test.ts`

## Validation
- `npx jest --runInBand tests/evaluation-poller-display.test.ts` (pass)
