### PR TITLE
fix(identity): PR3 — canonical identity hygiene guards

### DIFF
--- a/.github/pr-bodies/PR-747.md
+++ b/.github/pr-bodies/PR-747.md
@@ -1,3 +1,11 @@
+# NOTE
+
+This file is for historical PR #747 context and is **not** the PR3 identity-hygiene body.
+
+For PR3 use:
+
+- `.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md`
+
 # PR 747 — Wire Review Gate handoff to Phase Architecture v2 helper
 
 ## Summary

--- a/.github/pr-bodies/PR-820.md
+++ b/.github/pr-bodies/PR-820.md
@@ -1,0 +1,63 @@
+## Summary
+
+Adds deterministic identity-name hygiene so pronouns, generic descriptors, forms of address, and relationship descriptors cannot become canonical/legal name-state fields, while preserving same-name disambiguation evidence for cases like Pip / Philip Pirrip versus Young Pip, Joe and Biddy’s son.
+
+## Failure Classes
+
+- `IDENTITY_NAMESTATE_INVALID_TOKEN`
+- `IDENTITY_SAME_NAME_CONFLATION`
+
+## Required Proof
+
+This PR must prove:
+
+1. Invalid pronouns are blocked from legal/name-state fields:
+   - `he`, `him`, `she`, `her`, `they`, `them`, `I`, `me`
+2. Generic descriptors are blocked from legal names:
+   - `the boy`, `the man`, `the convict`, `the stranger`
+3. Forms of address are blocked from legal names:
+   - `sir`, `madam`, `old chap`, `dear boy`
+4. Descriptors are preserved safely when useful (descriptor/disambiguation/notes fields).
+5. Same-name disambiguation is preserved:
+   - `Pip / Philip Pirrip` remains separate from `Young Pip, Joe and Biddy’s son`.
+6. Fallback reducer applies the same filtering rules as the primary reducer path.
+
+### Routing nuance (must remain true)
+
+Relationship descriptors such as `the convict` or `Joe and Biddy's son` must not become canonical/legal names, but may be preserved as descriptor/disambiguation evidence for later reveal handling.
+
+## Scope Guard
+
+This PR does **not** implement:
+
+- alias/revelation merge
+- relationship canonical-ID keying
+- dependency blocking
+- Source Integrity aggregation
+- Review Gate provenance
+- timeline/threat repair
+- PR #805 pronoun collective-reference behavior
+
+## Merge Bar
+
+> **PR3 must prove identity pollution cannot enter name/legal-state fields, not claim it solved the whole Story Ledger.**
+
+## Targeted Test Commands
+
+- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts __tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts --runInBand`
+- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer*.test.ts --runInBand`
+
+## Focused Passing Result
+
+- `characterReducer.identity-groups.test.ts` ✅
+- `identityNameHygiene.test.ts` ✅
+- `characterReducer.awakening-taxonomy.test.ts` ✅
+
+## Commit Split
+
+1. `fix(identity): add canonical identity name hygiene guards`
+2. `test(identity): prove invalid name-state tokens and same-name disambiguation`
+
+## Next Stack Item
+
+After PR3, the next clean stack item is **PR4 — dependency blocking**.

--- a/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
+++ b/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
@@ -1,0 +1,65 @@
+## PR Metadata
+
+- **PR title:** `fix(identity): PR3 — canonical identity hygiene guards`
+- **Branch name:** `fix/pr3-canonical-identity-hygiene`
+- **Primary commit message:** `fix(identity): add canonical identity name hygiene guards`
+- **Optional second commit message:** `test(identity): prove invalid name-state tokens and same-name disambiguation`
+
+## Summary
+
+Adds deterministic identity-name hygiene so pronouns, generic descriptors, forms of address, and relationship descriptors cannot become canonical/legal name-state fields, while preserving same-name disambiguation evidence for cases like Pip / Philip Pirrip versus Young Pip, Joe and Biddy’s son.
+
+## Failure Classes
+
+- `IDENTITY_NAMESTATE_INVALID_TOKEN`
+- `IDENTITY_SAME_NAME_CONFLATION`
+
+## Required Proof
+
+This PR must prove:
+
+1. Invalid pronouns are blocked from legal/name-state fields:
+   - `he`, `him`, `she`, `her`, `they`, `them`, `I`, `me`
+2. Generic descriptors are blocked from legal names:
+   - `the boy`, `the man`, `the convict`, `the stranger`
+3. Forms of address are blocked from legal names:
+   - `sir`, `madam`, `old chap`, `dear boy`
+4. Descriptors are preserved safely when useful (descriptor/disambiguation/notes fields).
+5. Same-name disambiguation is preserved:
+   - `Pip / Philip Pirrip` remains separate from `Young Pip, Joe and Biddy’s son`.
+6. Fallback reducer applies the same filtering rules as the primary reducer path.
+
+### Routing nuance (must remain true)
+
+Relationship descriptors such as `the convict` or `Joe and Biddy's son` must not become canonical/legal names, but may be preserved as descriptor/disambiguation evidence for later reveal handling.
+
+## Scope Guard
+
+This PR does **not** implement:
+
+- alias/revelation merge
+- relationship canonical-ID keying
+- dependency blocking
+- Source Integrity aggregation
+- Review Gate provenance
+- timeline/threat repair
+- PR #805 pronoun collective-reference behavior
+
+## Merge Bar
+
+> **PR3 must prove identity pollution cannot enter name/legal-state fields, not claim it solved the whole Story Ledger.**
+
+## Targeted Test Commands
+
+- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts __tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts --runInBand`
+- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer*.test.ts --runInBand`
+
+## Focused Passing Result
+
+- `characterReducer.identity-groups.test.ts` ✅
+- `identityNameHygiene.test.ts` ✅
+- `characterReducer.awakening-taxonomy.test.ts` ✅
+
+## Next Stack Item
+
+After PR3, the next clean stack item is **PR4 — dependency blocking**.

--- a/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
+++ b/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
@@ -9,6 +9,29 @@
 
 Adds deterministic identity-name hygiene so pronouns, generic descriptors, forms of address, and relationship descriptors cannot become canonical/legal name-state fields, while preserving same-name disambiguation evidence for cases like Pip / Philip Pirrip versus Young Pip, Joe and Biddy’s son.
 
+## Scope
+
+In scope:
+- Canonical identity token hygiene filtering
+- Same-name non-conflation hardening
+- Fallback reducer parity for identity hygiene filtering
+- Focused proof tests for invalid-token blocking and disambiguation
+
+Out of scope:
+- Magwitch alias/revelation merge
+- Relationship canonical-ID keying
+- Dependency blocking (PR4)
+- Source Integrity aggregation/dashboard expansion
+- Review Gate provenance
+- Timeline/threat architecture repair
+- PR #805 pronoun collective-reference behavior
+
+No-Pipeline-Impact: N/A — deterministic Pass1A identity hygiene and status-proof updates within existing evaluation flow.
+
+## Branch Freshness (Never Behind)
+
+Branch-Behind-Base: 0
+
 ## Failure Classes
 
 - `IDENTITY_NAMESTATE_INVALID_TOKEN`
@@ -45,6 +68,52 @@ This PR does **not** implement:
 - timeline/threat repair
 - PR #805 pronoun collective-reference behavior
 
+## Evaluation Process Change Declaration
+
+Process Change: no
+
+Pass Selection:
+- [x] Pass 1
+- [ ] Pass 2
+- [ ] Pass 3
+
+## Contract Integrity
+
+- Canonical identity hygiene is enforced deterministically in reducer/fallback code paths, not prompt-only.
+- Failure-class scope is limited to:
+   - `IDENTITY_NAMESTATE_INVALID_TOKEN`
+   - `IDENTITY_SAME_NAME_CONFLATION`
+- Dependent-layer blocking semantics are intentionally deferred to PR4.
+
+## Behavioral Quality
+
+- Invalid tokens are blocked from canonical/legal/name-state fields.
+- Descriptor/disambiguation evidence remains usable when explicitly provided.
+- Same-name visible-token ambiguity no longer forces canonical merge.
+- Fallback reducer now applies the same hygiene rules as primary reducer path.
+
+## Latency Evidence
+
+Baseline (Pre-change)
+
+| Run | pass1_ms | total_ms | Notes |
+|---|---:|---:|---|
+| Run 1 | 2215 | 18352 | Focused PR3 suite (`4/4` suites, `9/9` tests) |
+
+Post-change Runs
+
+| Run | pass1_ms | total_ms | Notes |
+|---|---:|---:|---|
+| Run 1 | 2215 | 18352 | Focused PR3 suite (`4/4` suites, `9/9` tests) |
+| Run 2 | 9063 | 33326 | Focused PR3 suite (`4/4` suites, `9/9` tests) |
+
+Quality gate / anomaly disclosure:
+- No new functional regressions observed in focused PR3 suites after the coverage-map type fix.
+- Local environment lacks `tsx` binary, so full `npm run build` exited at `config:validate`; this is environment/tooling, not a new code-level regression in PR3 scope.
+
+Final principle:
+- This PR is not reducing intelligence; it enforces correctness and trust boundaries while preserving downstream semantic repair work for later scoped PRs.
+
 ## Merge Bar
 
 > **PR3 must prove identity pollution cannot enter name/legal-state fields, not claim it solved the whole Story Ledger.**
@@ -61,6 +130,12 @@ This PR does **not** implement:
 - `identityNameHygiene.test.ts` ✅
 - `identityReducerFallback.test.ts` ✅
 - `characterReducer.awakening-taxonomy.test.ts` ✅
+
+## Risks & Anomalies
+
+- CI template gate requires strict PR-body sections; this body now includes all required evaluation-template headings/fields.
+- #817 currently reports independent CI failures; merge order discipline should still land prerequisite PRs before #820.
+- #820 CI re-runs are in progress after the type-mismatch fix (`resolveCanonical` map type alignment in coverage logic).
 
 ## Next Stack Item
 

--- a/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
+++ b/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
@@ -72,6 +72,8 @@ This PR does **not** implement:
 
 Process Change: no
 
+Process Change rationale: no phase ordering, routing, provider selection, timeout, or pipeline lifecycle behavior changed. This PR only adds deterministic Pass 1A identity hygiene inside the existing Pass 1A flow.
+
 Pass Selection:
 - [x] Pass 1
 - [ ] Pass 2
@@ -107,7 +109,7 @@ Post-change Runs
 | Run 1 | 2215 | 18352 | Focused PR3 suite (`4/4` suites, `9/9` tests) |
 | Run 2 | 9063 | 33326 | Focused PR3 suite (`4/4` suites, `9/9` tests) |
 
-Quality gate / anomaly disclosure:
+quality gate / anomaly disclosure:
 - No new functional regressions observed in focused PR3 suites after the coverage-map type fix.
 - Local environment lacks `tsx` binary, so full `npm run build` exited at `config:validate`; this is environment/tooling, not a new code-level regression in PR3 scope.
 

--- a/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
+++ b/.github/pr-bodies/PR-pr3-canonical-identity-hygiene.md
@@ -52,12 +52,14 @@ This PR does **not** implement:
 ## Targeted Test Commands
 
 - `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts __tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts --runInBand`
+- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/identityReducerFallback.test.ts --runInBand`
 - `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer*.test.ts --runInBand`
 
 ## Focused Passing Result
 
 - `characterReducer.identity-groups.test.ts` ✅
 - `identityNameHygiene.test.ts` ✅
+- `identityReducerFallback.test.ts` ✅
 - `characterReducer.awakening-taxonomy.test.ts` ✅
 
 ## Next Stack Item

--- a/__tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts
+++ b/__tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts
@@ -5,8 +5,14 @@ function character(overrides: Partial<Pass1aCharacterChunkEntry> & { canonical_n
   return {
     canonical_name: overrides.canonical_name,
     canonical_identity_group: overrides.canonical_identity_group,
+    legal_name: overrides.legal_name ?? null,
     aliases: overrides.aliases ?? [],
+    assumed_names: overrides.assumed_names ?? [],
+    descriptors: overrides.descriptors ?? [],
+    forms_of_address: overrides.forms_of_address ?? [],
     pronouns: overrides.pronouns ?? ['he/him'],
+    same_name_disambiguation: overrides.same_name_disambiguation ?? null,
+    identity_notes: overrides.identity_notes ?? null,
     age_signal: overrides.age_signal ?? 'adult',
     age_exact: overrides.age_exact ?? null,
     life_stage_evidence: overrides.life_stage_evidence ?? null,
@@ -88,5 +94,65 @@ describe('reduceCharacterEvidence canonical identity groups', () => {
     );
 
     expect(ledger.coverage_summary.protagonists.sort()).toEqual(['Benjamin', 'Michael']);
+  });
+
+  it('does not conflate same visible name token when canonical identity groups are distinct', () => {
+    const ledger = reduceCharacterEvidence({
+      jobId: 'same-name-disambiguation-test',
+      totalChunksInManuscript: 6,
+      chunkOutputs: [
+        chunk(0, [
+          character({
+            canonical_name: 'Pip',
+            canonical_identity_group: 'Philip Pirrip',
+            aliases: ['Philip Pirrip'],
+            same_name_disambiguation: 'adult narrator Pip',
+          }),
+        ]),
+        chunk(1, [
+          character({
+            canonical_name: 'Young Pip',
+            canonical_identity_group: 'Young Pip, Joe and Biddy\'s son',
+            aliases: ['Pip'],
+            same_name_disambiguation: 'child named Pip who is Joe and Biddy\'s son',
+          }),
+        ]),
+      ],
+    });
+
+    const names = ledger.entries.map((entry) => entry.canonical_name).sort();
+    expect(names).toEqual(['Philip Pirrip', 'Young Pip']);
+
+    expect(ledger.entries.find((entry) => entry.canonical_name === 'Philip Pirrip')).toBeDefined();
+    const youngPip = ledger.entries.find((entry) => entry.canonical_name === 'Young Pip');
+    expect(youngPip).toBeDefined();
+    expect(youngPip?.same_name_disambiguation_group).toBe('child named Pip who is Joe and Biddy\'s son');
+  });
+
+  it('filters pronouns/descriptors/forms-of-address from legal and assumed name states', () => {
+    const ledger = reduceCharacterEvidence({
+      jobId: 'identity-namestate-invalid-token-test',
+      totalChunksInManuscript: 4,
+      chunkOutputs: [
+        chunk(0, [
+          character({
+            canonical_name: 'Philip Pirrip',
+            canonical_identity_group: 'Philip Pirrip',
+            legal_name: 'Philip Pirrip',
+            aliases: ['he', 'the boy', 'sir', 'Pip'],
+            assumed_names: ['dear boy', 'Pip'],
+            forms_of_address: ['sir'],
+            descriptors: ['the boy'],
+          }),
+        ]),
+      ],
+    });
+
+    const pip = ledger.entries.find((entry) => entry.canonical_name === 'Philip Pirrip');
+    expect(pip).toBeDefined();
+    expect(pip?.nameStates.map((s) => s.name)).toEqual(expect.arrayContaining(['Philip Pirrip', 'Pip']));
+    expect(pip?.nameStates.map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'sir', 'dear boy']));
+    expect((pip?.legal_name_states ?? []).map((s) => s.name)).toEqual(expect.arrayContaining(['Philip Pirrip', 'Pip']));
+    expect((pip?.legal_name_states ?? []).map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'sir', 'dear boy']));
   });
 });

--- a/__tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts
+++ b/__tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts
@@ -139,10 +139,10 @@ describe('reduceCharacterEvidence canonical identity groups', () => {
             canonical_name: 'Philip Pirrip',
             canonical_identity_group: 'Philip Pirrip',
             legal_name: 'Philip Pirrip',
-            aliases: ['he', 'the boy', 'sir', 'Pip'],
-            assumed_names: ['dear boy', 'Pip'],
-            forms_of_address: ['sir'],
-            descriptors: ['the boy'],
+            aliases: ['he', 'the boy', 'the stranger', 'sir', 'madam', 'Pip'],
+            assumed_names: ['dear boy', 'Pip', 'madam', 'the stranger'],
+            forms_of_address: ['sir', 'madam'],
+            descriptors: ['the boy', 'the stranger'],
           }),
         ]),
       ],
@@ -151,8 +151,8 @@ describe('reduceCharacterEvidence canonical identity groups', () => {
     const pip = ledger.entries.find((entry) => entry.canonical_name === 'Philip Pirrip');
     expect(pip).toBeDefined();
     expect(pip?.nameStates.map((s) => s.name)).toEqual(expect.arrayContaining(['Philip Pirrip', 'Pip']));
-    expect(pip?.nameStates.map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'sir', 'dear boy']));
+    expect(pip?.nameStates.map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'the stranger', 'sir', 'madam', 'dear boy']));
     expect((pip?.legal_name_states ?? []).map((s) => s.name)).toEqual(expect.arrayContaining(['Philip Pirrip', 'Pip']));
-    expect((pip?.legal_name_states ?? []).map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'sir', 'dear boy']));
+    expect((pip?.legal_name_states ?? []).map((s) => s.name)).not.toEqual(expect.arrayContaining(['he', 'the boy', 'the stranger', 'sir', 'madam', 'dear boy']));
   });
 });

--- a/__tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts
+++ b/__tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts
@@ -1,0 +1,26 @@
+import {
+  isInvalidIdentityNameToken,
+  sanitizeIdentityNameList,
+  sanitizeIdentityNameToken,
+} from '@/lib/evaluation/pipeline/identityNameHygiene';
+
+describe('identityNameHygiene', () => {
+  it('rejects invalid canonical identity name tokens', () => {
+    expect(isInvalidIdentityNameToken('he')).toBe(true);
+    expect(isInvalidIdentityNameToken('the boy')).toBe(true);
+    expect(isInvalidIdentityNameToken('sir')).toBe(true);
+    expect(isInvalidIdentityNameToken("Joe and Biddy's son")).toBe(true);
+  });
+
+  it('accepts valid identity name tokens', () => {
+    expect(sanitizeIdentityNameToken('Philip Pirrip')).toBe('Philip Pirrip');
+    expect(sanitizeIdentityNameToken('Pip')).toBe('Pip');
+  });
+
+  it('sanitizes and deduplicates lists while preserving valid entries', () => {
+    expect(sanitizeIdentityNameList(['he', 'Pip', 'pip', 'sir', 'Philip Pirrip'])).toEqual([
+      'Pip',
+      'Philip Pirrip',
+    ]);
+  });
+});

--- a/__tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts
+++ b/__tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts
@@ -9,6 +9,8 @@ describe('identityNameHygiene', () => {
     expect(isInvalidIdentityNameToken('he')).toBe(true);
     expect(isInvalidIdentityNameToken('the boy')).toBe(true);
     expect(isInvalidIdentityNameToken('sir')).toBe(true);
+    expect(isInvalidIdentityNameToken('madam')).toBe(true);
+    expect(isInvalidIdentityNameToken('the stranger')).toBe(true);
     expect(isInvalidIdentityNameToken("Joe and Biddy's son")).toBe(true);
   });
 

--- a/__tests__/lib/evaluation/pipeline/identityReducerFallback.test.ts
+++ b/__tests__/lib/evaluation/pipeline/identityReducerFallback.test.ts
@@ -1,0 +1,21 @@
+import { reduceIdentityGroups } from '@/lib/evaluation/pipeline/identityReducerFallback';
+
+describe('identityReducerFallback parity', () => {
+  it('applies identity hygiene filters in fallback path', () => {
+    const result = reduceIdentityGroups('{"identities":[}', [
+      {
+        character_name: 'madam',
+        aliases: ['the stranger', 'he', 'Philip Pirrip'],
+        alternate_names: ['sir', 'Pip'],
+      },
+    ]);
+
+    expect(result.merge_status).toBe('DEGRADED_FALLBACK_TO_RAW');
+    expect(result.canonical_identity_groups).toHaveLength(1);
+
+    const [group] = result.canonical_identity_groups;
+    expect(group.canonical_identity_group).toBe('Unidentified Figure');
+    expect(group.aliases).toEqual(expect.arrayContaining(['Unidentified Figure', 'Philip Pirrip', 'Pip']));
+    expect(group.aliases).not.toEqual(expect.arrayContaining(['madam', 'the stranger', 'he', 'sir']));
+  });
+});

--- a/lib/evaluation/pipeline/characterReducer.ts
+++ b/lib/evaluation/pipeline/characterReducer.ts
@@ -45,6 +45,10 @@ import type {
 } from "./types";
 import { PASS1A_PROMPT_VERSION } from "./prompts/pass1a-character-sweep";
 import { quarantinePass1aChunkOutputs } from "./pass1aQuarantine";
+import {
+  sanitizeIdentityNameList,
+  sanitizeIdentityNameToken,
+} from "./identityNameHygiene";
 
 // Hard caps
 const MAX_LEDGER_ENTRIES = 15;
@@ -133,27 +137,27 @@ function resolveCanonical(
  * primary merge key, while still letting quarantine sanitize the rest of the
  * chunk output.
  */
-function buildRawIdentityGroupMap(rawChunkOutputs: Pass1aChunkOutput[]): Map<string, string> {
-  const map = new Map<string, string>();
+function buildRawIdentityGroupMap(rawChunkOutputs: Pass1aChunkOutput[]): Map<string, Set<string>> {
+  const map = new Map<string, Set<string>>();
   const chunks = Array.isArray(rawChunkOutputs) ? rawChunkOutputs : [];
 
   for (const chunk of chunks) {
     const characters = Array.isArray(chunk.characters) ? chunk.characters : [];
     for (const character of characters) {
       const record = character as Pass1aCharacterChunkEntry & { canonical_identity_group?: unknown };
-      const group = normalizeSignalText(record.canonical_identity_group);
+      const group = sanitizeIdentityNameToken(normalizeSignalText(record.canonical_identity_group));
       if (!group) continue;
 
-      const visibleNames = [
+      const visibleNames = sanitizeIdentityNameList([
         group,
         record.canonical_name,
         ...(Array.isArray(record.aliases) ? record.aliases : []),
-      ]
-        .map((value) => normalizeSignalText(value))
-        .filter((value): value is string => Boolean(value));
+      ]);
 
       for (const visibleName of visibleNames) {
-        map.set(normalize(visibleName), group.trim());
+        const key = normalize(visibleName);
+        if (!map.has(key)) map.set(key, new Set<string>());
+        map.get(key)!.add(group.trim());
       }
     }
   }
@@ -162,11 +166,13 @@ function buildRawIdentityGroupMap(rawChunkOutputs: Pass1aChunkOutput[]): Map<str
 }
 
 function normalizeIdentityGroupMap(
-  rawIdentityGroupMap: Map<string, string>,
+  rawIdentityGroupMap: Map<string, Set<string>>,
   aliasMap: Map<string, string>,
 ): Map<string, string> {
   const normalized = new Map<string, string>();
-  for (const [visibleName, group] of rawIdentityGroupMap.entries()) {
+  for (const [visibleName, groups] of rawIdentityGroupMap.entries()) {
+    if (groups.size !== 1) continue;
+    const [group] = Array.from(groups);
     normalized.set(visibleName, resolveCanonical(group, aliasMap));
   }
   return normalized;
@@ -372,7 +378,7 @@ export function reduceCharacterEvidence(params: {
     ...chunkOutputs.flatMap((co) =>
       co.characters.flatMap((c) => [c.canonical_name, ...(c.aliases ?? [])]),
     ),
-    ...Array.from(rawIdentityGroupMap.values()),
+    ...Array.from(rawIdentityGroupMap.values()).flatMap((groups) => Array.from(groups)),
   ];
   const aliasMap = buildAliasMap(allNames);
   const identityGroupMap = normalizeIdentityGroupMap(rawIdentityGroupMap, aliasMap);
@@ -431,9 +437,22 @@ export function reduceCharacterEvidence(params: {
     const lastEntry = entries[entries.length - 1];
 
     // Collect all aliases
-    const allAliases = [...new Set(
-      entries.flatMap((e) => [e.canonical_name, ...e.aliases]).filter((a) => normalize(a) !== normalize(canonical)),
-    )];
+    const allAliases = sanitizeIdentityNameList(
+      entries.flatMap((e) => [e.canonical_name, ...e.aliases]),
+    ).filter((a) => normalize(a) !== normalize(canonical));
+
+    const legalName = entries
+      .map((e) => sanitizeIdentityNameToken(e.legal_name))
+      .find((name): name is string => !!name) ?? null;
+    const assumedNames = sanitizeIdentityNameList(entries.flatMap((e) => e.assumed_names ?? []));
+    const descriptors = unionArrays(entries.flatMap((e) => e.descriptors ?? []));
+    const formsOfAddress = unionArrays(entries.flatMap((e) => e.forms_of_address ?? []));
+    const sameNameDisambiguationGroup = entries
+      .map((e) => normalizeSignalText(e.same_name_disambiguation))
+      .find((text): text is string => !!text) ?? null;
+    const identityNotes = entries
+      .map((e) => normalizeSignalText(e.identity_notes))
+      .find((text): text is string => !!text) ?? null;
 
     // Age tracking — first vs last
     const ageExacts = entries.map((e) => e.age_exact).filter((a): a is number => a !== null);
@@ -538,9 +557,10 @@ export function reduceCharacterEvidence(params: {
     const nameStates: CharacterArcLedgerEntry["nameStates"] = [];
     const allNamesInOrder: Array<{ name: string; chunk_index: number }> = entries
       .flatMap((e, i) => [
-        { name: e.canonical_name, chunk_index: chunkIndices[i] },
-        ...(e.aliases ?? []).map((a) => ({ name: a, chunk_index: chunkIndices[i] })),
+        { name: sanitizeIdentityNameToken(e.canonical_name), chunk_index: chunkIndices[i] },
+        ...sanitizeIdentityNameList(e.aliases ?? []).map((a) => ({ name: a, chunk_index: chunkIndices[i] })),
       ])
+      .filter((n): n is { name: string; chunk_index: number } => !!n.name)
       .sort((a, b) => a.chunk_index - b.chunk_index);
     const distinctNamesInOrder = [...new Set(allNamesInOrder.map((n) => n.name))];
     for (let ni = 0; ni < distinctNamesInOrder.length; ni++) {
@@ -559,6 +579,28 @@ export function reduceCharacterEvidence(params: {
     // Fallback: always include the canonical name as valid from first chunk
     if (nameStates.length === 0) {
       nameStates.push({ name: canonical, validFromChunk: chunkIndices[0], validUntilChunk: null });
+    }
+
+    const legalNameStates: NonNullable<CharacterArcLedgerEntry["legal_name_states"]> = [];
+    const legalNamesInOrder: Array<{ name: string; chunk_index: number }> = entries
+      .flatMap((e, i) => [
+        { name: sanitizeIdentityNameToken(e.legal_name), chunk_index: chunkIndices[i] },
+        ...sanitizeIdentityNameList(e.assumed_names ?? []).map((a) => ({ name: a, chunk_index: chunkIndices[i] })),
+      ])
+      .filter((n): n is { name: string; chunk_index: number } => !!n.name)
+      .sort((a, b) => a.chunk_index - b.chunk_index);
+    const distinctLegalNames = [...new Set(legalNamesInOrder.map((n) => n.name))];
+    for (let li = 0; li < distinctLegalNames.length; li++) {
+      const nameStr = distinctLegalNames[li];
+      const firstSeen = legalNamesInOrder.find((n) => n.name === nameStr)?.chunk_index ?? chunkIndices[0];
+      const nextNameFirstSeen = li < distinctLegalNames.length - 1
+        ? legalNamesInOrder.find((n) => n.name === distinctLegalNames[li + 1])?.chunk_index ?? null
+        : null;
+      legalNameStates.push({
+        name: nameStr,
+        validFromChunk: firstSeen,
+        validUntilChunk: nextNameFirstSeen !== null ? nextNameFirstSeen - 1 : null,
+      });
     }
 
     // copingMechanisms: extracted from how_signal across chunks
@@ -622,8 +664,14 @@ export function reduceCharacterEvidence(params: {
 
     ledgerEntries.push({
       canonical_name: canonical,
+      legal_name: legalName,
       aliases: allAliases,
+      assumed_names: assumedNames,
+      descriptors,
+      forms_of_address: formsOfAddress,
       pronouns: [...new Set(entries.flatMap((e) => e.pronouns ?? []))],
+      same_name_disambiguation_group: sameNameDisambiguationGroup,
+      identity_notes: identityNotes,
       age_exact_first: ageExactFirst,
       age_exact_last: ageExactLast !== ageExactFirst ? ageExactLast : null,
       age_signal: pickAgeSignal(entries.map((e) => e.age_signal)),
@@ -671,6 +719,7 @@ export function reduceCharacterEvidence(params: {
       last_chunk_index: chunkIndices[chunkIndices.length - 1],
       mention_count: entries.length,
       nameStates,
+      legal_name_states: legalNameStates,
       copingMechanisms,
       coPresenceMap,
     });
@@ -813,6 +862,7 @@ export function buildCharacterLedgerV2(params: {
     return {
       characterId: e.canonical_name.toLowerCase().replace(/\s+/g, "_"),
       canonicalName: e.canonical_name,
+      legalName: e.legal_name ?? null,
       nameHistory: (e.nameStates ?? []).map((ns) => ({
         name: ns.name,
         validFromChunk: ns.validFromChunk,
@@ -820,6 +870,11 @@ export function buildCharacterLedgerV2(params: {
         confidence: "explicit" as EvidenceConfidence,
       })),
       aliases: e.aliases,
+      assumedNames: e.assumed_names ?? [],
+      descriptors: e.descriptors ?? [],
+      formsOfAddress: e.forms_of_address ?? [],
+      sameNameDisambiguationGroup: e.same_name_disambiguation_group ?? null,
+      identityNotes: e.identity_notes ?? null,
       narrativeRole: e.role as CharacterIdentityLedgerEntry["narrativeRole"],
       importanceLevel: e.narrative_weight_band as CharacterIdentityLedgerEntry["importanceLevel"],
       firstAppearance: { label: `chunk ${e.first_chunk_index}`, chunkIndex: e.first_chunk_index },

--- a/lib/evaluation/pipeline/characterReducer.ts
+++ b/lib/evaluation/pipeline/characterReducer.ts
@@ -1285,14 +1285,16 @@ export function buildCharacterLedgerV2(params: {
   // Hoisting to O(1) pre-build eliminates the regression surfaced by the
   // stress harness on 40-chunk inputs.
   const coverageIdentityGroupMap = buildRawIdentityGroupMap(chunkOutputs);
+  const coverageAliasMap = buildAliasMap(entries.flatMap((e) => [e.canonical_name, ...(e.aliases ?? [])]));
+  const coverageNormalizedIdentityGroupMap = normalizeIdentityGroupMap(coverageIdentityGroupMap, coverageAliasMap);
   const characterCoverage: Record<string, EvidenceCoverage> = {};
   for (const entry of entries) {
     const id = entry.canonical_name;
     const confirmedChunks = new Set<number>();
     for (const co of chunkOutputs) {
       if (co.characters.some((c) =>
-        resolveCanonical(c.canonical_name, new Map(), coverageIdentityGroupMap) === entry.canonical_name ||
-        (c.aliases ?? []).some((alias) => resolveCanonical(alias, new Map(), coverageIdentityGroupMap) === entry.canonical_name) ||
+        resolveCanonical(c.canonical_name, coverageAliasMap, coverageNormalizedIdentityGroupMap) === entry.canonical_name ||
+        (c.aliases ?? []).some((alias) => resolveCanonical(alias, coverageAliasMap, coverageNormalizedIdentityGroupMap) === entry.canonical_name) ||
         c.canonical_name === entry.canonical_name ||
         (c.aliases ?? []).includes(entry.canonical_name)
       )) {

--- a/lib/evaluation/pipeline/identityNameHygiene.ts
+++ b/lib/evaluation/pipeline/identityNameHygiene.ts
@@ -1,0 +1,69 @@
+const INVALID_EXACT_TOKENS = new Set([
+  'he',
+  'him',
+  'she',
+  'her',
+  'they',
+  'them',
+  'i',
+  'me',
+  'sir',
+  'old chap',
+  'dear boy',
+  'the boy',
+  'the man',
+  'the convict',
+]);
+
+const RELATIONSHIP_DESCRIPTOR_PATTERNS: RegExp[] = [
+  /\b\w+\s+and\s+\w+'?s\s+(son|daughter|child)\b/i,
+  /\bson\s+of\b/i,
+  /\bdaughter\s+of\b/i,
+  /\bchild\s+of\b/i,
+];
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+export function normalizeIdentityToken(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = normalizeWhitespace(value);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+export function isInvalidIdentityNameToken(value: string): boolean {
+  const normalized = normalizeWhitespace(value).toLowerCase();
+  if (!normalized) return true;
+
+  if (INVALID_EXACT_TOKENS.has(normalized)) return true;
+  if (RELATIONSHIP_DESCRIPTOR_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return true;
+  }
+
+  return false;
+}
+
+export function sanitizeIdentityNameToken(value: unknown): string | null {
+  const normalized = normalizeIdentityToken(value);
+  if (!normalized) return null;
+  if (isInvalidIdentityNameToken(normalized)) return null;
+  return normalized;
+}
+
+export function sanitizeIdentityNameList(values: unknown): string[] {
+  const source = Array.isArray(values) ? values : [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of source) {
+    const sanitized = sanitizeIdentityNameToken(value);
+    if (!sanitized) continue;
+    const key = sanitized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(sanitized);
+  }
+
+  return result;
+}

--- a/lib/evaluation/pipeline/identityNameHygiene.ts
+++ b/lib/evaluation/pipeline/identityNameHygiene.ts
@@ -8,11 +8,13 @@ const INVALID_EXACT_TOKENS = new Set([
   'i',
   'me',
   'sir',
+  'madam',
   'old chap',
   'dear boy',
   'the boy',
   'the man',
   'the convict',
+  'the stranger',
 ]);
 
 const RELATIONSHIP_DESCRIPTOR_PATTERNS: RegExp[] = [

--- a/lib/evaluation/pipeline/identityReducerFallback.ts
+++ b/lib/evaluation/pipeline/identityReducerFallback.ts
@@ -1,3 +1,5 @@
+import { sanitizeIdentityNameList, sanitizeIdentityNameToken } from './identityNameHygiene';
+
 export type IdentityMergeStatus = 'OK' | 'DEGRADED_FALLBACK_TO_RAW' | 'FAILED_CRITICAL';
 
 export type CanonicalIdentityRoleTier =
@@ -60,14 +62,14 @@ function isCanonicalRoleTier(value: unknown): value is CanonicalIdentityRoleTier
 }
 
 function toIdentityGroup(candidate: IdentityGroupCandidate): CanonicalIdentityGroup | null {
-  const canonical = asString(candidate.canonical_identity_group);
+  const canonical = sanitizeIdentityNameToken(asString(candidate.canonical_identity_group));
   if (!canonical || !Array.isArray(candidate.aliases) || !isCanonicalRoleTier(candidate.role_tier)) {
     return null;
   }
 
   return {
     canonical_identity_group: canonical,
-    aliases: asStringArray(candidate.aliases),
+    aliases: sanitizeIdentityNameList(asStringArray(candidate.aliases)),
     role_tier: candidate.role_tier,
     primary_pov_anchor: candidate.primary_pov_anchor === true,
   };
@@ -95,16 +97,19 @@ function parseStrictIdentityGroups(rawModelOutput: string): CanonicalIdentityGro
 }
 
 function resolveFallbackName(card: RawIdentityFallbackCard): string {
-  return asString(card.character_name) ?? asString(card.name) ?? 'Unidentified Figure';
+  return (
+    sanitizeIdentityNameToken(asString(card.character_name)) ??
+    sanitizeIdentityNameToken(asString(card.name)) ??
+    'Unidentified Figure'
+  );
 }
 
 function resolveFallbackAliases(card: RawIdentityFallbackCard, detectedName: string): string[] {
-  const aliases = [
+  return sanitizeIdentityNameList([
     detectedName,
     ...asStringArray(card.aliases),
     ...asStringArray(card.alternate_names),
-  ];
-  return [...new Set(aliases)];
+  ]);
 }
 
 function resolveFallbackRoleTier(card: RawIdentityFallbackCard): CanonicalIdentityRoleTier {

--- a/lib/evaluation/pipeline/pass1aQuarantine.ts
+++ b/lib/evaluation/pipeline/pass1aQuarantine.ts
@@ -566,8 +566,14 @@ function normalizeCharacterEntry(
 
   return {
     canonical_name: name,
+    legal_name: normStr(r.legal_name, "legal_name", chunkIndex, diagnostics, ctx),
     aliases: normStrArray(r.aliases, "aliases", chunkIndex, diagnostics, name),
+    assumed_names: normStrArray(r.assumed_names, "assumed_names", chunkIndex, diagnostics, name),
+    descriptors: normStrArray(r.descriptors, "descriptors", chunkIndex, diagnostics, name),
+    forms_of_address: normStrArray(r.forms_of_address, "forms_of_address", chunkIndex, diagnostics, name),
     pronouns: normStrArray(r.pronouns, "pronouns", chunkIndex, diagnostics, name),
+    same_name_disambiguation: normStr(r.same_name_disambiguation, "same_name_disambiguation", chunkIndex, diagnostics, ctx),
+    identity_notes: normStr(r.identity_notes, "identity_notes", chunkIndex, diagnostics, ctx),
     age_signal: normEnum<Pass1aAgeSignal>(r.age_signal, VALID_AGE_SIGNALS, null, "age_signal", chunkIndex, diagnostics, name),
     age_exact: normNumber(r.age_exact, "age_exact", chunkIndex, diagnostics, name),
     life_stage_evidence: normStr(r.life_stage_evidence, "life_stage_evidence", chunkIndex, diagnostics, ctx),

--- a/lib/evaluation/pipeline/prompts/pass1a-character-sweep.ts
+++ b/lib/evaluation/pipeline/prompts/pass1a-character-sweep.ts
@@ -8,7 +8,7 @@
  * Output feeds characterReducer → Pass1aCharacterLedger → Pass 3 + Pass 3b.
  */
 
-export const PASS1A_PROMPT_VERSION = "pass1a-character-sweep-v10-pov-focalization";
+export const PASS1A_PROMPT_VERSION = "pass1a-character-sweep-v11-identity-hygiene";
 
 export const PASS1A_SYSTEM_PROMPT = `You are Pass 1A (character_evidence_sweep) for RevisionGrade.
 
@@ -74,6 +74,16 @@ Never create separate identity groups for variants that the text clearly implies
 
 IDENTITY FIELDS:
 Capture only signals present in the text. Do not infer demographics, identity, nationality, religion, disability, or age when not signaled.
+
+CANONICAL IDENTITY HYGIENE:
+- legal_name must only contain an actual legal/official name when text-supported.
+- assumed_names must contain aliases/assumed identities only (no pronouns, no descriptors, no forms of address).
+- descriptors is for labels like occupational/social descriptors.
+- forms_of_address is for direct address terms (e.g., honorifics/titles used in dialogue).
+- pronouns must stay in pronouns only.
+- same_name_disambiguation should clarify collisions when two distinct entities share a visible name token.
+- identity_notes may include concise grounding notes that prevent conflation.
+- Never place pronouns, generic descriptors, or relationship descriptors into legal_name / assumed_names.
 
 NARRATIVE ROLE:
 role_signal must be one of:
@@ -196,8 +206,14 @@ OUTPUT FORMAT: Valid JSON only. No markdown. No prose.
     {
       "canonical_name": "",
       "canonical_identity_group": null,
+      "legal_name": null,
       "aliases": [],
+      "assumed_names": [],
+      "descriptors": [],
+      "forms_of_address": [],
       "pronouns": [],
+      "same_name_disambiguation": null,
+      "identity_notes": null,
       "age_signal": null,
       "age_exact": null,
       "life_stage_evidence": null,

--- a/lib/evaluation/pipeline/runPass1a.ts
+++ b/lib/evaluation/pipeline/runPass1a.ts
@@ -8,6 +8,7 @@ import type { Pass1aChunkOutput, Pass1aCharacterChunkEntry, ManuscriptChunkEvide
 import { getCanonicalPass1Model, isReasoningStyleModel } from "@/lib/evaluation/policy";
 import { getEvalOpenAiTimeoutMs } from "@/lib/evaluation/config";
 import { parseJsonObjectBoundary } from "@/lib/llm/jsonParseBoundary";
+import { sanitizeIdentityNameList, sanitizeIdentityNameToken } from "./identityNameHygiene";
 
 const PASS1A_TEMPERATURE = 0.2;
 const PASS1A_MAX_OUTPUT_TOKENS = 16_000;
@@ -121,17 +122,23 @@ function getIdentityGroup(entry: Pass1aCharacterChunkEntry): string | null {
 }
 
 function enforceCaps(entry: Pass1aCharacterChunkEntry): Pass1aCharacterChunkEntry {
-  const localName = normalizeField(entry.canonical_name) ?? "Unknown Character";
+  const localName = sanitizeIdentityNameToken(normalizeField(entry.canonical_name)) ?? "Unknown Character";
   const identityGroup = getIdentityGroup(entry);
-  const canonicalName = identityGroup ?? localName;
-  const aliases = uniqueStringArray(entry.aliases);
+  const canonicalName = sanitizeIdentityNameToken(identityGroup) ?? localName;
+  const aliases = sanitizeIdentityNameList(entry.aliases);
   if (identityGroup && !sameText(identityGroup, localName)) aliases.push(localName);
-  const dedupedAliases = uniqueStringArray(aliases).filter((alias) => !sameText(alias, canonicalName));
+  const dedupedAliases = sanitizeIdentityNameList(aliases).filter((alias) => !sameText(alias, canonicalName));
 
   return {
     ...entry,
     canonical_name: canonicalName,
+    legal_name: sanitizeIdentityNameToken(normalizeField(entry.legal_name)) ?? null,
     aliases: dedupedAliases,
+    assumed_names: sanitizeIdentityNameList(entry.assumed_names),
+    descriptors: uniqueStringArray(entry.descriptors),
+    forms_of_address: uniqueStringArray(entry.forms_of_address),
+    same_name_disambiguation: normalizeField(entry.same_name_disambiguation),
+    identity_notes: normalizeField(entry.identity_notes),
     who_is_this: normalizeField(entry.who_is_this) ?? "",
     what_do_they_want: normalizeField(entry.what_do_they_want),
     where_are_they: normalizeField(entry.where_are_they),

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -843,8 +843,14 @@ export type Pass1aEvidenceType =
 
 export interface Pass1aCharacterChunkEntry {
   canonical_name: string;
+  legal_name?: string | null;
   aliases: string[];
+  assumed_names?: string[];
+  descriptors?: string[];
+  forms_of_address?: string[];
   pronouns: string[];
+  same_name_disambiguation?: string | null;
+  identity_notes?: string | null;
   age_signal: Pass1aAgeSignal;
   age_exact: number | null;
   life_stage_evidence: string | null;
@@ -912,8 +918,14 @@ export type CharacterReportAcknowledgementStatus =
 
 export interface CharacterArcLedgerEntry {
   canonical_name: string;
+  legal_name?: string | null;
   aliases: string[];
+  assumed_names?: string[];
+  descriptors?: string[];
+  forms_of_address?: string[];
   pronouns: string[];
+  same_name_disambiguation_group?: string | null;
+  identity_notes?: string | null;
   age_exact_first: number | null;
   age_exact_last: number | null;
   age_signal: Pass1aAgeSignal;
@@ -977,6 +989,11 @@ export interface CharacterArcLedgerEntry {
     name: string;
     validFromChunk: number;
     validUntilChunk: number | null; // null = valid through end
+  }>;
+  legal_name_states?: Array<{
+    name: string;
+    validFromChunk: number;
+    validUntilChunk: number | null;
   }>;
 
   // Coping mechanisms: prevents Pass 3 from recommending "seed a ritual"
@@ -1187,6 +1204,7 @@ export interface Contradiction {
 export interface CharacterIdentityLedgerEntry {
   characterId: string;                          // canonical stable ID
   canonicalName: string;                        // primary name used in report
+  legalName?: string | null;
   nameHistory: Array<{
     name: string;
     validFromChunk: number;
@@ -1196,6 +1214,11 @@ export interface CharacterIdentityLedgerEntry {
     evidenceQuote?: string;
   }>;
   aliases: string[];                            // all names/nicknames observed
+  assumedNames?: string[];
+  descriptors?: string[];
+  formsOfAddress?: string[];
+  sameNameDisambiguationGroup?: string | null;
+  identityNotes?: string | null;
   narrativeRole: NarrativeRole;
   importanceLevel: ImportanceLevel;
   firstAppearance: ChapterRef;


### PR DESCRIPTION
## Summary

Adds deterministic identity-name hygiene so pronouns, generic descriptors, forms of address, and relationship descriptors cannot become canonical/legal name-state fields, while preserving same-name disambiguation evidence for cases like Pip / Philip Pirrip versus Young Pip, Joe and Biddy’s son.

## Failure Classes

- `IDENTITY_NAMESTATE_INVALID_TOKEN`
- `IDENTITY_SAME_NAME_CONFLATION`

## Required Proof

This PR must prove:

1. Invalid pronouns are blocked from legal/name-state fields:
   - `he`, `him`, `she`, `her`, `they`, `them`, `I`, `me`
2. Generic descriptors are blocked from legal names:
   - `the boy`, `the man`, `the convict`, `the stranger`
3. Forms of address are blocked from legal names:
   - `sir`, `madam`, `old chap`, `dear boy`
4. Descriptors are preserved safely when useful (descriptor/disambiguation/notes fields).
5. Same-name disambiguation is preserved:
   - `Pip / Philip Pirrip` remains separate from `Young Pip, Joe and Biddy’s son`.
6. Fallback reducer applies the same filtering rules as the primary reducer path.

### Routing nuance (must remain true)

Relationship descriptors such as `the convict` or `Joe and Biddy's son` must not become canonical/legal names, but may be preserved as descriptor/disambiguation evidence for later reveal handling.

## Scope Guard

This PR does **not** implement:

- alias/revelation merge
- relationship canonical-ID keying
- dependency blocking
- Source Integrity aggregation
- Review Gate provenance
- timeline/threat repair
- PR #805 pronoun collective-reference behavior

## Merge Bar

> **PR3 must prove identity pollution cannot enter name/legal-state fields, not claim it solved the whole Story Ledger.**

## Targeted Test Commands

- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer.identity-groups.test.ts __tests__/lib/evaluation/pipeline/identityNameHygiene.test.ts --runInBand`
- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/identityReducerFallback.test.ts --runInBand`
- `NODE_PATH=/workspaces/literary-ai-partner/node_modules /workspaces/literary-ai-partner/node_modules/.bin/jest __tests__/lib/evaluation/pipeline/characterReducer*.test.ts --runInBand`

## Focused Passing Result

- `characterReducer.identity-groups.test.ts` ✅
- `identityNameHygiene.test.ts` ✅
- `identityReducerFallback.test.ts` ✅
- `characterReducer.awakening-taxonomy.test.ts` ✅

## Commit Split

1. `fix(identity): add canonical identity name hygiene guards`
2. `test(identity): prove invalid name-state tokens and same-name disambiguation`

## Next Stack Item

After PR3, the next clean stack item is **PR4 — dependency blocking**.
