### PR TITLE
P0: Add admission synthesis gate for Revise Workbench queue

### DIFF
--- a/__tests__/lib/revision/workbenchQueue.test.ts
+++ b/__tests__/lib/revision/workbenchQueue.test.ts
@@ -1,0 +1,91 @@
+import { __testing } from "@/lib/revision/workbenchQueue";
+import type { DiagnosticFinding } from "@/lib/revision/types";
+
+function makeFinding(overrides: Partial<DiagnosticFinding> = {}): DiagnosticFinding {
+  return {
+    id: overrides.id ?? "finding-1",
+    evaluation_job_id: overrides.evaluation_job_id ?? "eval-1",
+    manuscript_version_id: overrides.manuscript_version_id ?? "mv-1",
+    artifact_id: overrides.artifact_id ?? null,
+    criterion_key: overrides.criterion_key ?? "PACING",
+    wave_id: overrides.wave_id ?? null,
+    finding_type: overrides.finding_type ?? "diagnostic_finding",
+    severity: overrides.severity ?? "medium",
+    confidence: overrides.confidence ?? 0.8,
+    location_ref: overrides.location_ref ?? null,
+    chunk_id: overrides.chunk_id ?? null,
+    chapter_index: overrides.chapter_index ?? null,
+    paragraph_index: overrides.paragraph_index ?? null,
+    sentence_index: overrides.sentence_index ?? null,
+    original_text: overrides.original_text ?? null,
+    evidence_excerpt: overrides.evidence_excerpt ?? null,
+    diagnosis: overrides.diagnosis ?? "Long paragraph may dilute pacing or visual clarity for the reader.",
+    recommendation: overrides.recommendation ?? "Condense repeated exposition beats.",
+    action_hint: overrides.action_hint ?? "refine",
+    status: overrides.status ?? "open",
+    created_at: overrides.created_at ?? "2026-05-29T00:00:00.000Z",
+  };
+}
+
+describe("workbench queue admission synthesis", () => {
+  test("holds findings with missing evidence and no location/manuscript-wide support", () => {
+    const findings: DiagnosticFinding[] = [
+      makeFinding({ id: "no-evidence", evidence_excerpt: null, original_text: null, location_ref: null, diagnosis: "Generic style issue." }),
+    ];
+
+    const result = __testing.synthesizeFindingsForWorkbench(findings, new Map());
+
+    expect(result.synthesis.held).toBe(1);
+    expect(result.synthesis.admitted).toBe(0);
+    expect(result.synthesis.clustered).toBe(0);
+    expect(result.opportunities).toHaveLength(0);
+  });
+
+  test("clusters repeated generic findings at threshold and suppresses duplicates", () => {
+    const findings: DiagnosticFinding[] = [
+      makeFinding({ id: "r1", evidence_excerpt: "Paragraph 1 excerpt" }),
+      makeFinding({ id: "r2", evidence_excerpt: "Paragraph 2 excerpt" }),
+      makeFinding({ id: "r3", evidence_excerpt: "Paragraph 3 excerpt" }),
+    ];
+
+    const result = __testing.synthesizeFindingsForWorkbench(findings, new Map());
+
+    expect(result.synthesis.clustered).toBe(1);
+    expect(result.synthesis.suppressed).toBe(2);
+    expect(result.opportunities).toHaveLength(1);
+    expect(result.opportunities[0].id.startsWith("cluster:")).toBe(true);
+    expect(result.opportunities[0].scope).toBe("Manuscript");
+  });
+
+  test("keeps findings individual when repetition is below clustering threshold", () => {
+    const findings: DiagnosticFinding[] = [
+      makeFinding({ id: "i1", evidence_excerpt: "excerpt one" }),
+      makeFinding({ id: "i2", evidence_excerpt: "excerpt two" }),
+    ];
+
+    const result = __testing.synthesizeFindingsForWorkbench(findings, new Map());
+
+    expect(result.synthesis.admitted).toBe(2);
+    expect(result.synthesis.clustered).toBe(0);
+    expect(result.synthesis.suppressed).toBe(0);
+    expect(result.opportunities).toHaveLength(2);
+    expect(result.opportunities.every((item) => !item.id.startsWith("cluster:"))).toBe(true);
+  });
+
+  test("treats manuscript-wide support as actionable evidence", () => {
+    const findings: DiagnosticFinding[] = [
+      makeFinding({
+        id: "manuscript-wide",
+        evidence_excerpt: null,
+        original_text: null,
+        location_ref: null,
+        diagnosis: "This pattern appears across the manuscript and creates drag.",
+      }),
+    ];
+
+    const result = __testing.synthesizeFindingsForWorkbench(findings, new Map());
+
+    expect(result.synthesis.held).toBe(0);
+    expect(result.opportunities).toHaveLength(1);
+  });
+});

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -48,6 +48,12 @@ export type WorkbenchQueuePayload = {
   opportunities: WorkbenchOpportunity[]
   totals: Record<WorkbenchSeverity, number>
   scopes: Record<WorkbenchScope, number>
+  synthesis?: {
+    admitted: number
+    clustered: number
+    held: number
+    suppressed: number
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +69,16 @@ type RichRecommendation = {
   action: string
   expected_impact: string
   priority: string
+}
+
+type QueueSynthesisResult = {
+  opportunities: WorkbenchOpportunity[]
+  synthesis: {
+    admitted: number
+    clustered: number
+    held: number
+    suppressed: number
+  }
 }
 
 const severityOrder: Record<WorkbenchSeverity, number> = { must: 0, should: 1, could: 2 }
@@ -110,6 +126,108 @@ function splitEvidence(value: string | null): { quoteHighlight: string; quoteRes
   return {
     quoteHighlight: words.slice(0, Math.min(words.length, 8)).join(' '),
     quoteRest: words.length > 8 ? ` ${words.slice(8).join(' ')}` : '',
+  }
+}
+
+function hasManuscriptWideSupport(finding: DiagnosticFinding): boolean {
+  const haystack = [finding.diagnosis, finding.recommendation, finding.evidence_excerpt, finding.location_ref]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes('across the manuscript') || haystack.includes('manuscript-wide') || haystack.includes('whole manuscript')
+}
+
+function hasActionableEvidence(finding: DiagnosticFinding): boolean {
+  const excerpt = (finding.evidence_excerpt ?? finding.original_text ?? '').trim()
+  const location = cleanLocationRef(finding.location_ref)
+  return Boolean(excerpt) || Boolean(location) || hasManuscriptWideSupport(finding)
+}
+
+function normalizeClusterKey(finding: DiagnosticFinding): string {
+  const source = firstSentence(finding.diagnosis || finding.recommendation || 'revision opportunity', 'revision opportunity')
+  return source.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim()
+}
+
+function clusterTitleForFinding(finding: DiagnosticFinding): string {
+  const title = (finding.diagnosis || finding.recommendation || '').toLowerCase()
+  if (title.includes('long paragraph')) return 'Long paragraph pacing pattern'
+  if (title.includes('long sentence')) return 'Long sentence density pattern'
+  return `${firstSentence(finding.diagnosis || finding.recommendation || 'Revision pattern', 'Revision pattern')} pattern`
+}
+
+function synthesizeFindingsForWorkbench(
+  findings: DiagnosticFinding[],
+  richLookup: RichLookup,
+): QueueSynthesisResult {
+  const held: DiagnosticFinding[] = []
+  const actionable: DiagnosticFinding[] = []
+
+  for (const finding of findings) {
+    if (hasActionableEvidence(finding)) {
+      actionable.push(finding)
+    } else {
+      held.push(finding)
+    }
+  }
+
+  const byKey = new Map<string, DiagnosticFinding[]>()
+  for (const finding of actionable) {
+    const key = normalizeClusterKey(finding)
+    const bucket = byKey.get(key) ?? []
+    bucket.push(finding)
+    byKey.set(key, bucket)
+  }
+
+  const CLUSTER_THRESHOLD = 3
+  const individual: DiagnosticFinding[] = []
+  const clusters: WorkbenchOpportunity[] = []
+  let suppressed = 0
+
+  for (const group of byKey.values()) {
+    if (group.length < CLUSTER_THRESHOLD) {
+      individual.push(...group)
+      continue
+    }
+
+    const representative = group[0]
+    const base = findingToOpportunity(representative, 0, richLookup)
+    const severity = group
+      .map((item) => toSeverity(item.severity))
+      .sort((a, b) => severityOrder[a] - severityOrder[b])[0] ?? base.severity
+
+    clusters.push({
+      ...base,
+      id: `cluster:${normalizeClusterKey(representative)}`,
+      severity,
+      scope: 'Manuscript',
+      mode: 'repair-brief',
+      title: clusterTitleForFinding(representative),
+      crumb: `${criterionLabel(representative.criterion_key)} · Pattern cluster (${group.length} instances)`,
+      meta: `${criterionLabel(representative.criterion_key)} · Pattern cluster`,
+      anchor: 'manuscript-wide pattern',
+      quoteHighlight: `Pattern detected across ${group.length} findings`,
+      quoteRest: ' Review top instances in Workbench V2 cluster expansion before applying broad edits.',
+      symptom: firstSentence(representative.diagnosis, 'Repeated finding pattern detected.'),
+      cause: 'Repeated similar findings were synthesized to prevent one-to-one raw diagnostic flooding.',
+      fixDirection: 'Review this pattern as a grouped issue and prioritize outliers with strongest evidence first.',
+      readerEffect: 'Grouping repeated low-granularity findings preserves author focus and revision trust.',
+      mistakeProofing: 'Do not mass-apply edits from pattern cards without validating local context and voice continuity.',
+    })
+
+    suppressed += group.length - 1
+  }
+
+  const individualOpportunities = individual.map((finding, index) => findingToOpportunity(finding, index, richLookup))
+  const opportunities = sortOpportunities([...individualOpportunities, ...clusters])
+
+  return {
+    opportunities,
+    synthesis: {
+      admitted: individualOpportunities.length,
+      clustered: clusters.length,
+      held: held.length,
+      suppressed,
+    },
   }
 }
 
@@ -366,6 +484,7 @@ function emptyPayload(error: string | null): WorkbenchQueuePayload {
     opportunities: [],
     totals: { must: 0, should: 0, could: 0 },
     scopes: { Line: 0, Passage: 0, Scene: 0, Chapter: 0, Structural: 0, Manuscript: 0 },
+    synthesis: { admitted: 0, clustered: 0, held: 0, suppressed: 0 },
   }
 }
 
@@ -427,9 +546,8 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
     loadEvaluationArtifactPayload(supabase, input.evaluationJobId),
   ])
 
-  const opportunities = sortOpportunities(
-    findings.map((f, i) => findingToOpportunity(f, i, richLookup)),
-  )
+  const synthesisResult = synthesizeFindingsForWorkbench(findings, richLookup)
+  const opportunities = synthesisResult.opportunities
   const totals: WorkbenchQueuePayload['totals'] = { must: 0, should: 0, could: 0 }
   const scopes: WorkbenchQueuePayload['scopes'] = { Line: 0, Passage: 0, Scene: 0, Chapter: 0, Structural: 0, Manuscript: 0 }
 
@@ -447,5 +565,11 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
     opportunities,
     totals,
     scopes,
+    synthesis: synthesisResult.synthesis,
   }
+}
+
+export const __testing = {
+  hasActionableEvidence,
+  synthesizeFindingsForWorkbench,
 }


### PR DESCRIPTION
## Summary

Root failure: raw diagnostic findings were becoming author-facing Revise opportunities one-for-one.
This PR adds a queue-level admission synthesis gate so a finding is not automatically a revision opportunity.

## Scope

Architecture-only change in queue synthesis for Revise pipeline output shaping.
Changed files are limited to:
- `lib/revision/workbenchQueue.ts`
- `__tests__/lib/revision/workbenchQueue.test.ts`

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## Tests Updated

Added focused regression coverage for admission synthesis behavior:
- holds missing-evidence findings
- clusters repeated generic findings
- keeps below-threshold findings individual
- treats manuscript-wide support as actionable evidence

Validation run:
- `npm test -- --runInBand --no-coverage --bail __tests__/lib/revision/workbenchQueue.test.ts`
- Result: PASS, 1 suite, 4 tests, 0 failures

## Risks & Anomalies

Low risk: queue payload now includes synthesis counters and clustered opportunities for repeated patterns.
No UI files or evaluation processor files changed in this PR.

## Unauthorized Input Sources

No new external inputs introduced. Data source remains existing persisted diagnostic findings and evaluation artifacts.

## Internal Process Leakage

No internal-only identifiers are newly exposed by this patch. Existing output shaping remains within current workbench payload contract.

## Input → Action → Output

Input: diagnostic findings + optional rich recommendation lookup.
Action: admission synthesis (hold missing evidence, cluster repeated findings, suppress one-to-one flooding).
Output: safer author-facing opportunities + synthesis counters (`admitted`, `clustered`, `held`, `suppressed`).

## Public-Safe Quality/Status Metrics

Synthesis counters are included in payload for observability and queue health posture.
Targeted regression tests pass for all admission behaviors added in this patch.

## Runtime/Pipeline Expansion

No-Pipeline-Impact: true — no new phases, workers, or runtime pipeline stages introduced.

## Latency Impact

Expected negligible impact. Synthesis runs in-memory over existing findings and replaces one-to-one mapping with bounded grouping logic.
