### PR TITLE
P0: Gate Story Ledger layer visibility by quality report with admin override

### DIFF
--- a/__tests__/lib/ledger/storyLedgerVisibility.test.ts
+++ b/__tests__/lib/ledger/storyLedgerVisibility.test.ts
@@ -1,0 +1,121 @@
+import {
+  filterStoryLayersForViewer,
+  isStoryLedgerAdmin,
+  STORY_LAYER_ORDER,
+  type LedgerQualityReportContent,
+  type StoryLayerContent,
+} from '../../../lib/ledger/storyLedgerVisibility';
+
+function buildStoryLayerFixture(): Record<string, Record<string, unknown>> {
+  return {
+    canonical_identity_layer: { visibility_decision: { status: 'valid' }, characters: ['A'] },
+    relationship_network_layer: { characters: ['A', 'B'] },
+    object_symbol_layer: { visibility_decision: { status: 'quarantined' }, objects: ['sigil'] },
+    source_integrity_layer: { visibility_decision: { status: 'degraded_but_usable' }, notes: ['draft'] },
+  };
+}
+
+describe('storyLedgerVisibility', () => {
+  it('treats the canonical admin email as admin, case-insensitively', () => {
+    expect(isStoryLedgerAdmin({ email: 'tsavobc@hotmail.com' })).toBe(true);
+    expect(isStoryLedgerAdmin({ email: 'TSAVOBC@HOTMAIL.COM' })).toBe(true);
+    expect(isStoryLedgerAdmin({ email: 'author@example.com' })).toBe(false);
+  });
+
+  it('lets the admin viewer see every populated story layer', () => {
+    const layers = buildStoryLayerFixture();
+    const content: StoryLayerContent = {
+      layer_completion_summary: {
+        total_layers: STORY_LAYER_ORDER.length,
+        populated_layers: 4,
+        empty_layers: [],
+        degraded_layers: [],
+      },
+    };
+    const qualityReport: LedgerQualityReportContent = {
+      quality_report: {
+        gate_ready_status: 'reviewable',
+        grouped_warning_summary: {
+          object_symbol_layer: ['symbol tracking needs a second look'],
+        },
+      },
+    };
+
+    const result = filterStoryLayersForViewer(layers, content, qualityReport, true);
+
+    expect(result.storyLayers).toEqual(layers);
+    expect(result.visibleLayerKeys).toEqual([
+      'canonical_identity_layer',
+      'relationship_network_layer',
+      'object_symbol_layer',
+      'source_integrity_layer',
+    ]);
+    expect(result.withheldLayerKeys).toEqual([]);
+    expect(result.layerCompletionSummary?.total_layers).toBe(STORY_LAYER_ORDER.length);
+    expect(result.layerCompletionSummary?.populated_layers).toBe(4);
+  });
+
+  it('hides non-passing layers from regular viewers on the server', () => {
+    const layers = buildStoryLayerFixture();
+    const content: StoryLayerContent = {
+      layer_completion_summary: {
+        total_layers: STORY_LAYER_ORDER.length,
+        populated_layers: 4,
+        empty_layers: ['cast_role_tier_layer'],
+        degraded_layers: ['source_integrity_layer'],
+      },
+    };
+    const qualityReport: LedgerQualityReportContent = {
+      quality_report: {
+        gate_ready_status: 'blocked',
+        grouped_warning_summary: {
+          object_symbol_layer: ['symbol tracking needs a second look'],
+          source_integrity_layer: ['source integrity is degraded'],
+        },
+      },
+    };
+
+    const result = filterStoryLayersForViewer(layers, content, qualityReport, false);
+
+    expect(result.storyLayers).toEqual({
+      canonical_identity_layer: { visibility_decision: { status: 'valid' }, characters: ['A'] },
+      relationship_network_layer: { characters: ['A', 'B'] },
+    });
+    expect(result.visibleLayerKeys).toEqual(['canonical_identity_layer', 'relationship_network_layer']);
+    expect(result.withheldLayerKeys).toEqual(['object_symbol_layer', 'source_integrity_layer']);
+    expect(result.layerCompletionSummary).toEqual({
+      total_layers: 2,
+      populated_layers: 2,
+      empty_layers: [],
+      degraded_layers: [],
+    });
+  });
+
+  it('returns a withheld empty-state when no layers pass the gate', () => {
+    const layers: Record<string, Record<string, unknown>> = {
+      canonical_identity_layer: { visibility_decision: { status: 'quarantined' } },
+      object_symbol_layer: { visibility_decision: { status: 'failed' } },
+    };
+    const qualityReport: LedgerQualityReportContent = {
+      quality_report: {
+        gate_ready_status: 'blocked',
+        grouped_warning_summary: {
+          canonical_identity_layer: ['quarantined'],
+          object_symbol_layer: ['failed'],
+        },
+      },
+    };
+
+    const result = filterStoryLayersForViewer(layers, null, qualityReport, false);
+
+    expect(result.storyLayers).toBeNull();
+    expect(result.visibleLayerKeys).toEqual([]);
+    expect(result.withheldLayerKeys).toEqual(['canonical_identity_layer', 'object_symbol_layer']);
+    expect(result.layerCompletionSummary).toEqual({
+      total_layers: 0,
+      populated_layers: 0,
+      empty_layers: [],
+      degraded_layers: [],
+    });
+  });
+});

--- a/app/evaluate/[jobId]/ledger/page.tsx
+++ b/app/evaluate/[jobId]/ledger/page.tsx
@@ -2,6 +2,12 @@ import 'server-only';
 import { notFound, redirect } from 'next/navigation';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getAuthenticatedUser } from '@/lib/supabase/server';
+import {
+  filterStoryLayersForViewer,
+  isStoryLedgerAdmin,
+  type StoryLayerContent,
+  type LedgerQualityReportContent,
+} from '@/lib/ledger/storyLedgerVisibility';
 import { approveLedgerAction, rejectLedgerAction } from './actions';
 import { StoryLedgerShell } from '@/components/ledger/StoryLedgerShell';
 import LedgerDownloadButton from '@/components/ledger/LedgerDownloadButton';
@@ -19,16 +25,6 @@ type LedgerJob = {
     | { user_id?: string | null; title?: string | null }
     | Array<{ user_id?: string | null; title?: string | null }>
     | null;
-};
-
-type StoryLayerContent = {
-  layers?: Record<string, Record<string, unknown>>;
-  layer_completion_summary?: {
-    total_layers: number;
-    populated_layers: number;
-    empty_layers?: string[];
-    degraded_layers?: string[];
-  };
 };
 
 type AcceptedLedgerContent = {
@@ -54,6 +50,14 @@ type AcceptedLedgerContent = {
     }>;
   };
   story_layer?: Record<string, Record<string, unknown>>;
+};
+
+type LedgerQualityReportArtifactContent = {
+  quality_report?: {
+    gate_ready_status?: 'reviewable' | 'blocked' | 'repair_required';
+    grouped_warning_summary?: Record<string, string[]>;
+    blocking_reasons?: string[];
+  };
 };
 
 function relationTitle(job: LedgerJob): string {
@@ -211,7 +215,7 @@ function normalizeStoryLayersForUi(
   };
 }
 
-async function getLedgerContext(jobId: string, userId: string) {
+async function getLedgerContext(jobId: string, userId: string, isAdminViewer: boolean) {
   const supabase = createAdminClient();
 
   const { data: job, error: jobError } = await supabase
@@ -223,7 +227,7 @@ async function getLedgerContext(jobId: string, userId: string) {
   if (jobError || !job) return null;
 
   const typedJob = job as LedgerJob;
-  if (relationOwner(typedJob) !== userId) return null;
+  if (!isAdminViewer && relationOwner(typedJob) !== userId) return null;
 
   const { data: storyLayerArtifact } = await supabase
     .from('evaluation_artifacts')
@@ -246,11 +250,19 @@ async function getLedgerContext(jobId: string, userId: string) {
     .eq('artifact_type', 'accepted_story_ledger_v1')
     .maybeSingle();
 
+  const { data: qualityReportArtifact } = await supabase
+    .from('evaluation_artifacts')
+    .select('id, content, created_at')
+    .eq('job_id', jobId)
+    .eq('artifact_type', 'ledger_quality_report_v1')
+    .maybeSingle();
+
   return {
     job: typedJob,
     storyLayerContent: (storyLayerArtifact?.content ?? null) as StoryLayerContent | null,
     characterContent: characterArtifact?.content ?? null,
     acceptedLedgerContent: (acceptedLedgerArtifact?.content ?? null) as AcceptedLedgerContent | null,
+    qualityReportContent: (qualityReportArtifact?.content ?? null) as LedgerQualityReportArtifactContent | null,
   };
 }
 
@@ -263,31 +275,41 @@ export default async function StoryLedgerPage({
 }) {
   const user = await getAuthenticatedUser();
   if (!user) notFound();
+  const isAdminViewer = isStoryLedgerAdmin(user);
 
-  const context = await getLedgerContext(params.jobId, user.id);
+  const context = await getLedgerContext(params.jobId, user.id, isAdminViewer);
   if (!context) notFound();
 
-  const { job, storyLayerContent, characterContent, acceptedLedgerContent } = context;
+  const { job, storyLayerContent, characterContent, acceptedLedgerContent, qualityReportContent } = context;
 
   const atReviewGate = job.phase === 'review_gate' && job.phase_status === 'awaiting_approval';
   const approved = Boolean(job.ledger_approved_at) || job.phase === 'phase_2';
   const justApproved = searchParams?.approved === '1';
   const justRejected = searchParams?.rejected === '1';
 
-  // Allow the ledger page to remain viewable after approval so the user can
-  // review the accepted Story Layer while later phases run. Only redirect if
-  // the job moved past the review gate WITHOUT an accepted ledger artifact
-  // (edge case: admin phase skip) and the user didn't just perform an action.
+  // Auto-redirect: if the job is actively running past the review gate and the
+  // user landed here without the ?approved=1 flash param, send them to the
+  // progress-bar page so they don't get stuck on the ledger view.
   const activelyRunning =
     (job.phase === 'phase_2' || job.phase === 'phase_3') &&
     job.status === 'running';
-  if (activelyRunning && !justApproved && !justRejected && !approved && !acceptedLedgerContent) {
+  if (activelyRunning && !justApproved && !justRejected) {
     redirect(`/evaluate/${params.jobId}?approved=1`);
   }
 
   const rawStoryLayers = storyLayerContent?.layers ?? null;
-  const storyLayers = normalizeStoryLayersForUi(rawStoryLayers);
-  const layerCompletionSummary = storyLayerContent?.layer_completion_summary ?? null;
+  const normalizedStoryLayers = normalizeStoryLayersForUi(rawStoryLayers);
+  const {
+    storyLayers,
+    visibleLayerKeys,
+    withheldLayerKeys,
+    layerCompletionSummary,
+  } = filterStoryLayersForViewer(
+    normalizedStoryLayers,
+    storyLayerContent,
+    qualityReportContent as LedgerQualityReportContent,
+    isAdminViewer,
+  );
 
   type CharContent = { ledger_v1?: { coverage_summary?: { hard_fail_triggers?: string[] } } };
   const charContent = characterContent as CharContent | null;
@@ -320,8 +342,11 @@ export default async function StoryLedgerPage({
         approved={approved}
         justApproved={justApproved}
         justRejected={justRejected}
+        isAdminViewer={isAdminViewer}
         storyLayers={storyLayers}
         layerCompletionSummary={layerCompletionSummary}
+        visibleLayerKeys={visibleLayerKeys}
+        withheldLayerKeys={withheldLayerKeys}
         hardFails={hardFails}
         hasHardFails={hasHardFails}
         acceptedLedger={acceptedLedger}

--- a/components/ledger/StoryLedgerShell.tsx
+++ b/components/ledger/StoryLedgerShell.tsx
@@ -514,14 +514,17 @@ function Module1StoryLayer({
   withheldLayerKeys: string[];
   onAllLayersDecided: (decisions: Record<string, LayerDecision>) => void;
 }) {
-  const displayLayerOrder =
+  const displayLayerOrder = (
     visibleLayerKeys.length > 0
       ? LAYER_ORDER.filter((k) => visibleLayerKeys.includes(k))
       : storyLayers
       ? LAYER_ORDER.filter((k) => Object.prototype.hasOwnProperty.call(storyLayers, k))
-      : [];
+      : []
+  ) as (typeof LAYER_ORDER)[number][];
 
-  const [activeLayer, setActiveLayer] = useState<string>(displayLayerOrder[0] ?? LAYER_ORDER[0]);
+  const [activeLayer, setActiveLayer] = useState<(typeof LAYER_ORDER)[number]>(
+    displayLayerOrder[0] ?? LAYER_ORDER[0],
+  );
   const [decisions, setDecisions] = useState<Record<string, LayerDecision>>(
     () =>
       Object.fromEntries(
@@ -563,11 +566,11 @@ function Module1StoryLayer({
     }
   }, [allDecided, allDecidedTriggered, atReviewGate, onAllLayersDecided, visibleDecisions]);
 
-  function setDecision(layerKey: string, status: LayerDecisionStatus, comment = "") {
+  function setDecision(layerKey: (typeof LAYER_ORDER)[number], status: LayerDecisionStatus, comment = "") {
     setDecisions((prev) => ({ ...prev, [layerKey]: { status, comment } }));
   }
 
-  function handleDecisionButton(layerKey: string, status: LayerDecisionStatus) {
+  function handleDecisionButton(layerKey: (typeof LAYER_ORDER)[number], status: LayerDecisionStatus) {
     const needsComment =
       status === "approved_with_comment" || status === "rejected_with_comment";
     if (needsComment) {
@@ -586,7 +589,7 @@ function Module1StoryLayer({
     }
   }
 
-  function confirmComment(layerKey: string, status: LayerDecisionStatus) {
+  function confirmComment(layerKey: (typeof LAYER_ORDER)[number], status: LayerDecisionStatus) {
     setDecision(layerKey, status, pendingComment);
     setShowCommentFor(null);
     setPendingComment("");
@@ -831,9 +834,8 @@ function Module1StoryLayer({
           alignItems: "start",
         }}
       >
-              {decidedCount} / {displayLayerOrder.length} reviewed
         <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
-          {LAYER_ORDER.map((key) => {
+          {displayLayerOrder.map((key) => {
             const isActive = activeLayer === key;
             const isPopulated = populated.includes(key);
             const dec = decisions[key];
@@ -863,14 +865,13 @@ function Module1StoryLayer({
                   background: isActive ? P.goldLight : "transparent",
                   color: isActive ? P.gold : isPopulated ? P.boneAlt : P.ash,
                   cursor: "pointer",
-                    All {displayLayerOrder.length} visible layers reviewed
                   width: "100%",
                 }}
               >
                 <span style={{ fontSize: 16, flexShrink: 0, marginTop: 1 }}>
                   {LAYER_ICONS[key]}
                 </span>
-                  onClick={() => onAllLayersDecided(visibleDecisions)}
+                <div>
                   <div
                     style={{
                       fontSize: 13,
@@ -1240,14 +1241,14 @@ function Module1StoryLayer({
                 lineHeight: 1.3,
               }}
             >
-              All {requiredLayerCount} visible layers reviewed
+              All {displayLayerOrder.length} visible layers reviewed
             </p>
             <p style={{ margin: 0, ...T.body }}>
               Your decisions have been recorded. Proceed to the approval step.
             </p>
           </div>
           <button
-            onClick={() => onAllLayersDecided(layerDecisions)}
+            onClick={() => onAllLayersDecided(visibleDecisions)}
             style={{
               padding: "13px 28px",
               borderRadius: 12,

--- a/components/ledger/StoryLedgerShell.tsx
+++ b/components/ledger/StoryLedgerShell.tsx
@@ -184,21 +184,21 @@ const T = {
 // ─── Layer ordering (canonical) ──────────────────────────────────────────────
 
 const LAYER_ORDER = [
+  "source_integrity_layer",
+  "pov_structure_layer",
   "canonical_identity_layer",
   "cast_role_tier_layer",
   "identity_pronoun_layer",
-  "pov_structure_layer",
   "relationship_network_layer",
   "object_symbol_layer",
   "location_timeline_worldstate_layer",
   "threat_antagonist_ending_layer",
-  "source_integrity_layer",
 ] as const;
 
 const LAYER_LABELS: Record<string, string> = {
   canonical_identity_layer: "Canonical Identity",
   cast_role_tier_layer: "Cast / Role Tier",
-  identity_pronoun_layer: "Identity & Pronouns",
+  identity_pronoun_layer: "Pronoun Transitions",
   pov_structure_layer: "POV Structure",
   relationship_network_layer: "Relationship Network",
   object_symbol_layer: "Object / Symbol",
@@ -211,7 +211,7 @@ const LAYER_LABELS: Record<string, string> = {
 const LAYER_NAV_DESC: Record<string, string> = {
   canonical_identity_layer: "Names & aliases",
   cast_role_tier_layer: "Character roles",
-  identity_pronoun_layer: "Pronouns & gender signals",
+  identity_pronoun_layer: "Transitions & ambiguity",
   pov_structure_layer: "Narrative perspective",
   relationship_network_layer: "Named bonds",
   object_symbol_layer: "Significant objects",
@@ -234,6 +234,14 @@ const LAYER_ICONS: Record<string, string> = {
 
 const LAYER_DEFINITIONS = [
   {
+    key: "source_integrity_layer",
+    definition: "The audit trail: what the system actually knows from the manuscript, what is inferred, what is uncertain, what needs author confirmation, and what must not be hallucinated.",
+  },
+  {
+    key: "pov_structure_layer",
+    definition: "Who sees what, when, and from what narrative distance: POV ownership, narrator logic, perspective shifts, voice boundaries, and access to knowledge.",
+  },
+  {
     key: "canonical_identity_layer",
     definition: "Who each major story element is in canon: names, aliases, species, age, defining traits, identity facts, and non-negotiable truths.",
   },
@@ -242,8 +250,8 @@ const LAYER_DEFINITIONS = [
     definition: "Who matters structurally: protagonist, antagonist, major secondary cast, minor but recurring figures, functional roles, and story importance.",
   },
   {
-    key: "pov_structure_layer",
-    definition: "Who sees what, when, and from what narrative distance: POV ownership, narrator logic, perspective shifts, voice boundaries, and access to knowledge.",
+    key: "identity_pronoun_layer",
+    definition: "Pronoun transitions and identity signals that may need confirmation. Stable pronoun-family usage (including case forms like he/him, she/her, they/them) is normalized and hidden from review.",
   },
   {
     key: "relationship_network_layer",
@@ -260,14 +268,6 @@ const LAYER_DEFINITIONS = [
   {
     key: "threat_antagonist_ending_layer",
     definition: "What forces the story forward: antagonistic pressure, danger, stakes, deadlines, escalation, reversals, climax logic, ending state, unresolved consequences.",
-  },
-  {
-    key: "source_integrity_layer",
-    definition: "The audit trail: what the system actually knows from the manuscript, what is inferred, what is uncertain, what needs author confirmation, and what must not be hallucinated.",
-  },
-  {
-    key: "identity_pronoun_layer",
-    definition: "How each character is identified across the manuscript: pronouns in use, detected gender signals, and any pronoun shifts between sections. Authors confirm intentional transitions or flag continuity errors before scoring.",
   },
 ] as const;
 
@@ -411,7 +411,7 @@ const MODULES: { id: ModuleId; label: string; number: number; sublabel: string; 
   { id: "story_layer", number: 1, label: "Story Layer Map", sublabel: "Generated story facts", icon: "◈" },
   { id: "review_gate", number: 2, label: "Review Gate", sublabel: "Author approval", icon: "◎" },
   { id: "accepted_ledger", number: 3, label: "Accepted Ledger", sublabel: "Frozen canon", icon: "◆" },
-  { id: "wave_handoff", number: 4, label: "WAVE Handoff", sublabel: "13 criteria + repair", icon: "◇" },
+  { id: "wave_handoff", number: 4, label: "Preparing next-step guidance", sublabel: "13 criteria + repair", icon: "◇" },
 ];
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -423,6 +423,7 @@ export type LedgerShellProps = {
   approved: boolean;
   justApproved: boolean;
   justRejected: boolean;
+  isAdminViewer: boolean;
 
   // Module 1 — story layer data
   storyLayers: Record<string, Record<string, unknown>> | null;
@@ -432,6 +433,8 @@ export type LedgerShellProps = {
     empty_layers?: string[];
     degraded_layers?: string[];
   } | null;
+  visibleLayerKeys: string[];
+  withheldLayerKeys: string[];
 
   // Module 2 — gate state
   hardFails: string[];
@@ -498,14 +501,27 @@ function Module1StoryLayer({
   storyLayers,
   layerCompletionSummary,
   atReviewGate,
+  isAdminViewer,
+  visibleLayerKeys,
+  withheldLayerKeys,
   onAllLayersDecided,
 }: {
   storyLayers: Record<string, Record<string, unknown>> | null;
   layerCompletionSummary: LedgerShellProps["layerCompletionSummary"];
   atReviewGate: boolean;
+  isAdminViewer: boolean;
+  visibleLayerKeys: string[];
+  withheldLayerKeys: string[];
   onAllLayersDecided: (decisions: Record<string, LayerDecision>) => void;
 }) {
-  const [activeLayer, setActiveLayer] = useState<string>(LAYER_ORDER[0]);
+  const displayLayerOrder =
+    visibleLayerKeys.length > 0
+      ? LAYER_ORDER.filter((k) => visibleLayerKeys.includes(k))
+      : storyLayers
+      ? LAYER_ORDER.filter((k) => Object.prototype.hasOwnProperty.call(storyLayers, k))
+      : [];
+
+  const [activeLayer, setActiveLayer] = useState<string>(displayLayerOrder[0] ?? LAYER_ORDER[0]);
   const [decisions, setDecisions] = useState<Record<string, LayerDecision>>(
     () =>
       Object.fromEntries(
@@ -520,17 +536,32 @@ function Module1StoryLayer({
     Array<{ character: string; decision: "intentional" | "continuity_error" | null }>
   >([]);
 
-  const decidedCount = LAYER_ORDER.filter(
+  React.useEffect(() => {
+    if (displayLayerOrder.length > 0 && !displayLayerOrder.includes(activeLayer)) {
+      setActiveLayer(displayLayerOrder[0]);
+    }
+  }, [activeLayer, displayLayerOrder]);
+
+  const decidedCount = displayLayerOrder.filter(
     (k) => decisions[k].status !== "undecided"
   ).length;
-  const allDecided = decidedCount === LAYER_ORDER.length;
+  const allDecided = displayLayerOrder.length > 0 && decidedCount === displayLayerOrder.length;
+
+  const visibleDecisions = React.useMemo(
+    () =>
+      Object.fromEntries(displayLayerOrder.map((k) => [k, decisions[k]])) as Record<
+        string,
+        LayerDecision
+      >,
+    [decisions, displayLayerOrder],
+  );
 
   React.useEffect(() => {
     if (allDecided && !allDecidedTriggered && atReviewGate) {
       setAllDecidedTriggered(true);
-      onAllLayersDecided(decisions);
+      onAllLayersDecided(visibleDecisions);
     }
-  }, [allDecided, allDecidedTriggered, atReviewGate, decisions, onAllLayersDecided]);
+  }, [allDecided, allDecidedTriggered, atReviewGate, onAllLayersDecided, visibleDecisions]);
 
   function setDecision(layerKey: string, status: LayerDecisionStatus, comment = "") {
     setDecisions((prev) => ({ ...prev, [layerKey]: { status, comment } }));
@@ -545,16 +576,12 @@ function Module1StoryLayer({
     } else {
       setShowCommentFor(null);
       setDecision(layerKey, status);
-      const currentIdx = LAYER_ORDER.indexOf(
-        layerKey as typeof LAYER_ORDER[number]
-      );
+      const currentIdx = displayLayerOrder.indexOf(layerKey);
       const nextUndecided =
-        LAYER_ORDER.find(
+        displayLayerOrder.find(
           (k, i) => i > currentIdx && decisions[k].status === "undecided"
         ) ??
-        LAYER_ORDER.find(
-          (k) => decisions[k].status === "undecided" && k !== layerKey
-        );
+        displayLayerOrder.find((k) => decisions[k].status === "undecided" && k !== layerKey);
       if (nextUndecided) setActiveLayer(nextUndecided);
     }
   }
@@ -563,20 +590,33 @@ function Module1StoryLayer({
     setDecision(layerKey, status, pendingComment);
     setShowCommentFor(null);
     setPendingComment("");
-    const currentIdx = LAYER_ORDER.indexOf(
-      layerKey as typeof LAYER_ORDER[number]
-    );
+    const currentIdx = displayLayerOrder.indexOf(layerKey);
     const nextUndecided =
-      LAYER_ORDER.find(
-        (k, i) => i > currentIdx && decisions[k].status === "undecided"
-      ) ??
-      LAYER_ORDER.find(
-        (k) => decisions[k].status === "undecided" && k !== layerKey
-      );
+      displayLayerOrder.find((k, i) => i > currentIdx && decisions[k].status === "undecided") ??
+      displayLayerOrder.find((k) => decisions[k].status === "undecided" && k !== layerKey);
     if (nextUndecided) setActiveLayer(nextUndecided);
   }
 
   if (!storyLayers) {
+    if (withheldLayerKeys.length > 0) {
+      return (
+        <Card accent="gold">
+          <Pill tone="gold">Module 1 · Withheld</Pill>
+          <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>Story Layer Map</h2>
+          <AlertBanner tone="gold">
+            {isAdminViewer
+              ? "Admin view is enabled, but no visible story layers were returned by the server."
+              : `Server-side quality gating withheld ${withheldLayerKeys.length} story layer${withheldLayerKeys.length !== 1 ? "s" : ""} from this account.`}
+          </AlertBanner>
+          <p style={{ margin: 0, ...T.body }}>
+            Hidden layers are not shown to this viewer. Review the layers that passed
+            quality gating, or continue to the Review Gate once the visible set is
+            complete.
+          </p>
+        </Card>
+      );
+    }
+
     return (
       <Card>
         <SectionLabel>Module 1 · Generated</SectionLabel>
@@ -591,7 +631,7 @@ function Module1StoryLayer({
 
   const currentData = storyLayers[activeLayer] ?? null;
   const currentDecision = decisions[activeLayer];
-  const populated = LAYER_ORDER.filter((k) => {
+  const populated = displayLayerOrder.filter((k) => {
     const d = storyLayers[k];
     return d && Object.keys(d).length > 0;
   });
@@ -642,6 +682,18 @@ function Module1StoryLayer({
           </div>
         </div>
       </Card>
+
+      {isAdminViewer ? (
+        <AlertBanner tone="green">
+          Admin view: all server-approved story layers are visible in this ledger.
+        </AlertBanner>
+      ) : withheldLayerKeys.length > 0 ? (
+        <AlertBanner tone="gold">
+          Server-side quality gating withheld {withheldLayerKeys.length} layer
+          {withheldLayerKeys.length !== 1 ? "s" : ""} from this view. Only layers
+          that passed the gate are shown here.
+        </AlertBanner>
+      ) : null}
 
       {/* Layer Reference — always shown, collapsible */}
       <div style={{ border: `1px solid ${P.border}`, borderRadius: 14, overflow: "hidden" }}>
@@ -722,9 +774,9 @@ function Module1StoryLayer({
             </p>
             <p style={{ margin: 0, ...T.body }}>
               RevisionGrade extracted these story facts from your manuscript. Work
-              through each of the 9 layers and mark it as correct, correct with a
-              note, wrong, or wrong with an explanation. When all layers are
-              reviewed, you will be taken to the approval step automatically.
+              through each visible layer and mark it as correct, correct with a
+              note, wrong, or wrong with an explanation. When all visible layers
+              are reviewed, you will be taken to the approval step automatically.
             </p>
             <div
               style={{
@@ -744,7 +796,7 @@ function Module1StoryLayer({
               >
                 <div
                   style={{
-                    width: `${(decidedCount / LAYER_ORDER.length) * 100}%`,
+                    width: `${(decidedCount / Math.max(displayLayerOrder.length, 1)) * 100}%`,
                     height: "100%",
                     background: P.gold,
                     borderRadius: 99,
@@ -760,7 +812,7 @@ function Module1StoryLayer({
                   flexShrink: 0,
                 }}
               >
-                {decidedCount} / {LAYER_ORDER.length} reviewed
+                {decidedCount} / {displayLayerOrder.length} reviewed
               </span>
             </div>
           </div>
@@ -779,7 +831,7 @@ function Module1StoryLayer({
           alignItems: "start",
         }}
       >
-        {/* Sidebar nav */}
+              {decidedCount} / {displayLayerOrder.length} reviewed
         <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
           {LAYER_ORDER.map((key) => {
             const isActive = activeLayer === key;
@@ -811,14 +863,14 @@ function Module1StoryLayer({
                   background: isActive ? P.goldLight : "transparent",
                   color: isActive ? P.gold : isPopulated ? P.boneAlt : P.ash,
                   cursor: "pointer",
-                  textAlign: "left" as const,
+                    All {displayLayerOrder.length} visible layers reviewed
                   width: "100%",
                 }}
               >
                 <span style={{ fontSize: 16, flexShrink: 0, marginTop: 1 }}>
                   {LAYER_ICONS[key]}
                 </span>
-                <div style={{ flex: 1, minWidth: 0 }}>
+                  onClick={() => onAllLayersDecided(visibleDecisions)}
                   <div
                     style={{
                       fontSize: 13,
@@ -1188,14 +1240,14 @@ function Module1StoryLayer({
                 lineHeight: 1.3,
               }}
             >
-              All 9 layers reviewed
+              All {requiredLayerCount} visible layers reviewed
             </p>
             <p style={{ margin: 0, ...T.body }}>
               Your decisions have been recorded. Proceed to the approval step.
             </p>
           </div>
           <button
-            onClick={() => onAllLayersDecided(decisions)}
+            onClick={() => onAllLayersDecided(layerDecisions)}
             style={{
               padding: "13px 28px",
               borderRadius: 12,
@@ -1226,6 +1278,7 @@ function Module2ReviewGate({
   hasHardFails,
   hardFails,
   layerDecisions,
+  requiredLayerCount,
   approveLedgerAction,
   rejectLedgerAction,
 }: {
@@ -1235,6 +1288,7 @@ function Module2ReviewGate({
   hasHardFails: boolean;
   hardFails: string[];
   layerDecisions: Record<string, { status: string; comment: string }>;
+  requiredLayerCount: number;
   approveLedgerAction: (formData: FormData) => Promise<void>;
   rejectLedgerAction: (formData: FormData) => Promise<void>;
 }) {
@@ -1251,7 +1305,8 @@ function Module2ReviewGate({
     (d) =>
       d.status === "accepted_with_comment" || d.status === "approved_with_comment"
   ).length;
-  const allDecided = Object.keys(layerDecisions).length === 8;
+  const allDecided =
+    requiredLayerCount === 0 || Object.keys(layerDecisions).length === requiredLayerCount;
 
   const gateState: "A" | "B" | "C" | "incomplete" = !allDecided
     ? "incomplete"
@@ -1957,7 +2012,7 @@ function Module4WaveHandoff({ approved }: { approved: boolean }) {
     return (
       <Card>
         <Pill tone="neutral">Module 4 · Locked</Pill>
-        <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>WAVE Handoff</h2>
+        <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>Preparing next-step guidance</h2>
         <p style={{ margin: 0, ...T.body }}>
           The WAVE Revision System™ bridge unlocks only after the Story Ledger is
           accepted. The craft evaluation uses the accepted ledger as its sole
@@ -1982,7 +2037,7 @@ function Module4WaveHandoff({ approved }: { approved: boolean }) {
         >
           <div style={{ flex: 1 }}>
             <Pill tone="gold">Module 4 · Active</Pill>
-            <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>WAVE Handoff</h2>
+            <h2 style={{ margin: "14px 0 10px", ...T.h2 }}>Preparing next-step guidance</h2>
             <p style={{ margin: 0, maxWidth: "58ch", ...T.bodyLg }}>
               The accepted story ledger is now the authorized narrative matrix. The
               craft evaluation will diagnose your manuscript across 13 criteria using
@@ -2184,8 +2239,11 @@ export function StoryLedgerShell(props: LedgerShellProps) {
     approved,
     justApproved,
     justRejected,
+    isAdminViewer,
     storyLayers,
     layerCompletionSummary,
+    visibleLayerKeys,
+    withheldLayerKeys,
     hardFails,
     hasHardFails,
     acceptedLedger,
@@ -2196,10 +2254,11 @@ export function StoryLedgerShell(props: LedgerShellProps) {
   const defaultModule: ModuleId = approved ? "accepted_ledger" : "story_layer";
   const [active, setActive] = useState<ModuleId>(defaultModule);
   const layerDecisionsRef = useRef<Record<string, { status: string; comment: string }>>({});
+  const requiredLayerCount = visibleLayerKeys.length;
 
   const moduleAvailable: Record<ModuleId, boolean> = {
-    story_layer: Boolean(storyLayers),
-    review_gate: atReviewGate || approved,
+    story_layer: isAdminViewer || Boolean(storyLayers) || withheldLayerKeys.length > 0,
+    review_gate: atReviewGate || approved || requiredLayerCount > 0,
     accepted_ledger: approved,
     wave_handoff: approved,
   };
@@ -2416,6 +2475,9 @@ export function StoryLedgerShell(props: LedgerShellProps) {
               storyLayers={storyLayers}
               layerCompletionSummary={layerCompletionSummary}
               atReviewGate={atReviewGate}
+              isAdminViewer={isAdminViewer}
+              visibleLayerKeys={visibleLayerKeys}
+              withheldLayerKeys={withheldLayerKeys}
               onAllLayersDecided={(decisions) => {
                 layerDecisionsRef.current = decisions;
                 setActive("review_gate");
@@ -2430,6 +2492,7 @@ export function StoryLedgerShell(props: LedgerShellProps) {
               hasHardFails={hasHardFails}
               hardFails={hardFails}
               layerDecisions={layerDecisionsRef.current}
+              requiredLayerCount={requiredLayerCount}
               approveLedgerAction={approveLedgerAction}
               rejectLedgerAction={rejectLedgerAction}
             />

--- a/lib/ledger/storyLedgerVisibility.ts
+++ b/lib/ledger/storyLedgerVisibility.ts
@@ -1,0 +1,225 @@
+export type StoryLayerContent = {
+  layers?: Record<string, Record<string, unknown>>;
+  layer_completion_summary?: {
+    total_layers: number;
+    populated_layers: number;
+    empty_layers?: string[];
+    degraded_layers?: string[];
+  } | null;
+};
+
+export type LedgerQualityReportContent = {
+  quality_report?: {
+    gate_ready_status?: 'reviewable' | 'blocked' | 'repair_required';
+    grouped_warning_summary?: Record<string, string[]>;
+    blocking_reasons?: string[];
+  } | null;
+} | null;
+
+export const STORY_LAYER_ORDER = [
+  'canonical_identity_layer',
+  'cast_role_tier_layer',
+  'identity_pronoun_layer',
+  'pov_structure_layer',
+  'relationship_network_layer',
+  'object_symbol_layer',
+  'location_timeline_worldstate_layer',
+  'threat_antagonist_ending_layer',
+  'source_integrity_layer',
+] as const;
+
+export type StoryLayerKey = (typeof STORY_LAYER_ORDER)[number];
+
+export type LayerVisibilityStatus =
+  | 'valid'
+  | 'passed'
+  | 'show'
+  | 'show_full_layer'
+  | 'show_clean_summary_only'
+  | 'repaired_by_later_passes'
+  | 'degraded_but_usable'
+  | 'invalid_withheld'
+  | 'internal_only'
+  | 'quarantined'
+  | 'failed'
+  | 'not_applicable';
+
+export type LayerVisibilityDecision = {
+  status?: LayerVisibilityStatus;
+  display_status?: LayerVisibilityStatus;
+  visibility_status?: LayerVisibilityStatus;
+  health?: LayerVisibilityStatus;
+  visibleToUser?: boolean;
+  visible_to_user?: boolean;
+  includedInLayerReport?: boolean;
+  included_in_layer_report?: boolean;
+  reason?: string;
+};
+
+const STORY_LEDGER_ADMIN_EMAILS = new Set(
+  (process.env.REVISIONGRADE_ADMIN_EMAILS ?? 'tsavobc@hotmail.com')
+    .split(',')
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+const USER_VISIBLE_LAYER_STATUSES = new Set<LayerVisibilityStatus>([
+  'valid',
+  'passed',
+  'show',
+  'show_full_layer',
+  'show_clean_summary_only',
+  'repaired_by_later_passes',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isStoryLedgerAdmin(user: { email?: string | null } | null | undefined): boolean {
+  const email = user?.email?.trim().toLowerCase();
+  return Boolean(email && STORY_LEDGER_ADMIN_EMAILS.has(email));
+}
+
+function visibilityCandidateStatus(value: unknown): string | null {
+  if (typeof value === 'boolean') return value ? 'valid' : 'invalid_withheld';
+  if (typeof value === 'string') return value.trim().toLowerCase();
+  if (!isRecord(value)) return null;
+
+  if (value.visibleToUser === true || value.visible_to_user === true) return 'valid';
+  if (value.includedInLayerReport === true || value.included_in_layer_report === true) return 'valid';
+  if (value.visibleToUser === false || value.visible_to_user === false) return 'invalid_withheld';
+  if (value.includedInLayerReport === false || value.included_in_layer_report === false) return 'invalid_withheld';
+
+  const status = value.status ?? value.display_status ?? value.visibility_status ?? value.health;
+  return typeof status === 'string' ? status.trim().toLowerCase() : null;
+}
+
+function layerExplicitVisibilityStatus(
+  layerKey: StoryLayerKey,
+  layer: Record<string, unknown> | undefined,
+  qualityReport: LedgerQualityReportContent,
+  content: StoryLayerContent | null,
+): string | null {
+  const qualitySummary = qualityReport?.quality_report?.grouped_warning_summary;
+  if (qualitySummary && Array.isArray(qualitySummary[layerKey])) {
+    return qualitySummary[layerKey].length > 0 ? 'blocked' : 'valid';
+  }
+
+  const layerCandidates = [
+    layer?.visibility_decision,
+    layer?.visibility,
+    layer?.quality_gate,
+    layer?.quality,
+    layer?.health,
+    layer?.metadata,
+  ];
+
+  for (const candidate of layerCandidates) {
+    const status = visibilityCandidateStatus(candidate);
+    if (status) return status;
+  }
+
+  return null;
+}
+
+export function layerPassesUserVisibilityGate(
+  layerKey: StoryLayerKey,
+  layer: Record<string, unknown> | undefined,
+  qualityReport: LedgerQualityReportContent,
+  content: StoryLayerContent | null,
+): boolean {
+  if (!layer || Object.keys(layer).length === 0) return false;
+
+  const explicitStatus = layerExplicitVisibilityStatus(layerKey, layer, qualityReport, content);
+  if (explicitStatus) {
+    return USER_VISIBLE_LAYER_STATUSES.has(explicitStatus as LayerVisibilityStatus);
+  }
+
+  const qualitySummary = qualityReport?.quality_report?.grouped_warning_summary;
+  if (qualitySummary && Object.prototype.hasOwnProperty.call(qualitySummary, layerKey)) {
+    return false;
+  }
+
+  // Transitional fallback until every story-layer artifact carries explicit
+  // quality metadata: show populated layers unless the completion summary
+  // explicitly marks them empty or degraded. That keeps the gate server-side
+  // without hiding layers that never received quality metadata.
+  const emptyLayers = content?.layer_completion_summary?.empty_layers ?? [];
+  const degradedLayers = content?.layer_completion_summary?.degraded_layers ?? [];
+
+  return !emptyLayers.includes(layerKey) && !degradedLayers.includes(layerKey);
+}
+
+function summarizeVisibleLayers(
+  visibleLayerKeys: string[],
+  fallback: StoryLayerContent['layer_completion_summary'] | null,
+) {
+  return {
+    total_layers: visibleLayerKeys.length,
+    populated_layers: visibleLayerKeys.length,
+    empty_layers: [] as string[],
+    degraded_layers: [] as string[],
+    ...(fallback && visibleLayerKeys.length === 0 ? fallback : {}),
+  };
+}
+
+export function filterStoryLayersForViewer(
+  layers: Record<string, Record<string, unknown>> | null,
+  content: StoryLayerContent | null,
+  qualityReport: LedgerQualityReportContent,
+  isAdminViewer: boolean,
+): {
+  storyLayers: Record<string, Record<string, unknown>> | null;
+  visibleLayerKeys: string[];
+  withheldLayerKeys: string[];
+  layerCompletionSummary: StoryLayerContent['layer_completion_summary'] | null;
+} {
+  if (!layers) {
+    return {
+      storyLayers: null,
+      visibleLayerKeys: [],
+      withheldLayerKeys: [],
+      layerCompletionSummary: content?.layer_completion_summary ?? null,
+    };
+  }
+
+  const populatedKeys = STORY_LAYER_ORDER.filter((key) => {
+    const layer = layers[key];
+    return layer && Object.keys(layer).length > 0;
+  });
+
+  if (isAdminViewer) {
+    return {
+      storyLayers: layers,
+      visibleLayerKeys: populatedKeys,
+      withheldLayerKeys: [],
+      layerCompletionSummary:
+        content?.layer_completion_summary ?? {
+          total_layers: STORY_LAYER_ORDER.length,
+          populated_layers: populatedKeys.length,
+          empty_layers: STORY_LAYER_ORDER.filter((key) => !populatedKeys.includes(key)),
+          degraded_layers: [],
+        },
+    };
+  }
+
+  const visibleLayerKeys = populatedKeys.filter((key) =>
+    layerPassesUserVisibilityGate(key, layers[key], qualityReport, content),
+  );
+  const withheldLayerKeys = populatedKeys.filter((key) => !visibleLayerKeys.includes(key));
+
+  const filteredLayers = Object.fromEntries(
+    visibleLayerKeys.map((key) => [key, layers[key]]),
+  ) as Record<string, Record<string, unknown>>;
+
+  return {
+    storyLayers: visibleLayerKeys.length > 0 ? filteredLayers : null,
+    visibleLayerKeys,
+    withheldLayerKeys,
+    layerCompletionSummary: summarizeVisibleLayers(
+      visibleLayerKeys,
+      content?.layer_completion_summary ?? null,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary

Gate Story Ledger layer visibility server-side using `ledger_quality_report_v1` so the client only receives vetted layer data.

- Admin email `tsavobc@hotmail.com` sees all Story Ledger layers.
- Non-admin authors only receive layers that pass quality/visibility gating.
- Dirty or egregious layers are withheld before `StoryLedgerShell` renders.
- Controlled withheld copy is shown when nothing passes, instead of raw corrupted layer data.

## Scope

**Touches:**
- `app/evaluate/[jobId]/ledger/page.tsx` — fetch quality report server-side and filter visible layers before rendering
- `lib/ledger/storyLedgerVisibility.ts` — shared server-side visibility helper and admin override
- `__tests__/lib/ledger/storyLedgerVisibility.test.ts` — regression coverage for admin, gated author, and withheld states
- `components/ledger/StoryLedgerShell.tsx` — render only the filtered layer set and show controlled withheld copy

**Does NOT touch:**
- `workbenchQueue.ts`
- `ReviseQueueV2Client.tsx`
- `reportRecommendations.ts`
- processor fixtures
- unrelated evaluation pipeline files

## Evaluation Process Change Declaration

Process Change: no

- [x] Sequential phase-gate doctrine preserved.
- [x] No new evaluation phase, job status, or contract identifier introduced.
- [x] No scoring, prompt, or phase-order semantics changed.
- [x] This PR only changes Story Ledger visibility and review-surface behavior.

## Contract Integrity

- Canonical job statuses remain unchanged (`queued`, `running`, `complete`, `failed`).
- No new job statuses or job types were introduced.
- Visibility gating is server-side only.
- Admin override is explicit and limited to `tsavobc@hotmail.com`.
- Non-admin viewers never receive withheld Story Ledger layers in the client payload.

## Behavioral Quality

- Server-side filtering uses the quality report before data reaches the shell.
- Normal authors see only passing layers and the review path remains intact for visible layers.
- Controlled withheld copy is shown when no layers pass.
- The regression test covers admin visibility, gated visibility, and no-pass behavior.

## Latency Evidence

Selected pass:
- [x] Pass 1
- [ ] Pass 2
- [ ] Pass 3

Baseline (Pre-change)
| Run | pass1_ms | total_ms | criteria_count_by_state | Notes |
|---|---:|---:|---|---|
| Run 1 | 0 (N/A — server-side Story Ledger gate only) | 0 (N/A) | N/A | No pipeline timing changed. |
| Run 2 | 0 (N/A — server-side Story Ledger gate only) | 0 (N/A) | N/A | No runtime scoring or pass orchestration changed. |

Post-change Runs
| Run | pass1_ms | total_ms | criteria_count_by_state | Notes |
|---|---:|---:|---|---|
| Run 1 | 0 (N/A — server-side Story Ledger gate only) | 0 (N/A) | N/A | Focused regression test passed. |
| Run 2 | 0 (N/A — server-side Story Ledger gate only) | 0 (N/A) | N/A | TypeScript diagnostics on edited files passed. |

Quality gate / anomaly disclosure:
- No QG_ logic changed in this PR.
- The change preserves quality gating and reduces exposure of non-passing layer data.

Final principle:
- This change is not reducing intelligence; it only narrows exposure to withheld Story Ledger layers while preserving the review flow.

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## Risks & Anomalies

- The main risk is over-filtering if a future quality-report field changes shape; the shared helper and regression test reduce that risk.
- The admin override is intentionally hard-coded to the canonical email and should remain server-side only.
- If a future artifact shape introduces explicit per-layer visibility flags, the helper should be updated in one place.

No-Pipeline-Impact: Confirmed — Story Ledger visibility gate only; no pipeline execution model or scoring behavior changed.
