### PR TITLE
test(benchmarks): add public-domain gold fixture harness for Awakening and Great Expectations

### DIFF
--- a/.github/pr-bodies/PR-825.md
+++ b/.github/pr-bodies/PR-825.md
@@ -1,0 +1,12 @@
+## Summary
+- add deterministic public-domain gold fixture harness tests for *The Awakening* and *Great Expectations*
+- verify benchmark governance metadata remains non-runtime authority ()
+- assert critical doctrine, canonical entities, governed-ledger sections, and index registration for calibration integrity
+
+## Validation
+- ran focused benchmark harness tests in-band
+- result: 2 suites passed / 10 tests passed
+
+## Scope
+- test-only harness scaffolding
+- no runtime evaluation logic changes

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "jest",
     "test:benchmark:ancient-bloodlines": "jest --runInBand --runTestsByPath tests/evaluation/benchmarks/ancient-bloodlines.shortform.test.ts tests/evaluation/benchmarks/ancient-bloodlines.fixture.test.ts tests/evaluation/benchmarks/ancient-bloodlines.governance.test.ts tests/evaluation/benchmarks/ancient-bloodlines.longform.layered.test.ts",
     "test:benchmark:ancient-bloodlines:live": "INCLUDE_LIVE_BENCHMARK_TESTS=1 jest --runInBand --runTestsByPath tests/evaluation/benchmarks/ancient-bloodlines.live-parity.test.ts",
+    "test:benchmark:public-domain-gold": "jest --runInBand --runTestsByPath tests/evaluation/benchmarks/public-domain-awakening.golden.test.ts tests/evaluation/benchmarks/public-domain-great-expectations.golden.test.ts",
     "probe:llr003": "tsx -r tsconfig-paths/register scripts/probe-llr003-job.ts",
     "test:ci": "jest --silent",
     "test:polling": "jest --testPathPatterns=polling",

--- a/tests/evaluation/benchmarks/public-domain-awakening.golden.spec.ts
+++ b/tests/evaluation/benchmarks/public-domain-awakening.golden.spec.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+const AWAKENING_PATH = join(
+  REPO_ROOT,
+  'docs/benchmarks/public-domain/the-awakening-dream-calibration.md',
+);
+const AWAKENING_ADDENDUM_PATH = join(
+  REPO_ROOT,
+  'docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md',
+);
+const INDEX_PATH = join(
+  REPO_ROOT,
+  'docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md',
+);
+
+function read(filePath: string): string {
+  return readFileSync(filePath, 'utf8');
+}
+
+describe('Public-domain gold fixture harness — The Awakening', () => {
+  it('keeps both calibration body and governed-ledger addendum present', () => {
+    expect(existsSync(AWAKENING_PATH)).toBe(true);
+    expect(existsSync(AWAKENING_ADDENDUM_PATH)).toBe(true);
+  });
+
+  it('keeps runtime authority false and public-domain calibration tier', () => {
+    const body = read(AWAKENING_PATH);
+    const addendum = read(AWAKENING_ADDENDUM_PATH);
+
+    expect(body).toContain('runtime-authority: false');
+    expect(body).toContain('benchmark-tier: public-domain-calibration');
+    expect(addendum).toContain('runtime-authority: false');
+    expect(addendum).toContain('benchmark-tier: public-domain-calibration');
+  });
+
+  it('preserves key Awakening detection doctrine in the base calibration', () => {
+    const body = read(AWAKENING_PATH).toLowerCase();
+
+    expect(body).toContain('interiority as plot pressure');
+    expect(body).toContain('social role constraint as antagonistic pressure');
+    expect(body).toContain('ambiguous closure');
+    expect(body).toContain('do not use this benchmark to force modern commercial pacing');
+  });
+
+  it('keeps all six governed-ledger sections in the addendum', () => {
+    const addendum = read(AWAKENING_ADDENDUM_PATH);
+
+    expect(addendum).toContain('## Character Coverage & Arc Ledger');
+    expect(addendum).toContain('## Relationship Spine Ledger');
+    expect(addendum).toContain('## Symbol-to-Character Payoff Ledger');
+    expect(addendum).toContain('## Sensory / Emotional Register Ledger');
+    expect(addendum).toContain('## Manuscript Integrity Confidence Notes');
+    expect(addendum).toContain('## Evidence Distribution / Confidence Notes');
+  });
+
+  it('anchors required character and symbol systems for Awakening', () => {
+    const addendum = read(AWAKENING_ADDENDUM_PATH);
+
+    for (const token of [
+      'Edna Pontellier',
+      'Léonce Pontellier',
+      'Robert Lebrun',
+      'Adèle Ratignolle',
+      'Mlle. Reisz',
+      'Sea / water',
+      'Birds',
+      'Piano / music',
+    ]) {
+      expect(addendum).toContain(token);
+    }
+  });
+
+  it('is registered in benchmark index as public-domain calibration with addendum', () => {
+    const index = read(INDEX_PATH);
+
+    expect(index).toContain('*The Awakening*');
+    expect(index).toContain('public-domain/the-awakening-dream-calibration.md');
+    expect(index).toContain('public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md');
+    expect(index).toContain('runtime-authority: false');
+  });
+});

--- a/tests/evaluation/benchmarks/public-domain-awakening.golden.test.ts
+++ b/tests/evaluation/benchmarks/public-domain-awakening.golden.test.ts
@@ -1,0 +1,1 @@
+import './public-domain-awakening.golden.spec';

--- a/tests/evaluation/benchmarks/public-domain-great-expectations.golden.spec.ts
+++ b/tests/evaluation/benchmarks/public-domain-great-expectations.golden.spec.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+const GREAT_EXPECTATIONS_PATH = join(
+  REPO_ROOT,
+  'docs/benchmarks/public-domain/great-expectations-dream-calibration.md',
+);
+
+const CANONICAL_13 = [
+  'Concept & Core Premise',
+  'Narrative Drive & Momentum',
+  'Character Depth & Psychological Coherence',
+  'Point of View & Voice Control',
+  'Scene Construction & Function',
+  'Dialogue Authenticity & Subtext',
+  'Thematic Integration',
+  'World-Building & Environmental Logic',
+  'Pacing & Structural Balance',
+  'Prose Control & Line-Level Craft',
+  'Tonal Authority & Consistency',
+  'Narrative Closure & Promises Kept',
+  'Professional Readiness & Market Positioning',
+];
+
+function read(filePath: string): string {
+  return readFileSync(filePath, 'utf8');
+}
+
+function parseScoreRows(markdown: string): number {
+  return markdown
+    .split('\n')
+    .filter((line) => /^\|\s*[^|]+\|\s*\*?\*?\d+(\.\d+)?\s*\/\s*10/.test(line))
+    .length;
+}
+
+describe('Public-domain gold fixture harness — Great Expectations', () => {
+  it('keeps the benchmark file present and tagged as non-runtime authority', () => {
+    expect(existsSync(GREAT_EXPECTATIONS_PATH)).toBe(true);
+
+    const doc = read(GREAT_EXPECTATIONS_PATH);
+    expect(doc).toContain('runtime-authority: false');
+    expect(doc).toContain('benchmark-tier: public-domain-calibration');
+  });
+
+  it('keeps executive verdict and full score grid surface', () => {
+    const doc = read(GREAT_EXPECTATIONS_PATH);
+
+    expect(doc).toContain('## Executive verdict');
+    expect(doc).toContain('## Scores');
+    expect(parseScoreRows(doc)).toBeGreaterThanOrEqual(13);
+
+    for (const criterion of CANONICAL_13) {
+      expect(doc).toContain(criterion);
+    }
+  });
+
+  it('anchors required Dickens canon entities and systems', () => {
+    const doc = read(GREAT_EXPECTATIONS_PATH);
+
+    for (const token of [
+      'Pip',
+      'Joe',
+      'Magwitch',
+      'Miss Havisham',
+      'Estella',
+      'Satis House',
+      'shame',
+      'false-causality revelation',
+    ]) {
+      expect(doc).toContain(token);
+    }
+  });
+
+  it('keeps all governed-ledger sections needed for gold calibration', () => {
+    const doc = read(GREAT_EXPECTATIONS_PATH);
+
+    expect(doc).toContain('## Character Coverage & Arc Ledger');
+    expect(doc).toContain('## Relationship Spine Ledger');
+    expect(doc).toContain('## Symbol-to-Character Payoff Ledger');
+    expect(doc).toContain('## Sensory / Emotional Register Ledger');
+    expect(doc).toContain('## Evidence Distribution / Confidence Notes');
+    expect(doc).toContain('## Required Detection / Failure Conditions');
+  });
+});

--- a/tests/evaluation/benchmarks/public-domain-great-expectations.golden.test.ts
+++ b/tests/evaluation/benchmarks/public-domain-great-expectations.golden.test.ts
@@ -1,0 +1,1 @@
+import './public-domain-great-expectations.golden.spec';


### PR DESCRIPTION
## Summary
- add deterministic public-domain gold fixture harness tests for *The Awakening* and *Great Expectations*
- verify benchmark governance metadata remains non-runtime authority (`runtime-authority: false`)
- assert critical doctrine, canonical entities, governed-ledger sections, and index registration for calibration integrity

## Validation
- ran focused benchmark harness tests in-band
- result: 2 suites passed / 10 tests passed

## Scope
- test-only harness scaffolding
- no runtime evaluation logic changes
