### PR TITLE
test(ledger): add gold fixture assertions for Story Ledger benchmark texts

### DIFF
--- a/.github/pr-bodies/PR-826.md
+++ b/.github/pr-bodies/PR-826.md
@@ -1,0 +1,41 @@
+## Purpose
+Add deterministic benchmark assertions for known texts so Story Ledger quality is measured against gold truth, not self-certified by model output.
+
+## First fixtures
+1. The Awakening
+2. Great Expectations
+
+## In scope
+- fixture definitions;
+- required-truth assertions;
+- forbidden-failure assertions;
+- deterministic test harness that evaluates Story Ledger artifacts against fixture expectations;
+- clear pass/fail output naming exact missing truth or forbidden failure.
+
+## Out of scope
+- no extraction logic repair;
+- no prompt changes;
+- no reducer semantic changes;
+- no UI changes;
+- no Revise changes;
+- no scoring changes;
+- no visibility gating or dependency blocking changes.
+
+## What this PR adds
+- `tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json`
+- `tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json`
+- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts`
+- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
+- `package.json` script: `test:benchmark:story-ledger-gold-fixtures`
+
+## Acceptance behavior proven
+- Tests fail loudly when required truths are missing.
+- Tests fail loudly when forbidden known failures recur.
+- Fail output names the exact missing truth / forbidden failure.
+- Tests run without live LLM calls using committed fixture payloads.
+
+## Validation
+- Ran focused harness suite:
+  - 1 suite passed
+  - 6 tests passed
+  - 0 failures

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "jest",
     "test:benchmark:ancient-bloodlines": "jest --runInBand --runTestsByPath tests/evaluation/benchmarks/ancient-bloodlines.shortform.test.ts tests/evaluation/benchmarks/ancient-bloodlines.fixture.test.ts tests/evaluation/benchmarks/ancient-bloodlines.governance.test.ts tests/evaluation/benchmarks/ancient-bloodlines.longform.layered.test.ts",
     "test:benchmark:ancient-bloodlines:live": "INCLUDE_LIVE_BENCHMARK_TESTS=1 jest --runInBand --runTestsByPath tests/evaluation/benchmarks/ancient-bloodlines.live-parity.test.ts",
+    "test:benchmark:story-ledger-gold-fixtures": "jest --runInBand --runTestsByPath tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts",
     "probe:llr003": "tsx -r tsconfig-paths/register scripts/probe-llr003-job.ts",
     "test:ci": "jest --silent",
     "test:polling": "jest --testPathPatterns=polling",

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
@@ -1,0 +1,257 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+const FIXTURE_DIR = join(REPO_ROOT, 'tests/testdata/evaluation/story-ledger');
+
+function readJson(fileName: string): any {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, fileName), 'utf8'));
+}
+
+function hasText(value: unknown, needle: string): boolean {
+  return String(value ?? '').toLowerCase().includes(needle.toLowerCase());
+}
+
+function getIdentity(ledger: any, characterId: string): any | undefined {
+  return (ledger.layers?.canonical_identity_layer?.identity_groups ?? []).find(
+    (entry: any) => entry.character_id === characterId,
+  );
+}
+
+function getTierEntries(ledger: any, tier: string): any[] {
+  return ledger.layers?.cast_role_tier_layer?.tier_map?.[tier] ?? [];
+}
+
+function validateGreatExpectations(ledger: any): string[] {
+  const errors: string[] = [];
+
+  const pip = getIdentity(ledger, 'ge:pip');
+  const joeChild = getIdentity(ledger, 'ge:joe_biddy_son');
+  if (!pip || !joeChild || pip.character_id === joeChild.character_id) {
+    errors.push('MISSING_REQUIRED_TRUTH: Pip / Philip Pirrip must be distinct from Joe and Biddy\'s son.');
+  }
+
+  const magwitch = getIdentity(ledger, 'ge:magwitch');
+  const magwitchAliases = new Set((magwitch?.aliases ?? []).map((a: string) => a.toLowerCase()));
+  for (const alias of ['magwitch', 'abel magwitch', 'provis', 'convict', 'unknown benefactor']) {
+    const inCanonical = hasText(magwitch?.canonical_name, alias);
+    const inAliases = Array.from(magwitchAliases).some((a) => a.includes(alias));
+    if (!inCanonical && !inAliases) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Magwitch identity linkage missing alias '${alias}'.`);
+    }
+  }
+
+  const povIds = new Set((ledger.layers?.pov_structure_layer?.pov_characters ?? []).map((entry: any) => entry.character_id));
+  if (povIds.has('ge:herbert')) {
+    errors.push('FORBIDDEN_FAILURE: Herbert Pocket must not be a POV owner.');
+  }
+
+  const pronounEntries = ledger.layers?.identity_pronoun_layer?.entries ?? [];
+  const pipPronounEntry = pronounEntries.find((entry: any) => hasText(entry.canonical_name, 'pip'));
+  if (!((pipPronounEntry?.pronouns ?? []).some((p: string) => p.toLowerCase().includes('he/him/his')))) {
+    errors.push('MISSING_REQUIRED_TRUTH: Pip pronoun record must include he/him/his.');
+  }
+  if ((pipPronounEntry?.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))) {
+    errors.push('FORBIDDEN_FAILURE: he/him/his must not be flagged as a pronoun shift.');
+  }
+
+  const relationshipPairs = ledger.layers?.relationship_network_layer?.relationship_pairs ?? [];
+  for (const pair of relationshipPairs) {
+    for (const side of ['character_a', 'character_b'] as const) {
+      const value = pair?.[side];
+      if (typeof value !== 'string' || !value.includes(':')) {
+        errors.push(
+          `FORBIDDEN_FAILURE: Relationship pair ${pair?.character_a ?? '?'} -> ${pair?.character_b ?? '?'} must use canonical ID references, not display names.`,
+        );
+      }
+    }
+  }
+
+  const threatText = JSON.stringify(
+    ledger.layers?.threat_antagonist_ending_layer?.threat_systems ??
+      ledger.layers?.threat_antagonist_ending_layer?.antagonists ?? [],
+  ).toLowerCase();
+  for (const requiredThreat of [
+    'magwitch',
+    'miss havisham',
+    'estella',
+    'jaggers/legal machinery',
+    'orlick',
+    'drummle',
+    'class shame',
+    'debt',
+    "pip's guilt",
+  ]) {
+    if (!threatText.includes(requiredThreat)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Threat system missing '${requiredThreat}'.`);
+    }
+  }
+
+  return errors;
+}
+
+function validateAwakening(ledger: any): string[] {
+  const errors: string[] = [];
+
+  const protagonists = getTierEntries(ledger, 'protagonist');
+  if (!protagonists.some((entry: any) => entry.character_id === 'aw:edna')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Edna Pontellier must be protagonist / primary focal center.');
+  }
+
+  const povIds = new Set((ledger.layers?.pov_structure_layer?.pov_characters ?? []).map((entry: any) => entry.character_id));
+  if (!povIds.has('aw:edna')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Edna Pontellier must own POV.');
+  }
+  if (povIds.has('aw:robert')) {
+    errors.push('FORBIDDEN_FAILURE: Robert Lebrun must not be POV owner.');
+  }
+
+  const coProtagonists = getTierEntries(ledger, 'co_protagonist');
+  if (coProtagonists.some((entry: any) => entry.character_id === 'aw:robert')) {
+    errors.push('FORBIDDEN_FAILURE: Robert Lebrun must not be default co-protagonist.');
+  }
+
+  if (!getTierEntries(ledger, 'patriarchal_pressure').some((entry: any) => entry.character_id === 'aw:leonce')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Léonce must be classified as marital/social/property pressure.');
+  }
+
+  if (!getTierEntries(ledger, 'sexual_destabilizer').some((entry: any) => entry.character_id === 'aw:arobin')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Alcée Arobin must be classified as sexual destabilizer.');
+  }
+
+  if (!getTierEntries(ledger, 'domestic_foil').some((entry: any) => entry.character_id === 'aw:adele')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Adèle Ratignolle must be classified as maternal/domestic foil.');
+  }
+
+  if (!getTierEntries(ledger, 'artistic_countermodel').some((entry: any) => entry.character_id === 'aw:reisz')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Mademoiselle Reisz must be classified as artistic counter-model / severe mentor.');
+  }
+
+  if (!getTierEntries(ledger, 'background_mention').some((entry: any) => entry.character_id === 'aw:celina_husband')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Célina\'s husband must remain background mention, not core cast.');
+  }
+
+  const relationshipLayer = ledger.layers?.relationship_network_layer ?? {};
+  const relationshipPairs = relationshipLayer.relationship_pairs ?? [];
+  if (!relationshipLayer.relationship_tiers || Object.keys(relationshipLayer.relationship_tiers).length === 0) {
+    errors.push('MISSING_REQUIRED_TRUTH: Relationship network must be tiered/classified.');
+  }
+  if (relationshipPairs.some((pair: any) => hasText(pair.relationship_type_start, 'unknown') || hasText(pair.relationship_type_end, 'unknown'))) {
+    errors.push('FORBIDDEN_FAILURE: Relationship pairs must not collapse into unknown co-occurrence dumping.');
+  }
+
+  const symbolText = JSON.stringify(ledger.layers?.object_symbol_layer?.objects ?? []).toLowerCase();
+  for (const symbolNeedle of [
+    'sea / gulf / water',
+    'birds / flight',
+    'pigeon house',
+    'wedding ring',
+    'music / piano',
+    'letters',
+    "edna's art / sketching",
+  ]) {
+    if (!symbolText.includes(symbolNeedle)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Core symbol missing '${symbolNeedle}'.`);
+    }
+  }
+
+  const pronounEntries = ledger.layers?.identity_pronoun_layer?.entries ?? [];
+  const targetNames = ['raoul pontellier', 'étienne pontellier', 'robert lebrun'];
+  for (const name of targetNames) {
+    const entry = pronounEntries.find((candidate: any) => hasText(candidate.canonical_name, name));
+    if (!entry) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Pronoun identity entry missing for '${name}'.`);
+      continue;
+    }
+    if ((entry.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))) {
+      errors.push(`FORBIDDEN_FAILURE: '${name}' must not be flagged as pronoun-transition problem.`);
+    }
+  }
+
+  const locations: string[] = ledger.layers?.location_timeline_worldstate_layer?.unique_locations ?? [];
+  for (const requiredLocation of ['grand isle', 'new orleans', 'chênière caminada', 'pigeon house']) {
+    if (!locations.some((loc) => loc.toLowerCase() === requiredLocation)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Location anchor missing '${requiredLocation}'.`);
+    }
+  }
+  if (locations.some((loc) => loc.trim().length < 4 || /[.!?]$/.test(loc.trim()))) {
+    errors.push('FORBIDDEN_FAILURE: Locations must be normalized anchors, not sentence fragments.');
+  }
+
+  return errors;
+}
+
+describe('Story Ledger gold fixture harness (deterministic, no live LLM calls)', () => {
+  const greatExpectations = readJson('great-expectations.accepted-story-ledger.fixture.json');
+  const awakening = readJson('the-awakening.accepted-story-ledger.fixture.json');
+
+  it('passes required-truth + forbidden-failure checks for Great Expectations fixture', () => {
+    const errors = validateGreatExpectations(greatExpectations);
+    expect(errors).toEqual([]);
+  });
+
+  it('fails loudly when Great Expectations required truth is missing', () => {
+    const mutated = JSON.parse(JSON.stringify(greatExpectations));
+    mutated.layers.canonical_identity_layer.identity_groups = mutated.layers.canonical_identity_layer.identity_groups.filter(
+      (entry: any) => entry.character_id !== 'ge:magwitch',
+    );
+
+    const errors = validateGreatExpectations(mutated);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('MISSING_REQUIRED_TRUTH: Magwitch identity linkage missing alias'),
+      ]),
+    );
+  });
+
+  it('fails loudly when Great Expectations forbidden failure recurs', () => {
+    const mutated = JSON.parse(JSON.stringify(greatExpectations));
+    mutated.layers.pov_structure_layer.pov_characters.push({
+      character_id: 'ge:herbert',
+      canonical_name: 'Herbert Pocket',
+      is_primary: false,
+    });
+
+    const errors = validateGreatExpectations(mutated);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'FORBIDDEN_FAILURE: Herbert Pocket must not be a POV owner.',
+      ]),
+    );
+  });
+
+  it('passes required-truth + forbidden-failure checks for The Awakening fixture', () => {
+    const errors = validateAwakening(awakening);
+    expect(errors).toEqual([]);
+  });
+
+  it('fails loudly when Awakening required truth is missing', () => {
+    const mutated = JSON.parse(JSON.stringify(awakening));
+    mutated.layers.object_symbol_layer.objects = mutated.layers.object_symbol_layer.objects.filter(
+      (entry: any) => !hasText(entry.name, 'pigeon house'),
+    );
+
+    const errors = validateAwakening(mutated);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "MISSING_REQUIRED_TRUTH: Core symbol missing 'pigeon house'.",
+      ]),
+    );
+  });
+
+  it('fails loudly when Awakening forbidden failure recurs', () => {
+    const mutated = JSON.parse(JSON.stringify(awakening));
+    mutated.layers.pov_structure_layer.pov_characters.push({
+      character_id: 'aw:robert',
+      canonical_name: 'Robert Lebrun',
+      is_primary: false,
+    });
+
+    const errors = validateAwakening(mutated);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'FORBIDDEN_FAILURE: Robert Lebrun must not be POV owner.',
+      ]),
+    );
+  });
+});

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts
@@ -1,0 +1,1 @@
+import './story-ledger-gold-fixtures.spec';

--- a/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
@@ -1,0 +1,139 @@
+{
+  "artifact_type": "accepted_story_ledger_v1",
+  "artifact_version": "v1",
+  "manuscript_id": "great-expectations",
+  "layers": {
+    "pov_structure_layer": {
+      "pov_characters": [
+        {
+          "character_id": "ge:pip",
+          "canonical_name": "Pip / Philip Pirrip",
+          "is_primary": true
+        },
+        {
+          "character_id": "ge:estella",
+          "canonical_name": "Estella",
+          "is_primary": false
+        }
+      ]
+    },
+    "canonical_identity_layer": {
+      "identity_groups": [
+        {
+          "character_id": "ge:pip",
+          "canonical_name": "Pip / Philip Pirrip",
+          "aliases": ["Pip", "Philip Pirrip"]
+        },
+        {
+          "character_id": "ge:joe",
+          "canonical_name": "Joe Gargery",
+          "aliases": ["Joe"]
+        },
+        {
+          "character_id": "ge:biddy",
+          "canonical_name": "Biddy",
+          "aliases": ["Biddy"]
+        },
+        {
+          "character_id": "ge:joe_biddy_son",
+          "canonical_name": "Joe and Biddy's son",
+          "aliases": ["little Pip", "Joe and Biddy's child"]
+        },
+        {
+          "character_id": "ge:magwitch",
+          "canonical_name": "Abel Magwitch",
+          "aliases": ["Magwitch", "Provis", "convict", "unknown benefactor"]
+        },
+        {
+          "character_id": "ge:herbert",
+          "canonical_name": "Herbert Pocket",
+          "aliases": ["Herbert"]
+        },
+        {
+          "character_id": "ge:miss_havisham",
+          "canonical_name": "Miss Havisham",
+          "aliases": ["Miss Havisham"]
+        },
+        {
+          "character_id": "ge:estella",
+          "canonical_name": "Estella",
+          "aliases": ["Estella"]
+        },
+        {
+          "character_id": "ge:jaggers",
+          "canonical_name": "Mr. Jaggers",
+          "aliases": ["Jaggers", "legal machinery"]
+        },
+        {
+          "character_id": "ge:orlick",
+          "canonical_name": "Orlick",
+          "aliases": ["Orlick"]
+        },
+        {
+          "character_id": "ge:drummle",
+          "canonical_name": "Bentley Drummle",
+          "aliases": ["Drummle"]
+        }
+      ]
+    },
+    "identity_pronoun_layer": {
+      "pronoun_shifts_detected": 0,
+      "entries": [
+        {
+          "canonical_name": "Pip / Philip Pirrip",
+          "pronouns": ["he/him/his"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Herbert Pocket",
+          "pronouns": ["he/him/his"],
+          "warnings": []
+        }
+      ]
+    },
+    "relationship_network_layer": {
+      "relationship_pairs": [
+        {
+          "character_a": "ge:pip",
+          "character_b": "ge:joe",
+          "relationship_type_start": "protege",
+          "relationship_type_end": "reconciled_family"
+        },
+        {
+          "character_a": "ge:pip",
+          "character_b": "ge:magwitch",
+          "relationship_type_start": "fear",
+          "relationship_type_end": "obligation_and_compassion"
+        },
+        {
+          "character_a": "ge:pip",
+          "character_b": "ge:estella",
+          "relationship_type_start": "desire",
+          "relationship_type_end": "scarred_recognition"
+        }
+      ],
+      "pair_count": 3
+    },
+    "threat_antagonist_ending_layer": {
+      "antagonists": [
+        { "character_id": "ge:magwitch", "canonical_name": "Abel Magwitch" },
+        { "character_id": "ge:miss_havisham", "canonical_name": "Miss Havisham" },
+        { "character_id": "ge:estella", "canonical_name": "Estella" },
+        { "character_id": "ge:jaggers", "canonical_name": "Mr. Jaggers" },
+        { "character_id": "ge:orlick", "canonical_name": "Orlick" },
+        { "character_id": "ge:drummle", "canonical_name": "Bentley Drummle" }
+      ],
+      "threat_systems": [
+        "Magwitch",
+        "Miss Havisham",
+        "Estella",
+        "Jaggers/legal machinery",
+        "Orlick",
+        "Drummle",
+        "class shame",
+        "debt",
+        "Pip's guilt"
+      ]
+    }
+  }
+}

--- a/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
@@ -1,0 +1,180 @@
+{
+  "artifact_type": "accepted_story_ledger_v1",
+  "artifact_version": "v1",
+  "manuscript_id": "the-awakening",
+  "layers": {
+    "pov_structure_layer": {
+      "pov_characters": [
+        {
+          "character_id": "aw:edna",
+          "canonical_name": "Edna Pontellier",
+          "is_primary": true
+        }
+      ]
+    },
+    "canonical_identity_layer": {
+      "identity_groups": [
+        {
+          "character_id": "aw:edna",
+          "canonical_name": "Edna Pontellier",
+          "aliases": ["Edna"]
+        },
+        {
+          "character_id": "aw:robert",
+          "canonical_name": "Robert Lebrun",
+          "aliases": ["Robert"]
+        },
+        {
+          "character_id": "aw:leonce",
+          "canonical_name": "Léonce Pontellier",
+          "aliases": ["Leonce"]
+        },
+        {
+          "character_id": "aw:arobin",
+          "canonical_name": "Alcée Arobin",
+          "aliases": ["Arobin"]
+        },
+        {
+          "character_id": "aw:adele",
+          "canonical_name": "Adèle Ratignolle",
+          "aliases": ["Adele"]
+        },
+        {
+          "character_id": "aw:reisz",
+          "canonical_name": "Mademoiselle Reisz",
+          "aliases": ["Reisz"]
+        },
+        {
+          "character_id": "aw:celina_husband",
+          "canonical_name": "Célina's husband",
+          "aliases": ["Celina husband"]
+        },
+        {
+          "character_id": "aw:raoul",
+          "canonical_name": "Raoul Pontellier",
+          "aliases": ["Raoul"]
+        },
+        {
+          "character_id": "aw:etienne",
+          "canonical_name": "Étienne Pontellier",
+          "aliases": ["Etienne"]
+        }
+      ]
+    },
+    "cast_role_tier_layer": {
+      "tier_map": {
+        "protagonist": [
+          { "character_id": "aw:edna", "canonical_name": "Edna Pontellier", "importance_level": "primary" }
+        ],
+        "romantic_catalyst": [
+          { "character_id": "aw:robert", "canonical_name": "Robert Lebrun", "importance_level": "major" }
+        ],
+        "patriarchal_pressure": [
+          { "character_id": "aw:leonce", "canonical_name": "Léonce Pontellier", "importance_level": "major" }
+        ],
+        "sexual_destabilizer": [
+          { "character_id": "aw:arobin", "canonical_name": "Alcée Arobin", "importance_level": "supporting" }
+        ],
+        "domestic_foil": [
+          { "character_id": "aw:adele", "canonical_name": "Adèle Ratignolle", "importance_level": "supporting" }
+        ],
+        "artistic_countermodel": [
+          { "character_id": "aw:reisz", "canonical_name": "Mademoiselle Reisz", "importance_level": "supporting" }
+        ],
+        "background_mention": [
+          { "character_id": "aw:celina_husband", "canonical_name": "Célina's husband", "importance_level": "minor" }
+        ]
+      }
+    },
+    "identity_pronoun_layer": {
+      "pronoun_shifts_detected": 0,
+      "entries": [
+        {
+          "canonical_name": "Edna Pontellier",
+          "pronouns": ["she/her"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Raoul Pontellier",
+          "pronouns": ["he/him"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Étienne Pontellier",
+          "pronouns": ["he/him"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Robert Lebrun",
+          "pronouns": ["he/him"],
+          "warnings": []
+        }
+      ]
+    },
+    "relationship_network_layer": {
+      "relationship_pairs": [
+        {
+          "character_a": "aw:edna",
+          "character_b": "aw:leonce",
+          "relationship_type_start": "marriage",
+          "relationship_type_end": "estrangement"
+        },
+        {
+          "character_a": "aw:edna",
+          "character_b": "aw:robert",
+          "relationship_type_start": "attraction",
+          "relationship_type_end": "fatal_unresolved_desire"
+        },
+        {
+          "character_a": "aw:edna",
+          "character_b": "aw:adele",
+          "relationship_type_start": "friendship",
+          "relationship_type_end": "maternal_domestic_counterpoint"
+        },
+        {
+          "character_a": "aw:edna",
+          "character_b": "aw:reisz",
+          "relationship_type_start": "mentorship_resistance",
+          "relationship_type_end": "artistic_countermodel"
+        }
+      ],
+      "pair_count": 4,
+      "relationship_tiers": {
+        "primary_spine": ["aw:edna|aw:leonce", "aw:edna|aw:robert"],
+        "secondary_structural": ["aw:edna|aw:adele", "aw:edna|aw:reisz"],
+        "background": ["aw:celina_husband"]
+      }
+    },
+    "object_symbol_layer": {
+      "objects": [
+        { "object_id": "aw:symbol:sea", "name": "sea / gulf / water" },
+        { "object_id": "aw:symbol:birds", "name": "birds / flight" },
+        { "object_id": "aw:symbol:pigeon_house", "name": "pigeon house" },
+        { "object_id": "aw:symbol:ring", "name": "wedding ring" },
+        { "object_id": "aw:symbol:music", "name": "music / piano" },
+        { "object_id": "aw:symbol:letters", "name": "letters" },
+        { "object_id": "aw:symbol:art", "name": "Edna's art / sketching" }
+      ]
+    },
+    "location_timeline_worldstate_layer": {
+      "unique_locations": [
+        "Grand Isle",
+        "New Orleans",
+        "Chênière Caminada",
+        "Pigeon House",
+        "Pontellier residence"
+      ],
+      "location_count": 5
+    },
+    "threat_antagonist_ending_layer": {
+      "threat_systems": [
+        "marital pressure",
+        "social propriety",
+        "property constraints",
+        "sexual destabilization",
+        "maternal domestic norm pressure",
+        "artistic vocation pressure"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Add deterministic benchmark assertions for known texts so Story Ledger quality is measured against gold truth, not self-certified by model output.

## First fixtures
1. The Awakening
2. Great Expectations

## In scope
- fixture definitions;
- required-truth assertions;
- forbidden-failure assertions;
- deterministic test harness that evaluates Story Ledger artifacts against fixture expectations;
- clear pass/fail output naming exact missing truth or forbidden failure.

## Out of scope
- no extraction logic repair;
- no prompt changes;
- no reducer semantic changes;
- no UI changes;
- no Revise changes;
- no scoring changes;
- no visibility gating or dependency blocking changes.

## What this PR adds
- `tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json`
- `tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json`
- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts`
- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
- `package.json` script: `test:benchmark:story-ledger-gold-fixtures`

## Acceptance behavior proven
- Tests fail loudly when required truths are missing.
- Tests fail loudly when forbidden known failures recur.
- Fail output names the exact missing truth / forbidden failure.
- Tests run without live LLM calls using committed fixture payloads.

## Validation
- Ran focused harness suite:
  - 1 suite passed
  - 6 tests passed
  - 0 failures
