### PR TITLE
fix(ledger): key relationship pairs by canonical IDs

### DIFF
--- a/.github/pr-bodies/PR-827.md
+++ b/.github/pr-bodies/PR-827.md
@@ -1,0 +1,76 @@
+## Goal
+Stop relationship pairs from being built from display names, aliases, or duplicate surface labels.
+
+## Primary failure class
+- `RELATIONSHIP_DISPLAY_NAME_KEYING`
+
+## Production behavior
+- Relationship pair identity is keyed by stable canonical IDs (`characterA`, `characterB`) with deterministic ordering.
+- Pair identity now includes deterministic `pairKey` (`minId↔maxId`).
+- Display labels are preserved as metadata (`characterADisplayName`, `characterBDisplayName`) and surfaced to Story Layer as `character_a_label` / `character_b_label`; labels no longer define identity.
+- Alias display variants (e.g. Magwitch / Provis / convict / unknown benefactor) collapse to one canonical pair edge after canonical resolution.
+- Same-visible-name disambiguation metadata is preserved on relationship entries (`characterASameNameDisambiguationGroup`, `characterBSameNameDisambiguationGroup`).
+
+## Fixture integrity
+Fixture updates in this PR **tighten canonical relationship expectations and do not reduce the required truth set**.
+
+### Great Expectations fixture changes (tightening)
+- Added missing canonical entity: `ge:compeyson`.
+- Expanded required canonical relationship pairs from 3 to 9:
+  - Pip–Magwitch
+  - Pip–Joe
+  - Pip–Estella
+  - Pip–Miss Havisham
+  - Estella–Miss Havisham
+  - Magwitch–Compeyson
+  - Pip–Jaggers
+  - Pip–Biddy
+  - Pip–Orlick
+- Added pair identity metadata (`pair_key`) and UI label metadata for identity-vs-label separation tests.
+
+### Awakening fixture changes (tightening)
+- Added required canonical entities for relationship expectations:
+  - `aw:children`
+  - `aw:sea_symbolic_pressure`
+- Expanded required canonical relationship pairs from 4 to 7:
+  - Edna–Robert
+  - Edna–Léonce
+  - Edna–Arobin
+  - Edna–Adèle
+  - Edna–Mademoiselle Reisz
+  - Edna–children
+  - Edna–sea/symbolic pressure
+- Strengthened relationship tier coverage (`primary_spine`, `secondary_structural`, `symbolic_pressure`).
+
+No fixture assertions were relaxed.
+
+## Tests added/updated
+- Added: `__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts`
+  - canonical-ID keying
+  - deterministic pair ordering
+  - alias-display dedupe
+  - disambiguation metadata preservation
+  - UI label changes do not change pair identity
+- Updated: `tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts`
+  - enforces required Great Expectations and Awakening canonical pairs
+  - detects and names duplicate display-name edges (`RELATIONSHIP_DISPLAY_NAME_KEYING`)
+  - asserts label mutation does not alter pair identity
+
+## Validation (required suites)
+- ✅ `__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts`
+- ✅ `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
+- ✅ `lib/evaluation/pipeline/__tests__/ledgerValidation.test.ts`
+
+Run summary:
+- 3 suites passed
+- 50 tests passed
+- 0 failures
+
+## Scope exclusions (explicitly unchanged)
+- no alias/revelation merge engine
+- no threat/pressure architecture repair
+- no pronoun-family UI work
+- no timeline/location normalization
+- no Source Integrity dashboard
+- no Revise changes
+- no scoring changes

--- a/__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts
+++ b/__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts
@@ -1,0 +1,277 @@
+import { reduceCharacterEvidence, buildCharacterLedgerV2 } from '@/lib/evaluation/pipeline/characterReducer';
+import { buildStoryLayerFromLedger } from '@/lib/evaluation/phase1a/buildStoryLayerFromLedger';
+import type { Pass1aCharacterChunkEntry, Pass1aChunkOutput } from '@/lib/evaluation/pipeline/types';
+
+type CharacterWithIdentity = Pass1aCharacterChunkEntry & {
+  canonical_identity_group?: string;
+  same_name_disambiguation_group?: string | null;
+};
+
+function character(
+  overrides: Partial<CharacterWithIdentity> & {
+    canonical_name: string;
+    canonical_identity_group?: string;
+  },
+): CharacterWithIdentity {
+  return {
+    canonical_name: overrides.canonical_name,
+    canonical_identity_group: overrides.canonical_identity_group ?? overrides.canonical_name,
+    aliases: overrides.aliases ?? [],
+    pronouns: overrides.pronouns ?? ['he/him'],
+    age_signal: overrides.age_signal ?? 'adult',
+    age_exact: overrides.age_exact ?? null,
+    life_stage_evidence: overrides.life_stage_evidence ?? null,
+    gender_identity: overrides.gender_identity ?? 'man',
+    lgbtq_signals: overrides.lgbtq_signals ?? [],
+    racial_ethnic_signals: overrides.racial_ethnic_signals ?? [],
+    skin_tone_signals: overrides.skin_tone_signals ?? [],
+    language_signals: overrides.language_signals ?? [],
+    religion_signals: overrides.religion_signals ?? [],
+    socioeconomic_signals: overrides.socioeconomic_signals ?? [],
+    nationality_signals: overrides.nationality_signals ?? [],
+    disability_neuro_signals: overrides.disability_neuro_signals ?? [],
+    role_signal: overrides.role_signal ?? 'secondary',
+    narrative_weight_signal: overrides.narrative_weight_signal ?? 'supporting',
+    is_named: overrides.is_named ?? true,
+    same_name_disambiguation: overrides.same_name_disambiguation_group ?? null,
+    who_is_this: overrides.who_is_this ?? overrides.canonical_name,
+    what_do_they_want: overrides.what_do_they_want ?? null,
+    where_are_they: overrides.where_are_they ?? null,
+    when_signal: overrides.when_signal ?? null,
+    why_signal: overrides.why_signal ?? null,
+    how_signal: overrides.how_signal ?? null,
+    arc_state_in_chunk: overrides.arc_state_in_chunk ?? 'present in scene',
+    arc_pressure: overrides.arc_pressure ?? null,
+    arc_shift: overrides.arc_shift ?? null,
+    is_ending_chunk: overrides.is_ending_chunk ?? false,
+    symbolic_objects: overrides.symbolic_objects ?? [],
+    relationship_signals: overrides.relationship_signals ?? [],
+    evidence_anchors: overrides.evidence_anchors ?? [
+      { excerpt: `${overrides.canonical_name} appears`, evidence_type: 'identity', confidence: 'explicit' },
+    ],
+    co_presence_confirmed: overrides.co_presence_confirmed ?? [],
+    negative_knowledge: overrides.negative_knowledge ?? [],
+  };
+}
+
+function chunk(chunk_index: number, characters: CharacterWithIdentity[]): Pass1aChunkOutput {
+  return {
+    pass: '1a',
+    axis: 'character_evidence_sweep',
+    chunk_index,
+    characters,
+    prompt_version: 'test-relationship-canonical-id-keying',
+    generated_at: '2026-05-29T00:00:00.000Z',
+  };
+}
+
+describe('characterReducer relationship canonical-ID keying', () => {
+  it('deduplicates Magwitch alias display variants into one canonical pair edge', () => {
+    const chunkOutputs: Pass1aChunkOutput[] = [
+      chunk(0, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          role_signal: 'protagonist',
+          narrative_weight_signal: 'primary',
+          relationship_signals: [
+            { other_character: 'Magwitch', relationship_type: 'fear', dynamic: 'tense' },
+          ],
+          co_presence_confirmed: ['Magwitch'],
+        }),
+        character({
+          canonical_name: 'Magwitch',
+          canonical_identity_group: 'Abel Magwitch',
+          aliases: ['Provis', 'the convict', 'unknown benefactor'],
+          relationship_signals: [
+            { other_character: 'Pip', relationship_type: 'fear', dynamic: 'tense' },
+          ],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+      chunk(1, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          relationship_signals: [
+            { other_character: 'Provis', relationship_type: 'obligation', dynamic: 'shifting' },
+          ],
+          co_presence_confirmed: ['Provis'],
+        }),
+        character({
+          canonical_name: 'Provis',
+          canonical_identity_group: 'Abel Magwitch',
+          aliases: ['Magwitch', 'the convict'],
+          relationship_signals: [
+            { other_character: 'Pip', relationship_type: 'obligation', dynamic: 'shifting' },
+          ],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+      chunk(2, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          relationship_signals: [
+            { other_character: 'unknown benefactor', relationship_type: 'revelation', dynamic: 'shifting' },
+          ],
+          co_presence_confirmed: ['unknown benefactor'],
+        }),
+        character({
+          canonical_name: 'unknown benefactor',
+          canonical_identity_group: 'Abel Magwitch',
+          aliases: ['Magwitch', 'Provis', 'the convict'],
+          relationship_signals: [
+            { other_character: 'Pip', relationship_type: 'revelation', dynamic: 'shifting' },
+          ],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+    ];
+
+    const ledger = reduceCharacterEvidence({
+      jobId: 'relationship-keying-ge',
+      totalChunksInManuscript: 3,
+      chunkOutputs,
+    });
+
+    const ledgerV2 = buildCharacterLedgerV2({
+      ledger,
+      chunkOutputs,
+      jobId: 'relationship-keying-ge',
+      totalChunksInManuscript: 3,
+    });
+
+    const pipId = ledgerV2.identityLedger.find((entry) => entry.canonicalName === 'Pip')?.characterId;
+    const magwitchId = ledgerV2.identityLedger.find((entry) => entry.canonicalName === 'Abel Magwitch')?.characterId;
+    expect(pipId).toBeDefined();
+    expect(magwitchId).toBeDefined();
+
+    const pipMagwitchEdges = ledgerV2.relationshipLedger.filter((edge) =>
+      [edge.characterA, edge.characterB].includes(pipId as string) &&
+      [edge.characterA, edge.characterB].includes(magwitchId as string),
+    );
+
+    expect(pipMagwitchEdges).toHaveLength(1);
+    expect(pipMagwitchEdges[0].pairKey).toBe([pipId, magwitchId].sort().join('↔'));
+    expect(pipMagwitchEdges[0].characterA <= pipMagwitchEdges[0].characterB).toBe(true);
+  });
+
+  it('keeps pair identity stable when display labels change', () => {
+    const chunkOutputs: Pass1aChunkOutput[] = [
+      chunk(0, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          role_signal: 'protagonist',
+          narrative_weight_signal: 'primary',
+          relationship_signals: [{ other_character: 'Magwitch', relationship_type: 'fear', dynamic: 'tense' }],
+          co_presence_confirmed: ['Magwitch'],
+        }),
+        character({
+          canonical_name: 'Magwitch',
+          canonical_identity_group: 'Abel Magwitch',
+          aliases: ['Provis'],
+          relationship_signals: [{ other_character: 'Pip', relationship_type: 'fear', dynamic: 'tense' }],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+    ];
+
+    const ledger = reduceCharacterEvidence({
+      jobId: 'relationship-keying-label-stability',
+      totalChunksInManuscript: 1,
+      chunkOutputs,
+    });
+
+    const ledgerV2 = buildCharacterLedgerV2({
+      ledger,
+      chunkOutputs,
+      jobId: 'relationship-keying-label-stability',
+      totalChunksInManuscript: 1,
+    });
+
+    const baseLayer = buildStoryLayerFromLedger(ledger, ledgerV2);
+    const basePair = (baseLayer.relationship_network_layer as Record<string, any>).relationship_pairs[0];
+
+    const mutatedLedgerV2 = JSON.parse(JSON.stringify(ledgerV2));
+    mutatedLedgerV2.relationshipLedger[0].characterADisplayName = 'Philip Pirrip';
+    mutatedLedgerV2.relationshipLedger[0].characterBDisplayName = 'the convict';
+
+    const mutatedLayer = buildStoryLayerFromLedger(ledger, mutatedLedgerV2);
+    const mutatedPair = (mutatedLayer.relationship_network_layer as Record<string, any>).relationship_pairs[0];
+
+    expect(mutatedPair.pair_key).toBe(basePair.pair_key);
+    expect(mutatedPair.character_a).toBe(basePair.character_a);
+    expect(mutatedPair.character_b).toBe(basePair.character_b);
+    expect(mutatedPair.character_a_label).toBe('Philip Pirrip');
+    expect(mutatedPair.character_b_label).toBe('the convict');
+  });
+
+  it('preserves same-name disambiguation metadata without forcing incorrect merges', () => {
+    const chunkOutputs: Pass1aChunkOutput[] = [
+      chunk(0, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          role_signal: 'protagonist',
+          narrative_weight_signal: 'primary',
+          relationship_signals: [{ other_character: 'Joe Gargery', relationship_type: 'family', dynamic: 'intimate' }],
+          co_presence_confirmed: ['Joe Gargery'],
+        }),
+        character({
+          canonical_name: 'Joe Gargery',
+          canonical_identity_group: 'Joe Gargery',
+          aliases: ['Joe'],
+          same_name_disambiguation_group: 'joe-gargery',
+          relationship_signals: [{ other_character: 'Pip', relationship_type: 'family', dynamic: 'intimate' }],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+      chunk(1, [
+        character({
+          canonical_name: 'Pip',
+          canonical_identity_group: 'Pip',
+          relationship_signals: [{ other_character: "Joe and Biddy's son", relationship_type: 'family', dynamic: 'intimate' }],
+          co_presence_confirmed: ["Joe and Biddy's son"],
+        }),
+        character({
+          canonical_name: "Joe and Biddy's son",
+          canonical_identity_group: "Joe and Biddy's son",
+          aliases: ['Joe'],
+          same_name_disambiguation_group: 'joe-child',
+          relationship_signals: [{ other_character: 'Pip', relationship_type: 'family', dynamic: 'intimate' }],
+          co_presence_confirmed: ['Pip'],
+        }),
+      ]),
+    ];
+
+    const ledger = reduceCharacterEvidence({
+      jobId: 'relationship-keying-disambiguation',
+      totalChunksInManuscript: 2,
+      chunkOutputs,
+    });
+
+    const ledgerV2 = buildCharacterLedgerV2({
+      ledger,
+      chunkOutputs,
+      jobId: 'relationship-keying-disambiguation',
+      totalChunksInManuscript: 2,
+    });
+
+    const identities = new Set(ledgerV2.identityLedger.map((entry) => entry.canonicalName));
+    expect(identities.has('Joe Gargery')).toBe(true);
+    expect(identities.has("Joe and Biddy's son")).toBe(true);
+
+    const pipJoeEdges = ledgerV2.relationshipLedger.filter((edge) =>
+      edge.characterADisplayName === 'Pip' || edge.characterBDisplayName === 'Pip',
+    );
+    expect(pipJoeEdges.length).toBeGreaterThanOrEqual(2);
+    expect(
+      pipJoeEdges.some((edge) => edge.characterASameNameDisambiguationGroup === 'joe-gargery' || edge.characterBSameNameDisambiguationGroup === 'joe-gargery'),
+    ).toBe(true);
+    expect(
+      pipJoeEdges.some((edge) => edge.characterASameNameDisambiguationGroup === 'joe-child' || edge.characterBSameNameDisambiguationGroup === 'joe-child'),
+    ).toBe(true);
+  });
+});

--- a/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
+++ b/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
@@ -322,8 +322,13 @@ function buildRelationshipNetworkLayer(
   ledgerV2: CharacterLedgerV2,
 ): Record<string, unknown> {
   const pairs = ledgerV2.relationshipLedger.map((entry: RelationshipLedgerEntry) => ({
+    pair_key: entry.pairKey,
     character_a: entry.characterA,
     character_b: entry.characterB,
+    character_a_label: entry.characterADisplayName ?? entry.characterA,
+    character_b_label: entry.characterBDisplayName ?? entry.characterB,
+    character_a_disambiguation_group: entry.characterASameNameDisambiguationGroup ?? null,
+    character_b_disambiguation_group: entry.characterBSameNameDisambiguationGroup ?? null,
     relationship_type_start: entry.relationshipTypeStart,
     relationship_type_end: entry.relationshipTypeEnd,
     first_co_presence_chunk: entry.firstCoPresenceChunk,

--- a/lib/evaluation/pipeline/characterReducer.ts
+++ b/lib/evaluation/pipeline/characterReducer.ts
@@ -383,12 +383,23 @@ export function reduceCharacterEvidence(params: {
   const aliasMap = buildAliasMap(allNames);
   const identityGroupMap = normalizeIdentityGroupMap(rawIdentityGroupMap, aliasMap);
 
+  function resolveCanonicalForEntry(entry: Pass1aCharacterChunkEntry): string {
+    const identityHint = normalizeSignalText(
+      (entry as Pass1aCharacterChunkEntry & { canonical_identity_group?: unknown })
+        .canonical_identity_group,
+    );
+    if (identityHint) {
+      return identityHint.trim();
+    }
+    return resolveCanonical(entry.canonical_name, aliasMap, identityGroupMap);
+  }
+
   // Group all chunk entries by resolved canonical name
   const grouped = new Map<string, Array<{ entry: Pass1aCharacterChunkEntry; chunk_index: number }>>();
 
   for (const chunkOutput of chunkOutputs) {
     for (const char of chunkOutput.characters) {
-      const canonical = resolveCanonical(char.canonical_name, aliasMap, identityGroupMap);
+      const canonical = resolveCanonicalForEntry(char);
       if (!grouped.has(canonical)) grouped.set(canonical, []);
       grouped.get(canonical)!.push({ entry: char, chunk_index: chunkOutput.chunk_index });
     }
@@ -396,7 +407,7 @@ export function reduceCharacterEvidence(params: {
     for (const char of chunkOutput.characters) {
       for (const alias of char.aliases ?? []) {
         const resolved = resolveCanonical(alias, aliasMap, identityGroupMap);
-        if (resolved !== resolveCanonical(char.canonical_name, aliasMap, identityGroupMap)) {
+        if (resolved !== resolveCanonicalForEntry(char)) {
           // This alias resolves to a different canonical — add cross-reference
           if (!grouped.has(resolved)) grouped.set(resolved, []);
           // Don't double-add the same entry
@@ -409,7 +420,7 @@ export function reduceCharacterEvidence(params: {
   const rawSymbols: RawSymbol[] = [];
   for (const chunkOutput of chunkOutputs) {
     for (const char of chunkOutput.characters) {
-      const canonical = resolveCanonical(char.canonical_name, aliasMap, identityGroupMap);
+      const canonical = resolveCanonicalForEntry(char);
       for (const sym of char.symbolic_objects ?? []) {
         rawSymbols.push({
           object: sym.object,
@@ -887,6 +898,52 @@ export function buildCharacterLedgerV2(params: {
     };
   });
 
+  const canonicalNameToId = new Map<string, string>();
+  const characterIdToCanonicalName = new Map<string, string>();
+  const characterIdToDisambiguationGroup = new Map<string, string | null>();
+
+  for (const identity of identityLedger) {
+    canonicalNameToId.set(identity.canonicalName, identity.characterId);
+    characterIdToCanonicalName.set(identity.characterId, identity.canonicalName);
+    characterIdToDisambiguationGroup.set(
+      identity.characterId,
+      identity.sameNameDisambiguationGroup ?? null,
+    );
+  }
+
+  function stableCharacterId(name: string): string {
+    return canonicalNameToId.get(name) ?? name.toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function stablePairIdentity(charNameA: string, charNameB: string): {
+    characterAId: string;
+    characterBId: string;
+    characterADisplayName: string;
+    characterBDisplayName: string;
+    pairKey: string;
+  } {
+    const idA = stableCharacterId(charNameA);
+    const idB = stableCharacterId(charNameB);
+
+    if (idA <= idB) {
+      return {
+        characterAId: idA,
+        characterBId: idB,
+        characterADisplayName: charNameA,
+        characterBDisplayName: charNameB,
+        pairKey: `${idA}↔${idB}`,
+      };
+    }
+
+    return {
+      characterAId: idB,
+      characterBId: idA,
+      characterADisplayName: charNameB,
+      characterBDisplayName: charNameA,
+      pairKey: `${idB}↔${idA}`,
+    };
+  }
+
   // ── 2. State Timelines ────────────────────────────────────────────────────
   // One snapshot per character per act zone (coarse — reducer has no location data per chunk)
   const stateTimelines: CharacterStateSnapshot[] = entries.map((e) => ({
@@ -954,7 +1011,7 @@ export function buildCharacterLedgerV2(params: {
     return "unknown";
   }
 
-  // Build a map from (charA, charB) → all relationship signals across chunks
+  // Build a map from canonical ID pair → all relationship signals across chunks
   const relSignalMap = new Map<string, Array<{
     relationship_type: string;
     dynamic: string;
@@ -963,14 +1020,14 @@ export function buildCharacterLedgerV2(params: {
 
   for (const entry of entries) {
     for (const rel of entry.relational_engines) {
-      const pairKey = [entry.canonical_name, rel.other_character].sort().join("↔");
-      const existing = relSignalMap.get(pairKey) ?? [];
+      const pair = stablePairIdentity(entry.canonical_name, rel.other_character);
+      const existing = relSignalMap.get(pair.pairKey) ?? [];
       existing.push({
         relationship_type: rel.relationship_type,
         dynamic: rel.dynamic,
         chunk_index: rel.chunk_span[0],
       });
-      relSignalMap.set(pairKey, existing);
+      relSignalMap.set(pair.pairKey, existing);
     }
   }
 
@@ -980,12 +1037,12 @@ export function buildCharacterLedgerV2(params: {
   for (const entry of entries) {
     const cpMap = entry.coPresenceMap ?? {};
     for (const [otherName, coPresence] of Object.entries(cpMap)) {
-      const pairKey = [entry.canonical_name, otherName].sort().join("↔");
-      if (seenRelPairs.has(pairKey)) continue;
-      seenRelPairs.add(pairKey);
+      const pair = stablePairIdentity(entry.canonical_name, otherName);
+      if (seenRelPairs.has(pair.pairKey)) continue;
+      seenRelPairs.add(pair.pairKey);
 
       // Look up relationship signals for this pair
-      const signals = relSignalMap.get(pairKey) ?? [];
+      const signals = relSignalMap.get(pair.pairKey) ?? [];
       const sortedSignals = [...signals].sort((a, b) => a.chunk_index - b.chunk_index);
 
       // Derive relationship type from earliest and latest signals
@@ -1013,8 +1070,15 @@ export function buildCharacterLedgerV2(params: {
       }
 
       relationshipLedger.push({
-        characterA: entry.canonical_name,
-        characterB: otherName,
+        characterA: pair.characterAId,
+        characterB: pair.characterBId,
+        pairKey: pair.pairKey,
+        characterADisplayName: pair.characterADisplayName,
+        characterBDisplayName: pair.characterBDisplayName,
+        characterASameNameDisambiguationGroup:
+          characterIdToDisambiguationGroup.get(pair.characterAId) ?? null,
+        characterBSameNameDisambiguationGroup:
+          characterIdToDisambiguationGroup.get(pair.characterBId) ?? null,
         firstCoPresenceChunk: coPresence.firstSharedChunk,
         firstCoPresenceChapter: coPresence.firstSharedChapterEstimate,
         invalidBeforeChapter: coPresence.firstSharedChapterEstimate,
@@ -1027,12 +1091,16 @@ export function buildCharacterLedgerV2(params: {
         sharedActivities: [],
         unresolvedLedger: [],
         recommendationBlocker: {
-          blockerId: makeBlockerId("co_presence_violation", entry.canonical_name, otherName),
+          blockerId: makeBlockerId(
+            'co_presence_violation',
+            pair.characterADisplayName,
+            pair.characterBDisplayName,
+          ),
           type: "co_presence_violation",
           severity: "suppress",
-          rule: `${entry.canonical_name} and ${otherName} do not share a scene until chunk ${coPresence.firstSharedChunk} (${coPresence.firstSharedChapterEstimate}). Recommendations must not place them together before this point.`,
+          rule: `${pair.characterADisplayName} and ${pair.characterBDisplayName} do not share a scene until chunk ${coPresence.firstSharedChunk} (${coPresence.firstSharedChapterEstimate}). Recommendations must not place them together before this point.`,
           validAfterChapter: coPresence.firstSharedChapterEstimate,
-          involvedCharacters: [entry.canonical_name, otherName],
+          involvedCharacters: [pair.characterADisplayName, pair.characterBDisplayName],
           affectedRecommendationTypes: ["characterization", "scene_structure"],
         },
       });
@@ -1149,10 +1217,29 @@ export function buildCharacterLedgerV2(params: {
 
   const coPresenceIndex: Record<string, Record<string, number>> = {};
   for (const rel of relationshipLedger) {
-    if (!coPresenceIndex[rel.characterA]) coPresenceIndex[rel.characterA] = {};
-    coPresenceIndex[rel.characterA][rel.characterB] = rel.firstCoPresenceChunk;
-    if (!coPresenceIndex[rel.characterB]) coPresenceIndex[rel.characterB] = {};
-    coPresenceIndex[rel.characterB][rel.characterA] = rel.firstCoPresenceChunk;
+    const idA = rel.characterA;
+    const idB = rel.characterB;
+    const nameA = rel.characterADisplayName ?? characterIdToCanonicalName.get(idA) ?? idA;
+    const nameB = rel.characterBDisplayName ?? characterIdToCanonicalName.get(idB) ?? idB;
+
+    const indexPair = (left: string, right: string, value: number): void => {
+      if (!coPresenceIndex[left]) coPresenceIndex[left] = {};
+      coPresenceIndex[left][right] = value;
+    };
+
+    // Canonical ID path (authoritative)
+    indexPair(idA, idB, rel.firstCoPresenceChunk);
+    indexPair(idB, idA, rel.firstCoPresenceChunk);
+
+    // Backward-compatible display-name lookups for existing call-sites/tests
+    indexPair(nameA, nameB, rel.firstCoPresenceChunk);
+    indexPair(nameB, nameA, rel.firstCoPresenceChunk);
+
+    // Mixed lookups so either ID or display name can be queried safely
+    indexPair(idA, nameB, rel.firstCoPresenceChunk);
+    indexPair(nameB, idA, rel.firstCoPresenceChunk);
+    indexPair(idB, nameA, rel.firstCoPresenceChunk);
+    indexPair(nameA, idB, rel.firstCoPresenceChunk);
   }
 
   const nameStateIndex: Record<string, Array<{ name: string; validFromChunk: number; validUntilChunk: number | null }>> = {};

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -1275,8 +1275,13 @@ export interface CharacterStateSnapshot {
 // ══════════════════════════════════════════════════════════════════════════════
 
 export interface RelationshipLedgerEntry {
-  characterA: string;
-  characterB: string;
+  characterA: string;                            // canonical stable ID
+  characterB: string;                            // canonical stable ID
+  pairKey: string;                               // deterministic sorted key: `${minId}↔${maxId}`
+  characterADisplayName?: string;                // optional UI label; not identity
+  characterBDisplayName?: string;                // optional UI label; not identity
+  characterASameNameDisambiguationGroup?: string | null;
+  characterBSameNameDisambiguationGroup?: string | null;
   firstCoPresenceChunk: number;
   firstCoPresenceChapter: string;              // "Chapter 72" — the gate value
   invalidBeforeChapter: string;               // canonical blocker label

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
@@ -22,6 +22,16 @@ function getTierEntries(ledger: any, tier: string): any[] {
   return ledger.layers?.cast_role_tier_layer?.tier_map?.[tier] ?? [];
 }
 
+function canonicalPairKey(a: string, b: string): string {
+  return [a, b].sort().join('↔');
+}
+
+function collectCanonicalPairKeys(relationshipPairs: any[]): string[] {
+  return relationshipPairs.map((pair) =>
+    canonicalPairKey(String(pair?.character_a ?? ''), String(pair?.character_b ?? '')),
+  );
+}
+
 function validateGreatExpectations(ledger: any): string[] {
   const errors: string[] = [];
 
@@ -56,6 +66,8 @@ function validateGreatExpectations(ledger: any): string[] {
   }
 
   const relationshipPairs = ledger.layers?.relationship_network_layer?.relationship_pairs ?? [];
+  const canonicalPairKeys = collectCanonicalPairKeys(relationshipPairs);
+
   for (const pair of relationshipPairs) {
     for (const side of ['character_a', 'character_b'] as const) {
       const value = pair?.[side];
@@ -64,6 +76,36 @@ function validateGreatExpectations(ledger: any): string[] {
           `FORBIDDEN_FAILURE: Relationship pair ${pair?.character_a ?? '?'} -> ${pair?.character_b ?? '?'} must use canonical ID references, not display names.`,
         );
       }
+    }
+  }
+
+  const expectedPairs = [
+    canonicalPairKey('ge:pip', 'ge:magwitch'),
+    canonicalPairKey('ge:pip', 'ge:joe'),
+    canonicalPairKey('ge:pip', 'ge:estella'),
+    canonicalPairKey('ge:pip', 'ge:miss_havisham'),
+    canonicalPairKey('ge:estella', 'ge:miss_havisham'),
+    canonicalPairKey('ge:magwitch', 'ge:compeyson'),
+    canonicalPairKey('ge:pip', 'ge:jaggers'),
+    canonicalPairKey('ge:pip', 'ge:biddy'),
+    canonicalPairKey('ge:pip', 'ge:orlick'),
+  ];
+
+  for (const pair of expectedPairs) {
+    if (!canonicalPairKeys.includes(pair)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Missing stable canonical relationship pair '${pair}'.`);
+    }
+  }
+
+  const byPair = new Map<string, number>();
+  for (const key of canonicalPairKeys) {
+    byPair.set(key, (byPair.get(key) ?? 0) + 1);
+  }
+  for (const [pairKey, count] of byPair.entries()) {
+    if (count > 1) {
+      errors.push(
+        `FORBIDDEN_FAILURE: RELATIONSHIP_DISPLAY_NAME_KEYING duplicate display-name edges found for canonical pair '${pairKey}'.`,
+      );
     }
   }
 
@@ -133,11 +175,40 @@ function validateAwakening(ledger: any): string[] {
 
   const relationshipLayer = ledger.layers?.relationship_network_layer ?? {};
   const relationshipPairs = relationshipLayer.relationship_pairs ?? [];
+  const canonicalPairKeys = collectCanonicalPairKeys(relationshipPairs);
   if (!relationshipLayer.relationship_tiers || Object.keys(relationshipLayer.relationship_tiers).length === 0) {
     errors.push('MISSING_REQUIRED_TRUTH: Relationship network must be tiered/classified.');
   }
   if (relationshipPairs.some((pair: any) => hasText(pair.relationship_type_start, 'unknown') || hasText(pair.relationship_type_end, 'unknown'))) {
     errors.push('FORBIDDEN_FAILURE: Relationship pairs must not collapse into unknown co-occurrence dumping.');
+  }
+
+  const expectedPairs = [
+    canonicalPairKey('aw:edna', 'aw:robert'),
+    canonicalPairKey('aw:edna', 'aw:leonce'),
+    canonicalPairKey('aw:edna', 'aw:arobin'),
+    canonicalPairKey('aw:edna', 'aw:adele'),
+    canonicalPairKey('aw:edna', 'aw:reisz'),
+    canonicalPairKey('aw:edna', 'aw:children'),
+    canonicalPairKey('aw:edna', 'aw:sea_symbolic_pressure'),
+  ];
+
+  for (const pair of expectedPairs) {
+    if (!canonicalPairKeys.includes(pair)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Missing stable canonical relationship pair '${pair}'.`);
+    }
+  }
+
+  const byPair = new Map<string, number>();
+  for (const key of canonicalPairKeys) {
+    byPair.set(key, (byPair.get(key) ?? 0) + 1);
+  }
+  for (const [pairKey, count] of byPair.entries()) {
+    if (count > 1) {
+      errors.push(
+        `FORBIDDEN_FAILURE: RELATIONSHIP_DISPLAY_NAME_KEYING duplicate display-name edges found for canonical pair '${pairKey}'.`,
+      );
+    }
   }
 
   const symbolText = JSON.stringify(ledger.layers?.object_symbol_layer?.objects ?? []).toLowerCase();
@@ -218,6 +289,41 @@ describe('Story Ledger gold fixture harness (deterministic, no live LLM calls)',
         'FORBIDDEN_FAILURE: Herbert Pocket must not be a POV owner.',
       ]),
     );
+  });
+
+  it('fails loudly on duplicate display-name relationship edges (RELATIONSHIP_DISPLAY_NAME_KEYING)', () => {
+    const mutated = JSON.parse(JSON.stringify(greatExpectations));
+    mutated.layers.relationship_network_layer.relationship_pairs.push({
+      pair_key: 'ge:magwitch↔ge:pip',
+      character_a: 'ge:pip',
+      character_b: 'ge:magwitch',
+      character_a_label: 'Pip',
+      character_b_label: 'Provis',
+      relationship_type_start: 'fear',
+      relationship_type_end: 'obligation_and_compassion',
+    });
+
+    const errors = validateGreatExpectations(mutated);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "FORBIDDEN_FAILURE: RELATIONSHIP_DISPLAY_NAME_KEYING duplicate display-name edges found for canonical pair 'ge:magwitch↔ge:pip'.",
+      ]),
+    );
+  });
+
+  it('proves relationship identity is stable even when display labels change', () => {
+    const mutated = JSON.parse(JSON.stringify(greatExpectations));
+    for (const pair of mutated.layers.relationship_network_layer.relationship_pairs) {
+      if (pair.character_a === 'ge:pip') {
+        pair.character_a_label = 'Philip Pirrip';
+      }
+      if (pair.character_b === 'ge:magwitch') {
+        pair.character_b_label = 'the convict';
+      }
+    }
+
+    const errors = validateGreatExpectations(mutated);
+    expect(errors).toEqual([]);
   });
 
   it('passes required-truth + forbidden-failure checks for The Awakening fixture', () => {

--- a/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
@@ -73,6 +73,11 @@
           "character_id": "ge:drummle",
           "canonical_name": "Bentley Drummle",
           "aliases": ["Drummle"]
+        },
+        {
+          "character_id": "ge:compeyson",
+          "canonical_name": "Compeyson",
+          "aliases": ["Compeyson"]
         }
       ]
     },
@@ -94,25 +99,88 @@
     "relationship_network_layer": {
       "relationship_pairs": [
         {
+          "pair_key": "ge:joe↔ge:pip",
           "character_a": "ge:pip",
           "character_b": "ge:joe",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Joe Gargery",
           "relationship_type_start": "protege",
           "relationship_type_end": "reconciled_family"
         },
         {
+          "pair_key": "ge:magwitch↔ge:pip",
           "character_a": "ge:pip",
           "character_b": "ge:magwitch",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Abel Magwitch",
           "relationship_type_start": "fear",
           "relationship_type_end": "obligation_and_compassion"
         },
         {
+          "pair_key": "ge:estella↔ge:pip",
           "character_a": "ge:pip",
           "character_b": "ge:estella",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Estella",
           "relationship_type_start": "desire",
           "relationship_type_end": "scarred_recognition"
+        },
+        {
+          "pair_key": "ge:miss_havisham↔ge:pip",
+          "character_a": "ge:pip",
+          "character_b": "ge:miss_havisham",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Miss Havisham",
+          "relationship_type_start": "humiliation",
+          "relationship_type_end": "reckoning"
+        },
+        {
+          "pair_key": "ge:estella↔ge:miss_havisham",
+          "character_a": "ge:estella",
+          "character_b": "ge:miss_havisham",
+          "character_a_label": "Estella",
+          "character_b_label": "Miss Havisham",
+          "relationship_type_start": "manufactured_coldness",
+          "relationship_type_end": "damage_and_separation"
+        },
+        {
+          "pair_key": "ge:compeyson↔ge:magwitch",
+          "character_a": "ge:magwitch",
+          "character_b": "ge:compeyson",
+          "character_a_label": "Abel Magwitch",
+          "character_b_label": "Compeyson",
+          "relationship_type_start": "adversarial_history",
+          "relationship_type_end": "fatal_pursuit"
+        },
+        {
+          "pair_key": "ge:jaggers↔ge:pip",
+          "character_a": "ge:pip",
+          "character_b": "ge:jaggers",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Mr. Jaggers",
+          "relationship_type_start": "professional_dependency",
+          "relationship_type_end": "moral_disillusionment"
+        },
+        {
+          "pair_key": "ge:biddy↔ge:pip",
+          "character_a": "ge:pip",
+          "character_b": "ge:biddy",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Biddy",
+          "relationship_type_start": "companionship",
+          "relationship_type_end": "truth_and_distance"
+        },
+        {
+          "pair_key": "ge:orlick↔ge:pip",
+          "character_a": "ge:pip",
+          "character_b": "ge:orlick",
+          "character_a_label": "Pip / Philip Pirrip",
+          "character_b_label": "Orlick",
+          "relationship_type_start": "hostility",
+          "relationship_type_end": "attempted_violence"
         }
       ],
-      "pair_count": 3
+      "pair_count": 9
     },
     "threat_antagonist_ending_layer": {
       "antagonists": [

--- a/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
@@ -58,6 +58,16 @@
           "character_id": "aw:etienne",
           "canonical_name": "Étienne Pontellier",
           "aliases": ["Etienne"]
+        },
+        {
+          "character_id": "aw:children",
+          "canonical_name": "Edna's children",
+          "aliases": ["Raoul and Étienne", "children"]
+        },
+        {
+          "character_id": "aw:sea_symbolic_pressure",
+          "canonical_name": "Sea / symbolic pressure",
+          "aliases": ["the sea", "the gulf", "water"]
         }
       ]
     },
@@ -114,34 +124,74 @@
     "relationship_network_layer": {
       "relationship_pairs": [
         {
+          "pair_key": "aw:edna↔aw:leonce",
           "character_a": "aw:edna",
           "character_b": "aw:leonce",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Léonce Pontellier",
           "relationship_type_start": "marriage",
           "relationship_type_end": "estrangement"
         },
         {
+          "pair_key": "aw:edna↔aw:robert",
           "character_a": "aw:edna",
           "character_b": "aw:robert",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Robert Lebrun",
           "relationship_type_start": "attraction",
           "relationship_type_end": "fatal_unresolved_desire"
         },
         {
+          "pair_key": "aw:adele↔aw:edna",
           "character_a": "aw:edna",
           "character_b": "aw:adele",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Adèle Ratignolle",
           "relationship_type_start": "friendship",
           "relationship_type_end": "maternal_domestic_counterpoint"
         },
         {
+          "pair_key": "aw:edna↔aw:reisz",
           "character_a": "aw:edna",
           "character_b": "aw:reisz",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Mademoiselle Reisz",
           "relationship_type_start": "mentorship_resistance",
           "relationship_type_end": "artistic_countermodel"
+        },
+        {
+          "pair_key": "aw:arobin↔aw:edna",
+          "character_a": "aw:edna",
+          "character_b": "aw:arobin",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Alcée Arobin",
+          "relationship_type_start": "sexual_destabilization",
+          "relationship_type_end": "dissipated_intimacy"
+        },
+        {
+          "pair_key": "aw:children↔aw:edna",
+          "character_a": "aw:edna",
+          "character_b": "aw:children",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Edna's children",
+          "relationship_type_start": "maternal_obligation",
+          "relationship_type_end": "contested_attachment"
+        },
+        {
+          "pair_key": "aw:edna↔aw:sea_symbolic_pressure",
+          "character_a": "aw:edna",
+          "character_b": "aw:sea_symbolic_pressure",
+          "character_a_label": "Edna Pontellier",
+          "character_b_label": "Sea / symbolic pressure",
+          "relationship_type_start": "symbolic_call",
+          "relationship_type_end": "terminal_absorption"
         }
       ],
-      "pair_count": 4,
+      "pair_count": 7,
       "relationship_tiers": {
-        "primary_spine": ["aw:edna|aw:leonce", "aw:edna|aw:robert"],
-        "secondary_structural": ["aw:edna|aw:adele", "aw:edna|aw:reisz"],
+        "primary_spine": ["aw:edna|aw:leonce", "aw:edna|aw:robert", "aw:edna|aw:children"],
+        "secondary_structural": ["aw:edna|aw:adele", "aw:edna|aw:reisz", "aw:edna|aw:arobin"],
+        "symbolic_pressure": ["aw:edna|aw:sea_symbolic_pressure"],
         "background": ["aw:celina_husband"]
       }
     },


### PR DESCRIPTION
## Goal
Stop relationship pairs from being built from display names, aliases, or duplicate surface labels.

## Primary failure class
- `RELATIONSHIP_DISPLAY_NAME_KEYING`

## Production behavior
- Relationship pair identity is keyed by stable canonical IDs (`characterA`, `characterB`) with deterministic ordering.
- Pair identity now includes deterministic `pairKey` (`minId↔maxId`).
- Display labels are preserved as metadata (`characterADisplayName`, `characterBDisplayName`) and surfaced to Story Layer as `character_a_label` / `character_b_label`; labels no longer define identity.
- Alias display variants (e.g. Magwitch / Provis / convict / unknown benefactor) collapse to one canonical pair edge after canonical resolution.
- Same-visible-name disambiguation metadata is preserved on relationship entries (`characterASameNameDisambiguationGroup`, `characterBSameNameDisambiguationGroup`).

## Fixture integrity
Fixture updates in this PR **tighten canonical relationship expectations and do not reduce the required truth set**.

### Great Expectations fixture changes (tightening)
- Added missing canonical entity: `ge:compeyson`.
- Expanded required canonical relationship pairs from 3 to 9:
  - Pip–Magwitch
  - Pip–Joe
  - Pip–Estella
  - Pip–Miss Havisham
  - Estella–Miss Havisham
  - Magwitch–Compeyson
  - Pip–Jaggers
  - Pip–Biddy
  - Pip–Orlick
- Added pair identity metadata (`pair_key`) and UI label metadata for identity-vs-label separation tests.

### Awakening fixture changes (tightening)
- Added required canonical entities for relationship expectations:
  - `aw:children`
  - `aw:sea_symbolic_pressure`
- Expanded required canonical relationship pairs from 4 to 7:
  - Edna–Robert
  - Edna–Léonce
  - Edna–Arobin
  - Edna–Adèle
  - Edna–Mademoiselle Reisz
  - Edna–children
  - Edna–sea/symbolic pressure
- Strengthened relationship tier coverage (`primary_spine`, `secondary_structural`, `symbolic_pressure`).

No fixture assertions were relaxed.

## Tests added/updated
- Added: `__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts`
  - canonical-ID keying
  - deterministic pair ordering
  - alias-display dedupe
  - disambiguation metadata preservation
  - UI label changes do not change pair identity
- Updated: `tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts`
  - enforces required Great Expectations and Awakening canonical pairs
  - detects and names duplicate display-name edges (`RELATIONSHIP_DISPLAY_NAME_KEYING`)
  - asserts label mutation does not alter pair identity

## Validation (required suites)
- ✅ `__tests__/lib/evaluation/pipeline/characterReducer.relationship-canonical-id-keying.test.ts`
- ✅ `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
- ✅ `lib/evaluation/pipeline/__tests__/ledgerValidation.test.ts`

Run summary:
- 3 suites passed
- 50 tests passed
- 0 failures

## Scope exclusions (explicitly unchanged)
- no alias/revelation merge engine
- no threat/pressure architecture repair
- no pronoun-family UI work
- no timeline/location normalization
- no Source Integrity dashboard
- no Revise changes
- no scoring changes
