### PR TITLE
fix(ledger): require evidence for POV ownership

### DIFF
--- a/.github/pr-bodies/PR-828.md
+++ b/.github/pr-bodies/PR-828.md
@@ -1,0 +1,52 @@
+## Primary failure class
+- `POV_ROLE_FALLBACK_OWNER`
+
+## Goal
+Prevent characters from becoming POV owners because they are co-protagonists, romantic catalysts, allies, or major secondary figures. POV ownership must be evidence-based.
+
+## What changed
+- Removed role-tier fallback ownership in `buildPovStructureLayer`.
+- POV owner list is now evidence-only from chunk-level POV/focalization signals.
+- Added explicit POV evidence status fields in POV layer output:
+  - `pov_evidence_status`
+  - `pov_role_fallback_derived`
+  - `pov_truth_status`
+- Added explicit degraded note when evidence is insufficient:
+  - "POV could not be confirmed from evidence..."
+
+## Required behavior coverage
+- role tier alone does not confer POV ownership
+- `co_protagonist ≠ POV owner`
+- `romantic catalyst ≠ POV owner`
+- `major secondary/ally/foil ≠ POV owner`
+- fallback-derived POV is blocked (not clean)
+- no-evidence path is explicit insufficiency, not invented owners
+
+## Fixture / harness updates (tightening)
+- Great Expectations fixture POV now enforces sole owner `ge:pip` plus mode metadata:
+  - `pov_mode: first-person retrospective`
+  - `pov_perspective_note: adult narrator looking back`
+- The Awakening fixture POV metadata added:
+  - `pov_mode: close third limited`
+  - focalization note anchored to Edna
+- Gold harness assertions now enforce:
+  - GE: Herbert/Jaggers/Magwitch/Estella/Joe/Biddy not POV owners
+  - Awakening: Robert/Léonce/Arobin/Adèle/Reisz not POV owners
+  - mode/note expectations for both texts
+
+## Validation
+- ✅ `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.awakening-pov.test.ts`
+- ✅ `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
+
+Run summary:
+- 2 suites passed
+- 12 tests passed
+- 0 failures
+
+## Out of scope (unchanged)
+- no relationship canonical-ID changes
+- no threat/pressure architecture
+- no pronoun-family display work
+- no timeline/location normalization
+- no Source Integrity dashboard
+- no Revise/scoring changes

--- a/__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.awakening-pov.test.ts
+++ b/__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.awakening-pov.test.ts
@@ -279,19 +279,17 @@ describe('buildStoryLayerFromLedger — POV focalization truth', () => {
     expect(robertPov).toBeUndefined();
   });
 
-  it('falls back to role-based POV when no chunk outputs provided (backward compat)', () => {
+  it('does not fall back to role-derived POV when chunk evidence is absent', () => {
     const payload = buildStoryLayerFromLedger(minimalLedger, minimalLedgerV2);
     const povLayer = payload.pov_structure_layer as Record<string, unknown>;
     const povChars = povLayer.pov_characters as Array<Record<string, unknown>>;
 
-    // Without chunk data, falls back to protagonist + co_protagonist filter
-    // Robert is co_protagonist in ledgerV2, so he appears in fallback mode
-    expect(povChars.length).toBeGreaterThanOrEqual(1);
-    const ednaEntry = povChars.find((c) => c.canonical_name === 'Edna Pontellier');
-    expect(ednaEntry).toBeDefined();
-
-    // Detection note should warn about role-based derivation
-    expect(povLayer.pov_detection_note).toContain('role');
+    expect(povChars).toHaveLength(0);
+    expect(povLayer.pov_identified).toBe(false);
+    expect(povLayer.pov_evidence_status).toBe('insufficient_evidence');
+    expect(povLayer.pov_role_fallback_derived).toBe(false);
+    expect(povLayer.pov_truth_status).toBe('degraded');
+    expect(String(povLayer.pov_detection_note)).toContain('could not be confirmed');
   });
 
   it('pov_identified is true and pov_character_count is accurate', () => {

--- a/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
+++ b/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
@@ -123,8 +123,8 @@ function buildPovStructureLayer(
   ledgerV2: CharacterLedgerV2,
   chunkOutputs?: Pass1aChunkOutput[],
 ): Record<string, unknown> {
-  // Use actual pov_signal data from chunks when available (accurate camera ownership).
-  // Fall back to role-based derivation only for legacy data without pov_signal.
+  // POV ownership must be evidence-based from chunk-level pov_signal/focalization.
+  // Narrative role tiers never confer POV ownership.
   const chunks = Array.isArray(chunkOutputs) ? chunkOutputs : [];
   const povFromChunks = chunks.length > 0
     ? buildPovStructureFromChunkOutputs({
@@ -155,25 +155,14 @@ function buildPovStructureLayer(
           coverage: identity ? (ledgerV2.characterCoverage?.[identity.characterId] ?? null) : null,
         };
       })
-    : ledgerV2.identityLedger
-        .filter(
-          (entry) =>
-            entry.narrativeRole === 'protagonist' || entry.narrativeRole === 'co_protagonist',
-        )
-        .map((entry) => ({
-          character_id: entry.characterId,
-          canonical_name: entry.canonicalName,
-          narrative_role: entry.narrativeRole,
-          importance_level: entry.importanceLevel,
-          first_appearance: entry.firstAppearance,
-          last_appearance: entry.lastAppearance,
-          coverage: ledgerV2.characterCoverage?.[entry.characterId] ?? null,
-        }));
+    : [];
 
   const protagonists = ledger.coverage_summary.protagonists ?? [];
   const co_protagonists = ledger.coverage_summary.co_protagonists ?? [];
   const totalIdentified = ledgerV2.identityLedger.length;
   const povCount = povCharacters.length;
+  const derivedFromRoleFallback = false;
+  const povEvidenceStatus = povCount > 0 ? 'evidence_confirmed' : 'insufficient_evidence';
 
   return {
     schema_version: 'pov_structure_layer_v1',
@@ -183,12 +172,15 @@ function buildPovStructureLayer(
     pov_character_count: povCount,
     total_characters_identified: totalIdentified,
     pov_identified: povCount > 0,
+    pov_evidence_status: povEvidenceStatus,
+    pov_role_fallback_derived: derivedFromRoleFallback,
+    pov_truth_status: povCount > 0 ? 'clean' : 'degraded',
     pov_detection_note:
       povCount === 0
-        ? 'No POV characters detected — character sweep may have low coverage'
+        ? 'POV could not be confirmed from evidence; role-tier fallback is blocked to prevent invented POV ownership.'
         : hasPovSignalData
           ? null
-          : 'POV derived from role (no pov_signal data); may overcount if co_protagonists are not true POV owners',
+          : null,
   };
 }
 

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
@@ -52,6 +52,25 @@ function validateGreatExpectations(ledger: any): string[] {
   }
 
   const povIds = new Set((ledger.layers?.pov_structure_layer?.pov_characters ?? []).map((entry: any) => entry.character_id));
+  if (povIds.size !== 1 || !povIds.has('ge:pip')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Great Expectations must have Pip / Philip Pirrip as sole POV owner.');
+  }
+
+  for (const forbiddenPovOwner of ['ge:herbert', 'ge:jaggers', 'ge:magwitch', 'ge:estella', 'ge:joe', 'ge:biddy']) {
+    if (povIds.has(forbiddenPovOwner)) {
+      errors.push(`FORBIDDEN_FAILURE: ${forbiddenPovOwner} must not be a POV owner in Great Expectations.`);
+    }
+  }
+
+  const povMode = String(ledger.layers?.pov_structure_layer?.pov_mode ?? '').toLowerCase();
+  const povNote = String(ledger.layers?.pov_structure_layer?.pov_perspective_note ?? '').toLowerCase();
+  if (!povMode.includes('first-person retrospective')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Great Expectations POV mode must be first-person retrospective.');
+  }
+  if (!povNote.includes('adult narrator looking back')) {
+    errors.push('MISSING_REQUIRED_TRUTH: Great Expectations POV note must state adult narrator looking back.');
+  }
+
   if (povIds.has('ge:herbert')) {
     errors.push('FORBIDDEN_FAILURE: Herbert Pocket must not be a POV owner.');
   }
@@ -141,6 +160,29 @@ function validateAwakening(ledger: any): string[] {
   }
 
   const povIds = new Set((ledger.layers?.pov_structure_layer?.pov_characters ?? []).map((entry: any) => entry.character_id));
+  if (povIds.size !== 1 || !povIds.has('aw:edna')) {
+    errors.push('MISSING_REQUIRED_TRUTH: The Awakening must keep Edna Pontellier as primary focal center and sole POV owner.');
+  }
+
+  for (const forbiddenPovOwner of ['aw:robert', 'aw:leonce', 'aw:arobin', 'aw:adele', 'aw:reisz']) {
+    if (povIds.has(forbiddenPovOwner)) {
+      errors.push(`FORBIDDEN_FAILURE: ${forbiddenPovOwner} must not be a POV owner in The Awakening.`);
+    }
+  }
+
+  const awakeningPovMode = String(ledger.layers?.pov_structure_layer?.pov_mode ?? '').toLowerCase();
+  const awakeningPovNote = String(ledger.layers?.pov_structure_layer?.pov_perspective_note ?? '').toLowerCase();
+  if (!awakeningPovMode.includes('close third limited')) {
+    errors.push('MISSING_REQUIRED_TRUTH: The Awakening POV mode must remain close third limited focalization.');
+  }
+  if (
+    awakeningPovNote.includes('romantic catalyst')
+    || awakeningPovNote.includes('co-protagonist')
+    || awakeningPovNote.includes('major secondary')
+  ) {
+    errors.push('FORBIDDEN_FAILURE: Awakening POV note must not promote romantic or secondary roles into camera ownership.');
+  }
+
   if (!povIds.has('aw:edna')) {
     errors.push('MISSING_REQUIRED_TRUTH: Edna Pontellier must own POV.');
   }

--- a/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
@@ -9,13 +9,10 @@
           "character_id": "ge:pip",
           "canonical_name": "Pip / Philip Pirrip",
           "is_primary": true
-        },
-        {
-          "character_id": "ge:estella",
-          "canonical_name": "Estella",
-          "is_primary": false
         }
-      ]
+      ],
+      "pov_mode": "first-person retrospective",
+      "pov_perspective_note": "adult narrator looking back"
     },
     "canonical_identity_layer": {
       "identity_groups": [

--- a/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
@@ -10,7 +10,9 @@
           "canonical_name": "Edna Pontellier",
           "is_primary": true
         }
-      ]
+      ],
+      "pov_mode": "close third limited",
+      "pov_perspective_note": "primary focalization remains with Edna; role tier does not confer camera ownership"
     },
     "canonical_identity_layer": {
       "identity_groups": [


### PR DESCRIPTION
## Primary failure class
- `POV_ROLE_FALLBACK_OWNER`

## Goal
Prevent characters from becoming POV owners because they are co-protagonists, romantic catalysts, allies, or major secondary figures. POV ownership must be evidence-based.

## What changed
- Removed role-tier fallback ownership in `buildPovStructureLayer`.
- POV owner list is now evidence-only from chunk-level POV/focalization signals.
- Added explicit POV evidence status fields in POV layer output:
  - `pov_evidence_status`
  - `pov_role_fallback_derived`
  - `pov_truth_status`
- Added explicit degraded note when evidence is insufficient:
  - "POV could not be confirmed from evidence..."

## Required behavior coverage
- role tier alone does not confer POV ownership
- `co_protagonist ≠ POV owner`
- `romantic catalyst ≠ POV owner`
- `major secondary/ally/foil ≠ POV owner`
- fallback-derived POV is blocked (not clean)
- no-evidence path is explicit insufficiency, not invented owners

## Fixture / harness updates (tightening)
- Great Expectations fixture POV now enforces sole owner `ge:pip` plus mode metadata:
  - `pov_mode: first-person retrospective`
  - `pov_perspective_note: adult narrator looking back`
- The Awakening fixture POV metadata added:
  - `pov_mode: close third limited`
  - focalization note anchored to Edna
- Gold harness assertions now enforce:
  - GE: Herbert/Jaggers/Magwitch/Estella/Joe/Biddy not POV owners
  - Awakening: Robert/Léonce/Arobin/Adèle/Reisz not POV owners
  - mode/note expectations for both texts

## Validation
- ✅ `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.awakening-pov.test.ts`
- ✅ `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`

Run summary:
- 2 suites passed
- 12 tests passed
- 0 failures

## Out of scope (unchanged)
- no relationship canonical-ID changes
- no threat/pressure architecture
- no pronoun-family display work
- no timeline/location normalization
- no Source Integrity dashboard
- no Revise/scoring changes
