### PR TITLE
fix(ledger): show only pronoun-family transitions requiring review

### DIFF
--- a/.github/pr-bodies/PR-829.md
+++ b/.github/pr-bodies/PR-829.md
@@ -1,0 +1,12 @@
+## Summary
+- limits pronoun inconsistency warnings to true pronoun-family transitions, mixed-family signals, or unresolved ownership
+- suppresses false shifts caused by case variants within the same family (e.g., `he/him` vs `he/him/his`)
+- updates identity/pronoun layer explanatory copy to reflect normalized stable forms and review-only transitions
+- tightens gold fixture benchmark assertions for Great Expectations and The Awakening so stable family usage cannot regress into false shift warnings
+
+## Tests
+- `__tests__/lib/evaluation/pipeline/characterReducer.pronoun-family-display.test.ts`
+- `__tests__/components/ledger/identityPronounLayer.copy.test.tsx`
+- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
+
+All above passed locally in this branch.

--- a/__tests__/components/ledger/identityPronounLayer.copy.test.tsx
+++ b/__tests__/components/ledger/identityPronounLayer.copy.test.tsx
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { StoryLayerRenderer } from '../../../components/ledger/StoryLedgerLayers';
+
+describe('IdentityPronounLayer display copy', () => {
+  it('shows required caption and normalized empty-state copy when no review transitions exist', () => {
+    render(
+      <StoryLayerRenderer
+        layerKey="identity_pronoun_layer"
+        data={{
+          entries: [
+            {
+              canonical_name: 'Pip / Philip Pirrip',
+              pronouns: ['he/him/his'],
+              gender_identity: 'man',
+              warnings: [],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'This layer only shows pronoun-family transitions, cross-family shifts, or identity signals that may need author confirmation. Subject/object forms such as he/him, she/her, and they/them are normalized and hidden.',
+      ),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByText(
+        'No pronoun transitions detected. Stable subject/object pronoun usage was normalized in the background and does not require review.',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/__tests__/lib/evaluation/pipeline/characterReducer.pronoun-family-display.test.ts
+++ b/__tests__/lib/evaluation/pipeline/characterReducer.pronoun-family-display.test.ts
@@ -1,0 +1,111 @@
+import { reduceCharacterEvidence } from '@/lib/evaluation/pipeline/characterReducer';
+import type { Pass1aCharacterChunkEntry, Pass1aChunkOutput } from '@/lib/evaluation/pipeline/types';
+
+type CharacterInput = Partial<Pass1aCharacterChunkEntry> & {
+  canonical_name: string;
+  pronouns: string[];
+};
+
+function makeCharacter(input: CharacterInput): Pass1aCharacterChunkEntry {
+  return {
+    canonical_name: input.canonical_name,
+    aliases: input.aliases ?? [],
+    pronouns: input.pronouns,
+    age_signal: input.age_signal ?? 'adult',
+    age_exact: input.age_exact ?? null,
+    life_stage_evidence: input.life_stage_evidence ?? null,
+    gender_identity: input.gender_identity ?? 'unknown',
+    lgbtq_signals: input.lgbtq_signals ?? [],
+    racial_ethnic_signals: input.racial_ethnic_signals ?? [],
+    skin_tone_signals: input.skin_tone_signals ?? [],
+    language_signals: input.language_signals ?? [],
+    religion_signals: input.religion_signals ?? [],
+    socioeconomic_signals: input.socioeconomic_signals ?? [],
+    nationality_signals: input.nationality_signals ?? [],
+    disability_neuro_signals: input.disability_neuro_signals ?? [],
+    role_signal: input.role_signal ?? 'secondary',
+    narrative_weight_signal: input.narrative_weight_signal ?? 'supporting',
+    is_named: input.is_named ?? true,
+    same_name_disambiguation: input.same_name_disambiguation ?? null,
+    who_is_this: input.who_is_this ?? input.canonical_name,
+    what_do_they_want: input.what_do_they_want ?? null,
+    where_are_they: input.where_are_they ?? null,
+    when_signal: input.when_signal ?? null,
+    why_signal: input.why_signal ?? null,
+    how_signal: input.how_signal ?? null,
+    arc_state_in_chunk: input.arc_state_in_chunk ?? 'present in scene',
+    arc_pressure: input.arc_pressure ?? null,
+    arc_shift: input.arc_shift ?? null,
+    is_ending_chunk: input.is_ending_chunk ?? false,
+    symbolic_objects: input.symbolic_objects ?? [],
+    relationship_signals: input.relationship_signals ?? [],
+    evidence_anchors: input.evidence_anchors ?? [
+      {
+        excerpt: `${input.canonical_name} appears`,
+        evidence_type: 'identity',
+        confidence: 'explicit',
+      },
+    ],
+    co_presence_confirmed: input.co_presence_confirmed ?? [],
+    negative_knowledge: input.negative_knowledge ?? [],
+  };
+}
+
+function makeChunk(index: number, character: Pass1aCharacterChunkEntry): Pass1aChunkOutput {
+  return {
+    pass: '1a',
+    axis: 'character_evidence_sweep',
+    chunk_index: index,
+    characters: [character],
+    prompt_version: 'test-pronoun-family-display',
+    generated_at: '2026-05-30T00:00:00.000Z',
+  };
+}
+
+function getWarningsFor(characterName: string, chunkOutputs: Pass1aChunkOutput[]): string[] {
+  const ledger = reduceCharacterEvidence({
+    jobId: `pronoun-family-${characterName.toLowerCase().replace(/\s+/g, '-')}`,
+    totalChunksInManuscript: chunkOutputs.length,
+    chunkOutputs,
+  });
+
+  const entry = ledger.entries.find((e) => e.canonical_name === characterName);
+  return (entry?.warnings ?? []).map((w) => w.type);
+}
+
+describe('characterReducer pronoun-family warning guardrails', () => {
+  it('does not flag stable masculine case variants as a pronoun shift', () => {
+    const warnings = getWarningsFor('Pip', [
+      makeChunk(0, makeCharacter({ canonical_name: 'Pip', pronouns: ['he/him'] })),
+      makeChunk(1, makeCharacter({ canonical_name: 'Pip', pronouns: ['he/him/his'] })),
+    ]);
+
+    expect(warnings).not.toContain('pronoun_inconsistency');
+  });
+
+  it('does not flag stable feminine case variants as a pronoun shift', () => {
+    const warnings = getWarningsFor('Edna Pontellier', [
+      makeChunk(0, makeCharacter({ canonical_name: 'Edna Pontellier', pronouns: ['she/her'] })),
+      makeChunk(1, makeCharacter({ canonical_name: 'Edna Pontellier', pronouns: ['she/her/hers'] })),
+    ]);
+
+    expect(warnings).not.toContain('pronoun_inconsistency');
+  });
+
+  it('flags cross-family shifts that require review', () => {
+    const warnings = getWarningsFor('Robin', [
+      makeChunk(0, makeCharacter({ canonical_name: 'Robin', pronouns: ['he/him'] })),
+      makeChunk(1, makeCharacter({ canonical_name: 'Robin', pronouns: ['she/her'] })),
+    ]);
+
+    expect(warnings).toContain('pronoun_inconsistency');
+  });
+
+  it('flags unresolved mixed-family ownership in the same pronoun signal', () => {
+    const warnings = getWarningsFor('Ambiguous Figure', [
+      makeChunk(0, makeCharacter({ canonical_name: 'Ambiguous Figure', pronouns: ['he/they'] })),
+    ]);
+
+    expect(warnings).toContain('pronoun_inconsistency');
+  });
+});

--- a/components/ledger/StoryLedgerLayers.tsx
+++ b/components/ledger/StoryLedgerLayers.tsx
@@ -145,7 +145,7 @@ const LABEL_HINTS: Record<string, string> = {
   // Source Integrity layer
   "Hard failure": "A critical extraction error — the system could not reliably identify this element and needs author guidance.",
   // Identity & Pronouns layer
-  "Pronoun variation detected": "The system found different pronouns used for this character in different parts of the manuscript. This may be intentional (character development) or a continuity error.",
+  "Pronoun variation detected": "The system found pronoun-family transitions, cross-family shifts, or unresolved identity signals that may need confirmation.",
 };
 
 function labelHint(label: string): string | undefined {
@@ -3579,6 +3579,26 @@ export function IdentityPronounLayer({
         }
         badgeTone={shiftCount > 0 ? "oxblood" : "gold"}
       />
+
+      <p style={{ fontSize: 13, color: C.textMuted, margin: "-4px 0 12px", lineHeight: 1.65 }}>
+        This layer only shows pronoun-family transitions, cross-family shifts, or identity signals that may need author confirmation. Subject/object forms such as he/him, she/her, and they/them are normalized and hidden.
+      </p>
+
+      {shiftCount === 0 && (
+        <div
+          style={{
+            border: `1px solid ${C.border}`,
+            borderRadius: 12,
+            padding: "12px 14px",
+            background: C.surface,
+            color: C.textMuted,
+            fontSize: 13,
+            marginBottom: 16,
+          }}
+        >
+          No pronoun transitions detected. Stable subject/object pronoun usage was normalized in the background and does not require review.
+        </div>
+      )}
 
       {shiftCount > 0 && (
         <div style={{ display: "flex", flexDirection: "column", gap: 14, marginBottom: 20 }}>

--- a/lib/evaluation/pipeline/characterReducer.ts
+++ b/lib/evaluation/pipeline/characterReducer.ts
@@ -260,6 +260,74 @@ function pickAgeSignal(signals: (Pass1aAgeSignal)[]): Pass1aAgeSignal {
   return signals.find((s) => s !== null) ?? null;
 }
 
+type PronounFamily =
+  | "masculine"
+  | "feminine"
+  | "neutral_plural"
+  | "neopronoun"
+  | "it_thing"
+  | "honorific"
+  | "unknown_or_custom";
+
+const PRONOUN_FAMILY_REGISTRY: Array<{ family: PronounFamily; forms: string[] }> = [
+  { family: "masculine", forms: ["he", "him", "his", "himself"] },
+  { family: "feminine", forms: ["she", "her", "hers", "herself"] },
+  { family: "neutral_plural", forms: ["they", "them", "their", "theirs", "themself", "themselves"] },
+  {
+    family: "neopronoun",
+    forms: [
+      "xe", "xem", "xyr", "xyrs", "xemself",
+      "ze", "zir", "zirs", "hir", "hirs", "hirself",
+      "ey", "em", "eir", "eirs", "eirself",
+      "fae", "faer", "faers", "faerself",
+      "per", "pers", "perself",
+      "ve", "ver", "vis", "verself",
+      "ae", "aer", "aers", "aerself",
+      "zie", "zirself",
+    ],
+  },
+  { family: "it_thing", forms: ["it", "its", "itself"] },
+  {
+    family: "honorific",
+    forms: [
+      "mr", "mrs", "ms", "mx", "sir", "madam", "lady", "lord", "dame", "miss", "madame",
+    ],
+  },
+];
+
+function tokenizePronounSignal(raw: string): string[] {
+  return raw
+    .toLowerCase()
+    .replace(/[()\[\]{}.,;:!?"']/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(/[\s/|]+/)
+    .filter(Boolean);
+}
+
+function extractPronounFamilies(pronouns: string[]): Set<PronounFamily> {
+  const families = new Set<PronounFamily>();
+
+  for (const raw of pronouns) {
+    if (typeof raw !== "string") continue;
+    for (const token of tokenizePronounSignal(raw)) {
+      let matched = false;
+      for (const registryEntry of PRONOUN_FAMILY_REGISTRY) {
+        if (registryEntry.forms.includes(token)) {
+          families.add(registryEntry.family);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        families.add("unknown_or_custom");
+      }
+    }
+  }
+
+  return families;
+}
+
 // ── Symbol deduplication ──────────────────────────────────────────────────
 
 interface RawSymbol {
@@ -555,9 +623,24 @@ export function reduceCharacterEvidence(params: {
 
     // Warnings
     const warnings: CharacterArcLedgerEntry["warnings"] = [];
-    const pronounSets = entries.map((e) => JSON.stringify([...(e.pronouns ?? [])].sort()));
-    if (new Set(pronounSets).size > 1 && pronounSets.some((p) => p !== "[]")) {
-      warnings.push({ type: "pronoun_inconsistency", message: `Pronoun variation detected across chunks for "${canonical}"` });
+    const pronounFamilySets = entries
+      .map((e) => extractPronounFamilies((e.pronouns ?? []).filter((p): p is string => typeof p === "string")))
+      .filter((familySet) => familySet.size > 0);
+
+    if (pronounFamilySets.length > 0) {
+      const familySignatures = pronounFamilySets.map((set) => JSON.stringify([...set].sort()));
+      const distinctSignatures = new Set(familySignatures);
+      const hasMixedKnownFamilies = pronounFamilySets.some(
+        (set) => [...set].filter((family) => family !== "unknown_or_custom" && family !== "honorific").length > 1,
+      );
+      const hasUnknownSignals = pronounFamilySets.some((set) => set.has("unknown_or_custom"));
+
+      if (hasMixedKnownFamilies || distinctSignatures.size > 1 || (hasUnknownSignals && pronounFamilySets.length > 1)) {
+        warnings.push({
+          type: "pronoun_inconsistency",
+          message: `Pronoun-family transition or unresolved pronoun ownership detected for "${canonical}"`,
+        });
+      }
     }
     if (endingStatus === "accidentally_abandoned") {
       warnings.push({ type: "ending_underpaid", message: `"${canonical}" last appears in chunk ${chunkIndices[chunkIndices.length - 1]} of ${totalChunksInManuscript} — possible abandoned arc` });

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
@@ -76,12 +76,27 @@ function validateGreatExpectations(ledger: any): string[] {
   }
 
   const pronounEntries = ledger.layers?.identity_pronoun_layer?.entries ?? [];
-  const pipPronounEntry = pronounEntries.find((entry: any) => hasText(entry.canonical_name, 'pip'));
-  if (!((pipPronounEntry?.pronouns ?? []).some((p: string) => p.toLowerCase().includes('he/him/his')))) {
-    errors.push('MISSING_REQUIRED_TRUTH: Pip pronoun record must include he/him/his.');
+  const stableMasculineExpectations = ['pip', 'herbert', 'jaggers', 'orlick'];
+  for (const name of stableMasculineExpectations) {
+    const entry = pronounEntries.find((candidate: any) => hasText(candidate.canonical_name, name));
+    if (!entry) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Pronoun identity entry missing for '${name}'.`);
+      continue;
+    }
+
+    const normalizedPronouns = (entry.pronouns ?? []).map((p: string) => p.toLowerCase());
+    const hasMasculineFamily = normalizedPronouns.some((p: string) => p.includes('he/him'));
+    if (!hasMasculineFamily) {
+      errors.push(`MISSING_REQUIRED_TRUTH: '${name}' pronoun record must include masculine family usage (he/him/his).`);
+    }
+
+    if ((entry.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))) {
+      errors.push(`FORBIDDEN_FAILURE: Stable masculine pronoun usage for '${name}' must not be flagged as a pronoun shift.`);
+    }
   }
-  if ((pipPronounEntry?.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))) {
-    errors.push('FORBIDDEN_FAILURE: he/him/his must not be flagged as a pronoun shift.');
+
+  if ((ledger.layers?.identity_pronoun_layer?.pronoun_shifts_detected ?? 0) !== 0) {
+    errors.push('FORBIDDEN_FAILURE: Great Expectations fixture must report zero pronoun shifts for stable pronoun-family usage.');
   }
 
   const relationshipPairs = ledger.layers?.relationship_network_layer?.relationship_pairs ?? [];
@@ -269,16 +284,41 @@ function validateAwakening(ledger: any): string[] {
   }
 
   const pronounEntries = ledger.layers?.identity_pronoun_layer?.entries ?? [];
-  const targetNames = ['raoul pontellier', 'étienne pontellier', 'robert lebrun'];
-  for (const name of targetNames) {
+  const stablePronounFamilies: Array<{ name: string; familyNeedle: string }> = [
+    { name: 'edna pontellier', familyNeedle: 'she/her' },
+    { name: 'raoul pontellier', familyNeedle: 'he/him' },
+    { name: 'étienne pontellier', familyNeedle: 'he/him' },
+    { name: 'robert lebrun', familyNeedle: 'he/him' },
+    { name: 'léonce pontellier', familyNeedle: 'he/him' },
+  ];
+
+  for (const { name, familyNeedle } of stablePronounFamilies) {
     const entry = pronounEntries.find((candidate: any) => hasText(candidate.canonical_name, name));
     if (!entry) {
       errors.push(`MISSING_REQUIRED_TRUTH: Pronoun identity entry missing for '${name}'.`);
       continue;
     }
+
+    if (!(entry.pronouns ?? []).some((p: string) => p.toLowerCase().includes(familyNeedle))) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Pronoun identity entry for '${name}' must include '${familyNeedle}'.`);
+    }
+
     if ((entry.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))) {
       errors.push(`FORBIDDEN_FAILURE: '${name}' must not be flagged as pronoun-transition problem.`);
     }
+  }
+
+  for (const entry of pronounEntries) {
+    if (
+      (hasText(entry.canonical_name, 'children') || hasText(entry.canonical_name, 'lovers'))
+      && (entry.warnings ?? []).some((warning: any) => hasText(warning?.type ?? warning, 'pronoun_inconsistency'))
+    ) {
+      errors.push("FORBIDDEN_FAILURE: 'children/lovers' labels must not appear as pronoun-transition review items without cross-family evidence.");
+    }
+  }
+
+  if ((ledger.layers?.identity_pronoun_layer?.pronoun_shifts_detected ?? 0) !== 0) {
+    errors.push('FORBIDDEN_FAILURE: The Awakening fixture must report zero pronoun shifts for stable pronoun-family usage.');
   }
 
   const locations: string[] = ledger.layers?.location_timeline_worldstate_layer?.unique_locations ?? [];

--- a/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
@@ -90,6 +90,16 @@
           "canonical_name": "Herbert Pocket",
           "pronouns": ["he/him/his"],
           "warnings": []
+        },
+        {
+          "canonical_name": "Mr. Jaggers",
+          "pronouns": ["he/him/his"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Dolge Orlick",
+          "pronouns": ["he/him/his"],
+          "warnings": []
         }
       ]
     },

--- a/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
@@ -103,22 +103,27 @@
       "entries": [
         {
           "canonical_name": "Edna Pontellier",
-          "pronouns": ["she/her"],
+          "pronouns": ["she/her/hers"],
           "warnings": []
         },
         {
           "canonical_name": "Raoul Pontellier",
-          "pronouns": ["he/him"],
+          "pronouns": ["he/him/his"],
           "warnings": []
         },
         {
           "canonical_name": "Étienne Pontellier",
-          "pronouns": ["he/him"],
+          "pronouns": ["he/him/his"],
           "warnings": []
         },
         {
           "canonical_name": "Robert Lebrun",
-          "pronouns": ["he/him"],
+          "pronouns": ["he/him/his"],
+          "warnings": []
+        },
+        {
+          "canonical_name": "Léonce Pontellier",
+          "pronouns": ["he/him/his"],
           "warnings": []
         }
       ]


### PR DESCRIPTION
## Summary
- limits pronoun inconsistency warnings to true pronoun-family transitions, mixed-family signals, or unresolved ownership
- suppresses false shifts caused by case variants within the same family (e.g., `he/him` vs `he/him/his`)
- updates identity/pronoun layer explanatory copy to reflect normalized stable forms and review-only transitions
- tightens gold fixture benchmark assertions for Great Expectations and The Awakening so stable family usage cannot regress into false shift warnings

## Tests
- `__tests__/lib/evaluation/pipeline/characterReducer.pronoun-family-display.test.ts`
- `__tests__/components/ledger/identityPronounLayer.copy.test.tsx`
- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`

All above passed locally in this branch.