### PR TITLE
fix(ledger): model threat and pressure systems beyond antagonists

### DIFF
--- a/.github/pr-bodies/PR-830.md
+++ b/.github/pr-bodies/PR-830.md
@@ -1,0 +1,36 @@
+## Summary
+- rewires `threat_antagonist_ending_layer` behavior to model **Narrative Pressure / Stakes / Consequence** instead of antagonist-only slots
+- adds structured `pressure_systems` with:
+  - pressure taxonomy type
+  - source kind (`character`, `non_character`, `internal`)
+  - target character references
+  - evidence summary
+  - escalation state
+  - ending-state classification (`resolved`, `transformed`, `terminal`, `unresolved`, `intentionally_ambiguous`, `ongoing_systemic_pressure`)
+- preserves backward compatibility via legacy key + `antagonists` + `threat_systems`
+- emits canonical `narrative_pressure_vectors` from pressure systems
+- updates quality diagnostics from `no_antagonist_detected` to pressure-system coverage language
+
+## Acceptance hardening
+- adds dedicated layer-builder regression suite:
+  - `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts`
+- tightens gold fixture benchmark assertions so tests fail when:
+  - layer is antagonist-only
+  - non-character pressure is discarded
+  - pressure taxonomy collapses to generic bucket
+  - Compeyson is mislabeled (e.g., maternal)
+  - Léonce/Arobin are flattened into generic antagonist semantics
+  - known terminal outcomes are marked unresolved
+
+## Fixture updates
+- modernizes Great Expectations and The Awakening threat layers to explicit pressure-system models
+- includes required social/legal/economic/internal/symbolic forces for both fixtures
+
+## Focused verification run
+Passed locally:
+- `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts`
+- `__tests__/lib/evaluation/pipeline/characterReducer.awakening-taxonomy.test.ts`
+- `__tests__/evaluation/layer8Validator.test.ts`
+- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`
+
+Result: 4 suites passed, 19 tests passed, 0 failures.

--- a/__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts
+++ b/__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts
@@ -1,0 +1,375 @@
+import { buildStoryLayerFromLedger } from '@/lib/evaluation/phase1a/buildStoryLayerFromLedger';
+import type { Pass1aCharacterLedger, CharacterLedgerV2 } from '@/lib/evaluation/pipeline/types';
+
+function makeLedger(overrides?: Partial<Pass1aCharacterLedger>): Pass1aCharacterLedger {
+  return {
+    schema_version: 'pass1a_character_ledger_v1',
+    prompt_version: 'test-threat-pressure-architecture',
+    job_id: 'test-threat-pressure-architecture',
+    generated_at: '2026-05-29T00:00:00.000Z',
+    total_chunks_processed: 12,
+    entries: [],
+    coverage_summary: {
+      protagonists: ['Pip'],
+      co_protagonists: [],
+      antagonists: ['Abel Magwitch', 'Compeyson'],
+      major_secondary_characters: [],
+      animal_companions: [],
+      relational_engines: [],
+      symbol_payoff_items: [],
+      missing_or_underweighted: [],
+      ending_accountability_warnings: [],
+      hard_fail_triggers: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeLedgerV2(overrides?: Partial<CharacterLedgerV2>): CharacterLedgerV2 {
+  return {
+    schema_version: 'character_ledger_v2',
+    prompt_version: 'test-threat-pressure-architecture',
+    job_id: 'test-threat-pressure-architecture',
+    generated_at: '2026-05-29T00:00:00.000Z',
+    total_chunks_processed: 12,
+    identityLedger: [],
+    stateTimelines: [],
+    relationshipLedger: [],
+    psychologyLedger: [],
+    objectLedger: [],
+    terminalLedger: [],
+    validationQueries: {
+      characterPresenceIndex: {},
+      coPresenceIndex: {},
+      nameStateIndex: {},
+      copingIndex: {},
+      objectPresenceIndex: {},
+      symbolPayoffIndex: {},
+      unresolvedPromisesIndex: {},
+    },
+    activeBlockers: [],
+    negativeKnowledge: [],
+    stateConflicts: [],
+    characterCoverage: {},
+    coverage_summary: {
+      protagonists: ['Pip'],
+      co_protagonists: [],
+      antagonists: ['Abel Magwitch', 'Compeyson'],
+      high_value_objects: [],
+      unresolved_promises: [],
+      open_terminal_ledgers: [],
+      hard_fail_triggers: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('buildStoryLayerFromLedger — narrative pressure architecture', () => {
+  it('captures character + non-character + internal pressure systems, not antagonist-only slots', () => {
+    const ledger = makeLedger({
+      coverage_summary: {
+        protagonists: ['Pip'],
+        co_protagonists: [],
+        antagonists: ['Abel Magwitch', 'Compeyson'],
+        major_secondary_characters: [],
+        animal_companions: [],
+        relational_engines: [],
+        symbol_payoff_items: [],
+        missing_or_underweighted: [],
+        ending_accountability_warnings: [],
+        hard_fail_triggers: [],
+      },
+    });
+
+    const ledgerV2 = makeLedgerV2({
+      identityLedger: [
+        {
+          characterId: 'ge:pip',
+          canonicalName: 'Pip',
+          nameHistory: [{ name: 'Pip', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: [],
+          narrativeRole: 'protagonist',
+          importanceLevel: 'primary',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 59' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'alive',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'ge:magwitch',
+          canonicalName: 'Abel Magwitch',
+          nameHistory: [{ name: 'Abel Magwitch', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['Magwitch', 'Provis'],
+          narrativeRole: 'antagonist',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 56' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 10,
+          finalStatus: 'dead',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'ge:miss_havisham',
+          canonicalName: 'Miss Havisham',
+          nameHistory: [{ name: 'Miss Havisham', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: [],
+          narrativeRole: 'antagonist',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 8' },
+          lastAppearance: { label: 'Chapter 49' },
+          firstChunkIndex: 1,
+          lastChunkIndex: 9,
+          finalStatus: 'dead',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'ge:compeyson',
+          canonicalName: 'Compeyson',
+          nameHistory: [{ name: 'Compeyson', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: [],
+          narrativeRole: 'antagonist',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 42' },
+          lastAppearance: { label: 'Chapter 56' },
+          firstChunkIndex: 7,
+          lastChunkIndex: 10,
+          finalStatus: 'dead',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'ge:jaggers',
+          canonicalName: 'Mr. Jaggers',
+          nameHistory: [{ name: 'Mr. Jaggers', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['legal machinery'],
+          narrativeRole: 'pressure_agent',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 20' },
+          lastAppearance: { label: 'Chapter 58' },
+          firstChunkIndex: 4,
+          lastChunkIndex: 11,
+          finalStatus: 'alive',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'ge:class_shame',
+          canonicalName: 'class shame',
+          nameHistory: [{ name: 'class shame', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['status hierarchy'],
+          narrativeRole: 'collective_force',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 59' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'unresolved',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+      ] as CharacterLedgerV2['identityLedger'],
+      terminalLedger: [
+        {
+          characterId: 'ge:miss_havisham',
+          terminalCondition: 'death',
+          terminalChunk: 9,
+          terminalChapter: 'Chapter 49',
+          lastLucidChunk: 9,
+          whoIsPresent: [],
+          finalBeliefState: null,
+          promisesKept: [],
+          promisesUnkept: [],
+          objectsPresentAtExit: [],
+          legacyTransferredTo: null,
+          finalRelationshipStates: [],
+          narrativeClosureStatus: 'fully_resolved',
+          evidenceQuote: 'House fire consequences close her arc.',
+          confidence: 'explicit',
+        },
+        {
+          characterId: 'ge:compeyson',
+          terminalCondition: 'death',
+          terminalChunk: 10,
+          terminalChapter: 'Chapter 56',
+          lastLucidChunk: 10,
+          whoIsPresent: [],
+          finalBeliefState: null,
+          promisesKept: [],
+          promisesUnkept: [],
+          objectsPresentAtExit: [],
+          legacyTransferredTo: null,
+          finalRelationshipStates: [],
+          narrativeClosureStatus: 'fully_resolved',
+          evidenceQuote: 'Fatal pursuit closes his arc.',
+          confidence: 'explicit',
+        },
+      ],
+      psychologyLedger: [
+        {
+          characterId: 'ge:pip',
+          copingMechanisms: [],
+          psychologicalArc: 'Pip wrestles with guilt, class shame, and moral obligation.',
+          seedingBlocked: false,
+          seedingBlockMessage: '',
+        },
+      ],
+    });
+
+    const payload = buildStoryLayerFromLedger(ledger, ledgerV2);
+    const layer = payload.threat_antagonist_ending_layer as any;
+
+    expect(Array.isArray(layer.pressure_systems)).toBe(true);
+    expect(layer.pressure_systems.length).toBeGreaterThan(layer.antagonist_count);
+    expect(layer.non_character_pressure_count).toBeGreaterThan(0);
+
+    const compeyson = layer.pressure_systems.find((p: any) => String(p.source_label).toLowerCase().includes('compeyson'));
+    expect(compeyson).toBeTruthy();
+    expect(String(compeyson.pressure_type)).not.toContain('maternal');
+    expect(String(compeyson.ending_state)).not.toContain('unresolved');
+
+    const missHavisham = layer.pressure_systems.find((p: any) => String(p.source_label).toLowerCase().includes('miss havisham'));
+    expect(missHavisham).toBeTruthy();
+    expect(String(missHavisham.ending_state)).not.toContain('unresolved');
+
+    expect(layer.threat_systems.join(' ').toLowerCase()).toContain('legal machinery');
+    expect(layer.threat_systems.join(' ').toLowerCase()).toContain('class shame');
+
+    const internal = layer.pressure_systems.find((p: any) => p.source_kind === 'internal');
+    expect(internal).toBeTruthy();
+  });
+
+  it('keeps Awakening pressure as literary systems and preserves non-character symbolic pressure', () => {
+    const ledger = makeLedger({
+      coverage_summary: {
+        protagonists: ['Edna Pontellier'],
+        co_protagonists: [],
+        antagonists: [],
+        major_secondary_characters: [],
+        animal_companions: [],
+        relational_engines: [],
+        symbol_payoff_items: [],
+        missing_or_underweighted: [],
+        ending_accountability_warnings: [],
+        hard_fail_triggers: [],
+      },
+    });
+
+    const ledgerV2 = makeLedgerV2({
+      identityLedger: [
+        {
+          characterId: 'aw:edna',
+          canonicalName: 'Edna Pontellier',
+          nameHistory: [{ name: 'Edna Pontellier', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: [],
+          narrativeRole: 'protagonist',
+          importanceLevel: 'primary',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 39' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'dead',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'aw:leonce',
+          canonicalName: 'Léonce Pontellier',
+          nameHistory: [{ name: 'Léonce Pontellier', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['marital property pressure'],
+          narrativeRole: 'patriarchal_pressure',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 39' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'alive',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'aw:arobin',
+          canonicalName: 'Alcée Arobin',
+          nameHistory: [{ name: 'Alcée Arobin', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['sexual destabilization'],
+          narrativeRole: 'sexual_destabilizer',
+          importanceLevel: 'supporting',
+          firstAppearance: { label: 'Chapter 20' },
+          lastAppearance: { label: 'Chapter 35' },
+          firstChunkIndex: 6,
+          lastChunkIndex: 10,
+          finalStatus: 'alive',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'aw:sea_symbolic_pressure',
+          canonicalName: 'Sea / symbolic pressure',
+          nameHistory: [{ name: 'Sea / symbolic pressure', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['Gulf', 'water'],
+          narrativeRole: 'symbolic_force',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 39' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'unresolved',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+        {
+          characterId: 'aw:creole_social_expectations',
+          canonicalName: 'Creole social expectations',
+          nameHistory: [{ name: 'Creole social expectations', validFromChunk: 0, validUntilChunk: null, confidence: 'explicit' }],
+          aliases: ['social convention'],
+          narrativeRole: 'collective_force',
+          importanceLevel: 'major',
+          firstAppearance: { label: 'Chapter 1' },
+          lastAppearance: { label: 'Chapter 39' },
+          firstChunkIndex: 0,
+          lastChunkIndex: 11,
+          finalStatus: 'unresolved',
+          contradictions: [],
+          recommendationBlockers: [],
+        },
+      ] as CharacterLedgerV2['identityLedger'],
+      psychologyLedger: [
+        {
+          characterId: 'aw:edna',
+          copingMechanisms: [],
+          psychologicalArc: 'Edna faces longing and autonomy pressure as internal contradiction intensifies.',
+          seedingBlocked: false,
+          seedingBlockMessage: '',
+        },
+      ],
+    });
+
+    const payload = buildStoryLayerFromLedger(ledger, ledgerV2);
+    const layer = payload.threat_antagonist_ending_layer as any;
+
+    expect(layer.antagonist_count).toBe(0);
+    expect(Array.isArray(layer.pressure_systems)).toBe(true);
+    expect(layer.pressure_systems.length).toBeGreaterThan(0);
+
+    const leonce = layer.pressure_systems.find((p: any) => String(p.source_label).toLowerCase().includes('léonce'));
+    expect(leonce).toBeTruthy();
+    expect(String(leonce.pressure_type)).not.toBe('interpersonal_pressure');
+
+    const arobin = layer.pressure_systems.find((p: any) => String(p.source_label).toLowerCase().includes('arobin'));
+    expect(arobin).toBeTruthy();
+    expect(String(arobin.pressure_type)).not.toBe('interpersonal_pressure');
+
+    const sea = layer.pressure_systems.find((p: any) => String(p.source_label).toLowerCase().includes('sea'));
+    expect(sea).toBeTruthy();
+    expect(sea.source_kind).toBe('non_character');
+
+    expect(layer.non_character_pressure_count).toBeGreaterThan(0);
+    expect(Array.isArray(layer.narrative_pressure_vectors)).toBe(true);
+    expect(layer.narrative_pressure_vectors.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/evaluation/phase1a/buildLedgerQualityReport.ts
+++ b/lib/evaluation/phase1a/buildLedgerQualityReport.ts
@@ -78,15 +78,30 @@ function runQualityChecks(
     });
   }
 
-  // No antagonists detected in V2
-  const antagonistCount = (ledgerV2.identityLedger ?? []).filter(
-    (e) => e.narrativeRole === 'antagonist',
+  // No pressure-bearing systems detected in V2
+  const pressureBearingRoles = new Set([
+    'antagonist',
+    'pressure_agent',
+    'romantic_catalyst',
+    'sexual_destabilizer',
+    'domestic_foil',
+    'artistic_countermodel',
+    'social_observer',
+    'social_catalyst',
+    'patriarchal_pressure',
+    'symbolic_force',
+    'collective_force',
+  ]);
+
+  const pressureSystemCount = (ledgerV2.identityLedger ?? []).filter(
+    (e) => pressureBearingRoles.has(String(e.narrativeRole ?? 'unknown')),
   ).length;
-  if (antagonistCount === 0) {
+
+  if (pressureSystemCount === 0) {
     results.push({
-      key: 'no_antagonist_detected',
+      key: 'no_pressure_system_detected',
       severity: 'warning',
-      message: 'No antagonists detected. Threat layer may be incomplete. Review cast role assignment.',
+      message: 'No narrative pressure systems detected. Pressure / stakes / consequence mapping may be incomplete.',
       layer: 'threat_antagonist_ending_layer',
     });
   }

--- a/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
+++ b/lib/evaluation/phase1a/buildStoryLayerFromLedger.ts
@@ -445,15 +445,323 @@ function buildLocationTimelineWorldstateLayer(
 // Layer 8 — Threat / Antagonist / Ending Accountability
 // ─────────────────────────────────────────────────────────────────────────────
 
+type PressureSourceKind = 'character' | 'non_character' | 'internal';
+
+type PressureEndingState =
+  | 'resolved'
+  | 'transformed'
+  | 'terminal'
+  | 'unresolved'
+  | 'intentionally_ambiguous'
+  | 'ongoing_systemic_pressure';
+
+type PressureEscalationState = 'latent' | 'active' | 'escalating' | 'terminal';
+
+type PressureTaxonomy =
+  | 'interpersonal_pressure'
+  | 'romantic_desire_pressure'
+  | 'marital_family_domestic_pressure'
+  | 'social_class_pressure'
+  | 'legal_institutional_pressure'
+  | 'economic_debt_pressure'
+  | 'internal_moral_pressure'
+  | 'symbolic_environmental_pressure'
+  | 'physical_danger_violence_pressure'
+  | 'time_deadline_pressure';
+
+interface PressureSystemEntry {
+  pressure_id: string;
+  pressure_type: PressureTaxonomy;
+  source_kind: PressureSourceKind;
+  source_character_id?: string;
+  source_label: string;
+  source_aliases: string[];
+  target_character_ids: string[];
+  target_character_names: string[];
+  evidence_summary: string[];
+  escalation_state: PressureEscalationState;
+  ending_state: PressureEndingState;
+}
+
+function slugifyPressureId(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function inferPressureTaxonomyFromIdentity(
+  role: string,
+  canonicalName: string,
+  aliases: string[],
+): PressureTaxonomy {
+  const roleNorm = String(role ?? '').toLowerCase();
+  const text = `${canonicalName} ${(aliases ?? []).join(' ')}`.toLowerCase();
+
+  if (roleNorm === 'romantic_catalyst') return 'romantic_desire_pressure';
+  if (roleNorm === 'sexual_destabilizer') return 'physical_danger_violence_pressure';
+  if (roleNorm === 'domestic_foil' || roleNorm === 'patriarchal_pressure' || roleNorm === 'pressure_agent') {
+    if (/(legal|court|judge|law|prison|machinery|institution|police|state)/.test(text)) {
+      return 'legal_institutional_pressure';
+    }
+    if (/(debt|money|class|poverty|shame|wealth|economic)/.test(text)) {
+      return 'economic_debt_pressure';
+    }
+    return 'marital_family_domestic_pressure';
+  }
+  if (roleNorm === 'social_observer' || roleNorm === 'social_catalyst') return 'social_class_pressure';
+  if (roleNorm === 'symbolic_force') return 'symbolic_environmental_pressure';
+  if (roleNorm === 'collective_force') {
+    if (/(court|law|legal|institution|state|police|prison)/.test(text)) return 'legal_institutional_pressure';
+    if (/(class|society|social|reputation|expectation|convention)/.test(text)) return 'social_class_pressure';
+    return 'symbolic_environmental_pressure';
+  }
+  if (roleNorm === 'antagonist') return 'interpersonal_pressure';
+
+  if (/(debt|economic|money|class shame|class)/.test(text)) return 'economic_debt_pressure';
+  if (/(legal|court|law|prison|institution)/.test(text)) return 'legal_institutional_pressure';
+  if (/(sea|gulf|water|river|weather|storm|environment)/.test(text)) return 'symbolic_environmental_pressure';
+  if (/(guilt|shame|longing|autonomy|moral|conscience)/.test(text)) return 'internal_moral_pressure';
+
+  return 'interpersonal_pressure';
+}
+
+function pressureSourceKindFromRole(role: string): PressureSourceKind {
+  const roleNorm = String(role ?? '').toLowerCase();
+  if (roleNorm === 'symbolic_force' || roleNorm === 'collective_force') return 'non_character';
+  return 'character';
+}
+
+function classifyPressureEndingState(params: {
+  sourceKind: PressureSourceKind;
+  finalStatus: string;
+  terminal: TerminalLedgerEntry | undefined;
+}): PressureEndingState {
+  const finalStatus = params.finalStatus.toLowerCase();
+  const terminal = params.terminal;
+
+  if (terminal) {
+    if (terminal.terminalCondition === 'death' || terminal.terminalCondition === 'departure' || terminal.terminalCondition === 'disappearance' || terminal.terminalCondition === 'transformation') {
+      return 'terminal';
+    }
+    if (terminal.narrativeClosureStatus === 'fully_resolved') return 'resolved';
+    if (terminal.narrativeClosureStatus === 'partially_resolved') return 'transformed';
+    if (terminal.narrativeClosureStatus === 'intentionally_open') return 'intentionally_ambiguous';
+    if (terminal.narrativeClosureStatus === 'underpaid') return 'unresolved';
+  }
+
+  if (finalStatus === 'dead' || finalStatus === 'missing') return 'terminal';
+  if (finalStatus === 'transformed') return 'transformed';
+
+  if (params.sourceKind === 'non_character') return 'ongoing_systemic_pressure';
+  return finalStatus === 'unresolved' ? 'unresolved' : 'resolved';
+}
+
+function escalationForEnding(ending: PressureEndingState, pressureType: PressureTaxonomy): PressureEscalationState {
+  if (ending === 'terminal') return 'terminal';
+  if (ending === 'ongoing_systemic_pressure') return 'escalating';
+  if (
+    pressureType === 'legal_institutional_pressure'
+    || pressureType === 'economic_debt_pressure'
+    || pressureType === 'physical_danger_violence_pressure'
+    || pressureType === 'internal_moral_pressure'
+  ) {
+    return 'escalating';
+  }
+  if (ending === 'resolved' || ending === 'transformed') return 'active';
+  return 'latent';
+}
+
+function inferInternalPressureTaxonomy(text: string): PressureTaxonomy {
+  const t = text.toLowerCase();
+  if (/(debt|money|economic|class shame|poverty)/.test(t)) return 'economic_debt_pressure';
+  if (/(guilt|shame|moral|conscience|autonomy|longing)/.test(t)) return 'internal_moral_pressure';
+  if (/(deadline|time|late|clock|running out)/.test(t)) return 'time_deadline_pressure';
+  return 'internal_moral_pressure';
+}
+
+function narrativePressureVectorSourceForSystem(system: PressureSystemEntry):
+  | 'person'
+  | 'institution'
+  | 'environment'
+  | 'internal_contradiction'
+  | 'social_pressure'
+  | 'poverty'
+  | 'systemic_constraint'
+  | 'family_obligation' {
+  if (system.source_kind === 'internal') return 'internal_contradiction';
+
+  switch (system.pressure_type) {
+    case 'legal_institutional_pressure':
+      return 'institution';
+    case 'economic_debt_pressure':
+      return 'poverty';
+    case 'symbolic_environmental_pressure':
+      return 'environment';
+    case 'social_class_pressure':
+      return 'social_pressure';
+    case 'marital_family_domestic_pressure':
+      return 'family_obligation';
+    case 'time_deadline_pressure':
+      return 'systemic_constraint';
+    default:
+      return system.source_kind === 'character' ? 'person' : 'systemic_constraint';
+  }
+}
+
 function buildThreatAntagonistEndingLayer(
   ledger: Pass1aCharacterLedger,
   ledgerV2: CharacterLedgerV2,
 ): Record<string, unknown> {
+  const pressureBearingRoles = new Set([
+    'antagonist',
+    'pressure_agent',
+    'romantic_catalyst',
+    'sexual_destabilizer',
+    'domestic_foil',
+    'artistic_countermodel',
+    'social_observer',
+    'social_catalyst',
+    'patriarchal_pressure',
+    'symbolic_force',
+    'collective_force',
+  ]);
+
   const antagonists = ledgerV2.identityLedger.filter(
     (e) => e.narrativeRole === 'antagonist',
   );
 
   const terminalLedger: TerminalLedgerEntry[] = ledgerV2.terminalLedger ?? [];
+
+  const terminalByCharacterId = new Map(terminalLedger.map((entry) => [entry.characterId, entry]));
+
+  const protagonistIdentityIds = ledgerV2.identityLedger
+    .filter((entry) => entry.narrativeRole === 'protagonist' || entry.narrativeRole === 'co_protagonist')
+    .map((entry) => entry.characterId);
+
+  const protagonistsFromCoverage = (ledger.coverage_summary.protagonists ?? [])
+    .map((name) => ledgerV2.identityLedger.find((entry) => entry.canonicalName === name)?.characterId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const targetCharacterIds = protagonistIdentityIds.length > 0
+    ? protagonistIdentityIds
+    : protagonistsFromCoverage;
+
+  const targetCharacterNames = targetCharacterIds
+    .map((id) => ledgerV2.identityLedger.find((entry) => entry.characterId === id)?.canonicalName ?? id);
+
+  const pressureSystemsById = new Map<string, PressureSystemEntry>();
+
+  for (const entry of ledgerV2.identityLedger) {
+    const role = String(entry.narrativeRole ?? 'unknown').toLowerCase();
+    if (!pressureBearingRoles.has(role)) continue;
+
+    const aliases = Array.isArray(entry.aliases) ? entry.aliases : [];
+    const pressureType = inferPressureTaxonomyFromIdentity(role, entry.canonicalName, aliases);
+    const sourceKind = pressureSourceKindFromRole(role);
+    const endingState = classifyPressureEndingState({
+      sourceKind,
+      finalStatus: String(entry.finalStatus ?? 'unresolved'),
+      terminal: terminalByCharacterId.get(entry.characterId),
+    });
+
+    const evidenceSummary = [
+      `${entry.canonicalName} classified as ${role.replace(/_/g, ' ')} in cast-role identity ledger.`,
+      ...(entry.recommendationBlockers ?? []).slice(0, 2).map((blocker) => blocker.rule),
+    ].filter((line) => line && line.trim().length > 0);
+
+    const baseId = `${entry.characterId}:${pressureType}`;
+    const pressureId = slugifyPressureId(baseId);
+
+    const existing = pressureSystemsById.get(pressureId);
+    if (existing) {
+      existing.source_aliases = Array.from(new Set([...existing.source_aliases, ...aliases]));
+      existing.evidence_summary = Array.from(new Set([...existing.evidence_summary, ...evidenceSummary]));
+      if (existing.ending_state === 'resolved' && endingState !== 'resolved') {
+        existing.ending_state = endingState;
+      }
+      if (existing.escalation_state !== 'terminal' && escalationForEnding(endingState, pressureType) === 'terminal') {
+        existing.escalation_state = 'terminal';
+      }
+      continue;
+    }
+
+    pressureSystemsById.set(pressureId, {
+      pressure_id: pressureId,
+      pressure_type: pressureType,
+      source_kind: sourceKind,
+      source_character_id: sourceKind === 'character' ? entry.characterId : undefined,
+      source_label: entry.canonicalName,
+      source_aliases: aliases,
+      target_character_ids: targetCharacterIds,
+      target_character_names: targetCharacterNames,
+      evidence_summary: evidenceSummary,
+      escalation_state: escalationForEnding(endingState, pressureType),
+      ending_state: endingState,
+    });
+  }
+
+  for (const psych of ledgerV2.psychologyLedger ?? []) {
+    const identity = ledgerV2.identityLedger.find((entry) => entry.characterId === psych.characterId);
+    const sourceLabel = identity?.canonicalName ?? psych.characterId;
+    const psychologicalEvidence = [
+      psych.psychologicalArc,
+      ...(psych.copingMechanisms ?? []).map((mechanism) => mechanism.description),
+    ]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .join(' ')
+      .trim();
+
+    if (!psychologicalEvidence) continue;
+
+    if (!/(guilt|shame|longing|autonomy|moral|conscience|debt|class|money|economic|deadline|time)/i.test(psychologicalEvidence)) {
+      continue;
+    }
+
+    const pressureType = inferInternalPressureTaxonomy(psychologicalEvidence);
+    const terminal = terminalByCharacterId.get(psych.characterId);
+    const endingState = classifyPressureEndingState({
+      sourceKind: 'internal',
+      finalStatus: String(identity?.finalStatus ?? 'unresolved'),
+      terminal,
+    });
+
+    const pressureId = slugifyPressureId(`${psych.characterId}:${pressureType}:internal`);
+    if (pressureSystemsById.has(pressureId)) continue;
+
+    pressureSystemsById.set(pressureId, {
+      pressure_id: pressureId,
+      pressure_type: pressureType,
+      source_kind: 'internal',
+      source_character_id: psych.characterId,
+      source_label: `${sourceLabel} internal pressure`,
+      source_aliases: [],
+      target_character_ids: [psych.characterId],
+      target_character_names: [sourceLabel],
+      evidence_summary: [
+        `${sourceLabel} carries internal pressure trajectory in psychology ledger.`,
+        psychologicalEvidence,
+      ],
+      escalation_state: escalationForEnding(endingState, pressureType),
+      ending_state: endingState,
+    });
+  }
+
+  const pressureSystems = Array.from(pressureSystemsById.values())
+    .sort((a, b) => a.source_label.localeCompare(b.source_label));
+
+  const threatSystems = Array.from(
+    new Set(
+      pressureSystems.flatMap((system) => {
+        const labels: string[] = [system.source_label];
+        if (system.source_aliases.some((alias) => /legal machinery/i.test(alias))) {
+          labels.push(`${system.source_label}/legal machinery`);
+        }
+        return labels;
+      }),
+    ),
+  );
 
   const endingAccountabilityWarnings =
     ledger.coverage_summary.ending_accountability_warnings ?? [];
@@ -471,6 +779,22 @@ function buildThreatAntagonistEndingLayer(
       recommendation_blockers: a.recommendationBlockers,
     })),
     antagonist_count: antagonists.length,
+    pressure_systems: pressureSystems,
+    pressure_system_count: pressureSystems.length,
+    non_character_pressure_count: pressureSystems.filter((system) => system.source_kind === 'non_character').length,
+    pressure_types_present: Array.from(new Set(pressureSystems.map((system) => system.pressure_type))).sort(),
+    threat_systems: threatSystems,
+    narrative_pressure_vectors: pressureSystems.map((system) => ({
+      vector_source: narrativePressureVectorSourceForSystem(system),
+      evidence_summary: system.evidence_summary.join(' ').slice(0, 400),
+      structural_impact_score: system.escalation_state === 'terminal'
+        ? 5
+        : system.escalation_state === 'escalating'
+          ? 4
+          : system.escalation_state === 'active'
+            ? 3
+            : 2,
+    })),
     terminal_ledger: terminalLedger,
     terminal_entry_count: terminalLedger.length,
     ending_accountability_warnings: endingAccountabilityWarnings,

--- a/lib/evaluation/pipeline/types.ts
+++ b/lib/evaluation/pipeline/types.ts
@@ -1078,7 +1078,10 @@ export interface ChapterRef {
 export type NarrativeRole =
   | "protagonist" | "co_protagonist" | "antagonist"
   | "mentor" | "foil" | "secondary" | "symbolic_force" | "collective_force"
-  | "animal_companion" | "unknown";
+  | "animal_companion" | "unknown"
+  | "pressure_agent" | "romantic_catalyst" | "sexual_destabilizer"
+  | "domestic_foil" | "artistic_countermodel" | "social_observer"
+  | "background_mention" | "social_catalyst" | "patriarchal_pressure";
 
 export type ImportanceLevel = "primary" | "major" | "supporting" | "minor" | "background";
 

--- a/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
+++ b/tests/evaluation/benchmarks/story-ledger-gold-fixtures.spec.ts
@@ -143,15 +143,16 @@ function validateGreatExpectations(ledger: any): string[] {
     }
   }
 
+  const threatLayer = ledger.layers?.threat_antagonist_ending_layer ?? {};
   const threatText = JSON.stringify(
-    ledger.layers?.threat_antagonist_ending_layer?.threat_systems ??
-      ledger.layers?.threat_antagonist_ending_layer?.antagonists ?? [],
+    threatLayer?.threat_systems ?? threatLayer?.antagonists ?? [],
   ).toLowerCase();
   for (const requiredThreat of [
     'magwitch',
     'miss havisham',
     'estella',
     'jaggers/legal machinery',
+    'compeyson',
     'orlick',
     'drummle',
     'class shame',
@@ -161,6 +162,41 @@ function validateGreatExpectations(ledger: any): string[] {
     if (!threatText.includes(requiredThreat)) {
       errors.push(`MISSING_REQUIRED_TRUTH: Threat system missing '${requiredThreat}'.`);
     }
+  }
+
+  const pressureSystems = Array.isArray(threatLayer?.pressure_systems)
+    ? threatLayer.pressure_systems
+    : [];
+
+  if (pressureSystems.length === 0) {
+    errors.push('FORBIDDEN_FAILURE: THREAT_PRESSURE_UNDER_EXTRACTION — pressure_systems must be populated, not antagonist-only.');
+  }
+
+  const nonCharacterPressureCount = pressureSystems.filter((system: any) => hasText(system?.source_kind, 'non_character')).length;
+  if (nonCharacterPressureCount === 0) {
+    errors.push('FORBIDDEN_FAILURE: Non-character pressure systems must not be discarded.');
+  }
+
+  const pressureByNeedle = (needle: string) =>
+    pressureSystems.find((system: any) => hasText(system?.source_label, needle) || hasText(system?.source_aliases, needle));
+
+  const compeysonPressure = pressureByNeedle('compeyson');
+  if (!compeysonPressure) {
+    errors.push("MISSING_REQUIRED_TRUTH: Compeyson pressure system must be present.");
+  } else {
+    if (hasText(compeysonPressure?.pressure_type, 'maternal')) {
+      errors.push("FORBIDDEN_FAILURE: Compeyson must not be mislabeled as maternal obligation.");
+    }
+    if (hasText(compeysonPressure?.ending_state, 'unresolved')) {
+      errors.push("FORBIDDEN_FAILURE: Compeyson must not be marked unresolved when terminal state is known.");
+    }
+  }
+
+  const missHavishamPressure = pressureByNeedle('miss havisham');
+  if (!missHavishamPressure) {
+    errors.push("MISSING_REQUIRED_TRUTH: Miss Havisham pressure system must be present.");
+  } else if (hasText(missHavishamPressure?.ending_state, 'unresolved')) {
+    errors.push("FORBIDDEN_FAILURE: Miss Havisham must not be marked unresolved when terminal state is known.");
   }
 
   return errors;
@@ -319,6 +355,66 @@ function validateAwakening(ledger: any): string[] {
 
   if ((ledger.layers?.identity_pronoun_layer?.pronoun_shifts_detected ?? 0) !== 0) {
     errors.push('FORBIDDEN_FAILURE: The Awakening fixture must report zero pronoun shifts for stable pronoun-family usage.');
+  }
+
+  const threatLayer = ledger.layers?.threat_antagonist_ending_layer ?? {};
+  const pressureSystems = Array.isArray(threatLayer?.pressure_systems)
+    ? threatLayer.pressure_systems
+    : [];
+
+  if (pressureSystems.length === 0) {
+    errors.push('FORBIDDEN_FAILURE: THREAT_PRESSURE_UNDER_EXTRACTION — pressure systems must be present for The Awakening.');
+  }
+
+  const uniquePressureTypes = new Set(pressureSystems.map((system: any) => String(system?.pressure_type ?? '')));
+  if (uniquePressureTypes.size <= 2) {
+    errors.push('FORBIDDEN_FAILURE: THREAT_ROLE_MISLABEL — pressure systems must not collapse into a generic single-role bucket.');
+  }
+
+  const pressureText = JSON.stringify(threatLayer?.threat_systems ?? pressureSystems).toLowerCase();
+  for (const requiredPressure of [
+    'léonce',
+    'robert',
+    'arobin',
+    'adèle',
+    'reisz',
+    'children',
+    'sea',
+    'creole social expectations',
+    'internal autonomy',
+  ]) {
+    if (!pressureText.includes(requiredPressure)) {
+      errors.push(`MISSING_REQUIRED_TRUTH: Awakening pressure system missing '${requiredPressure}'.`);
+    }
+  }
+
+  const pressureByNeedle = (needle: string) =>
+    pressureSystems.find((system: any) => hasText(system?.source_label, needle) || hasText(system?.source_aliases, needle));
+
+  const leoncePressure = pressureByNeedle('léonce');
+  if (!leoncePressure) {
+    errors.push('MISSING_REQUIRED_TRUTH: Léonce pressure system is required.');
+  } else if (hasText(leoncePressure?.pressure_type, 'interpersonal_pressure') || hasText(leoncePressure?.pressure_type, 'antagonist')) {
+    errors.push('FORBIDDEN_FAILURE: Léonce must not be flattened into a generic antagonist pressure type.');
+  }
+
+  const arobinPressure = pressureByNeedle('arobin');
+  if (!arobinPressure) {
+    errors.push('MISSING_REQUIRED_TRUTH: Arobin pressure system is required.');
+  } else if (hasText(arobinPressure?.pressure_type, 'interpersonal_pressure') || hasText(arobinPressure?.pressure_type, 'antagonist')) {
+    errors.push('FORBIDDEN_FAILURE: Arobin must not be flattened into a generic antagonist pressure type.');
+  }
+
+  const seaPressure = pressureByNeedle('sea');
+  if (!seaPressure) {
+    errors.push('MISSING_REQUIRED_TRUTH: Sea/Gulf symbolic pressure must be represented.');
+  } else if (!hasText(seaPressure?.source_kind, 'non_character')) {
+    errors.push('FORBIDDEN_FAILURE: Sea/Gulf pressure must be represented as non-character pressure.');
+  }
+
+  const nonCharacterPressureCount = pressureSystems.filter((system: any) => hasText(system?.source_kind, 'non_character')).length;
+  if (nonCharacterPressureCount === 0) {
+    errors.push('FORBIDDEN_FAILURE: Non-character pressure systems must not be discarded in Awakening fixture.');
   }
 
   const locations: string[] = ledger.layers?.location_timeline_worldstate_layer?.unique_locations ?? [];

--- a/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/great-expectations.accepted-story-ledger.fixture.json
@@ -194,20 +194,119 @@
         { "character_id": "ge:magwitch", "canonical_name": "Abel Magwitch" },
         { "character_id": "ge:miss_havisham", "canonical_name": "Miss Havisham" },
         { "character_id": "ge:estella", "canonical_name": "Estella" },
+        { "character_id": "ge:compeyson", "canonical_name": "Compeyson" },
         { "character_id": "ge:jaggers", "canonical_name": "Mr. Jaggers" },
         { "character_id": "ge:orlick", "canonical_name": "Orlick" },
         { "character_id": "ge:drummle", "canonical_name": "Bentley Drummle" }
+      ],
+      "pressure_systems": [
+        {
+          "pressure_id": "ge_magwitch_benefactor_revelation",
+          "pressure_type": "interpersonal_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:magwitch",
+          "source_label": "Abel Magwitch",
+          "source_aliases": ["Magwitch", "Provis", "benefactor revelation"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "ge_miss_havisham_manipulation",
+          "pressure_type": "interpersonal_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:miss_havisham",
+          "source_label": "Miss Havisham",
+          "source_aliases": ["manipulation"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "ge_estella_emotional_class",
+          "pressure_type": "social_class_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:estella",
+          "source_label": "Estella",
+          "source_aliases": ["emotional class pressure"],
+          "ending_state": "transformed"
+        },
+        {
+          "pressure_id": "ge_jaggers_legal_machinery",
+          "pressure_type": "legal_institutional_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:jaggers",
+          "source_label": "Mr. Jaggers",
+          "source_aliases": ["legal machinery"],
+          "ending_state": "resolved"
+        },
+        {
+          "pressure_id": "ge_compeyson_violence",
+          "pressure_type": "physical_danger_violence_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:compeyson",
+          "source_label": "Compeyson",
+          "source_aliases": ["pursuit"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "ge_orlick_violence",
+          "pressure_type": "physical_danger_violence_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:orlick",
+          "source_label": "Orlick",
+          "source_aliases": ["attempted violence"],
+          "ending_state": "resolved"
+        },
+        {
+          "pressure_id": "ge_drummle_brutality",
+          "pressure_type": "physical_danger_violence_pressure",
+          "source_kind": "character",
+          "source_character_id": "ge:drummle",
+          "source_label": "Drummle",
+          "source_aliases": ["brutality"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "ge_class_shame",
+          "pressure_type": "social_class_pressure",
+          "source_kind": "non_character",
+          "source_label": "class shame",
+          "source_aliases": ["status anxiety"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "ge_debt_economic",
+          "pressure_type": "economic_debt_pressure",
+          "source_kind": "non_character",
+          "source_label": "debt/economic pressure",
+          "source_aliases": ["debt", "economic pressure"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "ge_pip_internal_guilt",
+          "pressure_type": "internal_moral_pressure",
+          "source_kind": "internal",
+          "source_character_id": "ge:pip",
+          "source_label": "Pip's guilt/internal moral pressure",
+          "source_aliases": ["guilt", "moral pressure"],
+          "ending_state": "transformed"
+        }
       ],
       "threat_systems": [
         "Magwitch",
         "Miss Havisham",
         "Estella",
         "Jaggers/legal machinery",
+        "Compeyson",
         "Orlick",
         "Drummle",
         "class shame",
-        "debt",
+        "debt/economic pressure",
         "Pip's guilt"
+      ],
+      "narrative_pressure_vectors": [
+        { "vector_source": "person", "evidence_summary": "Magwitch's return and benefactor revelation destabilize Pip's social trajectory and safety.", "structural_impact_score": 5 },
+        { "vector_source": "institution", "evidence_summary": "Jaggers and legal machinery impose procedural and class-mediated pressure on key character decisions.", "structural_impact_score": 4 },
+        { "vector_source": "social_pressure", "evidence_summary": "Class shame and reputation hierarchy repeatedly constrain aspiration and attachment choices.", "structural_impact_score": 4 },
+        { "vector_source": "poverty", "evidence_summary": "Debt and economic pressure drive obligation, vulnerability, and risk exposure across arcs.", "structural_impact_score": 4 },
+        { "vector_source": "internal_contradiction", "evidence_summary": "Pip's guilt and moral conflict persist as internal pressure shaping consequence and repair.", "structural_impact_score": 4 }
       ]
     }
   }

--- a/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
+++ b/tests/testdata/evaluation/story-ledger/the-awakening.accepted-story-ledger.fixture.json
@@ -224,13 +224,103 @@
       "location_count": 5
     },
     "threat_antagonist_ending_layer": {
+      "pressure_systems": [
+        {
+          "pressure_id": "aw_leonce_marital_property",
+          "pressure_type": "marital_family_domestic_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:leonce",
+          "source_label": "Léonce / marital-property pressure",
+          "source_aliases": ["marital constraint", "property pressure"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "aw_robert_romantic_longing",
+          "pressure_type": "romantic_desire_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:robert",
+          "source_label": "Robert / romantic longing-absence",
+          "source_aliases": ["romantic longing", "absence"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "aw_arobin_sexual_destabilization",
+          "pressure_type": "physical_danger_violence_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:arobin",
+          "source_label": "Arobin / sexual destabilization",
+          "source_aliases": ["sexual destabilization"],
+          "ending_state": "resolved"
+        },
+        {
+          "pressure_id": "aw_adele_maternal_domestic",
+          "pressure_type": "marital_family_domestic_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:adele",
+          "source_label": "Adèle / maternal-domestic pressure",
+          "source_aliases": ["mother-woman countermodel"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "aw_reisz_artistic_severity",
+          "pressure_type": "interpersonal_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:reisz",
+          "source_label": "Reisz / artistic severity-counter-model",
+          "source_aliases": ["artistic countermodel"],
+          "ending_state": "transformed"
+        },
+        {
+          "pressure_id": "aw_children_maternal_obligation",
+          "pressure_type": "marital_family_domestic_pressure",
+          "source_kind": "character",
+          "source_character_id": "aw:children",
+          "source_label": "children / maternal obligation",
+          "source_aliases": ["maternal obligation"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "aw_sea_symbolic_terminal",
+          "pressure_type": "symbolic_environmental_pressure",
+          "source_kind": "non_character",
+          "source_label": "sea/Gulf/water / symbolic-terminal pressure",
+          "source_aliases": ["sea", "gulf", "water"],
+          "ending_state": "terminal"
+        },
+        {
+          "pressure_id": "aw_creole_social_expectations",
+          "pressure_type": "social_class_pressure",
+          "source_kind": "non_character",
+          "source_label": "Creole social expectations",
+          "source_aliases": ["social convention", "community surveillance"],
+          "ending_state": "ongoing_systemic_pressure"
+        },
+        {
+          "pressure_id": "aw_edna_internal_autonomy",
+          "pressure_type": "internal_moral_pressure",
+          "source_kind": "internal",
+          "source_character_id": "aw:edna",
+          "source_label": "Edna's internal autonomy pressure",
+          "source_aliases": ["autonomy pressure", "internal contradiction"],
+          "ending_state": "terminal"
+        }
+      ],
       "threat_systems": [
-        "marital pressure",
-        "social propriety",
-        "property constraints",
-        "sexual destabilization",
-        "maternal domestic norm pressure",
-        "artistic vocation pressure"
+        "Léonce / marital-property pressure",
+        "Robert / romantic longing/absence",
+        "Arobin / sexual destabilization",
+        "Adèle / maternal-domestic pressure",
+        "Reisz / artistic severity/counter-model",
+        "children / maternal obligation",
+        "sea/Gulf/water / symbolic-terminal pressure",
+        "Creole social expectations",
+        "Edna's internal autonomy pressure"
+      ],
+      "narrative_pressure_vectors": [
+        { "vector_source": "family_obligation", "evidence_summary": "Marital-property expectations and children-related obligations constrain Edna's agency.", "structural_impact_score": 4 },
+        { "vector_source": "social_pressure", "evidence_summary": "Creole social expectations and reputation surveillance enforce norm compliance across scenes.", "structural_impact_score": 4 },
+        { "vector_source": "environment", "evidence_summary": "Sea/Gulf/water functions as symbolic-terminal pressure that shapes the ending consequence.", "structural_impact_score": 5 },
+        { "vector_source": "internal_contradiction", "evidence_summary": "Edna's internal autonomy pressure and longing create escalating, unresolved moral contradiction.", "structural_impact_score": 5 }
       ]
     }
   }


### PR DESCRIPTION
## Summary
- rewires `threat_antagonist_ending_layer` behavior to model **Narrative Pressure / Stakes / Consequence** instead of antagonist-only slots
- adds structured `pressure_systems` with:
  - pressure taxonomy type
  - source kind (`character`, `non_character`, `internal`)
  - target character references
  - evidence summary
  - escalation state
  - ending-state classification (`resolved`, `transformed`, `terminal`, `unresolved`, `intentionally_ambiguous`, `ongoing_systemic_pressure`)
- preserves backward compatibility via legacy key + `antagonists` + `threat_systems`
- emits canonical `narrative_pressure_vectors` from pressure systems
- updates quality diagnostics from `no_antagonist_detected` to pressure-system coverage language

## Acceptance hardening
- adds dedicated layer-builder regression suite:
  - `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts`
- tightens gold fixture benchmark assertions so tests fail when:
  - layer is antagonist-only
  - non-character pressure is discarded
  - pressure taxonomy collapses to generic bucket
  - Compeyson is mislabeled (e.g., maternal)
  - Léonce/Arobin are flattened into generic antagonist semantics
  - known terminal outcomes are marked unresolved

## Fixture updates
- modernizes Great Expectations and The Awakening threat layers to explicit pressure-system models
- includes required social/legal/economic/internal/symbolic forces for both fixtures

## Focused verification run
Passed locally:
- `__tests__/lib/evaluation/phase1a/buildStoryLayerFromLedger.threat-pressure-architecture.test.ts`
- `__tests__/lib/evaluation/pipeline/characterReducer.awakening-taxonomy.test.ts`
- `__tests__/evaluation/layer8Validator.test.ts`
- `tests/evaluation/benchmarks/story-ledger-gold-fixtures.test.ts`

Result: 4 suites passed, 19 tests passed, 0 failures.