### PR TITLE
contracts(seed): register non-governing seed artifacts and schemas

### DIFF
--- a/.github/pr-bodies/PR-837.md
+++ b/.github/pr-bodies/PR-837.md
@@ -1,0 +1,21 @@
+## Summary
+Adds PR2 contract-safe scaffolding for seed artifacts.
+
+This PR is intentionally registry/schema/docs only:
+- registers `story_seed_v1` and `evaluation_seed_v1` as canonical artifact types
+- adds JSON schemas for both artifacts
+- adds `docs/canon/SEED_ARTIFACT_CONTRACT_V1.md`
+- keeps both artifacts explicitly non-governing (`phase2StoryAuthority: false`)
+
+## Guardrails preserved
+- `accepted_story_ledger_v1` remains the only Phase 2 story authority.
+- No Phase 2 routing or trust path changes.
+- No Review Gate or Approval Normalizer behavior changes.
+- No DB migration.
+
+## Validation notes
+- Static diagnostics on changed files: no errors.
+- Local jest execution is not available in this workspace shell (`jest: not found`).
+
+## Acceptance intent
+This PR corresponds to the contracts/schemas-first slice and prevents seed-to-canon leakage while enabling later runtime PRs.

--- a/docs/canon/SEED_ARTIFACT_CONTRACT_V1.md
+++ b/docs/canon/SEED_ARTIFACT_CONTRACT_V1.md
@@ -1,0 +1,59 @@
+# SEED_ARTIFACT_CONTRACT_V1
+
+## Purpose
+
+Define canonical seed artifacts as provisional scaffolds that reduce cold-start drift but never become governing story authority.
+
+## Canonical seed artifacts
+
+- `story_seed_v1`
+- `evaluation_seed_v1`
+
+Both are non-governing and must remain `phase2StoryAuthority: false` in registry policy.
+
+## Governing authority boundary
+
+- Governing story-understanding authority remains `accepted_story_ledger_v1`.
+- Seed artifacts may shape extraction/routing context but may not authorize downstream truth.
+- Phase 2 and Phase 3 must not consume seed artifacts as authority substitutes.
+
+## Status split (contract rule)
+
+Seed contracts must keep two layers of status semantics:
+
+### Artifact lifecycle state
+
+- `created`
+- `superseded`
+- `archived`
+- `failed`
+
+### Claim verification state
+
+- `proposed_unverified`
+- `partially_confirmed`
+- `confirmed_by_evidence`
+- `drift_detected`
+- `superseded_by_evidence`
+- `invalidated`
+
+## ID policy
+
+Allowed for provisional coordination:
+
+- temporary IDs such as `temp_seed_entity_id`
+
+Forbidden before normalization + gate + review:
+
+- final canon identifiers that imply governing identity.
+
+## PR2 boundary
+
+This contract layer registers schemas and artifact metadata only.
+
+It does not:
+
+- change runtime route logic;
+- alter Review Gate;
+- alter Approval Normalizer;
+- introduce seed-to-authority trust path.

--- a/lib/evaluation/artifacts/artifactRegistry.ts
+++ b/lib/evaluation/artifacts/artifactRegistry.ts
@@ -7,6 +7,7 @@ import {
 const CONTRACT_DOC = 'docs/canon/STORY_LAYER_CONTRACT_V1.md';
 const SUPPORT_CONTRACT_DOC = 'docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md';
 const PROVIDER_VERIFICATION_CONTRACT_DOC = 'docs/canon/EVAL2_PROVIDER_VERIFICATION_CONTRACT_V1.md';
+const SEED_CONTRACT_DOC = 'docs/canon/SEED_ARTIFACT_CONTRACT_V1.md';
 
 export const ARTIFACT_REGISTRY: Record<CanonicalEvaluationArtifactType, ArtifactRegistryEntry> = {
   dream_calibration_packet_v1: {
@@ -27,6 +28,28 @@ export const ARTIFACT_REGISTRY: Record<CanonicalEvaluationArtifactType, Artifact
     contractDocPath: PROVIDER_VERIFICATION_CONTRACT_DOC,
     authority: 'external_verification',
     phase: 'phase_0_calibration',
+    phase2StoryAuthority: false,
+    supportArtifact: false,
+    createsStoryLayer: false,
+  },
+  story_seed_v1: {
+    artifactType: 'story_seed_v1',
+    artifactVersion: 'v1',
+    schemaPath: 'schemas/evaluation/story_seed_v1.schema.json',
+    contractDocPath: SEED_CONTRACT_DOC,
+    authority: 'seed_scaffold',
+    phase: 'phase_0_seed',
+    phase2StoryAuthority: false,
+    supportArtifact: false,
+    createsStoryLayer: false,
+  },
+  evaluation_seed_v1: {
+    artifactType: 'evaluation_seed_v1',
+    artifactVersion: 'v1',
+    schemaPath: 'schemas/evaluation/evaluation_seed_v1.schema.json',
+    contractDocPath: SEED_CONTRACT_DOC,
+    authority: 'seed_scaffold',
+    phase: 'phase_0_seed',
     phase2StoryAuthority: false,
     supportArtifact: false,
     createsStoryLayer: false,

--- a/lib/evaluation/artifacts/artifactTypes.ts
+++ b/lib/evaluation/artifacts/artifactTypes.ts
@@ -8,6 +8,8 @@
 export const CANONICAL_EVALUATION_ARTIFACT_TYPES = [
   'dream_calibration_packet_v1',
   'factual_anomalies_detected_v1',
+  'story_seed_v1',
+  'evaluation_seed_v1',
   'pass1a_story_layer_v1',
   'ledger_quality_report_v1',
   'ledger_user_feedback_v1',
@@ -56,6 +58,7 @@ export type ArtifactAuthority =
   | 'governing_story_understanding'
   | 'gate_verdict'
   | 'review_trace'
+  | 'seed_scaffold'
   | 'phase2_enrichment'
   | 'calibration'
   | 'external_verification'
@@ -65,6 +68,7 @@ export type ArtifactAuthority =
 
 export type ArtifactPhase =
   | 'phase_0_calibration'
+  | 'phase_0_seed'
   | 'phase_1a_story_layer'
   | 'review_gate'
   | 'approval_normalizer'

--- a/schemas/evaluation/evaluation_seed_v1.schema.json
+++ b/schemas/evaluation/evaluation_seed_v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://revisiongrade.com/schema/evaluation_seed_v1.json",
+  "title": "evaluation_seed_v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "job_id",
+    "evaluation_project_id",
+    "manuscript_id",
+    "manuscript_version_hash",
+    "artifact_id",
+    "artifact_type",
+    "artifact_version",
+    "source_hash",
+    "generated_at",
+    "authority",
+    "artifact_status",
+    "scope_mode",
+    "claims"
+  ],
+  "properties": {
+    "job_id": { "type": "string", "minLength": 1 },
+    "evaluation_project_id": { "type": ["string", "null"] },
+    "stage_run_id": { "type": ["string", "null"] },
+    "manuscript_id": { "type": "number" },
+    "manuscript_version_hash": { "type": "string", "minLength": 1 },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "artifact_type": { "const": "evaluation_seed_v1" },
+    "artifact_version": { "type": "string", "minLength": 1 },
+    "source_hash": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "authority": { "const": "seed_only" },
+    "artifact_status": {
+      "enum": ["created", "superseded", "archived", "failed"]
+    },
+    "scope_mode": {
+      "enum": [
+        "short_form_evaluation",
+        "long_form_evaluation",
+        "long_form_multi_layer_evaluation"
+      ]
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["claim_id", "claim_status", "hypothesis"],
+        "properties": {
+          "claim_id": { "type": "string", "minLength": 1 },
+          "criterion_key": { "type": ["string", "null"] },
+          "claim_status": {
+            "enum": [
+              "proposed_unverified",
+              "partially_confirmed",
+              "confirmed_by_evidence",
+              "drift_detected",
+              "superseded_by_evidence",
+              "invalidated"
+            ]
+          },
+          "hypothesis": { "type": "string", "minLength": 1 },
+          "notes": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/schemas/evaluation/story_seed_v1.schema.json
+++ b/schemas/evaluation/story_seed_v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://revisiongrade.com/schema/story_seed_v1.json",
+  "title": "story_seed_v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "job_id",
+    "evaluation_project_id",
+    "manuscript_id",
+    "manuscript_version_hash",
+    "artifact_id",
+    "artifact_type",
+    "artifact_version",
+    "source_hash",
+    "generated_at",
+    "authority",
+    "artifact_status",
+    "claims"
+  ],
+  "properties": {
+    "job_id": { "type": "string", "minLength": 1 },
+    "evaluation_project_id": { "type": ["string", "null"] },
+    "stage_run_id": { "type": ["string", "null"] },
+    "manuscript_id": { "type": "number" },
+    "manuscript_version_hash": { "type": "string", "minLength": 1 },
+    "artifact_id": { "type": "string", "minLength": 1 },
+    "artifact_type": { "const": "story_seed_v1" },
+    "artifact_version": { "type": "string", "minLength": 1 },
+    "source_hash": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "authority": { "const": "seed_only" },
+    "artifact_status": {
+      "enum": ["created", "superseded", "archived", "failed"]
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["claim_id", "claim_status", "hypothesis"],
+        "properties": {
+          "claim_id": { "type": "string", "minLength": 1 },
+          "temp_seed_entity_id": { "type": ["string", "null"] },
+          "claim_status": {
+            "enum": [
+              "proposed_unverified",
+              "partially_confirmed",
+              "confirmed_by_evidence",
+              "drift_detected",
+              "superseded_by_evidence",
+              "invalidated"
+            ]
+          },
+          "hypothesis": { "type": "string", "minLength": 1 },
+          "notes": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds PR2 contract-safe scaffolding for seed artifacts.

This PR is intentionally registry/schema/docs only:
- registers `story_seed_v1` and `evaluation_seed_v1` as canonical artifact types
- adds JSON schemas for both artifacts
- adds `docs/canon/SEED_ARTIFACT_CONTRACT_V1.md`
- keeps both artifacts explicitly non-governing (`phase2StoryAuthority: false`)

## Guardrails preserved
- `accepted_story_ledger_v1` remains the only Phase 2 story authority.
- No Phase 2 routing or trust path changes.
- No Review Gate or Approval Normalizer behavior changes.
- No DB migration.

## Validation notes
- Static diagnostics on changed files: no errors.
- Local jest execution is not available in this workspace shell (`jest: not found`).

## Acceptance intent
This PR corresponds to the contracts/schemas-first slice and prevents seed-to-canon leakage while enabling later runtime PRs.
