### PR TITLE
guard(seed): fail-closed phase2 authority when seed artifacts are present

### DIFF
--- a/.github/pr-bodies/PR-838.md
+++ b/.github/pr-bodies/PR-838.md
@@ -1,0 +1,17 @@
+## Summary
+Adds an explicit fail-closed guard so seed artifacts can never be treated as Phase 2 story authority.
+
+## Changes
+- extends `ArtifactSet` with optional `story_seed_v1` and `evaluation_seed_v1`
+- updates `forbidPhase2WithoutAcceptedLedger` to return a seed-specific blocking reason when accepted authority is absent
+- adds regression test coverage in `reviewGate.phase2Guard.test.ts`
+
+## Guardrails preserved
+- `accepted_story_ledger_v1` remains the only unlock artifact for Phase 2 authority.
+- No Review Gate routing changes.
+- No Approval Normalizer changes.
+- No DB migration.
+
+## Validation notes
+- Static diagnostics on changed files: no errors.
+- Local jest execution is unavailable in this workspace shell (`jest: not found`).

--- a/__tests__/evaluation/reviewGate.phase2Guard.test.ts
+++ b/__tests__/evaluation/reviewGate.phase2Guard.test.ts
@@ -61,6 +61,11 @@ const withAcceptedLedger: ArtifactSet = {
   accepted_story_ledger_v1: artifact('accepted-ledger-123'),
 };
 
+const withSeedOnly: ArtifactSet = {
+  story_seed_v1: artifact('story-seed-only'),
+  evaluation_seed_v1: artifact('evaluation-seed-only'),
+};
+
 // ─── 1. forbidPhase2WithoutAcceptedLedger guard ───────────────────────────────
 
 describe('forbidPhase2WithoutAcceptedLedger', () => {
@@ -96,6 +101,16 @@ describe('forbidPhase2WithoutAcceptedLedger', () => {
     const result = forbidPhase2WithoutAcceptedLedger(withUserFeedback);
 
     expect(result.ok).toBe(false);
+  });
+
+  it('fails explicitly when only seed artifacts are present', () => {
+    const result = forbidPhase2WithoutAcceptedLedger(withSeedOnly);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/seed artifacts/);
+      expect(result.reason).toMatch(/accepted_story_ledger_v1/);
+    }
   });
 });
 

--- a/lib/evaluation/stage-machine/hardStopGuards.ts
+++ b/lib/evaluation/stage-machine/hardStopGuards.ts
@@ -12,6 +12,8 @@ export type SupportArtifactRef = {
 };
 
 export type ArtifactSet = {
+  story_seed_v1?: ArtifactRef;
+  evaluation_seed_v1?: ArtifactRef;
   pass1a_story_layer_v1?: ArtifactRef;
   ledger_quality_report_v1?: ArtifactRef;
   pass3_preflight_draft_v1?: ArtifactRef;
@@ -202,6 +204,12 @@ export function requireAcceptedLedger(set: ArtifactSet): GuardResult {
 export function forbidPhase2WithoutAcceptedLedger(set: ArtifactSet): GuardResult {
   if (hasArtifactRef(set.accepted_story_ledger_v1)) {
     return ok();
+  }
+
+  if (hasArtifactRef(set.story_seed_v1) || hasArtifactRef(set.evaluation_seed_v1)) {
+    return fail(
+      'Phase 2 cannot consume seed artifacts (story_seed_v1/evaluation_seed_v1); accepted_story_ledger_v1 is required',
+    );
   }
 
   if (hasArtifactRef(set.pass1a_story_layer_v1)) {


### PR DESCRIPTION
Closing as superseded by #853.

The useful runtime behavior from this PR — seed artifacts must not unlock Phase 2 and accepted_story_ledger_v1 remains the only Phase 2 story authority — has been folded into #853.

Folded into #853 via:
- e2cc009a262a9c405225fc8bc0fc9df9e05b4368 — Phase 2 seed-authority guard
- b27afec0758e08447ec71706831fcd707310e40b — seed-only Phase 2 regression coverage

Do not merge this stale branch separately.