### PR TITLE
docs(seed): bind seed phase to canonical evaluation mode/templates

### DIFF
--- a/.github/pr-bodies/PR-839.md
+++ b/.github/pr-bodies/PR-839.md
@@ -1,0 +1,15 @@
+## Summary
+Docs-only PR that binds seed-phase behavior to canonical evaluation mode and template authorities.
+
+## What this adds
+- `docs/governance/seed-phase-template-alignment-contract.md`
+- cross-link from `docs/governance/evaluation-output-mode-contract.md`
+
+## Guardrails
+- seed must align to existing modes (`short_form_evaluation`, `long_form_evaluation`, `long_form_multi_layer_evaluation`)
+- seed must align to existing canonical template files
+- seed remains non-governing scaffold
+- no Phase 2 trust-path changes in this PR
+
+## Runtime impact
+None (documentation only).

--- a/docs/governance/evaluation-output-mode-contract.md
+++ b/docs/governance/evaluation-output-mode-contract.md
@@ -166,3 +166,11 @@ docs/templates/evaluation/long-form-multi-layer-evaluation-template.md
 ```
 
 These templates define the expected public/report shape for each mode. Runtime code may render the same information differently, but the information hierarchy and boundaries must not contradict this contract.
+
+Seed-phase alignment must follow:
+
+```text
+docs/governance/seed-phase-template-alignment-contract.md
+```
+
+Seed scaffolds may align to these modes/templates but may not claim governing authority.

--- a/docs/governance/seed-phase-template-alignment-contract.md
+++ b/docs/governance/seed-phase-template-alignment-contract.md
@@ -1,0 +1,66 @@
+# Seed Phase Template Alignment Contract
+
+**Status:** Canonical documentation contract  
+**Owner:** Mmeraw  
+**Scope:** Seed-phase alignment to output-mode doctrine and templates  
+**Runtime impact:** Documentation only. No routing, scoring, gate, schema, database, or worker behavior changes in this contract slice.
+
+---
+
+## Purpose
+
+The seed phase may reduce cold-start extraction drift, but it must not invent parallel template logic.
+
+This contract binds seed behavior to the existing canonical output-mode system so seed artifacts align to the same mode doctrine used by evaluation.
+
+---
+
+## Canonical mode lock
+
+Seed-phase processing must classify and remain aligned to one of the existing canonical modes:
+
+- `short_form_evaluation`
+- `long_form_evaluation`
+- `long_form_multi_layer_evaluation`
+
+Seed phase must not introduce alternative mode names or aliases.
+
+---
+
+## Template authority lock
+
+Seed-phase scaffold outputs must align to the canonical template authorities:
+
+- `docs/templates/evaluation/short-form-evaluation-template.md`
+- `docs/templates/evaluation/long-form-evaluation-template.md`
+- `docs/templates/evaluation/long-form-multi-layer-evaluation-template.md`
+
+Alignment means seed hypotheses and routing hints may reference template sections conceptually, but seed must not claim template completion as verified truth.
+
+---
+
+## Governance boundaries
+
+- Seed is scaffold-only and non-governing.
+- Seed may shape downstream work but may not authorize downstream truth.
+- `accepted_story_ledger_v1` remains the only governing story-understanding authority for Phase 2.
+- Seed phase must not bypass Review Gate or Approval Normalizer.
+- Seed phase must not emit A/B/C revision proposals into evaluation output.
+
+---
+
+## Evidence and handoff posture
+
+Seed artifacts are handoff inputs, not final report authority.
+
+They may be persisted for retrieval by later steps only under scaffold status semantics and must remain subject to downstream evidence confirmation, normalization, integrity gating, and author review.
+
+---
+
+## PR4 acceptance criteria
+
+- docs-only changes;
+- no runtime trust-path changes;
+- no mode-name drift;
+- no template-name drift;
+- no authority leakage from seed to Phase 2 governance.


### PR DESCRIPTION
Closing as superseded by #853.

The useful documentation from this PR has been folded into #853:
- 0fcfb851a6e72928296c2d21d288a28b885f59e3 — cross-link from evaluation output mode contract
- 660cf5451c19f1f43d4e4fc7a64534694a8b7874 — seed phase template alignment contract

Do not merge this stale branch separately.