### PR TITLE
feat: lock revise card operation contract

### DIFF
--- a/.github/pr-bodies/PR-848.md
+++ b/.github/pr-bodies/PR-848.md
@@ -1,0 +1,83 @@
+## Summary
+
+Implements the first hard contract layer for the Revise Queue so cards can be validated as deterministic manuscript operations rather than loose editing suggestions.
+
+This PR adds a dedicated Revise Card Contract module with:
+
+- locked `RevisionOperation` enum values
+- operation-specific UI label maps
+- custom-entry labels that preserve the selected operation
+- copy-paste readiness validation for A/B/C candidate text
+- forbidden meta-suggestion detection
+- `ready_for_revise` vs `needs_targeting` readiness classification
+- structural-preview requirement detection for high-risk operations
+- inference helpers for legacy repair/fix direction text
+
+## Scope
+
+In scope:
+
+- contract/types/helper functions only
+- validation for exact passage, exact location, operation, and A/B/C candidate text
+- tests proving vague cards are shunted to Needs Targeting
+- tests proving lazy meta-suggestions are blocked
+- tests proving operation labels and custom labels are deterministic
+
+Out of scope:
+
+- no database migration
+- no destructive manuscript patch application
+- no pipeline/runtime expansion
+- no new background jobs
+- no prompt changes
+- no manuscript overwrite behavior
+- no TrustedPath changes
+
+## Why
+
+PR #846 merged the cockpit layout foundation. This PR starts the next layer: making each Revise card a precise manuscript operation.
+
+The product rule is:
+
+> Exact passage. Exact operation. Three copy-ready options. Author-controlled decision. Audit trail.
+
+Cards with `No excerpt available` or `Location pending` must not be treated as live Revise cards. They belong in Needs Targeting until the system can anchor the exact source passage and generate actual candidate prose.
+
+## Validation Rules Added
+
+A card is `ready_for_revise` only when it has:
+
+1. `revisionOperation`
+2. exact source location
+3. exact source passage
+4. A/B/C candidate texts
+5. candidate texts that are actual manuscript prose, not meta-instructions
+
+Blocked examples include:
+
+- “Review this opportunity...”
+- “Apply the same repair goal...”
+- “Choose the least disruptive repair...”
+- “Preserve author voice...”
+- “Stronger emphasis, image, or beat structure...”
+
+## Tests
+
+Added:
+
+- `__tests__/lib/revision/reviseCardContract.test.ts`
+
+Coverage:
+
+- accepts ready revise cards
+- shunts no-excerpt/location-pending cards to Needs Targeting
+- blocks meta-suggestion text
+- verifies deterministic operation/custom labels
+- verifies operation inference
+- verifies structural preview requirement classification
+
+## Latency Impact
+
+No-Pipeline-Impact: true
+
+This is a pure local contract/helper module plus unit tests. It does not add runtime jobs or evaluation stages.

--- a/__tests__/lib/revision/reviseCardContract.test.ts
+++ b/__tests__/lib/revision/reviseCardContract.test.ts
@@ -1,0 +1,64 @@
+import {
+  candidateTextIsCopyPasteReady,
+  customOperationLabels,
+  inferRevisionOperation,
+  operationLabels,
+  operationRequiresStructuralPreview,
+  validateReviseCardContract,
+} from '@/lib/revision/reviseCardContract'
+
+describe('revise card contract', () => {
+  test('accepts a ready card with exact source text, operation, location, and A/B/C candidate prose', () => {
+    const result = validateReviseCardContract({
+      sourceText: 'The lawyer read the clause again, and found it no less monstrous at the second reading.',
+      sourceLocationLabel: 'Chapter 2 — Search for Mr. Hyde, paragraph 3',
+      revisionOperation: 'insert_after_selected_passage',
+      candidateTexts: [
+        'To Mr. Utterson, this was no mere eccentricity of legal language.',
+        'The lawyer read the clause again, and found in it not eccentricity but surrender.',
+        'The paper had the dry face of law, but beneath it moved a private catastrophe.',
+      ],
+    })
+
+    expect(result).toEqual({ readiness: 'ready_for_revise', reason: null })
+  })
+
+  test('shunts no-excerpt and location-pending cards to needs targeting', () => {
+    const result = validateReviseCardContract({
+      sourceText: 'No excerpt available — this recommendation is based on patterns found across the manuscript rather than a single passage.',
+      sourceLocationLabel: 'Location pending',
+      revisionOperation: 'replace_selected_passage',
+      candidateTexts: [
+        'A valid replacement could exist here.',
+        'A second valid replacement could exist here.',
+        'A third valid replacement could exist here.',
+      ],
+    })
+
+    expect(result.readiness).toBe('needs_targeting')
+    expect(result.reason).toMatch(/source location/i)
+  })
+
+  test('blocks lazy meta-suggestion text from A/B/C candidates', () => {
+    expect(candidateTextIsCopyPasteReady('Apply the same repair goal with a lighter touch, preserving more of the original cadence.')).toBe(false)
+    expect(candidateTextIsCopyPasteReady('The door stood in the row like a warning no one had chosen to read.')).toBe(true)
+  })
+
+  test('maps operation labels and custom labels deterministically', () => {
+    expect(operationLabels.insert_after_selected_passage).toBe('Suggested insertion after passage')
+    expect(operationLabels.replace_selected_passage).toBe('Suggested replacement')
+    expect(customOperationLabels.insert_after_selected_passage).toBe('Write your custom insertion after this passage')
+  })
+
+  test('infers operation from fix direction and scope', () => {
+    expect(inferRevisionOperation({ fixDirection: 'Insert a reaction beat after the will is described.', scope: 'Passage' })).toBe('insert_after_selected_passage')
+    expect(inferRevisionOperation({ fixDirection: 'Compress this paragraph to reduce drag.', scope: 'Passage' })).toBe('compress_selected_passage')
+    expect(inferRevisionOperation({ fixDirection: 'Replace the selected sentence with a cleaner rendering.', scope: 'Line' })).toBe('replace_selected_passage')
+  })
+
+  test('marks structural operations as preview-required', () => {
+    expect(operationRequiresStructuralPreview('rewrite_multi_paragraph_span')).toBe(true)
+    expect(operationRequiresStructuralPreview('delete_selected_passage')).toBe(true)
+    expect(operationRequiresStructuralPreview('replace_selected_passage')).toBe(false)
+  })
+})

--- a/lib/revision/reviseCardContract.ts
+++ b/lib/revision/reviseCardContract.ts
@@ -1,0 +1,173 @@
+export const REVISION_OPERATIONS = [
+  'replace_selected_passage',
+  'insert_before_selected_passage',
+  'insert_after_selected_passage',
+  'rewrite_full_paragraph',
+  'rewrite_multi_paragraph_span',
+  'compress_selected_passage',
+  'delete_selected_passage',
+  'split_paragraph',
+  'merge_paragraphs',
+  'reorder_within_section',
+] as const
+
+export type RevisionOperation = typeof REVISION_OPERATIONS[number]
+
+export type RevisionReadiness = 'ready_for_revise' | 'needs_targeting'
+
+export type PatchApplicationStatus =
+  | 'not_applied'
+  | 'previewed'
+  | 'applied'
+  | 'failed'
+  | 'conflict_detected'
+
+export type RevisionOptionRole =
+  | 'recommended_repair'
+  | 'rhythm_variant'
+  | 'bolder_rendering_shift'
+
+export type ReviseCardValidationInput = {
+  sourceText: string | null | undefined
+  sourceLocationLabel: string | null | undefined
+  revisionOperation: RevisionOperation | null | undefined
+  candidateTexts: Array<string | null | undefined>
+}
+
+export type ReviseCardValidationResult = {
+  readiness: RevisionReadiness
+  reason: string | null
+}
+
+export const operationLabels: Record<RevisionOperation, string> = {
+  replace_selected_passage: 'Suggested replacement',
+  insert_before_selected_passage: 'Suggested insertion before passage',
+  insert_after_selected_passage: 'Suggested insertion after passage',
+  rewrite_full_paragraph: 'Suggested paragraph rewrite',
+  rewrite_multi_paragraph_span: 'Suggested multi-paragraph rewrite',
+  compress_selected_passage: 'Suggested compressed version',
+  delete_selected_passage: 'Suggested deletion',
+  split_paragraph: 'Suggested split',
+  merge_paragraphs: 'Suggested merged passage',
+  reorder_within_section: 'Suggested reordered sequence',
+}
+
+export const customOperationLabels: Record<RevisionOperation, string> = {
+  replace_selected_passage: 'Write your custom replacement',
+  insert_before_selected_passage: 'Write your custom insertion before this passage',
+  insert_after_selected_passage: 'Write your custom insertion after this passage',
+  rewrite_full_paragraph: 'Write your custom paragraph rewrite',
+  rewrite_multi_paragraph_span: 'Write your custom multi-paragraph rewrite',
+  compress_selected_passage: 'Write your custom compressed version',
+  delete_selected_passage: 'Write your custom deletion note',
+  split_paragraph: 'Write your custom split version',
+  merge_paragraphs: 'Write your custom merged passage',
+  reorder_within_section: 'Write your custom reordered sequence',
+}
+
+const FORBIDDEN_META_SUGGESTIONS = [
+  'review this opportunity',
+  'apply the same repair goal',
+  'choose the least disruptive repair',
+  'preserves author voice',
+  'preserve author voice',
+  'stronger emphasis, image, or beat structure',
+  'add the smallest connective beat',
+  're-sequence or deepen the affected beat',
+  'default repair path',
+  'primary repair path from the evaluation',
+  'higher-leverage option when local polish is not enough',
+]
+
+const MISSING_SOURCE_MARKERS = [
+  'no excerpt available',
+  'location pending',
+  'manuscript-wide pattern',
+  'available in diagnostic details',
+]
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+export function hasForbiddenMetaSuggestion(value: string | null | undefined): boolean {
+  const clean = normalize(value).toLowerCase()
+  if (!clean) return false
+  return FORBIDDEN_META_SUGGESTIONS.some((phrase) => clean.includes(phrase))
+}
+
+export function isMissingSourceMarker(value: string | null | undefined): boolean {
+  const clean = normalize(value).toLowerCase()
+  if (!clean) return true
+  return MISSING_SOURCE_MARKERS.some((marker) => clean.includes(marker))
+}
+
+export function candidateTextIsCopyPasteReady(value: string | null | undefined): boolean {
+  const clean = normalize(value)
+  if (!clean) return false
+  if (hasForbiddenMetaSuggestion(clean)) return false
+
+  // Copy-paste prose must have at least enough substance to be a manuscript patch.
+  // This intentionally allows short insertions, but blocks one-word placeholders.
+  return clean.split(/\s+/).length >= 5
+}
+
+export function validateReviseCardContract(input: ReviseCardValidationInput): ReviseCardValidationResult {
+  if (!input.revisionOperation) {
+    return { readiness: 'needs_targeting', reason: 'Missing revision operation.' }
+  }
+
+  if (!normalize(input.sourceLocationLabel) || isMissingSourceMarker(input.sourceLocationLabel)) {
+    return { readiness: 'needs_targeting', reason: 'Missing exact source location.' }
+  }
+
+  if (!normalize(input.sourceText) || isMissingSourceMarker(input.sourceText)) {
+    return { readiness: 'needs_targeting', reason: 'Missing exact source passage.' }
+  }
+
+  if (input.candidateTexts.length < 3) {
+    return { readiness: 'needs_targeting', reason: 'Missing A/B/C candidate patches.' }
+  }
+
+  const invalidIndex = input.candidateTexts.findIndex((text) => !candidateTextIsCopyPasteReady(text))
+  if (invalidIndex !== -1) {
+    return { readiness: 'needs_targeting', reason: `Candidate ${String.fromCharCode(65 + invalidIndex)} is not copy-paste ready.` }
+  }
+
+  return { readiness: 'ready_for_revise', reason: null }
+}
+
+export function inferRevisionOperation(input: {
+  scope?: string | null
+  mode?: string | null
+  fixDirection?: string | null
+  recommendation?: string | null
+}): RevisionOperation {
+  const scope = normalize(input.scope).toLowerCase()
+  const haystack = [input.fixDirection, input.recommendation, input.mode, input.scope]
+    .map(normalize)
+    .join(' ')
+    .toLowerCase()
+
+  if (/\b(insert|add|include|introduce)\b/.test(haystack) && /\bbefore\b/.test(haystack)) return 'insert_before_selected_passage'
+  if (/\b(insert|add|include|introduce)\b/.test(haystack)) return 'insert_after_selected_passage'
+  if (/\b(compress|condense|trim|tighten|shorten)\b/.test(haystack)) return 'compress_selected_passage'
+  if (/\b(delete|remove|cut)\b/.test(haystack)) return 'delete_selected_passage'
+  if (/\bsplit\b/.test(haystack)) return 'split_paragraph'
+  if (/\bmerge\b/.test(haystack)) return 'merge_paragraphs'
+  if (/\b(reorder|re-sequence|resequence)\b/.test(haystack)) return 'reorder_within_section'
+
+  if (scope === 'line' || scope === 'passage') return 'replace_selected_passage'
+  if (scope === 'scene' || scope === 'chapter' || scope === 'structural' || scope === 'manuscript') return 'rewrite_multi_paragraph_span'
+
+  return 'replace_selected_passage'
+}
+
+export function operationRequiresStructuralPreview(operation: RevisionOperation): boolean {
+  return [
+    'rewrite_multi_paragraph_span',
+    'delete_selected_passage',
+    'merge_paragraphs',
+    'reorder_within_section',
+  ].includes(operation)
+}


### PR DESCRIPTION
## Summary

Implements the first hard contract layer for the Revise Queue so cards can be validated as deterministic manuscript operations rather than loose editing suggestions.

This PR adds a dedicated Revise Card Contract module with:

- locked `RevisionOperation` enum values
- operation-specific UI label maps
- custom-entry labels that preserve the selected operation
- copy-paste readiness validation for A/B/C candidate text
- forbidden meta-suggestion detection
- `ready_for_revise` vs `needs_targeting` readiness classification
- structural-preview requirement detection for high-risk operations
- inference helpers for legacy repair/fix direction text

## Scope

In scope:

- contract/types/helper functions only
- validation for exact passage, exact location, operation, and A/B/C candidate text
- tests proving vague cards are shunted to Needs Targeting
- tests proving lazy meta-suggestions are blocked
- tests proving operation labels and custom labels are deterministic

Out of scope:

- no database migration
- no destructive manuscript patch application
- no pipeline/runtime expansion
- no new background jobs
- no prompt changes
- no manuscript overwrite behavior
- no TrustedPath changes

## Why

PR #846 merged the cockpit layout foundation. This PR starts the next layer: making each Revise card a precise manuscript operation.

The product rule is:

> Exact passage. Exact operation. Three copy-ready options. Author-controlled decision. Audit trail.

Cards with `No excerpt available` or `Location pending` must not be treated as live Revise cards. They belong in Needs Targeting until the system can anchor the exact source passage and generate actual candidate prose.

## Validation Rules Added

A card is `ready_for_revise` only when it has:

1. `revisionOperation`
2. exact source location
3. exact source passage
4. A/B/C candidate texts
5. candidate texts that are actual manuscript prose, not meta-instructions

Blocked examples include:

- “Review this opportunity...”
- “Apply the same repair goal...”
- “Choose the least disruptive repair...”
- “Preserve author voice...”
- “Stronger emphasis, image, or beat structure...”

## Tests

Added:

- `__tests__/lib/revision/reviseCardContract.test.ts`

Coverage:

- accepts ready revise cards
- shunts no-excerpt/location-pending cards to Needs Targeting
- blocks meta-suggestion text
- verifies deterministic operation/custom labels
- verifies operation inference
- verifies structural preview requirement classification

## Latency Impact

No-Pipeline-Impact: true

This is a pure local contract/helper module plus unit tests. It does not add runtime jobs or evaluation stages.
