### PR TITLE
fix: route Revise workbench entry to latest eligible evaluation

### DIFF
--- a/.github/pr-bodies/PR-852.md
+++ b/.github/pr-bodies/PR-852.md
@@ -1,0 +1,1 @@
+Fixes the Revise/Open Workbench entry path so users are routed to /workbench-v2 with concrete manuscriptId/evaluationJobId when they have a completed eligible evaluation. This PR contains no patch application, no manuscript versioning, no destructive writes, no prompt changes, no pipeline changes, and no TrustedPath changes.

--- a/app/revise/page.tsx
+++ b/app/revise/page.tsx
@@ -124,7 +124,7 @@ export default function RevisePage() {
                   </div>
                 ))}
               </div>
-              <Link href="/workbench" className="mt-8 inline-block border border-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold transition hover:bg-rg-gold hover:text-rg-ink">
+              <Link href="/workbench-v2" className="mt-8 inline-block border border-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold transition hover:bg-rg-gold hover:text-rg-ink">
                 Open Workbench
               </Link>
             </article>
@@ -218,7 +218,7 @@ export default function RevisePage() {
             Both paths keep the same principle: the manuscript is diagnosed first, repairs are evidence-backed, and the author remains the final authority.
           </p>
           <div className="mt-8 flex flex-wrap gap-4">
-            <Link href="/workbench" className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Open Revise Queue →</Link>
+            <Link href="/workbench-v2" className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Open Revise Queue →</Link>
             <Link href="/pricing" className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">See pricing →</Link>
             <Link href="/reliability" className="font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-gold hover:text-rg-cream">Reliability →</Link>
           </div>

--- a/app/workbench-v2/page.tsx
+++ b/app/workbench-v2/page.tsx
@@ -1,6 +1,8 @@
 import { getWorkbenchQueue } from "@/lib/revision/workbenchQueue";
 import ReviseCockpitClient from "@/components/revision/ReviseCockpitClient";
 import { buildRevisionOpportunityLedger, persistRevisionOpportunityLedger } from "@/lib/revision/revisionOpportunityLedgerArtifact";
+import { redirect } from "next/navigation";
+import { resolveWorkbenchRouteTargetForUser } from "@/lib/revision/workbenchQueue";
 
 export default async function WorkbenchV2Page({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const params = (await searchParams) ?? {};
@@ -8,6 +10,14 @@ export default async function WorkbenchV2Page({ searchParams }: { searchParams?:
   const evaluationJobIdRaw = params.evaluationJobId;
   const manuscriptId = Array.isArray(manuscriptIdRaw) ? manuscriptIdRaw[0] : manuscriptIdRaw;
   const evaluationJobId = Array.isArray(evaluationJobIdRaw) ? evaluationJobIdRaw[0] : evaluationJobIdRaw;
+
+  if (!manuscriptId || !evaluationJobId) {
+    const resolved = await resolveWorkbenchRouteTargetForUser();
+    if (resolved) {
+      redirect(`/workbench-v2?${new URLSearchParams(resolved).toString()}`);
+    }
+  }
+
   const payload = await getWorkbenchQueue({ manuscriptId, evaluationJobId });
   const manuscriptNumericId = Number(manuscriptId);
   if (payload.ok && manuscriptId && evaluationJobId && Number.isInteger(manuscriptNumericId)) {

--- a/app/workbench/page.tsx
+++ b/app/workbench/page.tsx
@@ -1,5 +1,5 @@
-import { getWorkbenchQueue } from "@/lib/revision/workbenchQueue";
-import ReviseWorkbenchClient from "@/components/revision/ReviseWorkbenchClient";
+import { redirect } from "next/navigation";
+import { resolveWorkbenchRouteTargetForUser } from "@/lib/revision/workbenchQueue";
 
 export default async function WorkbenchPage({
   searchParams,
@@ -12,7 +12,14 @@ export default async function WorkbenchPage({
   const manuscriptId = Array.isArray(manuscriptIdRaw) ? manuscriptIdRaw[0] : manuscriptIdRaw;
   const evaluationJobId = Array.isArray(evaluationJobIdRaw) ? evaluationJobIdRaw[0] : evaluationJobIdRaw;
 
-  const payload = await getWorkbenchQueue({ manuscriptId, evaluationJobId });
+  if (manuscriptId && evaluationJobId) {
+    redirect(`/workbench-v2?${new URLSearchParams({ manuscriptId, evaluationJobId }).toString()}`);
+  }
 
-  return <ReviseWorkbenchClient payload={payload} />;
+  const resolved = await resolveWorkbenchRouteTargetForUser();
+  if (resolved) {
+    redirect(`/workbench-v2?${new URLSearchParams(resolved).toString()}`);
+  }
+
+  redirect("/workbench-v2");
 }

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -58,6 +58,11 @@ export type WorkbenchQueuePayload = {
   }
 }
 
+type ResolvedWorkbenchTarget = {
+  manuscriptId: string
+  evaluationJobId: string
+}
+
 // ---------------------------------------------------------------------------
 // Rich recommendation from evaluation artifact (6-part diagnostic + proposals)
 // ---------------------------------------------------------------------------
@@ -516,6 +521,40 @@ function emptyPayload(error: string | null): WorkbenchQueuePayload {
   }
 }
 
+async function resolveLatestEligibleEvaluationForUser(
+  supabase: ReturnType<typeof createAdminClient>,
+  userId: string,
+): Promise<ResolvedWorkbenchTarget | null> {
+  const { data, error } = await supabase
+    .from('evaluation_jobs')
+    .select('id, manuscript_id, status, manuscript_version_id, created_at, manuscripts!inner(user_id)')
+    .eq('manuscripts.user_id', userId)
+    .eq('status', 'complete')
+    .not('manuscript_version_id', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error || !data) return null
+
+  const manuscriptId = Number(data.manuscript_id)
+  const evaluationJobId = String(data.id ?? '').trim()
+  if (!Number.isInteger(manuscriptId) || !evaluationJobId) return null
+
+  return {
+    manuscriptId: String(manuscriptId),
+    evaluationJobId,
+  }
+}
+
+export async function resolveWorkbenchRouteTargetForUser(): Promise<ResolvedWorkbenchTarget | null> {
+  const user = await getAuthenticatedUser()
+  if (!user) return null
+
+  const supabase = createAdminClient()
+  return resolveLatestEligibleEvaluationForUser(supabase, user.id)
+}
+
 // ---------------------------------------------------------------------------
 // Load raw evaluation artifact to extract rich recommendation fields
 // ---------------------------------------------------------------------------
@@ -537,15 +576,23 @@ async function loadEvaluationArtifactPayload(
 }
 
 export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluationJobId?: string }): Promise<WorkbenchQueuePayload> {
-  if (!input.manuscriptId || !input.evaluationJobId) return emptyPayload('Open the workbench from a completed manuscript evaluation so RevisionGrade knows which queue to load.')
-
   const user = await getAuthenticatedUser()
   if (!user) return emptyPayload('Please sign in to open your Revise Workbench.')
 
-  const manuscriptNumericId = Number(input.manuscriptId)
+  const supabase = createAdminClient()
+  let manuscriptId = input.manuscriptId
+  let evaluationJobId = input.evaluationJobId
+
+  if (!manuscriptId || !evaluationJobId) {
+    const resolved = await resolveLatestEligibleEvaluationForUser(supabase, user.id)
+    if (!resolved) return emptyPayload('Open the workbench from a completed manuscript evaluation so RevisionGrade knows which queue to load.')
+    manuscriptId = resolved.manuscriptId
+    evaluationJobId = resolved.evaluationJobId
+  }
+
+  const manuscriptNumericId = Number(manuscriptId)
   if (!Number.isInteger(manuscriptNumericId)) return emptyPayload('Invalid manuscript id.')
 
-  const supabase = createAdminClient()
   const { data: manuscript, error: manuscriptError } = await supabase
     .from('manuscripts')
     .select('id, title, user_id')
@@ -559,17 +606,18 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
   const { data: job, error: jobError } = await supabase
     .from('evaluation_jobs')
     .select('id, status, manuscript_id, manuscript_version_id')
-    .eq('id', input.evaluationJobId)
+    .eq('id', evaluationJobId)
     .eq('manuscript_id', manuscriptNumericId)
     .maybeSingle()
 
   if (jobError) return emptyPayload(jobError.message)
   if (!job) return emptyPayload('Evaluation job not found for this manuscript.')
   if (job.status !== 'complete') return emptyPayload('This evaluation is not complete yet. Revise can load after the report is finished.')
+  if (job.manuscript_version_id == null) return emptyPayload('This evaluation is not eligible for Revise yet because no manuscript version is attached.')
 
   const { opportunities: revisionLedgerOpportunities } = await ensureRevisionOpportunityLedgerArtifact(
     supabase,
-    input.evaluationJobId,
+    evaluationJobId,
   )
 
   const opportunities = revisionLedgerOpportunities.map((opportunity) => {
@@ -628,8 +676,8 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
   return {
     ok: true,
     error: null,
-    manuscriptId: input.manuscriptId,
-    evaluationJobId: input.evaluationJobId,
+    manuscriptId,
+    evaluationJobId,
     manuscriptTitle: manuscript.title ?? 'Untitled Manuscript',
     opportunities,
     totals,


### PR DESCRIPTION
Fixes the Revise/Open Workbench entry path so users are routed to /workbench-v2 with concrete manuscriptId/evaluationJobId when they have a completed eligible evaluation. This PR contains no patch application, no manuscript versioning, no destructive writes, no prompt changes, no pipeline changes, and no TrustedPath changes.