### PR TITLE
guard(seed): require complete seed artifacts before Phase 1A

### DIFF
--- a/.github/pr-bodies/PR-853.md
+++ b/.github/pr-bodies/PR-853.md
@@ -1,0 +1,49 @@
+## Summary
+
+Adds the seed mistake-proofing guard needed before Phase 1A can run.
+
+This PR introduces `seedCompletenessGuard.ts`, which validates the two required seed artifacts:
+
+1. `story_seed_v1` — complete provisional Story Ledger layer scaffold
+2. `evaluation_seed_v1` — complete provisional evaluation scaffold for short/long/multilayer routing
+
+If either seed is incomplete, the guard produces `seed_fit_gap_report_v1` and blocks downstream processing.
+
+## Doctrine
+
+- Seed 1 is the Story Ledger baseline scaffold.
+- Seed 2 is the evaluation-template baseline scaffold.
+- Both seeds must be complete before Phase 1A.
+- Phase 1A must use seed as the baseline for Story Ledger layer creation.
+- Phase 1A must verify seed against manuscript evidence.
+- Seed remains non-authoritative.
+- `accepted_story_ledger_v1` remains the Phase 2 authority.
+
+## Mistake-proofing behavior
+
+If a seed is missing, malformed, generic, or incomplete:
+
+- do not start Phase 1A chunk extraction
+- do not build `pass1a_story_layer_v1`
+- create `seed_fit_gap_report_v1`
+- block with `SEED_FIT_GAP_BLOCKED`
+- kick the fit-gap back to the seed generator / ChatGPT repair path
+
+## Files
+
+- `lib/evaluation/seed/seedCompletenessGuard.ts`
+- `lib/evaluation/artifacts/artifactTypes.ts`
+
+## Acceptance criteria
+
+- story seed requires all 9 Story Ledger layer scaffolds
+- story seed requires all candidate input collections
+- evaluation seed requires manuscript profile and template routing
+- evaluation seed requires all 13 criterion scaffolds
+- seed fit-gap report is first-class
+- seed cannot authorize downstream truth
+- Phase 2 remains locked behind `accepted_story_ledger_v1`
+
+## Follow-up required
+
+Wire this guard into the processor before Phase 1A chunk work so incomplete seeds block runtime execution.

--- a/__tests__/evaluation/reviewGate.phase2Guard.test.ts
+++ b/__tests__/evaluation/reviewGate.phase2Guard.test.ts
@@ -35,7 +35,6 @@
  */
 
 import { evaluateStageTransition } from '../../lib/evaluation/stage-machine/stageMachine';
-import { isAllowedStageTransition } from '../../lib/evaluation/stage-machine/stageTransitions';
 import {
   requireAcceptedLedger,
   requireUserFeedback,
@@ -348,5 +347,114 @@ describe('Review Gate disposition contract', () => {
 
   it('rejected is the third disposition', () => {
     expect(VALID_DISPOSITIONS[2]).toBe('rejected');
+  });
+});
+
+// ─── 8. Review Gate API job transition contract ───────────────────────────────
+
+describe('Review Gate API job transition contract', () => {
+  /**
+   * On approval: job must transition to phase='phase_2', phase_status='queued',
+   * status='queued' — so the worker can claim it on the next tick.
+   *
+   * Critically:
+   * - status must be 'queued' (CANON: queued/running/failed/complete only)
+   * - phase must be 'phase_2' (now claimable by worker)
+   * - phase_status must be 'queued' (not 'awaiting_approval' or 'running')
+   *
+   * On rejection: phase stays 'review_gate', phase_status='failed', status='failed'.
+   */
+  const VALID_JOB_STATUSES = ['queued', 'running', 'failed', 'complete'] as const;
+  const CLAIMABLE_PHASES = ['phase_1a', 'phase_2', 'phase_3'] as const;
+
+  it('accepted approval transition produces a claimable job state', () => {
+    const approvalTransition = {
+      status: 'queued',
+      phase: 'phase_2',
+      phase_status: 'queued',
+    };
+
+    // status is canonical
+    expect(VALID_JOB_STATUSES).toContain(approvalTransition.status);
+    // phase is now claimable
+    expect(CLAIMABLE_PHASES).toContain(approvalTransition.phase);
+    // phase_status is not the gate state anymore
+    expect(approvalTransition.phase_status).not.toBe('awaiting_approval');
+  });
+
+  it('rejected disposition produces a terminal job state', () => {
+    const rejectTransition = {
+      status: 'failed',
+      phase: 'review_gate',
+      phase_status: 'failed',
+      failure_code: 'REVIEW_GATE_REJECTED_BY_AUTHOR',
+    };
+
+    // status is canonical
+    expect(VALID_JOB_STATUSES).toContain(rejectTransition.status);
+    // phase is NOT claimable — job is dead
+    expect(CLAIMABLE_PHASES).not.toContain(rejectTransition.phase);
+    // failure_code is set
+    expect(rejectTransition.failure_code).toBe('REVIEW_GATE_REJECTED_BY_AUTHOR');
+  });
+
+  it('review_gate phase is never claimable regardless of status', () => {
+    expect(CLAIMABLE_PHASES).not.toContain('review_gate');
+  });
+});
+
+// ─── 9. Support artifact freshness guard (Phase 2 context) ───────────────────
+
+describe('Support artifact freshness relative to accepted_story_ledger_v1', () => {
+  const acceptedHash = 'sha256:accepted-ledger-123';
+
+  it('passes when support artifacts reference the current accepted ledger source hash', () => {
+    const result = checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
+      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: acceptedHash },
+      manuscript_signal_appendix_v1: { accepted_story_ledger_source_hash: acceptedHash },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('passes when no support artifacts are present (nothing to be stale)', () => {
+    const result = checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when story_shape_signal_map_v1 references a stale accepted ledger hash', () => {
+    const result = checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
+      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: 'sha256:OLD-hash' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/stale/);
+    }
+  });
+
+  it('fails when manuscript_signal_appendix_v1 references a stale hash', () => {
+    const result = checkSupportArtifactFreshness({
+      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
+      manuscript_signal_appendix_v1: { accepted_story_ledger_source_hash: 'sha256:STALE' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/stale/);
+    }
+  });
+
+  it('fails when accepted_story_ledger_v1 is absent (cannot validate freshness)', () => {
+    const result = checkSupportArtifactFreshness({
+      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: acceptedHash },
+    });
+
+    expect(result.ok).toBe(false);
   });
 });

--- a/__tests__/evaluation/reviewGate.phase2Guard.test.ts
+++ b/__tests__/evaluation/reviewGate.phase2Guard.test.ts
@@ -8,11 +8,13 @@
  *   1. Stage machine transition approval_normalizer → phase_2_evaluation
  *      requires accepted_story_ledger_v1. Missing it hard-stops.
  *
- *   2. forbidPhase2WithoutAcceptedLedger distinguishes three cases:
+ *   2. forbidPhase2WithoutAcceptedLedger distinguishes four cases:
  *      a. accepted_story_ledger_v1 present → ok
- *      b. raw pass1a_story_layer_v1 present, no accepted → specific error naming
+ *      b. seed-only artifacts present, no accepted → specific error naming
+ *         seed artifacts and accepted_story_ledger_v1
+ *      c. raw pass1a_story_layer_v1 present, no accepted → specific error naming
  *         the raw artifact so the operator knows exactly what is missing
- *      c. neither present → generic error
+ *      d. neither present → generic error
  *
  *   3. Review Gate → Approval Normalizer requires ledger_user_feedback_v1
  *      (even for accepted_without_changes — feedback artifact is mandatory).
@@ -46,6 +48,11 @@ import {
 
 const artifact = (id: string) => ({ artifact_id: id, source_hash: `sha256:${id}` });
 
+const seedOnly: ArtifactSet = {
+  story_seed_v1: artifact('story-seed-only'),
+  evaluation_seed_v1: artifact('evaluation-seed-only'),
+};
+
 const storyLayerOnly: ArtifactSet = {
   pass1a_story_layer_v1: artifact('story-layer-abc'),
 };
@@ -67,6 +74,16 @@ describe('forbidPhase2WithoutAcceptedLedger', () => {
   it('passes when accepted_story_ledger_v1 is present', () => {
     const result = forbidPhase2WithoutAcceptedLedger(withAcceptedLedger);
     expect(result.ok).toBe(true);
+  });
+
+  it('fails explicitly when only seed artifacts are present', () => {
+    const result = forbidPhase2WithoutAcceptedLedger(seedOnly);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/seed artifacts/);
+      expect(result.reason).toMatch(/accepted_story_ledger_v1/);
+    }
   });
 
   it('fails with a raw-artifact-specific error when only pass1a_story_layer_v1 is present', () => {
@@ -206,6 +223,19 @@ describe('Stage machine: approval_normalizer → phase_2_evaluation', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('blocks when only seed artifacts are present', () => {
+    const result = evaluateStageTransition({
+      from: 'approval_normalizer',
+      to: 'phase_2_evaluation',
+      artifacts: seedOnly,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/accepted_story_ledger_v1/);
+    }
+  });
+
   it('blocks when only pass1a_story_layer_v1 is present (raw handoff attempt)', () => {
     const result = evaluateStageTransition({
       from: 'approval_normalizer',
@@ -318,114 +348,5 @@ describe('Review Gate disposition contract', () => {
 
   it('rejected is the third disposition', () => {
     expect(VALID_DISPOSITIONS[2]).toBe('rejected');
-  });
-});
-
-// ─── 8. Review Gate API job transition contract ───────────────────────────────
-
-describe('Review Gate API job transition contract', () => {
-  /**
-   * On approval: job must transition to phase='phase_2', phase_status='queued',
-   * status='queued' — so the worker can claim it on the next tick.
-   *
-   * Critically:
-   * - status must be 'queued' (CANON: queued/running/failed/complete only)
-   * - phase must be 'phase_2' (now claimable by worker)
-   * - phase_status must be 'queued' (not 'awaiting_approval' or 'running')
-   *
-   * On rejection: phase stays 'review_gate', phase_status='failed', status='failed'.
-   */
-  const VALID_JOB_STATUSES = ['queued', 'running', 'failed', 'complete'] as const;
-  const CLAIMABLE_PHASES = ['phase_1a', 'phase_2', 'phase_3'] as const;
-
-  it('accepted approval transition produces a claimable job state', () => {
-    const approvalTransition = {
-      status: 'queued',
-      phase: 'phase_2',
-      phase_status: 'queued',
-    };
-
-    // status is canonical
-    expect(VALID_JOB_STATUSES).toContain(approvalTransition.status);
-    // phase is now claimable
-    expect(CLAIMABLE_PHASES).toContain(approvalTransition.phase);
-    // phase_status is not the gate state anymore
-    expect(approvalTransition.phase_status).not.toBe('awaiting_approval');
-  });
-
-  it('rejected disposition produces a terminal job state', () => {
-    const rejectTransition = {
-      status: 'failed',
-      phase: 'review_gate',
-      phase_status: 'failed',
-      failure_code: 'REVIEW_GATE_REJECTED_BY_AUTHOR',
-    };
-
-    // status is canonical
-    expect(VALID_JOB_STATUSES).toContain(rejectTransition.status);
-    // phase is NOT claimable — job is dead
-    expect(CLAIMABLE_PHASES).not.toContain(rejectTransition.phase);
-    // failure_code is set
-    expect(rejectTransition.failure_code).toBe('REVIEW_GATE_REJECTED_BY_AUTHOR');
-  });
-
-  it('review_gate phase is never claimable regardless of status', () => {
-    expect(CLAIMABLE_PHASES).not.toContain('review_gate');
-  });
-});
-
-// ─── 9. Support artifact freshness guard (Phase 2 context) ───────────────────
-
-describe('Support artifact freshness relative to accepted_story_ledger_v1', () => {
-  const acceptedHash = 'sha256:accepted-ledger-123';
-
-  it('passes when support artifacts reference the current accepted ledger source hash', () => {
-    const result = checkSupportArtifactFreshness({
-      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
-      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: acceptedHash },
-      manuscript_signal_appendix_v1: { accepted_story_ledger_source_hash: acceptedHash },
-    });
-
-    expect(result.ok).toBe(true);
-  });
-
-  it('passes when no support artifacts are present (nothing to be stale)', () => {
-    const result = checkSupportArtifactFreshness({
-      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
-    });
-
-    expect(result.ok).toBe(true);
-  });
-
-  it('fails when story_shape_signal_map_v1 references a stale accepted ledger hash', () => {
-    const result = checkSupportArtifactFreshness({
-      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
-      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: 'sha256:OLD-hash' },
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toMatch(/stale/);
-    }
-  });
-
-  it('fails when manuscript_signal_appendix_v1 references a stale hash', () => {
-    const result = checkSupportArtifactFreshness({
-      accepted_story_ledger_v1: { artifact_id: 'accepted', source_hash: acceptedHash },
-      manuscript_signal_appendix_v1: { accepted_story_ledger_source_hash: 'sha256:STALE' },
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toMatch(/stale/);
-    }
-  });
-
-  it('fails when accepted_story_ledger_v1 is absent (cannot validate freshness)', () => {
-    const result = checkSupportArtifactFreshness({
-      story_shape_signal_map_v1: { accepted_story_ledger_source_hash: acceptedHash },
-    });
-
-    expect(result.ok).toBe(false);
   });
 });

--- a/__tests__/lib/evaluation/seed/seedCompletenessGuard.minimal.test.ts
+++ b/__tests__/lib/evaluation/seed/seedCompletenessGuard.minimal.test.ts
@@ -1,0 +1,78 @@
+import { STORY_LAYER_KEYS } from '@/lib/evaluation/artifacts/artifactTypes';
+import { CRITERIA_KEYS } from '@/schemas/criteria-keys';
+import {
+  buildSeedFitGapReport,
+  validateEvaluationSeedCompleteness,
+  validateStorySeedCompleteness,
+} from '@/lib/evaluation/seed/seedCompletenessGuard';
+
+const storySeed = () => ({
+  artifact_type: 'story_seed_v1',
+  authority: 'seed_only',
+  artifact_status: 'created',
+  layer_scaffolds: Object.fromEntries(STORY_LAYER_KEYS.map((layer) => [layer, {}])),
+  global_candidate_inputs: {
+    candidate_entity_registry: [],
+    candidate_alias_map: {},
+    candidate_pov_map: [],
+    candidate_relationship_map: [],
+    candidate_pressure_map: [],
+    candidate_object_shortlist: [],
+    candidate_location_map: [],
+    candidate_timeline_hypotheses: [],
+    uncertainty_flags: [],
+  },
+  governance_rail: {
+    seed_must_be_used_as_phase1a_baseline: true,
+    phase1a_must_verify_seed_against_manuscript_evidence: true,
+    seed_may_authorize_downstream_truth: false,
+    accepted_story_ledger_required_for_phase2: true,
+  },
+});
+
+const evaluationSeed = () => ({
+  artifact_type: 'evaluation_seed_v1',
+  authority: 'seed_only',
+  artifact_status: 'created',
+  manuscript_profile: {
+    word_count: 12000,
+    word_count_tier: 'short_under_25k',
+    evaluation_mode: 'short_form_evaluation',
+    work_type: 'novella',
+  },
+  reporting_template_path: {
+    selected_template: 'templates/evaluation/short-form-13-criteria-v1',
+    short_form_template: 'templates/evaluation/short-form-13-criteria-v1',
+    long_form_template: 'templates/evaluation/long-form-v1',
+    long_form_multilayer_template: 'templates/evaluation/long-form-multilayer-v1',
+  },
+  criterion_scaffolds: CRITERIA_KEYS.map((criterion_key) => ({ criterion_key })),
+  governance_rail: {
+    seed_must_be_used_as_phase1a_evaluation_baseline: true,
+    phase1a_must_verify_seed_against_manuscript_evidence: true,
+    seed_may_authorize_downstream_truth: false,
+    final_craft_scores_forbidden: true,
+    final_executive_verdict_forbidden: true,
+    accepted_story_ledger_required_for_phase2: true,
+  },
+});
+
+describe('seedCompletenessGuard minimal contract', () => {
+  it('blocks generic story seeds that lack layer scaffolds', () => {
+    const gaps = validateStorySeedCompleteness({ artifact_type: 'story_seed_v1', authority: 'seed_only' });
+    expect(gaps.some((gap) => gap.section === 'layer_scaffolds')).toBe(true);
+  });
+
+  it('blocks generic evaluation seeds that lack criteria and template routing', () => {
+    const gaps = validateEvaluationSeedCompleteness({ artifact_type: 'evaluation_seed_v1', authority: 'seed_only' });
+    expect(gaps.some((gap) => gap.section === 'manuscript_profile.word_count')).toBe(true);
+    expect(gaps.some((gap) => gap.section === 'reporting_template_path.selected_template')).toBe(true);
+    expect(gaps.some((gap) => gap.section === 'criterion_scaffolds.marketability')).toBe(true);
+  });
+
+  it('passes only when both required seeds are complete', () => {
+    const report = buildSeedFitGapReport({ storySeed: storySeed(), evaluationSeed: evaluationSeed() });
+    expect(report.status).toBe('passed');
+    expect(report.gaps).toHaveLength(0);
+  });
+});

--- a/__tests__/lib/evaluation/seed/seedCompletenessGuard.test.ts
+++ b/__tests__/lib/evaluation/seed/seedCompletenessGuard.test.ts
@@ -1,0 +1,145 @@
+import { CRITERIA_KEYS } from '@/schemas/criteria-keys';
+import { STORY_LAYER_KEYS } from '@/lib/evaluation/artifacts/artifactTypes';
+import {
+  SeedFitGapBlockedError,
+  assertSeedsCompleteForPhase1a,
+  buildSeedFitGapReport,
+  validateEvaluationSeedCompleteness,
+  validateStorySeedCompleteness,
+} from '@/lib/evaluation/seed/seedCompletenessGuard';
+
+const filledLayerScaffold = (layer: string) => ({
+  baseline_expectation: `${layer} must be verified against manuscript evidence`,
+  required_verification_targets: [`${layer}:target`],
+});
+
+function completeStorySeed() {
+  return {
+    artifact_type: 'story_seed_v1',
+    authority: 'seed_only',
+    artifact_status: 'created',
+    layer_scaffolds: Object.fromEntries(STORY_LAYER_KEYS.map((layer) => [layer, filledLayerScaffold(layer)])),
+    global_candidate_inputs: {
+      candidate_entity_registry: [],
+      candidate_alias_map: {},
+      candidate_pov_map: [],
+      candidate_relationship_map: [],
+      candidate_pressure_map: [],
+      candidate_object_shortlist: [],
+      candidate_location_map: [],
+      candidate_timeline_hypotheses: [],
+      uncertainty_flags: [],
+    },
+    governance_rail: {
+      seed_must_be_used_as_phase1a_baseline: true,
+      phase1a_must_verify_seed_against_manuscript_evidence: true,
+      seed_may_authorize_downstream_truth: false,
+      accepted_story_ledger_required_for_phase2: true,
+    },
+  };
+}
+
+function completeEvaluationSeed() {
+  return {
+    artifact_type: 'evaluation_seed_v1',
+    authority: 'seed_only',
+    artifact_status: 'created',
+    manuscript_profile: {
+      word_count: 12000,
+      word_count_tier: 'short_under_25k',
+      evaluation_mode: 'short_form_evaluation',
+      work_type: 'novella',
+    },
+    reporting_template_path: {
+      selected_template: 'templates/evaluation/short-form-13-criteria-v1',
+      short_form_template: 'templates/evaluation/short-form-13-criteria-v1',
+      long_form_template: 'templates/evaluation/long-form-v1',
+      long_form_multilayer_template: 'templates/evaluation/long-form-multilayer-v1',
+    },
+    criterion_scaffolds: CRITERIA_KEYS.map((criterion_key) => ({
+      criterion_key,
+      baseline_expectation: `${criterion_key} must be evidence-backed`,
+    })),
+    governance_rail: {
+      seed_must_be_used_as_phase1a_evaluation_baseline: true,
+      phase1a_must_verify_seed_against_manuscript_evidence: true,
+      seed_may_authorize_downstream_truth: false,
+      final_craft_scores_forbidden: true,
+      final_executive_verdict_forbidden: true,
+      accepted_story_ledger_required_for_phase2: true,
+    },
+  };
+}
+
+describe('seedCompletenessGuard', () => {
+  it('passes complete story and evaluation seeds', () => {
+    const report = buildSeedFitGapReport({
+      storySeed: completeStorySeed(),
+      evaluationSeed: completeEvaluationSeed(),
+      generatedAt: '2026-05-31T00:00:00.000Z',
+    });
+
+    expect(report.status).toBe('passed');
+    expect(report.gaps).toEqual([]);
+  });
+
+  it('blocks missing, empty, and malformed Story Ledger scaffolds', () => {
+    const seed = completeStorySeed();
+    seed.layer_scaffolds[STORY_LAYER_KEYS[0]] = {};
+    seed.layer_scaffolds[STORY_LAYER_KEYS[1]] = null;
+    delete seed.layer_scaffolds[STORY_LAYER_KEYS[2]];
+
+    const gaps = validateStorySeedCompleteness(seed);
+
+    expect(gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: `layer_scaffolds.${STORY_LAYER_KEYS[0]}` }),
+      expect.objectContaining({ section: `layer_scaffolds.${STORY_LAYER_KEYS[1]}` }),
+      expect.objectContaining({ section: `layer_scaffolds.${STORY_LAYER_KEYS[2]}` }),
+    ]));
+  });
+
+  it('blocks malformed candidate input collections', () => {
+    const seed = completeStorySeed();
+    seed.global_candidate_inputs.candidate_entity_registry = {};
+    seed.global_candidate_inputs.candidate_alias_map = [];
+
+    const gaps = validateStorySeedCompleteness(seed);
+
+    expect(gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: 'global_candidate_inputs.candidate_entity_registry' }),
+      expect.objectContaining({ section: 'global_candidate_inputs.candidate_alias_map' }),
+    ]));
+  });
+
+  it('blocks malformed criterion scaffold items instead of crashing', () => {
+    const seed = completeEvaluationSeed();
+    seed.criterion_scaffolds = [null, 'bad', { criterion_key: CRITERIA_KEYS[0] }];
+
+    const gaps = validateEvaluationSeedCompleteness(seed);
+
+    expect(gaps).toEqual(expect.arrayContaining([
+      expect.objectContaining({ section: 'criterion_scaffolds.malformed' }),
+      expect.objectContaining({ section: `criterion_scaffolds.${CRITERIA_KEYS[1]}` }),
+    ]));
+  });
+
+  it('throws a typed block error with the full seed_fit_gap_report_v1 attached', () => {
+    expect(() => assertSeedsCompleteForPhase1a({
+      storySeed: { artifact_type: 'story_seed_v1', authority: 'seed_only' },
+      evaluationSeed: completeEvaluationSeed(),
+    })).toThrow(SeedFitGapBlockedError);
+
+    try {
+      assertSeedsCompleteForPhase1a({
+        storySeed: { artifact_type: 'story_seed_v1', authority: 'seed_only' },
+        evaluationSeed: completeEvaluationSeed(),
+      });
+      throw new Error('expected block');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SeedFitGapBlockedError);
+      expect((error as SeedFitGapBlockedError).report.artifact_type).toBe('seed_fit_gap_report_v1');
+      expect((error as SeedFitGapBlockedError).report.status).toBe('blocked');
+      expect((error as SeedFitGapBlockedError).report.gaps.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/docs/benchmarks/story-ledger/FROGGIN_NOGGIN_9_LAYER_OPTIMIZATION_ADDENDUM.md
+++ b/docs/benchmarks/story-ledger/FROGGIN_NOGGIN_9_LAYER_OPTIMIZATION_ADDENDUM.md
@@ -1,0 +1,339 @@
+---
+benchmark-schema: ideal-story-ledger-9-layer-optimization-addendum-v1
+title: Froggin Noggin — Nine-Layer Story Ledger Optimization Addendum
+manuscript: Froggin Noggin FULL NOVEL
+author: Michael J. Meraw
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: gold-standard-story-ledger-addendum
+benchmark-tier: required-gold
+created: 2026-05-31T04:25:00Z
+applies-to:
+  - docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_FROGGIN_NOGGIN.md
+---
+
+# Froggin Noggin — Nine-Layer Story Ledger Optimization Addendum
+
+This addendum tightens the existing Froggin Noggin ideal Story Ledger benchmark. It turns the current macro scaffold into a stronger operational answer key for SEED and Phase 1A.
+
+## Verdict
+
+The current Froggin benchmark is directionally correct but too high-level. It names the philosophical spine, but it does not yet fully mistake-proof the extraction target for the full novel.
+
+Approximate current score before this addendum: `58 / 100`.
+
+Primary gap: the benchmark reads like literary summary rather than a full extraction answer key.
+
+---
+
+# Required governing-canon rule
+
+Phase 2 cannot proceed cleanly if the governing Story Ledger omits the following minimum structures:
+
+- Zimeon
+- Hyla
+- Brutus
+- Chey
+- Thorander
+- Rana
+- Newton
+- Maximilian
+- Beiana
+- Lacerta
+- Twillow
+- shard / crystalline substance
+- toadstone / froggin noggin
+- Dead Zone
+- mine / human-contamination system
+- council / governance system
+- final unresolved retaliation and shard-dependency state
+
+## Version-contamination guard
+
+Snappy belongs to Ancient Bloodlines, not this Froggin Noggin FULL NOVEL review copy unless a different edition proves otherwise. A Froggin ledger that imports Snappy from Ancient Bloodlines is contaminated.
+
+---
+
+# Layer 1 — Source Integrity: required additions
+
+The Source Integrity layer must add these guards:
+
+1. Full-manuscript coverage guard: the Story Ledger must represent all 14 chapters or equivalent narrative zones, not only opening/middle/ending.
+2. Human-contamination guard: Brutus's human chemical-workspace, mine disposal lane, road-trip pursuit, and final retaliation are structural, not incidental background.
+3. Council/governance guard: Hyla's council, enforcement roles, secrecy roles, reproductive policy, and disease/blight governance must be tracked.
+4. Ending guard: the ending is unresolved escalation, not clean closure.
+5. Benchmark contamination guard: Ancient Bloodlines-only entities must not appear in this Froggin benchmark unless the specific manuscript edition proves them.
+
+---
+
+# Layer 2 — POV Structure: required additions
+
+The POV layer must distinguish:
+
+- omniscient mythic narrator
+- human satirical/predatory camera
+- frog governance camera
+- newt vulnerability camera
+- Zimeon shard-dependency camera
+- Rana/Thorander pedagogy camera
+- Chey partial-conscience camera
+- Brutus spectacle/predator camera
+
+Mandatory focal centers:
+
+- Hyla
+- Zimeon
+- Thorander
+- Rana
+- Newton
+- Lacerta
+- Twillow
+- Maximilian
+- Brutus
+- Chey
+- Beiana where Hyla's private governance is active
+
+Failure condition: any generated ledger that says `No POV characters identified` is incorrect for this manuscript.
+
+---
+
+# Layer 3 — Canonical Identity: required additions
+
+The Canonical Identity layer must add or verify these entities and systems:
+
+| Canonical item | Required treatment |
+|---|---|
+| Maximilian | Major late-stage friend, co-rebel, and shard co-user; omission indicates incomplete full-manuscript coverage |
+| Beiana | Hyla's loyal foot-maiden and secrecy instrument; not background servant only |
+| Lacerta | Newton's mother and tenderness anchor |
+| Twillow | Bullying/newt-social-cruelty pressure |
+| Enoch | Governance/enforcement figure where evidenced |
+| Magus | Council/governance figure where evidenced |
+| Arcana | Philosopher/doubt-carrier where evidenced |
+| Phyto | Naturalist/healing/governance figure where evidenced |
+| Molly | Matron / education / funeral / social-order figure |
+| Lilianna | Matron / education / care figure |
+| Skyla | Verify and track if sustained |
+| Proto | Verify and track if sustained |
+| Mage | Verify and track if sustained |
+| King Amphibia | Mythic-origin entity; not present-day character |
+| Prince Anura | Mythic frog-line origin entity |
+| Prince Urodela | Mythic salamander/newt-line origin entity |
+| Orgon frogs | Species/collective; do not merge with Thorander |
+| Columbian spotted frogs | Species/polity collective |
+| rough-skinned newts | Species/collective; do not merge with Newton/Twillow |
+| humans/giants | Species/collective; keep Brutus and Chey separate |
+| Elemental Gorf manifestations | Doctrine/worldview manifestations unless evidence requires distinct entity treatment |
+
+The layer must separate:
+
+- royal titles from names
+- species collectives from individuals
+- doctrine terms from characters
+- elemental Gorf manifestations from ordinary characters
+- toadstone as physical/symbolic object from Gorf doctrine
+- shard/crystalline substance from Maalik/Dominatus/New World metaphysics
+
+---
+
+# Layer 4 — Cast / Role Tier: required additions
+
+The cast tier should include these tiers:
+
+| Tier | Required members / systems |
+|---|---|
+| Primary plot engines | Zimeon, Hyla, Brutus, Chey |
+| Major structural counterforces | Thorander, Rana, Newton, Maximilian |
+| Governance system | Hyla, Enoch, Magus, Arcana, Phyto, Molly, Lilianna, Beiana, council, sentinels, matrons |
+| Authority / doctrine | Hyla, Thorander, Gorf system, elemental Gorfs, mythic ancestors |
+| Vulnerability / tenderness | Newton, Lacerta, Rana/Newton bond |
+| Human threat system | Brutus, Chey, human-contamination lane, mine disposal lane, road-trip pursuit, final retaliation |
+| Human partial-conscience lane | Chey |
+| Symbolic / metaphysical systems | Gorf, elemental Gorfs, toadstone, shard, Maalik, Dominatus, New World |
+| Collective forces | frog polity, Orgon frogs, Columbians, rough-skinned newts, humans/giants, predators, disease/blight, ecology |
+| Local social cruelty | Twillow and newt youth gang |
+
+Failure condition: a ledger fails this benchmark if Maximilian, Beiana, Lacerta, Twillow, or the council/governance system are missing.
+
+---
+
+# Layer 5 — Pronoun Transitions: required additions
+
+This layer is mostly correct if it says:
+
+`No reviewable pronoun-family transitions detected.`
+
+Additional mistake-proofing:
+
+- Do not treat species terms as pronoun transitions.
+- Do not treat divine titles or elemental Gorf manifestations as pronoun transitions.
+- Do not treat royal titles, Chosen One language, Newbie, Lord, Crown, Keeper, or insults/social labels as pronoun-family changes.
+
+---
+
+# Layer 6 — Relationship Network: required additions
+
+The relationship network must add:
+
+| Relationship / system | Function |
+|---|---|
+| Hyla / Zimeon | Mother-ruler conflict, transference, control, late fear for Zimeon |
+| Zimeon / Maximilian | Friendship, rebellion, shard co-use, desire to return for more |
+| Zimeon / shard | Dependency/transformation relation |
+| Hyla / Beiana | Secrecy, loyalty, private governance access, coercive obedience |
+| Hyla / Enoch | Ruler/enforcement arm |
+| Hyla / council | Authority and deliberative theater |
+| Hyla / Thorander | Cross-species power, parentage, authority rivalry |
+| Thorander / Rana | Pedagogy, reform, patriarchy, divergence |
+| Rana / Newton | Tenderness, vulnerability, cross-species cooperation |
+| Rana / Thorander / Newton triad | Reform vs tenderness vs inherited doctrine |
+| Newton / Lacerta | Maternal shelter and survival reframing |
+| Newton / Twillow | Bully/victim and social-cruelty pressure |
+| Brutus / Chey | Human damage and compromised conscience |
+| Brutus / frogs | Predator/extraction relationship |
+| Chey / frogs | Witness/partial-conscience relationship |
+| Brutus / mine-human-contamination system | Human contamination and ecological damage |
+| Frog polity / human pollution | Mirror system |
+| Frog polity / disease-blight | Survival and governance pressure |
+| Frog polity / mating-breeding order | Reproductive and social-order pressure |
+| Hyla / toadstone | Authority-object relationship |
+| Thorander / Orgon mythology | Patriarchal doctrine and origin myth system |
+| Brutus / Chey / toadstone triad | Human ignorance, appetite, and partial restraint |
+
+Do not reduce the relationship layer to ordinary character pairs only. This manuscript requires character-system relationships.
+
+---
+
+# Layer 7 — Object / Symbol: required additions
+
+The object/symbol layer must include:
+
+| Object / symbol / system | Required treatment |
+|---|---|
+| Gorf system | Behavior-governing theology and political justification |
+| Elemental Gorfs | Doctrine/worldview manifestations |
+| Toadstone / froggin noggin | Sacred object, authority source, human-extraction desire |
+| Shard / crystalline substance | Exposure, dependency, side effects, ecological consequence, final unresolved danger |
+| Dead Zone | Poisoned/compromised geography and source of shard power |
+| Human chemical-workspace | Human contamination system; not incidental setting |
+| Mine shaft / disposal site | Human waste burial and underworld imagery |
+| Human toxic product system | Human appetite, production, pollution, and body-harm system |
+| Road flare / false-cleansing object | Human attempt to erase evidence of contamination |
+| Inhalation / altered-state objects | Human self-poisoning and distorted perception |
+| Weaponized-retaliation objects | Human force escalation and amphibian threat |
+| Internet / road-trip research | Human curiosity made predatory |
+| Frog Heads song / Bobblehead parody | Human dehumanization and violence rehearsal |
+| Chasing Rainbows | Hope/illusion motif where evidenced |
+| Driftwood/log transport | Zimeon movement and possible shard transport |
+| Vomerine teeth / Orgon teeth / catacombs | Sacred relic system and ancestry authority |
+| Ray-fin fish teeth | Origin logic and symbiosis myth |
+| Blood/mucus transference | Maternal authority, danger, inheritance, possible harm |
+| Hibernation circles | Social order and royal death/burial recognition |
+| Council chambers / wall etchings | Governance memory and procedural authority |
+| Sanctuary / leper colony | Illness, exile, care, contamination rules |
+| Silver-scale fish / predator disposal | Punishment, erasure, and body-disposal system |
+| Stones / stoning | Political punishment where evidenced |
+| New World | Literal, ethical, spiritual, or plural possibility |
+| Maalik / light-darkness | Moral ambiguity and shard theology |
+| Dominatus | Dominion indictment and moral frame |
+
+Mistake-proofing:
+
+- Do not treat dialogue as object.
+- Do not treat doctrine as a physical object.
+- Do not miss human contamination objects.
+- Do not miss final retaliation objects.
+- Do not miss shard dependency as biochemical/ecological pressure rather than simple magic.
+
+---
+
+# Layer 8 — Timeline / Location / Worldstate: required additions
+
+The benchmark should require this narrative-zone map:
+
+| Narrative zone | Required function |
+|---|---|
+| Chapter 1 — human campsite / Aqua World / hibernation | Brutus/Chey toadstone setup; humans as giants; Hyla-Zimeon transference; frog governance |
+| Chapter 2 — Dead Zone / human contamination lane / mine shaft / Newton-Twillow-Lacerta | Zimeon shard exposure; human contamination; Newton bullying; Lacerta comfort |
+| Chapter 3 — Thorander/Rana pedagogy / mythic origin | Frog/newt origin myth, immortality, Orgon doctrine, Rana's ethical questioning |
+| Chapter 4 — Rana/Newton bridge where evidenced | Emerging cross-species tenderness and ethical pressure |
+| Chapter 5 — shardcoming / Dead Zone / Rana/Newton/Thorander | Shard/Dead Zone and reform pressure |
+| Chapter 6 — Hyla governance / council / Enoch / reproduction order | Council procedure, sex/breeding control, social discipline |
+| Chapter 7 — council/pollies/Brutus-Chey escalation | Governance and human threat braided |
+| Chapter 8 — human research / road trip / toadstone obsession | Human pursuit logic and myth research |
+| Chapter 9 — Zimeon-Maximilian shard friendship / games / rebellion seed | Full-manuscript coverage test; Maximilian must appear |
+| Chapter 10 — shard release / force escalation / congregation site | Human/amphibian conflict escalation |
+| Chapter 11 — Dominatus paratext / human retaliation | Moral frame and retaliation pressure |
+| Chapter 12 — emergency council / Hyla-Zimeon-Beiana-Maximilian | Governance crisis, secrecy, late shard pressure |
+| Chapter 13 — road trip / human pursuit | Brutus/Chey travel-threat lane |
+| Chapter 14 — Maalik / shard dependency / final retaliation / unresolved poison | Final pressure state, not clean closure |
+
+Required locations/worldstates:
+
+- human campsite
+- Kingdom Lake / Aqua World
+- Dead Zone
+- mine shaft / disposal site
+- frog polity / council chambers
+- newt world / forest / moss shelter
+- Thorander/Rana pedagogy spaces
+- Sanctuary / disease worldstate
+- congregation site / beachfront property where evidenced
+- road-trip / human pursuit locations
+- final bank / amphibian-track / retaliation site
+- New World / ending-space
+
+---
+
+# Layer 9 — Threat / Pressure / Ending: required additions
+
+The pressure map must include:
+
+| Pressure type | Required content |
+|---|---|
+| Human predator pressure | Brutus as toadstone seeker, experimenter, human-contamination actor, final retaliatory force |
+| Human compromised-witness pressure | Chey as partial restraint, spiritual foil, witness, and failure-to-stop force |
+| Ecological contamination | Toxic residue, mine disposal, Dead Zone, lake/world contamination |
+| Individual antagonists | Brutus, Twillow, Enoch/Hyla where acting coercively, other named forces where evidenced |
+| Governance pressure | Hyla, council, Enoch, sentinels, breeding policy, punishment, secrecy, toadstone authority |
+| Patriarchal/reform pressure | Thorander's Orgon superiority, immortality doctrine, command desire, Rana's ethical divergence |
+| Social cruelty pressure | Twillow/newt gang bullying Newton; frog name-calling/deviance policing |
+| Biological/body pressure | Amphibian skin, dehydration, poison, disease/blight, hibernation risk, reproduction, predators, injuries |
+| Shard dependency / poison pressure | Zimeon exposure, Maximilian co-use, side effects, desire to return, Hyla's fear the shard may kill him |
+| Symbolic/metaphysical pressure | Gorf, elemental Gorfs, Maalik, Dominatus, New World, immortality and afterlife doctrine |
+| Relational pressure | Rana/Newton tenderness, Hyla/Zimeon mother-ruler conflict, Zimeon/Maximilian co-rebellion |
+| Closure pressure | Toadstone, shard, Gorf, Dominatus, New World, human retaliation, disease/blight, and whether any peace is real |
+
+Ending accountability must account for:
+
+- Hyla's authority consequence and maternal fear.
+- Zimeon's shard dependence and possible poisoning.
+- Maximilian's co-participation and desire to return for more shard.
+- Thorander's reform/patriarchal logic and whether it is answered or left active.
+- Chey's conscience/action/failure.
+- Brutus's continuing human danger and final retaliation.
+- Rana's ethical intelligence and whether the cross-species bridge changes anything.
+- Newton's tenderness/vulnerability contribution and whether it is structurally paid.
+- Human damage as unresolved or answered system.
+- Mine/human-contamination system and Dead Zone poison as continuing pressures.
+- New World as literal/ethical/spiritual/plural possibility, not guaranteed closure.
+- Dominatus as indictment of domination, not decorative ending thesis.
+
+Failure condition: a ledger fails if it treats the ending as mood only, treats it as clean closure, misses Brutus's final retaliation, misses Zimeon's shard dependence, misses Maximilian, misses Hyla's fear that the crystalline substance is dangerous, or reduces all pressure to a single villain.
+
+---
+
+# Seed / Phase 1A Fit-Gap Tests
+
+A generated Story Ledger for Froggin Noggin must produce a `seed_fit_gap_report_v1` or degraded Story Ledger health if any of these are missing:
+
+1. Maximilian in canonical identity, cast role, relationship network, shard/object layer, timeline, and ending pressure.
+2. Beiana in canonical identity and governance relationship network.
+3. Lacerta and Twillow in the Newton vulnerability/social-cruelty lane.
+4. Brutus's human-contamination system, mine disposal, final retaliation, and road-trip/toadstone pursuit.
+5. Dead Zone and shard dependency as biochemical/ecological pressure, not generic magic.
+6. Hyla's council/governance system beyond vague “frog polity.”
+7. Elemental Gorf manifestations correctly routed as doctrine/worldview, not accidental extra characters.
+8. Ending classified as unresolved escalation/dependency/human retaliation, not clean closure.
+9. Ancient Bloodlines contamination guard: no Snappy unless this specific manuscript edition proves Snappy exists.

--- a/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
+++ b/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
@@ -1,0 +1,204 @@
+---
+benchmark-schema: ideal-story-ledger-9-layer-v1
+title: Cartel Babies — Ideal Story Ledger 9-Layer Benchmark
+manuscript: Cartel Babies
+author: Michael J. Meraw
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: gold-standard-story-ledger
+benchmark-tier: required-gold
+generated-for: seed-phase-and-phase-1a-baseline
+created: 2026-05-31T01:22:25Z
+source-benchmarks:
+  - docs/benchmarks/cartel-babies-dream.md
+  - docs/benchmarks/cartel-babies-dream-v2-governed-ledger-addendum.md
+---
+
+# Cartel Babies — Ideal Story Ledger 9-Layer Benchmark
+
+> Benchmark purpose: This is a filled, idealized nine-layer Story Ledger target, not a blank template.
+> Runtime purpose: SEED and Phase 1A should use this kind of completed structure as a benchmark shape.
+> Authority rule: Seed proposes; Phase 1A must use the seed as the baseline scaffold and verify/correct/reject every claim against manuscript evidence. Review Gate/accepted_story_ledger_v1 remains the authority for Phase 2.
+> Display rule: never show machine chunk labels to authors. Use chapter, scene, paragraph, page, or quoted evidence anchors.
+
+
+## Completion Standard
+
+Incomplete if it misses Benjamin as dual-POV co-protagonist, Michael/Benjamin relationship spine, Paolito-to-Paul identity payoff, table tennis as bridge activity, Raúl/Navarro governance conflict, blue evil-eye charm lifecycle, sound/music as coercive or emotional system, local Sinaloa anchors, or integrity distinctions between true defect/motif/TOC artifact/anchor issue/manual verification.
+
+---
+
+# Layer 1 — Source Integrity
+
+## Ideal status
+
+`complete_with_integrity_caveats`
+
+| Field | Gold-standard value |
+|---|---|
+| Scope | Full manuscript |
+| Route | Long-form / multi-layer |
+| Evidence distribution | Opening abduction; camp hierarchy; Paolito/table tennis; Raúl authority; Benjamin search lane; Raúl/Navarro conflict; extraction/release; Vancouver aftercare |
+
+| Concern | Correct classification |
+|---|---|
+| Repeated `Canvas Morning` issue | Distinguish confirmed duplicate body from intentional motif/mirroring and anchor/TOC artifact |
+| Chapter 37 title issue | Verify body-title before calling defect |
+| Title/package notes | Package hygiene, not story craft weakness |
+| Research/companion notes | Package/governance issue where readiness affected |
+| Violence/captivity intensity | Market/reader positioning risk, not automatically defect |
+
+Mistake-proofing: do not use opening abduction only; do not convert metadata problems into narrative defects; do not show chunk IDs.
+
+---
+
+# Layer 2 — POV Structure
+
+## Ideal status
+
+`complete_dual_lane`
+
+| POV / lane | Structural function | Required treatment |
+|---|---|---|
+| Michael | Primary captivity POV / survival intelligence | Captive observer → tactical protector → family carrier |
+| Benjamin | Dual-POV co-protagonist / Culiacán search lane | Parallel narrative engine: OCD rituals, empty house, search agency, aftercare |
+| Paolito / Paul | Emotional hinge / child-collateral identity lane | Track through Michael/Raúl/Benjamin systems |
+| Raúl | Authority/governance contradiction | Power, paternal transfer, doctrine conflict |
+| Navarro | Antagonistic doctrine pressure | Coercive order and conflict catalyst |
+
+Fails if Benjamin is only absent spouse, Michael is only structural camera, or Raúl/Navarro conflict appears sudden because authority camera was missed.
+
+---
+
+# Layer 3 — Canonical Identity
+
+## Ideal status
+
+`complete_with_identity_payoff`
+
+| Canonical entity | Type | Identity obligations |
+|---|---|---|
+| Michael | Primary character | Captive, protector, family carrier |
+| Benjamin | Co-protagonist | Search lane, rituals, empty-house behavior, Vancouver aftercare |
+| Paolito / Paul | Identity transformation character | Cartel child/collateral → protected child → renamed family member |
+| Raúl | Authority/father/governance contradiction | Cartel authority and paternal transfer |
+| Navarro | Antagonistic doctrine pressure | Must connect to Raúl conflict |
+| Camp guards | Collective force | Hierarchy/surveillance/social machine |
+| Captives | Collective force | Labor/fear/permission/dignity system |
+| El Tomatero/local anchors | Cultural specificity | Local grounding, not generic set dressing |
+
+Paolito and Paul are identity-payoff states, not random aliases. “Paul Raúl Wagner” payoff must link family legitimacy, Raúl transfer, and Benjamin/Michael aftercare.
+
+---
+
+# Layer 4 — Cast / Role Tier
+
+## Ideal status
+
+`complete_structural_roles`
+
+| Tier | Entities / forces | Role obligation |
+|---|---|---|
+| Primary protagonist | Michael | Captivity survival intelligence and protection |
+| Co-protagonist | Benjamin | Search, absence, domestic aftermath, aftercare |
+| Major emotional hinge | Paolito / Paul | Child collateral, trust, identity, family payoff |
+| Major authority | Raúl | Cartel power, paternal contradiction, transfer |
+| Antagonistic doctrine | Navarro | Coercive order and moral/governance pressure |
+| Collective social machine | Camp guards/captives | Surveillance, labor, permission, negotiated dignity |
+| Local/cultural frame | Sinaloa, El Tomatero, camp/social markers | Specificity and grounding |
+
+Failure if Benjamin underweighted, Paolito/Paul only rescued child, Raúl simple helper/villain, camp only setting, or table tennis omitted.
+
+---
+
+# Layer 5 — Pronoun Transitions
+
+## Ideal status
+
+`complete_no_reviewable_transition_unless_evidenced`
+
+Expected display unless evidence says otherwise:
+
+`No reviewable pronoun-family transitions detected.`
+
+Paolito → Paul is naming/identity/family-legitimacy transformation, not pronoun-family transition. Do not show stable registry as review burden.
+
+---
+
+# Layer 6 — Relationship Network
+
+## Ideal status
+
+`complete_relationship_spine`
+
+| Relationship / system | Function | Beginning / middle / ending obligation |
+|---|---|---|
+| Michael / Benjamin | Queer stewardship, absence, search, reunion, aftercare | Separation/fear → search agency → Vancouver aftercare |
+| Michael / Paolito-Paul | Captivity-to-family transformation | Care under coercion → identity/legal/family payoff |
+| Raúl / Navarro | Governance doctrine conflict | Make confrontation inevitable |
+| Raúl / Paolito | Fatherhood, authority, transfer | Power and paternal contradiction |
+| Benjamin / Paul | Aftercare, family legitimacy | Paul belongs to family system, not only Michael rescue story |
+| Table tennis bridge | Rules/play/permission/trust | Plot architecture linking captives, guards, Raúl, Paolito |
+| Camp guards / captives | Social system | Hierarchy, surveillance, labor, fear, dignity |
+
+Named sustained relationships here; collectives only as labeled systems.
+
+---
+
+# Layer 7 — Object / Symbol
+
+## Ideal status
+
+`complete_symbol_lifecycle`
+
+| Symbol / system | Attached characters/layers | Lifecycle obligation |
+|---|---|---|
+| Blue evil-eye charm | Michael, Paolito/Paul, Benjamin | Chapter 1 loss into crate → Paolito keeps it → Benjamin threads it in Vancouver |
+| Key ring / keys | Raúl, Michael, camp authority | Access, control, permission, authority transfer |
+| Naming / renaming | Paolito/Paul, Benjamin, Michael, Raúl | Identity instability into family-legitimacy payoff |
+| Canvas / crates / benches | Michael, captives, camp | Body-as-cargo / confinement / logistics |
+| Table tennis equipment/play-space | Paolito, Michael, guards, Raúl | Mediates trust, authority, permission |
+| Music/sound systems | Camp, punishment, trauma | Coercive or emotional system where evidenced |
+| Local cultural anchors | El Tomatero/civic markers | Sinaloa specificity |
+
+---
+
+# Layer 8 — Timeline / Location / Worldstate
+
+## Ideal status
+
+`complete_multi_location_causality`
+
+| Timeline lane | Required coverage |
+|---|---|
+| Opening abduction | Overpass/tailgate/crate/key/charm/survival logic |
+| Camp hierarchy | Guards/captives/permission/fear/labor/social rules |
+| Paolito/table tennis | Trust transfer, child protection, play under coercion |
+| Benjamin search lane | Culiacán search, rituals, empty-house behavior, agency |
+| Raúl/Navarro conflict | Doctrine conflict, governance pressure, confrontation |
+| Extraction/release | Release mechanics and moral transfer |
+| Vancouver aftercare | Renaming, family legitimacy, quiet after violence, charm payoff |
+
+Locations/worldstates: Culiacán/Sinaloa, mountain cartel camp, confinement/body spaces, table tennis play-space, Vancouver/home aftercare, cartel governance system.
+
+---
+
+# Layer 9 — Threat / Pressure / Ending
+
+## Ideal status
+
+`complete_pressure_and_closure`
+
+| Pressure type | Required content |
+|---|---|
+| Coercive antagonist | Navarro and violent cartel actors |
+| Governance contradiction | Raúl’s authority, paternal transfer, doctrine conflict |
+| Social-machine | Camp guards/captives, surveillance, labor, permission |
+| Captivity/body | Crates, canvas, benches, bodily vulnerability |
+| Separation/absence | Benjamin/Michael separation and search |
+| Identity/family | Paolito/Paul renaming, family legitimacy |
+| Sound/music | Conditioning, punishment, trauma, silence |
+| Market/ethical | Violence, cartel economy, child collateral, queer family aftercare |
+
+Ending must account for Michael, Benjamin, Paolito/Paul, Raúl, Navarro, blue charm, table tennis, and Vancouver aftercare.

--- a/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
+++ b/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
@@ -10,7 +10,7 @@ benchmark-role: gold-standard-story-ledger
 benchmark-tier: required-gold
 generated-for: seed-phase-and-phase-1a-baseline
 created: 2026-05-31T01:22:25Z
-revised: 2026-05-31T03:48:00Z
+revised: 2026-05-31T03:56:00Z
 source-benchmarks:
   - docs/benchmarks/cartel-babies-dream.md
   - docs/benchmarks/cartel-babies-dream-v2-governed-ledger-addendum.md
@@ -39,7 +39,12 @@ Incomplete if it misses any of the following:
 - Raúl / Navarro governance conflict.
 - Cobra as critical hidden-traitor / internal-coup pressure: he attempts to kill Raúl and steal a drug batch.
 - Diego as loyalty-tax / weak-link pressure: product theft, punishment, mercy, and camp discipline logic.
+- El Tomatero / Raúl / Paolito triad: El Tomatero's red-bat threat against Paolito forces Raúl to assert paternal and command authority.
 - Blue evil-eye charm lifecycle.
+- El Tomatero's red bat as an object-symbol of ritualized cartel violence, tallying, intimidation, and power reversal.
+- The pig pen / pigs as disposal-terror object-system: pigs eat leftovers and, where evidenced, dead people; this must be tracked as a fear/disposal mechanism, not scenery.
+- Crystal meth / fentanyl / cartel-lab product as a chemical-control object-system: product, lab, punishment, forced ingestion, overdose death, and suicide pressure where evidenced.
+- Radio-channel punishment system: eight radio channels escalating from minor punishment to death, with Beethoven's Fifth marking the death channel.
 - Sound/music as coercive or emotional system where supported.
 - Transit geography: mountain camp → Mazatlán/transit point → Mexico City Canadian Embassy → Vancouver/new protected home.
 - El Delgado, El Tomatero and his red bat, El Árbol, Cobra, and Diego as named cartel/camp pressure agents where evidenced.
@@ -58,7 +63,7 @@ Incomplete if it misses any of the following:
 |---|---|
 | Scope | Full manuscript |
 | Route | Long-form / multi-layer |
-| Evidence distribution | Opening abduction; Benjamin's pre-Michael family/church/school pressure; Michael/Benjamin relationship formation; camp hierarchy; El Tomatero/El Delgado/El Árbol/Cobra/Diego/cartel hierarchy; Paolito/table tennis; Raúl authority; Benjamin search lane; Cobra betrayal/drug-batch theft attempt; Raúl/Navarro conflict; extraction/release; Mazatlán/Mexico City Embassy transition; Vancouver protected-address aftercare |
+| Evidence distribution | Opening abduction; Benjamin's pre-Michael family/church/school pressure; Michael/Benjamin relationship formation; camp hierarchy; El Tomatero/El Delgado/El Árbol/Cobra/Diego/cartel hierarchy; pig pen / disposal-terror scenes; lab/product/punishment scenes; radio-channel punishment scenes; Paolito/table tennis; Raúl authority; Benjamin search lane; Cobra betrayal/drug-batch theft attempt; Raúl/Navarro conflict; extraction/release; Mazatlán/Mexico City Embassy transition; Vancouver protected-address aftercare |
 
 | Concern | Correct classification |
 |---|---|
@@ -71,8 +76,11 @@ Incomplete if it misses any of the following:
 | Benjamin's religious/family/social pressure | Formative co-protagonist pressure, not backstory filler |
 | Cobra betrayal | Internal cartel threat/coup pressure, not minor guard noise |
 | Diego product theft / loyalty tax | Camp discipline and mercy-pressure event, not incidental prisoner misconduct |
+| Pig pen / pigs | Disposal-terror and intimidation system, not only setting detail |
+| Crystal meth / fentanyl / lab product | Cartel product, chemical punishment, overdose/suicide pressure, and moral system evidence; not generic drug scenery |
+| Radio channels / Beethoven's Fifth | Punishment-code object system; eight channels from minor punishment to death, with Beethoven's Fifth as death-channel signal |
 
-Mistake-proofing: do not use opening abduction only; do not convert metadata problems into narrative defects; do not show chunk IDs; do not flatten Benjamin's social/family/religious pressure into generic homophobia; do not treat embassy/new-identity material as paperwork only; do not omit Cobra or Diego from the internal camp pressure map.
+Mistake-proofing: do not use opening abduction only; do not convert metadata problems into narrative defects; do not show chunk IDs; do not flatten Benjamin's social/family/religious pressure into generic homophobia; do not treat embassy/new-identity material as paperwork only; do not omit Cobra, Diego, El Tomatero's bat, pigs/pig-pen disposal terror, cartel-lab product, or radio-channel punishment system from the pressure map.
 
 ---
 
@@ -84,18 +92,18 @@ Mistake-proofing: do not use opening abduction only; do not convert metadata pro
 
 | POV / lane | Structural function | Required treatment |
 |---|---|---|
-| Michael | Primary captivity POV / survival intelligence | Captive observer → tactical protector → conditional negotiator → family carrier |
+| Michael | Primary captivity POV / survival intelligence | Captive observer → tactical protector → conditional negotiator → family carrier; must register the camp's disposal, product, punishment, radio-channel, and terror systems |
 | Benjamin | Dual-POV co-protagonist / Culiacán search lane | Parallel engine: family pressure, church condemnation, professor/classmate hostility, OCD/rituals, empty-house behavior, search agency, embassy transition, Canadian aftercare |
-| Paolito / Paul | Emotional hinge / child-collateral identity lane | Track through Raúl, Michael, Benjamin, embassy identity, and Canadian family systems |
-| Raúl | Authority/governance contradiction | Power, paternal transfer, doctrine conflict, gradual trust in Michael around Paolito, attempted betrayal/assassination pressure from Cobra |
+| Paolito / Paul | Emotional hinge / child-collateral identity lane | Track through Raúl, Michael, Benjamin, El Tomatero threat, embassy identity, and Canadian family systems |
+| Raúl | Authority/governance contradiction | Power, paternal transfer, doctrine conflict, gradual trust in Michael around Paolito, attempted betrayal/assassination pressure from Cobra, refusal or assertion when enforcer violence threatens Paolito |
 | Navarro | Antagonistic doctrine pressure | Coercive order and conflict catalyst |
 | Cobra | Hidden traitor / internal coup pressure | Track as apparent camp operative who later attempts to kill Raúl and steal a drug batch; must not be treated as ordinary guard background |
-| Diego | Weak-link / loyalty-tax pressure | Track product theft, punishment, Raúl's mercy, and the way his instability exposes camp discipline rules |
-| El Tomatero | Camp enforcer / ritualized violence / bat-symbol carrier | Track intimidation, child threat, red-bat hierarchy, and confrontation with Raúl |
+| Diego | Weak-link / loyalty-tax pressure | Track product theft, punishment, Raúl's mercy, and how instability exposes camp discipline rules |
+| El Tomatero | Camp enforcer / ritualized violence / bat-symbol carrier | Track intimidation, child threat, red-bat hierarchy, pig-pen terror, radio-channel punishment logic, and confrontation with Raúl |
 | El Delgado | Named cartel/camp pressure agent where evidenced | Must be tracked if present as more than a one-off label |
 | El Árbol | Big-boss / cartel command pressure where evidenced | Must be tracked as hierarchy pressure and assassination/camp destabilization event where evidenced |
 
-Fails if Benjamin is only absent spouse, Michael is only structural camera, Raúl/Navarro conflict appears sudden, Cobra is omitted from betrayal logic, Diego is omitted from loyalty-tax logic, or the Benjamin family/church/school pressure lane is treated as disposable background.
+Fails if Benjamin is only absent spouse, Michael is only structural camera, Raúl/Navarro conflict appears sudden, Cobra is omitted from betrayal logic, Diego is omitted from loyalty-tax logic, El Tomatero's red-bat threat against Paolito is omitted, or the pig/product/radio punishment systems are treated as scenery.
 
 ---
 
@@ -110,7 +118,7 @@ Fails if Benjamin is only absent spouse, Michael is only structural camera, Raú
 | Michael / Michael Wagner | Primary character | Captive, protector, family carrier; original identity and embassy-issued new identity must be connected |
 | Benjamin / Benjamin Wagner | Co-protagonist | Search lane, family/church/school pressure, rituals, empty-house behavior, Mexico City Embassy transition, Vancouver aftercare, protected identity |
 | Paolito / Paul / Paul Raúl Wagner | Identity transformation character | Cartel child/collateral → protected child → Paolito Raúl Wagner / Paul Raúl Wagner family member; do not split as unrelated people |
-| Raúl | Authority/father/governance contradiction | Cartel authority, Paolito's father, paternal transfer, conditional trust in Michael, target of Cobra betrayal |
+| Raúl | Authority/father/governance contradiction | Cartel authority, Paolito's father, paternal transfer, conditional trust in Michael, target of Cobra betrayal, command authority tested by El Tomatero's threat against Paolito |
 | Navarro | Antagonistic doctrine pressure | Must connect to Raúl conflict |
 | Cobra | Hidden traitor / internal cartel threat | Do not treat as generic driver/guard; track betrayal arc, attempted killing of Raúl, and attempted drug-batch theft |
 | Diego | Weak-link / loyalty-tax figure | Track product theft, punishment, mercy, and later instability/pressure function |
@@ -122,10 +130,13 @@ Fails if Benjamin is only absent spouse, Michael is only structural camera, Raú
 | Female classmates | Protective social buffer where evidenced | Do not overstate as romance; functions as shield/social cover |
 | Camp guards | Collective force | Hierarchy/surveillance/social machine |
 | Captives | Collective force | Labor/fear/permission/dignity system |
-| El Tomatero | Named enforcer / symbolic violence carrier | Red bat, notches/marks, intimidation, Paolito threat, Raúl confrontation |
+| El Tomatero | Named enforcer / symbolic violence carrier | Red bat, notches/marks, intimidation, Paolito threat, pig-pen terror, radio-channel punishment logic, Raúl confrontation |
 | El Delgado | Named cartel/camp pressure agent | Include if evidenced as distinct person/role |
 | El Árbol | Big boss / command hierarchy | Include as cartel authority and assassination/camp hierarchy event where evidenced |
 | El Tomatero's bat | Object-symbol, not person | Do not create separate character from object |
+| Pigs / pig pen | Object-location pressure system, not character | Disposal-terror system; do not classify as simple animal character unless a specific named animal exists |
+| Crystal meth / fentanyl / lab product | Object/product/system | Chemical product and punishment vector; do not treat as generic background substance |
+| Radio channels / Beethoven's Fifth | Object-symbol / punishment-code system | Eight radio channels map punishment escalation from minor consequence to death; Beethoven's Fifth marks death-channel signal |
 | Canadian Embassy / CBSA / Public Safety Canada | Institutional rescue/protection systems | Treat as institutional actors, not ordinary characters |
 
 Paolito, Paul, Paolito Raúl Wagner, and Paul Raúl Wagner are identity states under one canonical child. Michael and Benjamin's embassy-issued names must remain linked to prior identities. Cobra must remain separate from other guards because his betrayal changes the internal threat structure.
@@ -142,19 +153,22 @@ Paolito, Paul, Paolito Raúl Wagner, and Paul Raúl Wagner are identity states u
 |---|---|---|
 | Primary protagonist | Michael | Captivity survival intelligence, protection, negotiation, family carrying |
 | Co-protagonist | Benjamin | Family/church/school pressure, relationship origin, search, absence, domestic aftermath, aftercare |
-| Major emotional hinge | Paolito / Paul | Child collateral, trust, identity, family payoff |
-| Major authority | Raúl | Cartel power, paternal contradiction, transfer, trust evolution with Michael |
+| Major emotional hinge | Paolito / Paul | Child collateral, trust, identity, family payoff; threat target in El Tomatero/Raúl conflict |
+| Major authority | Raúl | Cartel power, paternal contradiction, transfer, trust evolution with Michael, command/paternal assertion against El Tomatero |
 | Antagonistic doctrine | Navarro | Coercive order and moral/governance pressure |
 | Internal betrayal / coup pressure | Cobra | Apparent operative/driver/insider who attempts to kill Raúl and steal a drug batch; major internal threat |
 | Weak-link discipline pressure | Diego | Product theft, loyalty tax, punishment/mercy, camp discipline proof |
-| Named enforcer pressure | El Tomatero | Red-bat violence, intimidation, Paolito threat, confrontation with Raúl |
+| Named enforcer pressure | El Tomatero | Red-bat violence, intimidation, Paolito threat, pig-pen terror, radio-channel punishment control, confrontation with Raúl |
 | Named cartel hierarchy pressure | El Delgado, El Árbol | Include as distinct hierarchy/command agents when evidenced |
 | Benjamin origin-pressure system | Father, mother, church/pastor, professors, classmates/students | Machismo, religious condemnation, educational pressure, homophobic social threat |
+| Cartel product/punishment system | Lab, crystal meth/fentanyl/product, forced ingestion, overdose, suicide pressure | Chemical violence and punishment logic, not mere object inventory |
+| Radio-channel punishment system | Eight radio channels, Beethoven's Fifth death channel | Encoded camp control system escalating punishment severity, not background sound |
+| Disposal-terror system | Pig pen / pigs / leftovers / dead bodies | Camp terror and disposal infrastructure, not scenery |
 | Collective social machine | Camp guards/captives | Surveillance, labor, permission, negotiated dignity |
 | Institutional rescue/protection | Canadian Embassy, CBSA, Public Safety Canada | New identities, protected address, relocation, safety architecture |
 | Local/cultural frame | Culiacán, Sinaloa, Mazatlán, El Tomatero/baseball mythology, El Tomatero's bat | Specificity and grounding |
 
-Failure if Benjamin's father/church/professors/students disappear, Michael/Raúl is missing, Cobra is not treated as a major internal betrayal force, Diego is not tracked as loyalty-tax pressure, El Tomatero is only a local anchor instead of enforcer, or the Canada relocation/protection system is omitted.
+Failure if Benjamin's father/church/professors/students disappear, Michael/Raúl is missing, Cobra is not treated as a major internal betrayal force, Diego is not tracked as loyalty-tax pressure, El Tomatero is only a local anchor instead of enforcer, the Raúl/El Tomatero/Paolito triad is missing, or the pigs/lab/product/radio-channel punishment systems are omitted.
 
 ---
 
@@ -198,12 +212,14 @@ Paolito → Paul / Paul Raúl Wagner is naming, guardianship, legal/family ident
 | Michael / Diego | Watchfulness and weak-link management | Michael observes Diego's instability and understands how weakness spreads through the camp system |
 | Raúl / El Tomatero | Authority vs enforcer violence | Red-bat intimidation culminates in Raúl defending Paolito and asserting command |
 | El Tomatero / Paolito | Child-threat pressure | Track bat-marking, pig-pen danger, fear, and why Raúl's response matters |
+| Raúl / El Tomatero / Paolito triad | Authority, enforcer violence, and paternal protection | El Tomatero's red-bat threat against Paolito forces Raúl to choose between tolerating enforcer cruelty and asserting paternal/command authority |
+| Radio channels / camp population | Encoded punishment communication | Eight channels signal escalating punishment levels from minor consequence to death; Beethoven's Fifth marks the death channel and turns music into control infrastructure |
 | Benjamin / Paul | Aftercare, family legitimacy, renaming reception | Paul belongs to family system, not only Michael's rescue story |
 | Table tennis bridge | Rules/play/permission/trust | Plot architecture linking captives, guards, Raúl, Michael, and Paolito |
 | Camp guards / captives | Social system | Hierarchy, surveillance, labor, fear, dignity |
 | Benjamin's family / Canadian relocation | Protective consequence | Benjamin's family relocation to Canada must be tracked as downstream safety consequence where evidenced |
 
-Named sustained relationships here; collectives only as labeled systems. Do not route Cobra's betrayal, Diego's product-theft/mercy sequence, or Benjamin's origin pressure to vague “background pressure” if they materially shape the arc.
+Named sustained relationships here; collectives only as labeled systems. Do not route Cobra's betrayal, Diego's product-theft/mercy sequence, El Tomatero's red-bat threat, the radio-channel punishment system, or Benjamin's origin pressure to vague “background pressure” if they materially shape the arc.
 
 ---
 
@@ -219,17 +235,20 @@ Named sustained relationships here; collectives only as labeled systems. Do not 
 | Key ring / keys | Raúl, Michael, camp authority | Access, control, permission, authority transfer |
 | Emergency passports / travel documents / protected identity papers | Michael, Benjamin, Paolito/Paul, Embassy/CBSA/Public Safety | Michael Wagner, Benjamin Wagner, Paul/Paolito Raúl Wagner identity transition; safety and erased trail |
 | Naming / renaming | Paolito/Paul, Benjamin, Michael, Raúl | Identity instability into family-legitimacy payoff |
+| Radio channels / Beethoven's Fifth | Camp, guards, captives, El Tomatero, punishment system | Eight-channel punishment code: lower channels indicate lesser punishment, escalating to death; Beethoven's Fifth marks or announces the death channel |
 | Cobra's stolen/targeted drug batch | Cobra, Raúl, camp hierarchy | Internal betrayal object: product becomes motive for attempted killing and coup/escape pressure |
 | Product / stolen product | Diego, Raúl, Delegado/camp discipline | Loyalty-tax object: product theft triggers punishment/mercy logic |
+| Crystal meth / fentanyl / lab product | Lab, cartel economy, punishment scenes, captives | Chemical product and punishment vector: forced ingestion, overdose death, suicide pressure, and cartel economy logic |
+| Pig pen / pigs / leftovers / dead bodies | El Tomatero, camp, captives, Paolito, Raúl | Disposal-terror system: pigs eat leftovers and, where evidenced, dead people; converts the pig pen into intimidation and body-disposal infrastructure |
 | Canvas / crates / benches | Michael, captives, camp | Body-as-cargo / confinement / logistics |
 | Table tennis equipment/play-space | Paolito, Michael, guards, Raúl | Mediates trust, authority, permission, social temperature |
 | El Tomatero's red bat | El Tomatero, Paolito, Raúl, camp | Ritualized violence, tally marks, intimidation, child threat, power reversal when Raúl takes it |
-| Music/sound systems | Camp, punishment, trauma | Coercive or emotional system where evidenced |
+| Music/sound systems | Camp, punishment, trauma, radio channels | Coercive or emotional system where evidenced; include Beethoven's Fifth when it functions as death-channel signal |
 | VIBER / Grindr / phone/profile | Benjamin, Michael | Queer self-recognition and relationship origin where evidenced |
 | Church/pulpit language | Benjamin, pastor, family/community pressure | Symbolic/religious condemnation system, not decorative background |
 | Local cultural anchors | El Tomatero/civic markers, Mazatlán/Culiacán/Sinaloa markers | Sinaloa specificity |
 
-Do not treat embassy documents as mere props; they are identity/safety/legal-payoff objects. Do not treat the red bat only as scenery. Do not miss drug/product as a pressure object when it drives Diego's punishment or Cobra's betrayal.
+Do not treat embassy documents as mere props; they are identity/safety/legal-payoff objects. Do not treat the red bat only as scenery. Do not treat pigs as ordinary animals if they function as disposal terror. Do not miss drug/product as a pressure object when it drives Diego's punishment, Cobra's betrayal, forced ingestion, overdose, or suicide pressure. Do not treat Beethoven's Fifth as mere background music if it marks a death channel.
 
 ---
 
@@ -246,9 +265,12 @@ Do not treat embassy documents as mere props; they are identity/safety/legal-pay
 | Mountain camp hierarchy | Guards/captives/permission/fear/labor/social rules, El Tomatero, El Delgado, El Árbol, Cobra, Diego/cartel command hierarchy where evidenced |
 | Michael / Raúl evolution | Captive-captor assessment → conversations/utility → trust around Paolito |
 | Paolito/table tennis | Trust transfer, child protection, play under coercion |
-| El Tomatero / bat escalation | Bat marks, child threat, pig-pen incident, Raúl confrontation |
+| El Tomatero / Raúl / Paolito triad | Bat marks, child threat, pig-pen incident, Raúl confrontation, Raúl's paternal/command assertion |
 | Diego loyalty-tax sequence | Product theft → public discipline → Raúl mercy → changed cost/accountability |
 | Cobra betrayal sequence | Insider watchfulness/suspicion → attempted killing of Raúl → attempted drug-batch theft → internal camp rupture |
+| Radio-channel punishment sequence | Eight channels escalate punishment from minor to death; Beethoven's Fifth signals death-channel terror where evidenced |
+| Pig pen / disposal-terror sequence | Leftovers, dead-body disposal where evidenced, pig-pen threat, and its intimidation effect on Paolito/captives |
+| Lab/product punishment sequence | Crystal meth/fentanyl/product production, forced ingestion, overdose death, and suicide pressure where evidenced |
 | Benjamin search lane | Culiacán search, rituals, empty-house behavior, agency |
 | Raúl/Navarro conflict | Doctrine conflict, governance pressure, confrontation |
 | Extraction/release | Release mechanics and moral transfer |
@@ -257,7 +279,7 @@ Do not treat embassy documents as mere props; they are identity/safety/legal-pay
 | Vancouver protected home | CBSA/Public Safety processing, protected-address arrangement, family aftercare |
 | Benjamin family relocation | Benjamin's family relocation to Canada for safety where evidenced |
 
-Locations/worldstates: Culiacán/Sinaloa, Benjamin's family home, church/community, medical school/university, VIBER/Grindr/social spaces, mountain camp, pig pen, table tennis space, El Tomatero's camp sphere, Cobra/Diego loyalty fracture scenes, Mazatlán transit point, Mexico City Canadian Embassy, aircraft/controlled transit, Vancouver hangar/private processing suite, protected Canadian home/address.
+Locations/worldstates: Culiacán/Sinaloa, Benjamin's family home, church/community, medical school/university, VIBER/Grindr/social spaces, mountain camp, pig pen, lab/product area, radio-channel/audio punishment infrastructure, table tennis space, El Tomatero's camp sphere, Cobra/Diego loyalty fracture scenes, Mazatlán transit point, Mexico City Canadian Embassy, aircraft/controlled transit, Vancouver hangar/private processing suite, protected Canadian home/address.
 
 ---
 
@@ -272,7 +294,10 @@ Locations/worldstates: Culiacán/Sinaloa, Benjamin's family home, church/communi
 | Coercive antagonist | Navarro, violent cartel actors, El Delgado/El Árbol hierarchy where evidenced |
 | Internal betrayal / coup pressure | Cobra attempts to kill Raúl and steal a drug batch; this must be tracked as a major internal cartel rupture |
 | Weak-link / loyalty-tax pressure | Diego steals product, is punished/spared, and exposes the cost of mercy/discipline |
-| Enforcer violence | El Tomatero, red bat, child-threat pressure, pig-pen danger |
+| Enforcer violence | El Tomatero, red bat, child-threat pressure, pig-pen danger, and the Raúl/Paolito command-protection rupture |
+| Radio-channel punishment pressure | Eight radio channels encode escalating punishment from minor consequence to death; Beethoven's Fifth marks death-channel terror |
+| Chemical punishment / product pressure | Crystal meth/fentanyl/product, forced ingestion, overdose death, suicide pressure, lab economy |
+| Disposal-terror pressure | Pig pen, pigs eating leftovers and dead people where evidenced, body-disposal intimidation |
 | Governance contradiction | Raúl's authority, paternal transfer, doctrine conflict, trust in Michael |
 | Social-machine | Camp guards/captives, surveillance, labor, permission |
 | Captivity/body | Crates, canvas, benches, injuries, bodily vulnerability |
@@ -280,7 +305,7 @@ Locations/worldstates: Culiacán/Sinaloa, Benjamin's family home, church/communi
 | Benjamin origin pressure | Father, mother, church/pastor, professors, classmates, homophobic/machismo pressure |
 | Identity/family | Paolito/Paul renaming, Michael/Benjamin new identities, protected-address arrangement, family legitimacy |
 | Transit/safety | Mazatlán, Mexico City Embassy, controlled departure, Vancouver, Benjamin family relocation |
-| Sound/music | Conditioning, punishment, trauma, silence |
+| Sound/music | Conditioning, punishment, trauma, silence, Beethoven's Fifth death-channel signal |
 | Market/ethical | Violence, cartel economy, child collateral, queer family aftercare |
 
-Ending must account for Michael, Benjamin, Paolito/Paul, Raúl, Navarro, Cobra, Diego, El Tomatero, El Delgado/El Árbol if evidenced, blue charm, red bat, table tennis, embassy identity transition, Vancouver aftercare, protected address, and Benjamin-family relocation safety logic. A ledger fails if it treats the ending as only rescue or romance and misses legal identity, relocation, Cobra's betrayal, Diego's loyalty-tax function, and safety architecture.
+Ending must account for Michael, Benjamin, Paolito/Paul, Raúl, Navarro, Cobra, Diego, El Tomatero, El Delgado/El Árbol if evidenced, blue charm, red bat, radio-channel punishment code, Beethoven's Fifth, pig-pen disposal terror, lab/product chemical punishment, table tennis, embassy identity transition, Vancouver aftercare, protected address, and Benjamin-family relocation safety logic. A ledger fails if it treats the ending as only rescue or romance and misses legal identity, relocation, Cobra's betrayal, Diego's loyalty-tax function, El Tomatero/Raúl/Paolito, radio-channel terror, pig disposal, chemical punishment, and safety architecture.

--- a/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
+++ b/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
@@ -10,6 +10,7 @@ benchmark-role: gold-standard-story-ledger
 benchmark-tier: required-gold
 generated-for: seed-phase-and-phase-1a-baseline
 created: 2026-05-31T01:22:25Z
+revised: 2026-05-31T03:48:00Z
 source-benchmarks:
   - docs/benchmarks/cartel-babies-dream.md
   - docs/benchmarks/cartel-babies-dream-v2-governed-ledger-addendum.md
@@ -22,10 +23,28 @@ source-benchmarks:
 > Authority rule: Seed proposes; Phase 1A must use the seed as the baseline scaffold and verify/correct/reject every claim against manuscript evidence. Review Gate/accepted_story_ledger_v1 remains the authority for Phase 2.
 > Display rule: never show machine chunk labels to authors. Use chapter, scene, paragraph, page, or quoted evidence anchors.
 
-
 ## Completion Standard
 
-Incomplete if it misses Benjamin as dual-POV co-protagonist, Michael/Benjamin relationship spine, Paolito-to-Paul identity payoff, table tennis as bridge activity, Raúl/Navarro governance conflict, blue evil-eye charm lifecycle, sound/music as coercive or emotional system, local Sinaloa anchors, or integrity distinctions between true defect/motif/TOC artifact/anchor issue/manual verification.
+Incomplete if it misses any of the following:
+
+- Benjamin as dual-POV co-protagonist, not merely Michael's absent partner.
+- Benjamin's father, mother, church/pastor, professors, classmates, and medical-school social environment as formative pressure systems.
+- Michael / Benjamin relationship spine.
+- Michael / Raúl captive-captor relationship and its evolution into conditional trust.
+- Raúl trusting Michael with Paolito.
+- Paolito-to-Paul identity transformation.
+- Embassy/new-identity transition for Michael, Benjamin, and Paolito/Paul.
+- Benjamin's family relocation to Canada as protective consequence.
+- Table tennis as bridge activity.
+- Raúl / Navarro governance conflict.
+- Cobra as critical hidden-traitor / internal-coup pressure: he attempts to kill Raúl and steal a drug batch.
+- Diego as loyalty-tax / weak-link pressure: product theft, punishment, mercy, and camp discipline logic.
+- Blue evil-eye charm lifecycle.
+- Sound/music as coercive or emotional system where supported.
+- Transit geography: mountain camp → Mazatlán/transit point → Mexico City Canadian Embassy → Vancouver/new protected home.
+- El Delgado, El Tomatero and his red bat, El Árbol, Cobra, and Diego as named cartel/camp pressure agents where evidenced.
+- Sinaloa/local anchors such as El Tomatero, El Tomatero's bat, El Delgado, El Árbol, El Tomatero/baseball mythology, Mazatlán, Culiacán, and civic/local markers.
+- Integrity distinctions between true defect, motif, TOC artifact, anchor issue, and manual verification.
 
 ---
 
@@ -39,7 +58,7 @@ Incomplete if it misses Benjamin as dual-POV co-protagonist, Michael/Benjamin re
 |---|---|
 | Scope | Full manuscript |
 | Route | Long-form / multi-layer |
-| Evidence distribution | Opening abduction; camp hierarchy; Paolito/table tennis; Raúl authority; Benjamin search lane; Raúl/Navarro conflict; extraction/release; Vancouver aftercare |
+| Evidence distribution | Opening abduction; Benjamin's pre-Michael family/church/school pressure; Michael/Benjamin relationship formation; camp hierarchy; El Tomatero/El Delgado/El Árbol/Cobra/Diego/cartel hierarchy; Paolito/table tennis; Raúl authority; Benjamin search lane; Cobra betrayal/drug-batch theft attempt; Raúl/Navarro conflict; extraction/release; Mazatlán/Mexico City Embassy transition; Vancouver protected-address aftercare |
 
 | Concern | Correct classification |
 |---|---|
@@ -48,8 +67,12 @@ Incomplete if it misses Benjamin as dual-POV co-protagonist, Michael/Benjamin re
 | Title/package notes | Package hygiene, not story craft weakness |
 | Research/companion notes | Package/governance issue where readiness affected |
 | Violence/captivity intensity | Market/reader positioning risk, not automatically defect |
+| Canadian Embassy / protected-identity material | Identity/authority/ending-payoff logic, not administrative trivia |
+| Benjamin's religious/family/social pressure | Formative co-protagonist pressure, not backstory filler |
+| Cobra betrayal | Internal cartel threat/coup pressure, not minor guard noise |
+| Diego product theft / loyalty tax | Camp discipline and mercy-pressure event, not incidental prisoner misconduct |
 
-Mistake-proofing: do not use opening abduction only; do not convert metadata problems into narrative defects; do not show chunk IDs.
+Mistake-proofing: do not use opening abduction only; do not convert metadata problems into narrative defects; do not show chunk IDs; do not flatten Benjamin's social/family/religious pressure into generic homophobia; do not treat embassy/new-identity material as paperwork only; do not omit Cobra or Diego from the internal camp pressure map.
 
 ---
 
@@ -57,17 +80,22 @@ Mistake-proofing: do not use opening abduction only; do not convert metadata pro
 
 ## Ideal status
 
-`complete_dual_lane`
+`complete_dual_lane_plus_origin_pressure`
 
 | POV / lane | Structural function | Required treatment |
 |---|---|---|
-| Michael | Primary captivity POV / survival intelligence | Captive observer → tactical protector → family carrier |
-| Benjamin | Dual-POV co-protagonist / Culiacán search lane | Parallel narrative engine: OCD rituals, empty house, search agency, aftercare |
-| Paolito / Paul | Emotional hinge / child-collateral identity lane | Track through Michael/Raúl/Benjamin systems |
-| Raúl | Authority/governance contradiction | Power, paternal transfer, doctrine conflict |
+| Michael | Primary captivity POV / survival intelligence | Captive observer → tactical protector → conditional negotiator → family carrier |
+| Benjamin | Dual-POV co-protagonist / Culiacán search lane | Parallel engine: family pressure, church condemnation, professor/classmate hostility, OCD/rituals, empty-house behavior, search agency, embassy transition, Canadian aftercare |
+| Paolito / Paul | Emotional hinge / child-collateral identity lane | Track through Raúl, Michael, Benjamin, embassy identity, and Canadian family systems |
+| Raúl | Authority/governance contradiction | Power, paternal transfer, doctrine conflict, gradual trust in Michael around Paolito, attempted betrayal/assassination pressure from Cobra |
 | Navarro | Antagonistic doctrine pressure | Coercive order and conflict catalyst |
+| Cobra | Hidden traitor / internal coup pressure | Track as apparent camp operative who later attempts to kill Raúl and steal a drug batch; must not be treated as ordinary guard background |
+| Diego | Weak-link / loyalty-tax pressure | Track product theft, punishment, Raúl's mercy, and the way his instability exposes camp discipline rules |
+| El Tomatero | Camp enforcer / ritualized violence / bat-symbol carrier | Track intimidation, child threat, red-bat hierarchy, and confrontation with Raúl |
+| El Delgado | Named cartel/camp pressure agent where evidenced | Must be tracked if present as more than a one-off label |
+| El Árbol | Big-boss / cartel command pressure where evidenced | Must be tracked as hierarchy pressure and assassination/camp destabilization event where evidenced |
 
-Fails if Benjamin is only absent spouse, Michael is only structural camera, or Raúl/Navarro conflict appears sudden because authority camera was missed.
+Fails if Benjamin is only absent spouse, Michael is only structural camera, Raúl/Navarro conflict appears sudden, Cobra is omitted from betrayal logic, Diego is omitted from loyalty-tax logic, or the Benjamin family/church/school pressure lane is treated as disposable background.
 
 ---
 
@@ -75,20 +103,32 @@ Fails if Benjamin is only absent spouse, Michael is only structural camera, or R
 
 ## Ideal status
 
-`complete_with_identity_payoff`
+`complete_with_identity_payoff_and_rename_chain`
 
 | Canonical entity | Type | Identity obligations |
 |---|---|---|
-| Michael | Primary character | Captive, protector, family carrier |
-| Benjamin | Co-protagonist | Search lane, rituals, empty-house behavior, Vancouver aftercare |
-| Paolito / Paul | Identity transformation character | Cartel child/collateral → protected child → renamed family member |
-| Raúl | Authority/father/governance contradiction | Cartel authority and paternal transfer |
+| Michael / Michael Wagner | Primary character | Captive, protector, family carrier; original identity and embassy-issued new identity must be connected |
+| Benjamin / Benjamin Wagner | Co-protagonist | Search lane, family/church/school pressure, rituals, empty-house behavior, Mexico City Embassy transition, Vancouver aftercare, protected identity |
+| Paolito / Paul / Paul Raúl Wagner | Identity transformation character | Cartel child/collateral → protected child → Paolito Raúl Wagner / Paul Raúl Wagner family member; do not split as unrelated people |
+| Raúl | Authority/father/governance contradiction | Cartel authority, Paolito's father, paternal transfer, conditional trust in Michael, target of Cobra betrayal |
 | Navarro | Antagonistic doctrine pressure | Must connect to Raúl conflict |
+| Cobra | Hidden traitor / internal cartel threat | Do not treat as generic driver/guard; track betrayal arc, attempted killing of Raúl, and attempted drug-batch theft |
+| Diego | Weak-link / loyalty-tax figure | Track product theft, punishment, mercy, and later instability/pressure function |
+| Benjamin's father | Family authority / machismo-pressure force | Precision, obedience, masculinity expectations; must not be omitted from Benjamin's origin pressure |
+| Benjamin's mother | Respectability/order pressure | Cleanliness, appearance, social fear, family pressure |
+| Benjamin's church / pastor | Religious condemnation system | Tracks sermons/expectations/shame around being gay |
+| Professors / medical-school authority | Institutional pressure | Smirks, professional gatekeeping, teacher who calls him maricón where evidenced |
+| Male classmates / students | Peer hostility | Mockery, sexualized homophobic insult, masculinity policing |
+| Female classmates | Protective social buffer where evidenced | Do not overstate as romance; functions as shield/social cover |
 | Camp guards | Collective force | Hierarchy/surveillance/social machine |
 | Captives | Collective force | Labor/fear/permission/dignity system |
-| El Tomatero/local anchors | Cultural specificity | Local grounding, not generic set dressing |
+| El Tomatero | Named enforcer / symbolic violence carrier | Red bat, notches/marks, intimidation, Paolito threat, Raúl confrontation |
+| El Delgado | Named cartel/camp pressure agent | Include if evidenced as distinct person/role |
+| El Árbol | Big boss / command hierarchy | Include as cartel authority and assassination/camp hierarchy event where evidenced |
+| El Tomatero's bat | Object-symbol, not person | Do not create separate character from object |
+| Canadian Embassy / CBSA / Public Safety Canada | Institutional rescue/protection systems | Treat as institutional actors, not ordinary characters |
 
-Paolito and Paul are identity-payoff states, not random aliases. “Paul Raúl Wagner” payoff must link family legitimacy, Raúl transfer, and Benjamin/Michael aftercare.
+Paolito, Paul, Paolito Raúl Wagner, and Paul Raúl Wagner are identity states under one canonical child. Michael and Benjamin's embassy-issued names must remain linked to prior identities. Cobra must remain separate from other guards because his betrayal changes the internal threat structure.
 
 ---
 
@@ -96,19 +136,25 @@ Paolito and Paul are identity-payoff states, not random aliases. “Paul Raúl W
 
 ## Ideal status
 
-`complete_structural_roles`
+`complete_structural_roles_with_origin_and_exit_systems`
 
 | Tier | Entities / forces | Role obligation |
 |---|---|---|
-| Primary protagonist | Michael | Captivity survival intelligence and protection |
-| Co-protagonist | Benjamin | Search, absence, domestic aftermath, aftercare |
+| Primary protagonist | Michael | Captivity survival intelligence, protection, negotiation, family carrying |
+| Co-protagonist | Benjamin | Family/church/school pressure, relationship origin, search, absence, domestic aftermath, aftercare |
 | Major emotional hinge | Paolito / Paul | Child collateral, trust, identity, family payoff |
-| Major authority | Raúl | Cartel power, paternal contradiction, transfer |
+| Major authority | Raúl | Cartel power, paternal contradiction, transfer, trust evolution with Michael |
 | Antagonistic doctrine | Navarro | Coercive order and moral/governance pressure |
+| Internal betrayal / coup pressure | Cobra | Apparent operative/driver/insider who attempts to kill Raúl and steal a drug batch; major internal threat |
+| Weak-link discipline pressure | Diego | Product theft, loyalty tax, punishment/mercy, camp discipline proof |
+| Named enforcer pressure | El Tomatero | Red-bat violence, intimidation, Paolito threat, confrontation with Raúl |
+| Named cartel hierarchy pressure | El Delgado, El Árbol | Include as distinct hierarchy/command agents when evidenced |
+| Benjamin origin-pressure system | Father, mother, church/pastor, professors, classmates/students | Machismo, religious condemnation, educational pressure, homophobic social threat |
 | Collective social machine | Camp guards/captives | Surveillance, labor, permission, negotiated dignity |
-| Local/cultural frame | Sinaloa, El Tomatero, camp/social markers | Specificity and grounding |
+| Institutional rescue/protection | Canadian Embassy, CBSA, Public Safety Canada | New identities, protected address, relocation, safety architecture |
+| Local/cultural frame | Culiacán, Sinaloa, Mazatlán, El Tomatero/baseball mythology, El Tomatero's bat | Specificity and grounding |
 
-Failure if Benjamin underweighted, Paolito/Paul only rescued child, Raúl simple helper/villain, camp only setting, or table tennis omitted.
+Failure if Benjamin's father/church/professors/students disappear, Michael/Raúl is missing, Cobra is not treated as a major internal betrayal force, Diego is not tracked as loyalty-tax pressure, El Tomatero is only a local anchor instead of enforcer, or the Canada relocation/protection system is omitted.
 
 ---
 
@@ -122,7 +168,7 @@ Expected display unless evidence says otherwise:
 
 `No reviewable pronoun-family transitions detected.`
 
-Paolito → Paul is naming/identity/family-legitimacy transformation, not pronoun-family transition. Do not show stable registry as review burden.
+Paolito → Paul / Paul Raúl Wagner is naming, guardianship, legal/family identity, and safety transformation, not a pronoun-family transition. Michael Wagner and Benjamin Wagner are protected-identity transitions, not pronoun transitions. Do not show stable pronoun registry as review burden.
 
 ---
 
@@ -130,19 +176,34 @@ Paolito → Paul is naming/identity/family-legitimacy transformation, not pronou
 
 ## Ideal status
 
-`complete_relationship_spine`
+`complete_relationship_spine_plus_pressure_network`
 
 | Relationship / system | Function | Beginning / middle / ending obligation |
 |---|---|---|
-| Michael / Benjamin | Queer stewardship, absence, search, reunion, aftercare | Separation/fear → search agency → Vancouver aftercare |
-| Michael / Paolito-Paul | Captivity-to-family transformation | Care under coercion → identity/legal/family payoff |
+| Michael / Benjamin | Queer stewardship, safety, confidence, absence, search, reunion, aftercare | First connection and public gay confidence → separation/fear → search agency → embassy/family transition → Vancouver protected home |
+| Benjamin / father | Machismo, obedience, conditional love, gender/sexuality pressure | Family expectation and silence become part of Benjamin's need for a self-owned life |
+| Benjamin / mother | Order, respectability, fear of softness/shame | Track domestic pressure and social appearance logic |
+| Benjamin / church / pastor | Religious condemnation and internalized shame | Must be treated as formative pressure, not incidental setting |
+| Benjamin / professors | Institutional status pressure and professional humiliation | Track medical-school authority pressure and “teacher/professor” hostility where evidenced |
+| Benjamin / male classmates/students | Homophobic peer threat | Track mockery, sexualized insult, masculinity policing, and isolation |
+| Benjamin / female classmates | Social shield/protective buffer | Track as cover/protection where evidenced, not romance |
+| Michael / Raúl | Captive-captor relationship evolving into conditional trust | Starts as ownership/problem assessment → utility conversations → Michael proves protective/competent → Raúl trusts Michael with Paolito |
+| Michael / Paolito-Paul | Captivity-to-family transformation | Care under coercion → protection from camp harm → embassy guardianship → Canadian family payoff |
+| Raúl / Paolito | Fatherhood, authority, transfer | Raúl's paternal contradiction and eventual transfer of responsibility |
+| Raúl / Michael / Paolito triad | Trust transfer / paternal delegation | Must show how Michael becomes trusted with Raúl's son |
 | Raúl / Navarro | Governance doctrine conflict | Make confrontation inevitable |
-| Raúl / Paolito | Fatherhood, authority, transfer | Power and paternal contradiction |
-| Benjamin / Paul | Aftercare, family legitimacy | Paul belongs to family system, not only Michael rescue story |
-| Table tennis bridge | Rules/play/permission/trust | Plot architecture linking captives, guards, Raúl, Paolito |
+| Raúl / Cobra | Insider betrayal / attempted assassination pressure | Must track the reveal that Cobra attempts to kill Raúl and steal a drug batch |
+| Cobra / Diego | Suspicion, weakness, discipline, and betrayal-adjacent pressure | Track how Diego's instability/product theft and Cobra's presence expose loyalty fractures in the camp |
+| Raúl / Diego | Discipline, mercy, and loyalty tax | Diego steals product; Raúl spares him; the camp records that mercy has a cost |
+| Michael / Diego | Watchfulness and weak-link management | Michael observes Diego's instability and understands how weakness spreads through the camp system |
+| Raúl / El Tomatero | Authority vs enforcer violence | Red-bat intimidation culminates in Raúl defending Paolito and asserting command |
+| El Tomatero / Paolito | Child-threat pressure | Track bat-marking, pig-pen danger, fear, and why Raúl's response matters |
+| Benjamin / Paul | Aftercare, family legitimacy, renaming reception | Paul belongs to family system, not only Michael's rescue story |
+| Table tennis bridge | Rules/play/permission/trust | Plot architecture linking captives, guards, Raúl, Michael, and Paolito |
 | Camp guards / captives | Social system | Hierarchy, surveillance, labor, fear, dignity |
+| Benjamin's family / Canadian relocation | Protective consequence | Benjamin's family relocation to Canada must be tracked as downstream safety consequence where evidenced |
 
-Named sustained relationships here; collectives only as labeled systems.
+Named sustained relationships here; collectives only as labeled systems. Do not route Cobra's betrayal, Diego's product-theft/mercy sequence, or Benjamin's origin pressure to vague “background pressure” if they materially shape the arc.
 
 ---
 
@@ -150,17 +211,25 @@ Named sustained relationships here; collectives only as labeled systems.
 
 ## Ideal status
 
-`complete_symbol_lifecycle`
+`complete_symbol_lifecycle_plus_legal_identity`
 
 | Symbol / system | Attached characters/layers | Lifecycle obligation |
 |---|---|---|
 | Blue evil-eye charm | Michael, Paolito/Paul, Benjamin | Chapter 1 loss into crate → Paolito keeps it → Benjamin threads it in Vancouver |
 | Key ring / keys | Raúl, Michael, camp authority | Access, control, permission, authority transfer |
+| Emergency passports / travel documents / protected identity papers | Michael, Benjamin, Paolito/Paul, Embassy/CBSA/Public Safety | Michael Wagner, Benjamin Wagner, Paul/Paolito Raúl Wagner identity transition; safety and erased trail |
 | Naming / renaming | Paolito/Paul, Benjamin, Michael, Raúl | Identity instability into family-legitimacy payoff |
+| Cobra's stolen/targeted drug batch | Cobra, Raúl, camp hierarchy | Internal betrayal object: product becomes motive for attempted killing and coup/escape pressure |
+| Product / stolen product | Diego, Raúl, Delegado/camp discipline | Loyalty-tax object: product theft triggers punishment/mercy logic |
 | Canvas / crates / benches | Michael, captives, camp | Body-as-cargo / confinement / logistics |
-| Table tennis equipment/play-space | Paolito, Michael, guards, Raúl | Mediates trust, authority, permission |
+| Table tennis equipment/play-space | Paolito, Michael, guards, Raúl | Mediates trust, authority, permission, social temperature |
+| El Tomatero's red bat | El Tomatero, Paolito, Raúl, camp | Ritualized violence, tally marks, intimidation, child threat, power reversal when Raúl takes it |
 | Music/sound systems | Camp, punishment, trauma | Coercive or emotional system where evidenced |
-| Local cultural anchors | El Tomatero/civic markers | Sinaloa specificity |
+| VIBER / Grindr / phone/profile | Benjamin, Michael | Queer self-recognition and relationship origin where evidenced |
+| Church/pulpit language | Benjamin, pastor, family/community pressure | Symbolic/religious condemnation system, not decorative background |
+| Local cultural anchors | El Tomatero/civic markers, Mazatlán/Culiacán/Sinaloa markers | Sinaloa specificity |
+
+Do not treat embassy documents as mere props; they are identity/safety/legal-payoff objects. Do not treat the red bat only as scenery. Do not miss drug/product as a pressure object when it drives Diego's punishment or Cobra's betrayal.
 
 ---
 
@@ -168,19 +237,27 @@ Named sustained relationships here; collectives only as labeled systems.
 
 ## Ideal status
 
-`complete_multi_location_causality`
+`complete_multi_location_causality_with_transit_chain`
 
 | Timeline lane | Required coverage |
 |---|---|
+| Benjamin origin pressure | Father/mother house rules, church condemnation, professors/classmates/medical-school pressure, Grindr/VIBER/Michael origin |
 | Opening abduction | Overpass/tailgate/crate/key/charm/survival logic |
-| Camp hierarchy | Guards/captives/permission/fear/labor/social rules |
+| Mountain camp hierarchy | Guards/captives/permission/fear/labor/social rules, El Tomatero, El Delgado, El Árbol, Cobra, Diego/cartel command hierarchy where evidenced |
+| Michael / Raúl evolution | Captive-captor assessment → conversations/utility → trust around Paolito |
 | Paolito/table tennis | Trust transfer, child protection, play under coercion |
+| El Tomatero / bat escalation | Bat marks, child threat, pig-pen incident, Raúl confrontation |
+| Diego loyalty-tax sequence | Product theft → public discipline → Raúl mercy → changed cost/accountability |
+| Cobra betrayal sequence | Insider watchfulness/suspicion → attempted killing of Raúl → attempted drug-batch theft → internal camp rupture |
 | Benjamin search lane | Culiacán search, rituals, empty-house behavior, agency |
 | Raúl/Navarro conflict | Doctrine conflict, governance pressure, confrontation |
 | Extraction/release | Release mechanics and moral transfer |
-| Vancouver aftercare | Renaming, family legitimacy, quiet after violence, charm payoff |
+| Transit chain | Mountain camp → Mazatlán/transit point → Mexico City Canadian Embassy → flight → Vancouver |
+| Embassy identity transition | Michael Wagner, Benjamin Wagner, Paul/Paolito Raúl Wagner; documents and sealed prior identities |
+| Vancouver protected home | CBSA/Public Safety processing, protected-address arrangement, family aftercare |
+| Benjamin family relocation | Benjamin's family relocation to Canada for safety where evidenced |
 
-Locations/worldstates: Culiacán/Sinaloa, mountain cartel camp, confinement/body spaces, table tennis play-space, Vancouver/home aftercare, cartel governance system.
+Locations/worldstates: Culiacán/Sinaloa, Benjamin's family home, church/community, medical school/university, VIBER/Grindr/social spaces, mountain camp, pig pen, table tennis space, El Tomatero's camp sphere, Cobra/Diego loyalty fracture scenes, Mazatlán transit point, Mexico City Canadian Embassy, aircraft/controlled transit, Vancouver hangar/private processing suite, protected Canadian home/address.
 
 ---
 
@@ -188,17 +265,22 @@ Locations/worldstates: Culiacán/Sinaloa, mountain cartel camp, confinement/body
 
 ## Ideal status
 
-`complete_pressure_and_closure`
+`complete_pressure_and_closure_with_identity_safety_payoff`
 
 | Pressure type | Required content |
 |---|---|
-| Coercive antagonist | Navarro and violent cartel actors |
-| Governance contradiction | Raúl’s authority, paternal transfer, doctrine conflict |
+| Coercive antagonist | Navarro, violent cartel actors, El Delgado/El Árbol hierarchy where evidenced |
+| Internal betrayal / coup pressure | Cobra attempts to kill Raúl and steal a drug batch; this must be tracked as a major internal cartel rupture |
+| Weak-link / loyalty-tax pressure | Diego steals product, is punished/spared, and exposes the cost of mercy/discipline |
+| Enforcer violence | El Tomatero, red bat, child-threat pressure, pig-pen danger |
+| Governance contradiction | Raúl's authority, paternal transfer, doctrine conflict, trust in Michael |
 | Social-machine | Camp guards/captives, surveillance, labor, permission |
-| Captivity/body | Crates, canvas, benches, bodily vulnerability |
+| Captivity/body | Crates, canvas, benches, injuries, bodily vulnerability |
 | Separation/absence | Benjamin/Michael separation and search |
-| Identity/family | Paolito/Paul renaming, family legitimacy |
+| Benjamin origin pressure | Father, mother, church/pastor, professors, classmates, homophobic/machismo pressure |
+| Identity/family | Paolito/Paul renaming, Michael/Benjamin new identities, protected-address arrangement, family legitimacy |
+| Transit/safety | Mazatlán, Mexico City Embassy, controlled departure, Vancouver, Benjamin family relocation |
 | Sound/music | Conditioning, punishment, trauma, silence |
 | Market/ethical | Violence, cartel economy, child collateral, queer family aftercare |
 
-Ending must account for Michael, Benjamin, Paolito/Paul, Raúl, Navarro, blue charm, table tennis, and Vancouver aftercare.
+Ending must account for Michael, Benjamin, Paolito/Paul, Raúl, Navarro, Cobra, Diego, El Tomatero, El Delgado/El Árbol if evidenced, blue charm, red bat, table tennis, embassy identity transition, Vancouver aftercare, protected address, and Benjamin-family relocation safety logic. A ledger fails if it treats the ending as only rescue or romance and misses legal identity, relocation, Cobra's betrayal, Diego's loyalty-tax function, and safety architecture.

--- a/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_FROGGIN_NOGGIN.md
+++ b/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_FROGGIN_NOGGIN.md
@@ -1,0 +1,222 @@
+---
+benchmark-schema: ideal-story-ledger-9-layer-v1
+title: Froggin Noggin — Ideal Story Ledger 9-Layer Benchmark
+manuscript: Froggin Noggin FULL NOVEL
+author: Michael J. Meraw
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: gold-standard-story-ledger
+benchmark-tier: required-gold
+generated-for: seed-phase-and-phase-1a-baseline
+created: 2026-05-31T01:22:25Z
+source-benchmarks:
+  - docs/benchmarks/froggin-noggin-dream.md
+  - docs/benchmarks/froggin-noggin-dream-v2-governed-ledger-addendum.md
+---
+
+# Froggin Noggin — Ideal Story Ledger 9-Layer Benchmark
+
+> Benchmark purpose: This is a filled, idealized nine-layer Story Ledger target, not a blank template.
+> Runtime purpose: SEED and Phase 1A should use this kind of completed structure as a benchmark shape.
+> Authority rule: Seed proposes; Phase 1A must use the seed as the baseline scaffold and verify/correct/reject every claim against manuscript evidence. Review Gate/accepted_story_ledger_v1 remains the authority for Phase 2.
+> Display rule: never show machine chunk labels to authors. Use chapter, scene, paragraph, page, or quoted evidence anchors.
+
+
+## Completion Standard
+
+A compliant Story Ledger for this manuscript is incomplete if it misses Hyla, Zimeon, Thorander, Chey, Rana, Newton, Rana/Newton as tenderness and cross-species cooperation, Gorf, toadstone/froggin noggin, shard, Maalik/light-dark frame, Dominatus, New World, human-damage as mirror system, closure as payoff ledger, and sensory/body ecology as worldbuilding mechanism.
+
+---
+
+# Layer 1 — Source Integrity
+
+## Ideal status
+
+`complete_with_review_flags`
+
+## Required source facts
+
+| Field | Gold-standard value |
+|---|---|
+| Scope | Full manuscript |
+| Route | Long-form / multi-layer evaluation |
+| Benchmark role | Required gold-standard long-form |
+| Evidence distribution | Opening human damage/frog-polity setup; middle shard/toadstone/governance escalation; Rana/Newton/Thorander reform material; sanctuary/disease/endgame material; final New World/Dominatus closure |
+
+## Required review flags
+
+| Risk | Correct classification |
+|---|---|
+| Paratext / epigraph / chapter-closing questions | Intentional formal system unless evidence proves accidental drift |
+| Doctrine proliferation | Craft/structure risk, not copy defect |
+| Continuity around shard / toadstone / Gorf / Dominatus | Symbolic-system integrity risk |
+| Sexual / grotesque / adult material | Market/tonal risk, not automatically defect |
+| Ending metaphysics / New World | Closure interpretation risk; must not be flattened to one literal reading without evidence |
+
+## Mistake-proofing
+
+Do not rely only on the opening frog/human collision. Do not treat unusual doctrine, amphibian biology, satire, or grotesque content as extraction corruption. Do not show machine chunk IDs.
+
+---
+
+# Layer 2 — POV Structure
+
+## Ideal status
+
+`complete_with_confidence`
+
+## Narrative camera
+
+Multi-perspective mythic/satirical ecological fantasy with shifting close attention across amphibian, human, and doctrinal/political systems.
+
+| POV / camera owner | Structural use | Required treatment |
+|---|---|---|
+| Hyla | Authority / monarchy / maternal governance pressure | Track as ruler, protective/cruel maternal force, doctrine carrier |
+| Zimeon | Curiosity / shard exposure / consequence carrier | Track curiosity → boundary crossing → exposure → payoff |
+| Rana | Ethical intelligence / bridge character | Track divergence from Thorander and cooperation with Newton |
+| Newton | Vulnerability / tenderness / non-dominating intelligence | Treat as structural, not decorative |
+| Chey | Human conscience / complicity hinge | Track recognition, failure/action, and mirror function |
+| Brutus / human lane | Human appetite, extraction, violence | Track as systemic human pressure, not only spectacle |
+
+## POV failure conditions
+
+Fails if it says “no POV characters identified,” reduces Rana/Newton scenes to background, or confuses omniscient/mythic narration with absence of focal centers.
+
+---
+
+# Layer 3 — Canonical Identity
+
+## Ideal status
+
+`complete_with_merge_split_controls`
+
+| Canonical entity | Type | Identity obligations |
+|---|---|---|
+| Hyla | Named character / monarch / maternal governance force | Queen/authority titles are roles or aliases, not separate people |
+| Zimeon | Named character / plot engine | Child/youth/status variants stay under one canonical identity |
+| Thorander | Named character / reformer / patriarchal pressure | Do not classify only as helper or villain |
+| Rana | Named character / bridge intelligence | Do not reduce to Thorander extension |
+| Newton | Named character / tenderness/vulnerability engine | Newt address terms, insults, and social labels are not legal names |
+| Chey | Named human / conscience hinge | Do not omit as minor witness if structurally active |
+| Brutus | Named human / appetite/damage pressure | Do not make him the only human system |
+| Gorf | Doctrine/system/deity construct | Not an ordinary physical object |
+| Maalik | Mythic/moral frame | Do not force literal character if symbolic |
+| Dominatus | Moral/paratext/ending frame | Not late decorative thesis only |
+| New World | Ending/migration/ethical/spiritual construct | Do not force one literal category without evidence |
+
+## Merge / split risks
+
+Separate titles from names, doctrine words from characters, species groups from named people, and sacred objects from deity concepts. Missing Hyla, Zimeon, Thorander, Chey, Rana, Newton, Gorf, toadstone, shard, or New World is a blocker.
+
+---
+
+# Layer 4 — Cast / Role Tier
+
+## Ideal status
+
+`complete_with_structural_weight`
+
+| Tier | Entities / forces | Role obligation |
+|---|---|---|
+| Primary structural forces | Hyla, Zimeon, Rana, Newton, Thorander, Chey | Each requires distinct functional treatment |
+| Authority/governance | Hyla, Thorander, frog polity | Power, doctrine, reform, control |
+| Vulnerability/tenderness | Newton, Rana/Newton bond | Emotional counter-logic to domination |
+| Human-damage lane | Brutus, Chey, broader human damage | Mirror amphibian governance and appetite |
+| Symbolic/systemic forces | Gorf, shard, toadstone, Maalik, Dominatus, New World | Story-bearing systems |
+| Collective forces | frog polity, human appetite/damage, ecology | Do not misclassify as individual cast |
+
+## Role-tier failure conditions
+
+Hyla flattened to generic ruler, Zimeon incidental, Thorander simple helper/villain, Rana only student, Newton decorative, or Chey background = failure.
+
+---
+
+# Layer 5 — Pronoun Transitions
+
+## Ideal status
+
+`complete_no_reviewable_transition_unless_evidenced`
+
+Only pronoun-family transitions, cross-family shifts, or identity signals requiring author confirmation should be shown. Unless evidence says otherwise, display:
+
+`No reviewable pronoun-family transitions detected.`
+
+Stable pronoun registry should be hidden by default. Do not treat species terms, titles, royal terms, or doctrine labels as pronoun transitions.
+
+---
+
+# Layer 6 — Relationship Network
+
+## Ideal status
+
+`complete_named_relationships_plus_system_routes`
+
+| Relationship / system | Function | Beginning / middle / ending obligation |
+|---|---|---|
+| Rana / Newton | Tenderness, vulnerability, cross-species cooperation | Difference/danger → care/cooperation; ending must show consequence |
+| Hyla / Zimeon | Authority vs curiosity / control vs transformation | Governance pressures shard-crisis carrier |
+| Thorander / Rana | Pedagogy, reform, patriarchy, divergence | Rana inherits, resists, or transforms Thorander’s logic |
+| Brutus / Chey | Human damage and partial conscience | Recognition as action, failure, or unresolved witness |
+| Frog polity / human damage | Mirror system | Human appetite and frog governance mirror/distort one another |
+| Rana / Thorander / Newton triad | Reform vs tenderness vs inherited doctrine | Rana changes pressure between worlds |
+
+Named sustained relationships belong here. Groups, species, mobs, institutions, or doctrine systems appear only as explicitly labeled systems.
+
+---
+
+# Layer 7 — Object / Symbol
+
+## Ideal status
+
+`complete_with_symbol_lifecycle`
+
+| Symbol / system | Attached characters/layers | Lifecycle obligation |
+|---|---|---|
+| Gorf system | Hyla, frog polity, doctrine | Behavior-governing theology, not decoration |
+| Toadstone / froggin noggin | Brutus, Hyla, sacred-object system | Desire, authority, extraction, cost |
+| Shard | Zimeon, lake/ecology, Maalik frame | Exposure, release/transfer, ecological consequence, payoff/underpayment |
+| Maalik / light-darkness | Shard, theology, moral ambiguity | Seeded, active, or underused |
+| Dominatus | Paratext/ending/human dominion indictment | Moral frame, not late thesis only |
+| New World | Ending/reform/migration/afterlife/alternative order | Literal, ethical, spiritual, or deliberately plural |
+
+Do not treat dialogue as object. Separate physical object, symbolic system, belief holder, and motif.
+
+---
+
+# Layer 8 — Timeline / Location / Worldstate
+
+## Ideal status
+
+`complete_with_world_rules`
+
+| Location / worldstate | Required function |
+|---|---|
+| Human damage zone / human world | Appetite, extraction, pollution, violence, mirror pressure |
+| Frog polity / authority world | Doctrine, governance, hierarchy, Hyla power |
+| Newt / tenderness counter-world | Vulnerability, biology, difference, alternative relation |
+| Lake/ecological system | Shard exposure, disease, water/body logic |
+| Sanctuary / disease / endgame | Late evidence and closure proof |
+| New World / ending space | Ethical/spiritual/literal ambiguity |
+
+Required sequence: opening human damage/frog-polity setup; middle shard/toadstone/governance; Rana/Newton/Thorander reform; sanctuary/disease/endgame; final New World/Dominatus closure.
+
+---
+
+# Layer 9 — Threat / Pressure / Ending
+
+## Ideal status
+
+`complete_multi_pressure_map`
+
+| Pressure type | Required content |
+|---|---|
+| Individual antagonists | Brutus and other named antagonistic forces where evidenced |
+| Governance pressure | Hyla, frog polity, Thorander logic, doctrine |
+| Human damage | Appetite, extraction, pollution, violence, domination |
+| Environmental / biological | Disease, poison, amphibian body limits, ecology |
+| Symbolic/metaphysical | Gorf, Maalik, Dominatus, New World |
+| Relational | Rana/Newton tenderness under cross-species danger |
+| Closure | Payoff ledger for shard, toadstone, Gorf, Dominatus, New World |
+
+Ending must account for Hyla, Zimeon, Thorander, Chey, Rana, Newton, human damage, and New World. Fails if pressure collapses to a single villain or ending is mood only.

--- a/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_LET_THE_RIVER_DECIDE.md
+++ b/docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_LET_THE_RIVER_DECIDE.md
@@ -1,0 +1,209 @@
+---
+benchmark-schema: ideal-story-ledger-9-layer-v1
+title: Let the River Decide — Ideal Story Ledger 9-Layer Benchmark
+manuscript: Let the River Decide
+author: Michael J. Meraw, with contributions from Clifford R. Wagner
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: gold-standard-story-ledger
+benchmark-tier: calibration
+generated-for: seed-phase-and-phase-1a-baseline
+created: 2026-05-31T01:22:25Z
+source-benchmarks:
+  - docs/benchmarks/let-the-river-decide-dream.md
+  - docs/benchmarks/let-the-river-decide-dream-v2-governed-ledger-addendum.md
+---
+
+# Let the River Decide — Ideal Story Ledger 9-Layer Benchmark
+
+> Benchmark purpose: This is a filled, idealized nine-layer Story Ledger target, not a blank template.
+> Runtime purpose: SEED and Phase 1A should use this kind of completed structure as a benchmark shape.
+> Authority rule: Seed proposes; Phase 1A must use the seed as the baseline scaffold and verify/correct/reject every claim against manuscript evidence. Review Gate/accepted_story_ledger_v1 remains the authority for Phase 2.
+> Display rule: never show machine chunk labels to authors. Use chapter, scene, paragraph, page, or quoted evidence anchors.
+
+
+## Completion Standard
+
+Incomplete if it misses Mike/Cliff/dogs as travel-family unit, dogs as animal-sensory detection layer, river agency as symbolic/sensory system, Smokehouse Camp as living social/protocol center, outsider-witness boundaries, research proof versus witness ambiguity, or Leanna/Verdant/OCEA as causal pressure.
+
+---
+
+# Layer 1 — Source Integrity
+
+## Ideal status
+
+`complete_with_protocol_caveats`
+
+| Field | Gold-standard value |
+|---|---|
+| Scope | Full manuscript |
+| Route | Long-form / multi-layer |
+| Evidence distribution | Road-trip witness layer; Mike/Cliff/dogs setup; Smokehouse Camp protocol; river agency; animal alerts; research/corporate pressure; ending/epilogue/inheritance |
+
+| Concern | Correct classification |
+|---|---|
+| Research proof vs witness ambiguity | Craft/structure risk, not document defect |
+| Cultural/protocol uncertainty | Sensitivity/manual-review risk; external review required before final claims |
+| Timeline/location accuracy | Confirm only with route/time evidence; otherwise needs manual verification |
+| Documentary inserts / ledgers | Structural compression risk if over-explaining |
+| Plunkett / lineage note | Package/closure-integration risk if under-braided |
+
+Mistake-proofing: do not over-certify culture/protocol; do not treat witness ambiguity as contradiction; do not show chunk IDs.
+
+---
+
+# Layer 2 — POV Structure
+
+## Ideal status
+
+`complete_first_person_witness`
+
+| POV / camera owner | Structural function | Required treatment |
+|---|---|---|
+| Mike | First-person witness / investigator / travel companion | Curiosity/investigation → witness responsibility/restraint |
+| Cliff | Aging competence / stepfather / road-family anchor | Practical knowledge, vulnerability, masculine silence |
+| Fritz and Schultz | Animal-sensory sentinels | Alerts/refusals are evidence channel |
+| Smokehouse Camp community | Protocol/custody layer through Mike | Observe, receive, respect, avoid over-claiming |
+| Leanna/corporate lane | External pressure as discovered | Causal pressure without exposition flattening |
+| River | Symbolic/environmental witness | Sensory agency, archive, possible judge |
+
+Fails if dogs are ignored, Smokehouse Camp is exposition only, or river is setting mood only.
+
+---
+
+# Layer 3 — Canonical Identity
+
+## Ideal status
+
+`complete_with_human_animal_system_entities`
+
+| Canonical entity / force | Type | Identity obligations |
+|---|---|---|
+| Mike | First-person narrator/witness/investigator | Do not split narrator/traveler/researcher |
+| Cliff | Stepfather/road-family anchor | Aging competence, vulnerability, practical authority |
+| Fritz | Dog / sensory sentinel | Animal perception and alerts/refusals |
+| Schultz | Dog / sensory sentinel | Animal perception and travel-family bond |
+| William | Community/protocol carrier where material | Cultural authority/custody if evidenced |
+| Nila | Community/protocol carrier where material | Cultural authority/custody if evidenced |
+| Anthony | Community/protocol carrier where material | Cultural authority/custody if evidenced |
+| Esmé | Community/protocol carrier where material | Cultural authority/custody if evidenced |
+| Leanna | Divided inheritance / Verdant pressure hinge | Corporate/family/moral bridge |
+| Verdant / OCEA | Institutional pressure | System entity, not person |
+| River | Symbolic/environmental force | Force, archive, witness, possible judge |
+
+Dogs are named animal characters/sentinels, not objects. River may be force/entity, not human character.
+
+---
+
+# Layer 4 — Cast / Role Tier
+
+## Ideal status
+
+`complete_travel_family_plus_systems`
+
+| Tier | Entities / forces | Role obligation |
+|---|---|---|
+| Primary witness | Mike | Investigation, restraint, receiving story |
+| Road-family anchor | Cliff | Aging competence, stepfather bond, practical survival |
+| Animal sentinel layer | Fritz and Schultz | Detect danger/places before human interpretation |
+| Community/protocol carriers | William, Nila, Anthony, Esmé where material | Cultural authority, story custody, protocol boundaries |
+| External pressure hinge | Leanna | Divided inheritance and corporate/moral bridge |
+| Institutional pressure | Verdant / OCEA | Corporate causal pressure |
+| Symbolic/environmental force | River | Witness, archive, nervous system, possible judge |
+
+Failure if dogs decorative, river location-only, Smokehouse Camp exposition, or Mike/Cliff inheritance underweighted.
+
+---
+
+# Layer 5 — Pronoun Transitions
+
+## Ideal status
+
+`complete_no_reviewable_transition_unless_evidenced`
+
+Expected display unless evidence says otherwise:
+
+`No reviewable pronoun-family transitions detected.`
+
+Do not treat dogs, river personification, institutions, or community-role labels as pronoun transitions.
+
+---
+
+# Layer 6 — Relationship Network
+
+## Ideal status
+
+`complete_relationship_and_protocol_spine`
+
+| Relationship / system | Function | Beginning / middle / ending obligation |
+|---|---|---|
+| Mike / Cliff | Road-family, aging, labor, care, witness training | Practical travel bond and emotional inheritance |
+| Mike / dogs | Nonhuman perception / sentinel trust | Dogs test places before humans interpret them |
+| Cliff / dogs | Family unit, care, routine, tenderness | Ground danger and vulnerability |
+| Mike / Smokehouse Camp community | Witness versus ownership | Observing, receiving, respecting, avoiding over-claiming |
+| Leanna / Verdant / OCEA | External plot system | Corporate language tied to river/community stakes |
+| River / community / outsiders | Moral and sensory relation | Exact but not overexplained |
+| Mike / research ledger | Investigation and restraint | Useful patterning vs over-proof |
+
+Named people and animals belong here if sustained; river/institutions appear as systems.
+
+---
+
+# Layer 7 — Object / Symbol
+
+## Ideal status
+
+`complete_symbol_and_sensory_payoff`
+
+| Symbol / system | Attached characters/layers | Lifecycle obligation |
+|---|---|---|
+| River | Mike, Cliff, Smokehouse Camp, missing persons, corporate layer | Sensory force, witness, memory, possible agency |
+| NV115 / black truck / missing signs | Road witness layer | Dread, pursuit, pattern recognition, investigation |
+| Dogs' refusals / alerts | Dogs, Mike/Cliff, river agency | Embodied evidence, not atmosphere |
+| Smoke / fish / bannock / camp practices | Smokehouse Camp/protocol | Living social texture and story custody |
+| Maps / research ledgers | Mike/investigation | Useful patterning vs over-proof |
+| Plunkett / family lineage | Cliff/epilogue/inheritance | Integrate only if closing argument strengthened |
+
+Do not classify dogs as objects or river only as place.
+
+---
+
+# Layer 8 — Timeline / Location / Worldstate
+
+## Ideal status
+
+`complete_route_protocol_worldstate`
+
+| Location / timeline system | Function |
+|---|---|
+| Road-trip route | Movement, witness frame, travel-family pressure |
+| Bralorne/BC origin and route north where evidenced | Starting world/geographic specificity |
+| River corridors/banks/crossings | Threat, agency, memory, sensory evidence |
+| Smokehouse Camp | Protocol, hospitality, cultural custody, outsider limits |
+| Missing-person / sign / black-truck locations | Pattern recognition, dread, investigation |
+| Corporate/Verdant/OCEA layer | External causal pressure/institutional language |
+| Ending/epilogue/family inheritance | Closure, Plunkett/lineage, witness burden |
+
+Mark location accuracy as needs manual verification unless route evidence confirms.
+
+---
+
+# Layer 9 — Threat / Pressure / Ending
+
+## Ideal status
+
+`complete_environmental_social_pressure_map`
+
+| Pressure type | Required content |
+|---|---|
+| Environmental/symbolic | River as witness, archive, possible judge |
+| Animal-sensory | Dogs’ refusals/alerts as embodied warning |
+| Road/investigation | Missing signs, black truck, route dread |
+| Cultural/protocol | Smokehouse Camp, outsider limits, story custody |
+| Corporate/institutional | Leanna / Verdant / OCEA causal system |
+| Research-proof | Witness ambiguity vs over-explanation |
+| Family/aging | Mike/Cliff stepfamily bond, aging/vulnerability |
+| Closure | Ending/epilogue/inheritance, river accountability, restraint |
+
+Ending must account for Mike’s witness responsibility, Cliff’s aging competence, dogs’ sentinel logic, Smokehouse Camp protocol, river agency, Leanna/Verdant/OCEA pressure, research ambiguity, and Plunkett/lineage only if integrated.

--- a/docs/benchmarks/story-ledger/LET_THE_RIVER_DECIDE_9_LAYER_OPTIMIZATION_ADDENDUM.md
+++ b/docs/benchmarks/story-ledger/LET_THE_RIVER_DECIDE_9_LAYER_OPTIMIZATION_ADDENDUM.md
@@ -1,0 +1,390 @@
+---
+benchmark-schema: ideal-story-ledger-9-layer-optimization-addendum-v1
+title: Let the River Decide — Nine-Layer Story Ledger Optimization Addendum
+manuscript: Let the River Decide
+author: Michael J. Meraw, with contributions from Clifford R. Wagner
+scope: full-manuscript
+route: LONG_FORM
+output-mode: multi_layer_long_form
+benchmark-role: gold-standard-story-ledger-addendum
+benchmark-tier: required-gold
+created: 2026-05-31T04:45:00Z
+applies-to:
+  - docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_LET_THE_RIVER_DECIDE.md
+source-manuscript:
+  - Let the River Decide uploaded review copy, 37 chapters plus epilogue
+---
+
+# Let the River Decide — Nine-Layer Story Ledger Optimization Addendum
+
+This addendum tightens the existing Let the River Decide ideal Story Ledger benchmark. It turns the current macro scaffold into a full operational answer key for SEED and Phase 1A.
+
+## Verdict
+
+The existing Let the River Decide benchmark correctly recognizes the Mike / Cliff / dogs travel-family unit, the river as symbolic agency, Smokehouse Camp, outsider-witness boundaries, research ambiguity, and Leanna / Verdant / OCEA pressure. But it is not yet textured enough to serve as a gold-standard Story Ledger for the full 37-chapter manuscript plus epilogue.
+
+Primary gap: the current benchmark names the large systems but does not yet force extraction of the human community network, object-symbol chain, missing-person ledger, corporate-energy arc, treaty/MOU arc, language/culture protocol, or the ending's witness-and-voice obligation.
+
+---
+
+# Required governing-canon rule
+
+Phase 2 cannot proceed cleanly if the governing Story Ledger omits these minimum structures:
+
+- Mike as first-person witness, investigator, outsider guest, and reluctant carrier of story.
+- Cliff as road-family anchor, aging competence, practical skepticism, father/stepfather bond, and Plunkett/Edwin inheritance carrier.
+- Fritz and Schultz as named animal sentinels, not decorative dogs.
+- William as elder, river-law interpreter, protocol gatekeeper, grief carrier, and father figure connected to Leanna and Anthony.
+- Esmé as elder protocol authority who limits what outsiders may carry.
+- Nila as food/protocol/camp-labor authority and origin of the “we eat everything except the bones” ethos.
+- Anthony as messenger, liminal youth/branch-hidden figure, cake/stones/paper-plane/longhouse carrier, and witness-between-children-and-elders.
+- Leanna Katchi as corporate-energy leader, divided daughter, Verdant/OCEA pressure hinge, and river-test subject.
+- Verdant Energy, OCEA, Mackenzie Sovereign Energy Corridor, and MOU / non-binding agreement as institutional pressure systems.
+- NV115 as numbered black-truck marker, not merely a suspicious vehicle.
+- NV121 as late sequence-confirmation marker.
+- Raymond Calder, Wexley, Thorsten, Romero, the Alberta-plates man, and Leanna as part of the disappearance / marked-person ledger where evidenced.
+- Smokehouse Camp as living protocol/labor/social field, not tourist setting.
+- River / water cycle as judging, remembering, selecting, and communicating system.
+- Plunkett / Edwin / Cliff family lineage as epilogue inheritance, not afterthought.
+
+## Sensitivity and authority guard
+
+The manuscript states it is fiction and includes a note on Tłekeh Dene naming, the Tł’enáá Dzeh Deneh autonym, T’atsan language, and preserved diacritics. Story Ledger output must preserve those names carefully, but must not over-certify cultural/protocol interpretations as factual external truth. Mark cultural/protocol claims as manuscript-internal unless externally reviewed.
+
+---
+
+# Layer 1 — Source Integrity: required additions
+
+The Source Integrity layer must treat this as a full long-form manuscript with 37 chapters plus epilogue. It must not collapse the book into a road-trip opening or eco-thriller premise.
+
+Required source checks:
+
+1. Fiction/name-note guard: preserve Tłekeh Dene / Tł’enáá Dzeh Deneh / T’atsan naming exactly, but mark cultural content as manuscript-internal fiction unless externally reviewed.
+2. Full-route coverage guard: the ledger must include the northern opening, Smokehouse Camp, Stonepine Flats, Yukon return route, Bralorne/Gold Bridge investigation, Minto memory, Tyaughton dog/life-risk material, return to Smokehouse Camp, Leanna/Verdant/OCEA arc, final longhouse/river-mouth ending, and Plunkett epilogue.
+3. Community-network guard: William, Esmé, Nila, Brie, Amber, Anthony, Martin, Dana, Jackson, Teddy, Robin, Tajina, K’Nesh, Rae, Gloria, and other sustained camp/community figures must be verified or intentionally collapsed, not ignored.
+4. Missing-person ledger guard: Raymond Calder, the Alberta-plates man, Wexley, Thorsten, Romero, Leanna, and the pattern map must be tracked as disappearance/accountability material where evidenced.
+5. Corporate/institutional guard: Verdant, OCEA, the Mackenzie project, MOU / unsigned non-binding language, federal/provincial/infrastructure actors, RCMP, and public-notice systems are institutional pressure, not background exposition.
+6. Object-symbol guard: NV115/NV121, birch-bark map, river stones, black/dark/red-streaked stones, eagle/crow feather, paper airplane, cake, bannock, fish/offal/black-pan dish, smokehouses, wood chips/chipper, dogs’ collars/leashes, Jeep/trailer, maps/notebooks, press release, floatplane C-CTRL, and Edwin’s medals must be routed to Object/Symbol where structurally active.
+7. Ending guard: the ending is witness-transfer and system activation, not neat closure. The reader is left with a voice obligation: carry this one, not all stories.
+
+Failure condition: a ledger fails Source Integrity if it treats the uploaded manuscript as a generic wilderness thriller or generic eco-thriller and omits the protocol, memory, language, corporate, and epilogue inheritance systems.
+
+---
+
+# Layer 2 — POV Structure: required additions
+
+The POV layer must distinguish:
+
+- Mike as first-person narrator, witness, investigator, pattern-maker, outsider guest, and reluctant story carrier.
+- Cliff as close relational counter-camera: skeptic, practical elder, stepfather, aging body, dog-father, Plunkett/Edwin inheritance carrier.
+- Fritz and Schultz as animal-sensory focal instruments: they detect, refuse, alert, test places, and expose Cliff/Mike favoritism.
+- William as elder interpreter and river-law/protocol voice, but not a conventional POV owner.
+- Esmé as boundary-setting authority: she controls what outsiders may carry.
+- Anthony as liminal messenger: cake, birch-bark map, stones, longhouse entry, paper-plane funeral logic, and child/elder bridge.
+- Leanna as divided insider-outsider: corporate authority, daughter, returnee, and river-tested figure.
+- River / water cycle as nonhuman agency: judgment, memory, selection, communication, and balancing.
+
+Mandatory focal centers:
+
+- Mike
+- Cliff
+- Fritz
+- Schultz
+- William
+- Anthony
+- Esmé
+- Leanna
+- River / water cycle
+- Smokehouse Camp community
+- Verdant/OCEA pressure system
+
+Mistake-proofing:
+
+- Do not treat the river’s personification as ordinary human POV.
+- Do not flatten Cliff into sidekick/comic relief.
+- Do not treat dogs as atmosphere.
+- Do not treat community elders as exposition machines.
+- Do not treat Leanna as simple villain or simple victim.
+
+---
+
+# Layer 3 — Canonical Identity: required additions
+
+The Canonical Identity layer must add or verify these entities and systems:
+
+| Canonical item | Required treatment |
+|---|---|
+| Mike | First-person narrator, investigator, outsider witness, guest, and story-carrier candidate |
+| Cliff | Stepdad/father figure, aging practical authority, dog-father, Plunkett/Edwin inheritance carrier |
+| Fritz | Named Jagdterrier; favored dog, quick/nerve/sentinel function |
+| Schultz | Named Jagdterrier; heavier/stubborn/sentinel function and Mike-affection counterweight |
+| William | Elder, river-law interpreter, protocol gatekeeper, Leanna/Anthony family axis |
+| Esmé | Elder/protocol authority; “you cannot carry our stories” boundary keeper |
+| Nila | Food/protocol/camp-labor authority; black-pan/offal ethos; “except the bones” frame |
+| Brie | William’s grandniece / care figure |
+| Amber | Record keeper: water clarity, fish runs, algae blooms |
+| Gloria | Gas-station inviter / Smokehouse Camp summons figure |
+| Anthony | Messenger, cake carrier, birch-bark map carrier, liminal youth, longhouse guide |
+| Martin | Grounds/wood/maintenance figure; forest-management and contamination logic |
+| Dana | Camp labor/mother figure connected to fish preparation and Jackson |
+| Jackson | Child learning fish work; generational protocol/labor continuity |
+| Teddy | Child worker / play/labor counterpoint; OFF/Teddy Bear title relation where evidenced |
+| Robin | Camp woman / bannock / balance conversation / K’Nesh explainer |
+| Tajina | Camp woman; social texture where evidenced |
+| K’Nesh | Elder with crow feather; watcher; flood-loss grief and child-watch duty |
+| Rae | Stone/spiral/apology figure where evidenced |
+| Leanna Katchi | Verdant CEO, William’s daughter/claimed daughter, divided inheritance, dam-project pressure, river-test figure |
+| Verdant Energy | Corporate energy institution and legacy-loop pressure system |
+| OCEA | Institutional/energy corridor actor; confirm exact role from manuscript evidence |
+| Mackenzie Sovereign Energy Corridor | Project/system pressure: dam/energy/export/workforce/future claim |
+| NV115 | Numbered black crew cab / marker / ledger gap / possible watcher system |
+| NV121 | Late numbered-truck sequence marker; confirms missing/sequence logic |
+| Raymond Calder | Missing-person poster and early ledger seed |
+| Alberta-plates man | Disrespect/trespass figure at Smokehouse Camp and Stonepine disappearance pressure |
+| Wexley / Thorsten / Romero | Pattern-map disappearance names; verify and preserve spelling |
+| RCMP / Red | State authority, public-notice system, colonial/policing pressure |
+| Young man expelled by RCMP | Protocol/policing scene pressure; do not reduce to random disturbance |
+| Leanna’s floatplane / C-CTRL | Object/institutional disappearance anchor, not person |
+| Edwin | Cliff’s brother, WWII death/medals inheritance |
+| Plunkett | Origin/family-lineage location that functions almost like a memory entity |
+| River / water cycle | Nonhuman force/system; do not convert into ordinary character or mere setting |
+
+Merge/split rules:
+
+- Keep Smokehouse Camp, Tłekeh Dene community, elders, children, and institutional actors distinct.
+- Do not collapse William, Anthony, Esmé, Nila, and Martin into “Indigenous elders/community.” They serve different structural functions.
+- Do not split the river into separate entities every time it appears as Liard, Mackenzie, creek, rain, snowmelt, fog, or sea; track as water-cycle system while preserving location-specific rivers.
+- Do not turn “NV115” into a human identity; it is a marker/system/object unless evidence proves the vehicle occupant identity.
+- Do not treat Leanna only as Verdant CEO; she is also daughter/returnee/one-of-us figure.
+
+---
+
+# Layer 4 — Cast / Role Tier: required additions
+
+| Tier | Required members / systems |
+|---|---|
+| Primary witness / narrator | Mike |
+| Road-family anchor | Cliff |
+| Animal sentinel layer | Fritz, Schultz, Nanuk by memory/function where evidenced |
+| Camp/protocol authority | William, Esmé, Nila |
+| Messenger / liminal bridge | Anthony |
+| Camp labor / continuity network | Brie, Amber, Dana, Jackson, Teddy, Martin, Robin, Tajina, Rae, K’Nesh, children, aunties/elders |
+| Corporate divided figure | Leanna Katchi |
+| Corporate / institutional pressure | Verdant, OCEA, Mackenzie project, MOU, federal/provincial/infrastructure actors |
+| State/policing pressure | RCMP, Red, public notices, search/rescue language |
+| Disappearance ledger | Raymond Calder, Alberta-plates man, Wexley, Thorsten, Romero, Leanna, NV115-related pattern |
+| Symbolic/environmental force | River, Liard, Mackenzie, Upper Wathah, rain, fog, snowmelt, water cycle |
+| Settler/family inheritance layer | Plunkett, Edwin, Cliff’s family history, German/Canadian lineage, military medals |
+| Object-symbol carriers | stones, feather, birch-bark map, cake, fish/offal, smokehouses, paper airplane, press release, floatplane, dogs’ collars/leashes, maps/notebooks |
+
+Failure condition: treating the cast as only Mike/Cliff/William/Leanna fails the benchmark. The ledger must track community, animals, institutions, missing persons, and water as separate structural layers.
+
+---
+
+# Layer 5 — Pronoun Transitions: required additions
+
+Expected default unless evidence says otherwise:
+
+`No reviewable pronoun-family transitions detected.`
+
+Additional mistake-proofing:
+
+- Do not treat the river’s she/her personification as a pronoun-family transition.
+- Do not treat institutional names, project names, vehicle numbers, or community names as pronoun transitions.
+- Do not treat Tłekeh Dene / Tł’enáá Dzeh Deneh naming as a pronoun issue; it belongs to Source Integrity / Canonical Identity / cultural naming.
+- Do not show stable he/him, she/her, they/them inventories to the author.
+
+---
+
+# Layer 6 — Relationship Network: required additions
+
+| Relationship / system | Function |
+|---|---|
+| Mike / Cliff | Road-family, stepfather bond, skepticism vs pattern recognition, aging, care, inherited silence |
+| Mike / Fritz / Schultz | Animal sentinel trust and nonhuman evidence channel |
+| Cliff / Fritz / Schultz | Dog favoritism, care, aging, practical love, vulnerability |
+| Mike / William | Outsider witness tested by elder/protocol authority |
+| Cliff / William | Elder-to-elder recognition, practical memory, masculinity/silence resonance |
+| William / River | Interpreter/aligner of river law, not owner of it |
+| William / Leanna | Father/daughter or claimed-daughter grief, silence, divided belonging |
+| William / Anthony | Elder/youth continuity and hidden-branch relationship |
+| William / Esmé | Protocol authority network; Esmé can limit what William/Mike/Cliff carry |
+| Mike / Esmé | Story boundary: cannot carry all stories, can carry this one |
+| Anthony / Mike-Cliff | Messenger relationship: cake, birch-bark map, longhouse guidance, stones |
+| Nila / Mike-Cliff | Food/protocol initiation through fish/offal/black-pan ethos |
+| Martin / Mike | Environmental-contamination explanation through fuel/soil/water logic |
+| RCMP Red / young man / camp | State authority interrupting community space; colonial/policing pressure |
+| Mike-Cliff / Smokehouse Camp | Outsider guests moving from curiosity to obligation |
+| Mike-Cliff / NV115 | Suspicion, surveillance, marking, narrative dread, ledger gap |
+| River / desecrators | Balancing, selection, disappearance, removal of imbalance |
+| River / community | Care, feeding, memory, judgment, protocol, reciprocal relation |
+| Leanna / Verdant | Corporate project, ambition, energy rhetoric, legacy loop |
+| Leanna / William / community | Divided belonging: CEO and daughter/one-of-us figure |
+| Leanna / river | Test at confluence; disappearance as accountability ambiguity |
+| Verdant / OCEA / Mackenzie project / MOU | Institutional alliance and extraction/development pressure |
+| Mike / research map | Pattern-making relationship that can either reveal or over-control |
+| Cliff / Plunkett / Edwin | Family inheritance, war memory, aging, farewell-to-self arc |
+| K’Nesh / crow feather / children | Watcher role, grief, flood loss, duty to protect |
+| Dogs / land / river | Scent, refusal, alert, recognition before human interpretation |
+
+Do not reduce the relationship layer to interpersonal bonds only. This manuscript requires character-system, character-place, character-object, and community-protocol relationships.
+
+---
+
+# Layer 7 — Object / Symbol: required additions
+
+| Object / symbol / system | Required treatment |
+|---|---|
+| River / water cycle | Central symbol-system: memory, judgment, selection, communication, balancing, archive |
+| NV115 | Numbered black-truck marker, surveillance/dread object, ledger gap |
+| NV121 | Late numbered-truck sequence marker; confirms pattern/sequencing pressure |
+| Missing-person poster / RCMP notice | Public/official disappearance ledger; early clue system |
+| Pressure-washer / industrial soap / wash bay | Cleansing/erasure image tied to NV115 and ground traces |
+| Jeep / trailer / jerry can | Vulnerability, mobility, outsider gear, stealable value, shelter at river edge |
+| Dogs’ collars/leashes/crate | Animal sentinel infrastructure and family dependency |
+| Smokehouses | Living food/labor/protocol architecture, not rustic setting |
+| Fish / offal / black-pan dish / bones | Reciprocity, use-everything ethos, initiation into camp logic |
+| Black spruce / fireweed / carob cake | Covenant food; two- and four-legged kinship marker; not ordinary dessert |
+| Birch-bark map | Watershed/missing-person/memory map; Anthony’s object of revelation |
+| River stones / stone bowl / red-streaked stone | Verdict, memory, carried story, ritual handoff |
+| Eagle feather / crow feather | Authority, witness, warning, mourning, child-watch duty |
+| Paper airplane | Leanna/floating/funeral object; child memory turned mourning ritual |
+| Wood chips / chipper / bark mulch | Forest management, ground-cover, trace-handling, transformation of land material |
+| Maps / notebooks / overlays | Mike’s investigation apparatus; pattern-making and over-proof risk |
+| MOU / unsigned non-binding agreement | Institutional betrayal object; paper that tries to tame river reality |
+| Press release / news broadcast / legacy loop | Corporate rhetoric object-system and public narrative control |
+| Floatplane C-CTRL | Leanna disappearance anchor and confluence test object |
+| Bannock / tea / fish tables / tubs / knives | Hospitality, labor, and protocol material culture |
+| OFF! / bug spray / wilderness supplies | Boundary between comfort, intrusion, and travel-family survival where evidenced |
+| Edwin’s medals | Cliff family inheritance, silence, war memory, epilogue closure object |
+| Plunkett | Origin-place symbol and late-life return/farewell marker |
+
+Mistake-proofing:
+
+- Do not classify dogs as objects; their collars/leashes/crate are objects, Fritz and Schultz are named animal characters.
+- Do not classify river only as location.
+- Do not treat cake, fish, stones, feather, or paper airplane as atmosphere; each is a protocol or memory object.
+- Do not treat MOU/press releases as mere exposition; they are institutional artifacts.
+
+---
+
+# Layer 8 — Timeline / Location / Worldstate: required additions
+
+The benchmark should require this narrative-zone map:
+
+| Narrative zone | Required function |
+|---|---|
+| Chapter 1 — Billy Landing / Stonepine Flats / Liard River | NV115, Raymond Calder, dogs, Stonepine vulnerability, river dread, trailer/outsider setup |
+| Chapter 2 — Sáh Degh Village / Smokehouse Camp / Upper Wathah | Gloria summons, William, Brie, Amber, Nila, Martin, Anthony, fish/offal/cake, RCMP interruption, camp protocol |
+| Chapter 3 — Stonepine / Fort Simpson / Smokehouse return | Alberta-plates disappearance, RCMP public notice, William's river-law explanation, offering logic |
+| Chapter 4 — Smokehouse to Alaska Highway | Departure pressure, road threshold, river memory continuing beyond place |
+| Chapter 5 — Yukon route | Waterways and route movement as pattern expansion |
+| Chapter 6 — Teslin to Bralorne return | Long-distance return, missing/disappearance pattern emerging, home not safety |
+| Chapter 7 — Bralorne | Research begins; what is taken is marked |
+| Chapter 8 — Bralorne / Lillooet / province autopsy | Historical/political/ecological diagnosis expands |
+| Chapter 9 — Bralorne / Gold Bridge | Rivers write eulogies; pattern of place and loss |
+| Chapter 10 — Cliff cabin / Slatebird | Blood/skin/currency logic and family vulnerability |
+| Chapter 11 — Norfolk 1984 | Cliff/Mike/father-history insertion; military/family memory |
+| Chapter 12 — Bralorne | River memory doctrine intensifies |
+| Chapter 13 — Drinking/turning | Water ingestion/contamination/agency logic |
+| Chapter 14 — Watershed/workforce/will | Institutional/industrial pressure system |
+| Chapter 15 — Same script/new uniforms | Historical repetition under new institutional faces |
+| Chapter 16 — Minto | Internment/memory erasure and “do not remove” logic |
+| Chapter 17 — Tuktoyaktuk route | Earlier northern journey and land’s end/water without end |
+| Chapter 18 — Trading for silence | Institutional compromise and silence economy |
+| Chapter 19 — From One Wolf to Another | Dream/wolf/water warning and map pattern pressure |
+| Chapter 20 — Next name on the list | Missing-person ledger deepens |
+| Chapter 21 — Map without the missing | Pattern map becomes method and risk |
+| Chapter 22 — Hymns in the Dust | Gold Bridge/Bralorne historical-spiritual pressure |
+| Chapter 23 — OFF! for Teddy Bears Only | Dog/wilderness/body-risk material; survival humor with serious stakes |
+| Chapter 24 — Tyaughton threshold | Threshold crossing and dog/family vulnerability |
+| Chapter 25 — Digging hours | Dogs and land disturbance; embodied warning logic |
+| Chapter 26 — Third summons | Return to Smokehouse Camp; river calls again |
+| Chapter 27 — Birch Holds the Verdict | William confirms choosing/balance; birch/ledger/verdict logic |
+| Chapter 28 — Crow Feather | K’Nesh, Robin, bannock, child/flood grief, watchfulness |
+| Chapter 29 — Mother Tongue | Language, naming, belonging, cultural transmission |
+| Chapter 30 — Astonishment, Then Silence | Smokehouse / Peacekeeper's River juxtaposition; global water-law echo |
+| Chapter 31 — Black ones last | Sewing/selection/grief/community labor where evidenced |
+| Chapter 32 — Leanna at river's edge | Leanna return, William, Verdant/OCEA pressure, NV115 shadow |
+| Chapter 33 — Unsigned / non-binding | MOU, river disagreement, paper vs water authority |
+| Chapter 34 — Miles between questions | Away-from-river processing and unresolved doubt |
+| Chapter 35 — River Road to Brass Sky | Calgary / corporate aftermath / Leanna disappearance news |
+| Chapter 36 — Cannot carry our stories | Return to Smokehouse; mourning, stones, feather, longhouse, story boundary |
+| Chapter 37 — River opens its mouth | Water-cycle activation, final witness obligation |
+| Epilogue — Plunkett | Cliff origin, Edwin medals, family paradox, settler inheritance, final crossing of personal and national memory |
+
+Required locations/worldstates:
+
+- Billy Landing
+- Stonepine Flats
+- Liard River
+- Sáh Degh Village
+- Smokehouse Camp
+- Upper Wathah River
+- Fort Simpson
+- Alaska Highway / Yukon route
+- Teslin, Watson Lake, Prince George, Williams Lake, Pine River
+- Bralorne / Gold Bridge / Slatebird Valley
+- Lillooet
+- Minto / Carpenter Lake
+- Tuktoyaktuk / Arctic Ocean route
+- Tyaughton Creek
+- Peacekeeper's River, Central America
+- Calgary / Verdant corporate world
+- Mackenzie / confluence / Fort McPherson route
+- Plunkett, Saskatchewan
+
+---
+
+# Layer 9 — Threat / Pressure / Ending: required additions
+
+The pressure map must include:
+
+| Pressure type | Required content |
+|---|---|
+| River judgment / water-cycle pressure | River remembers, marks, removes imbalance, communicates through mist/cloud/rain/snowmelt/sea |
+| Missing-person pressure | Raymond Calder, Alberta-plates man, Wexley, Thorsten, Romero, Leanna, other named/marked disappearances where evidenced |
+| NV115 / numbered-truck pressure | Surveillance, marking, sequence gap, possible human agent or river-agent ambiguity |
+| Corporate-energy pressure | Verdant, OCEA, Mackenzie project, 30% ownership rhetoric, energy corridor, export capacity, legacy loop |
+| Paper-authority pressure | MOU, unsigned/non-binding language, press releases, official reports, RCMP notices |
+| Colonial/state pressure | RCMP interruption at camp, historical erasure, pass/reserve/residential-school/dam history as manuscript-internal context |
+| Cultural/protocol pressure | Outsider cannot own/carry all stories; must receive only what is given |
+| Dog-sentinel pressure | Fritz/Schultz refusals, alerts, favoritism, risk, and animal knowledge before human interpretation |
+| Aging/family pressure | Cliff’s age, travel risk, practical competence, Plunkett, Edwin medals, father/son/stepfather silence |
+| Witness-proof pressure | Mike's map-making, research, desire for pattern, risk of overclaiming |
+| Leanna pressure | Daughter vs CEO, belonging vs extraction, one-of-us vs corporate figure, confluence test |
+| Community-continuity pressure | Children learning fish work, Anthony, elders, camp labor, language, memory, food protocols |
+| Environmental memory pressure | Fish runs, algae blooms, water clarity, land scars, oil stains, chipper/wood/forest management |
+
+Ending accountability must account for:
+
+- Mike's transformation from curious outsider to constrained witness.
+- Cliff's movement from skepticism to recognition and toward Plunkett/family reckoning.
+- Fritz and Schultz as nonhuman sensors and family dependents.
+- William's grief and law of balance.
+- Esmé's boundary: cannot carry all stories, but can carry this one.
+- Anthony's messenger role and future-continuity function.
+- Leanna as both corporate force and mourned one-of-us figure.
+- Verdant/OCEA/Mackenzie project as still-active institutional pressure.
+- NV115/NV121 as unresolved marker/sequence logic.
+- Water cycle as activated system: not angry, done.
+- Plunkett as epilogue expansion from river story to family/national inheritance.
+
+Failure condition: a ledger fails if it treats the ending as a solved mystery, simple revenge, simple supernatural judgment, or clean eco-thriller closure. The correct ending state is witness-transfer plus continuing water-cycle accountability.
+
+---
+
+# Seed / Phase 1A Fit-Gap Tests
+
+A generated Story Ledger for Let the River Decide must produce a `seed_fit_gap_report_v1` or degraded Story Ledger health if any of these are missing:
+
+1. William, Esmé, Anthony, Nila, Leanna, Fritz, Schultz, Verdant, OCEA, NV115, and Plunkett.
+2. Dogs as named animal sentinels, not objects or decorative pets.
+3. River/water-cycle as active symbolic/environmental pressure, not mere setting.
+4. Smokehouse Camp as protocol/labor/community system, not tourist stop.
+5. Leanna as divided daughter/CEO/one-of-us figure, not simple villain or victim.
+6. MOU/press release/Verdant/OCEA as institutional objects and pressure systems.
+7. The story-boundary rule: outsiders cannot carry all stories, only the one given.
+8. Full chapter-route coverage through Epilogue—Plunkett.
+9. Sensitivity guard for Tłekeh Dene / Tł’enáá Dzeh Deneh / T’atsan names and cultural protocol.
+10. Ending classified as witness-transfer and continuing accountability, not solved mystery or clean closure.

--- a/docs/benchmarks/story-ledger/README.md
+++ b/docs/benchmarks/story-ledger/README.md
@@ -1,0 +1,53 @@
+# Ideal Story Ledger 9-Layer Benchmarks
+
+These files are filled benchmark examples, not blank templates.
+
+They define what a completed, high-quality nine-layer Story Ledger should look like for three benchmark manuscripts:
+
+1. `IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_FROGGIN_NOGGIN.md`
+2. `IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md`
+3. `IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_LET_THE_RIVER_DECIDE.md`
+
+## Purpose
+
+These benchmarks support:
+
+- SEED output quality
+- Phase 1A baseline scaffolding
+- Story Ledger layer extraction
+- Review Gate comparison
+- `seed_fit_gap_report_v1` generation
+- regression testing against known answer keys
+
+## Required nine layers
+
+Every ideal benchmark uses the same nine-layer Story Ledger structure:
+
+1. Source Integrity
+2. POV Structure
+3. Canonical Identity
+4. Cast / Role Tier
+5. Pronoun Transitions
+6. Relationship Network
+7. Object / Symbol
+8. Timeline / Location / Worldstate
+9. Threat / Pressure / Ending
+
+## Governance note
+
+Seed artifacts may use these as benchmark shape and quality targets, but seed remains non-authoritative.
+
+The authority chain remains:
+
+```text
+Seed proposes.
+Phase 1A must use the seed as baseline.
+Phase 1A verifies against manuscript evidence.
+Reducer normalizes.
+Review Gate authorizes.
+accepted_story_ledger_v1 governs Phase 2.
+```
+
+## Author-facing display rule
+
+Never show machine chunk labels to authors. Use chapter, scene, paragraph, page, or quoted evidence anchors.

--- a/docs/governance/evaluation-output-mode-contract.md
+++ b/docs/governance/evaluation-output-mode-contract.md
@@ -1,153 +1,79 @@
-# RevisionGrade Evaluation Output Mode Contract
+# Evaluation Output Mode Contract
 
-**Status:** Canonical documentation contract  
+**Status:** Canonical governance contract  
 **Owner:** Mmeraw  
-**Scope:** Short-form, long-form, and long-form multi-layer evaluation outputs  
-**Runtime impact:** Documentation only. This contract does not change scoring, pipeline execution, provider calls, WAVE governance, database schema, or Revise behavior.
+**Scope:** Evaluation output mode boundaries, public/report shape, and template authority
 
 ---
 
 ## Purpose
 
-RevisionGrade supports three evaluation-output modes. They share the same editorial standard, but they must not promise the same depth of analysis.
+RevisionGrade evaluations must route to the correct public-output mode before report synthesis.
 
-The modes are:
+This contract prevents mode drift between:
 
-1. `short_form_evaluation`
-2. `long_form_evaluation`
-3. `long_form_multi_layer_evaluation`
+- short-form evaluations;
+- long-form evaluations;
+- long-form multi-layer evaluations;
+- DREAM long-form synthesis;
+- Story Ledger / governed-ledger benchmark artifacts.
 
-This contract prevents public copy, benchmark files, corpus artifacts, generated reports, and templates from implying that all submissions receive the same analysis depth.
-
----
-
-## Universal boundaries
-
-All evaluation modes must preserve these boundaries:
-
-- Evaluation diagnoses the manuscript. Revise applies or manages repairs later.
-- Top Recommendations are summary-level and must not be verbatim copies of criterion opportunities.
-- Criterion opportunities use the six-part diagnostic contract when there is a meaningful opportunity: Evidence, Symptom, Cause, Fix direction, Reader effect, and Mistake-proofing.
-- Eval output does not include A/B/C rewrite proposals. A/B/C belongs in Revise Queue.
-- Eval output does not expose the full Revise Queue inventory.
-- Author-facing reports must not expose engine/provider/prompt/version/internal governance telemetry unless the author has explicitly granted support access under the support-access model.
-- Protected WAVE/governance internals must not appear in public report copy.
+The contract also prevents a seed, benchmark, DREAM document, or public-domain calibration file from silently replacing the canonical mode/template authority.
 
 ---
 
-## Mode 1 — Short-form evaluation
+## Canonical modes
 
-**Canonical label:** `short_form_evaluation`  
-**Typical threshold:** submissions under 25,000 words  
-**Route:** `SHORT_FORM`
+RevisionGrade uses exactly these evaluation modes:
 
-Short-form evaluation uses the 13 story criteria only. It may diagnose craft, scene, voice, pacing, theme, closure, and market-readiness issues in the submitted excerpt or short work, but it must not imply full-manuscript continuity proof.
+```text
+short_form_evaluation
+long_form_evaluation
+long_form_multi_layer_evaluation
+```
 
-### Required output surfaces
-
-- Manuscript / submission metadata.
-- Executive summary.
-- Overall score and verdict.
-- The 13 story criteria.
-- Criterion rationales.
-- Top Recommendations as summary-level guidance.
-- Up to the top three criterion opportunities per criterion when warranted.
-- Download/print versions that show all surfaced criterion opportunities and diagnostic details.
-
-### Explicit non-promises
-
-Short-form evaluation must not promise:
-
-- Golden Spine analysis.
-- DREAM governed ledgers.
-- long-form continuity proof.
-- full-manuscript promise tracking.
-- WAVE-level manuscript architecture coverage.
-- full Story Ledger extraction.
-
-Short-form may identify a local continuity, promise, or closure concern, but it must frame that concern as local to the submitted text unless additional manuscript evidence was supplied.
+No alternate spellings, aliases, or undocumented mode names should be introduced.
 
 ---
 
-## Mode 2 — Long-form evaluation
+## Mode boundaries
 
-**Canonical label:** `long_form_evaluation`  
-**Typical threshold:** 25,000+ words  
-**Route:** `LONG_FORM`  
-**Output mode:** `standard_long_form`
+### `short_form_evaluation`
 
-Long-form evaluation applies manuscript-scale analysis to a substantial or complete manuscript without requiring separate layer architecture rendering.
+Used for submissions below the long-form threshold.
 
-### Required output surfaces
+Short-form evaluation focuses on the 13 story criteria only. It must not imply full Golden Spine / WAVE / long-form continuity coverage.
 
-- Manuscript metadata including word count, route, and output mode.
-- Executive verdict.
-- Overall score or readiness score.
-- Full 13-criteria score grid.
-- Criterion rationales.
-- Top Recommendations as paraphrased executive summaries.
-- Up to the top three criterion opportunities per criterion when warranted.
-- Evidence-backed diagnosis across the manuscript.
-- Plain-editorial long-form continuity findings.
-- Promise / payoff / closure tracking where material.
-- Character, relationship, symbol, and evidence coverage where material.
-- Revision priority order in plain editorial language.
-- Download/print versions that show all surfaced criterion opportunities and diagnostic details.
+Sparse submissions are valid. RevisionGrade permits submissions at 200 words and up. Sparse evidence should be rendered with caution, limited confidence, N/A where appropriate, or Needs Targeting for unsupported Revise items. Sparse evidence must not by itself fail evaluation or Revise.
 
-### WAVE boundary
+### `long_form_evaluation`
 
-Long-form evaluation may be WAVE-informed, but author-facing copy must describe findings in plain editorial language. WAVE must not be represented as a revision process or as manuscript-change application.
+Used for manuscripts at or above the long-form threshold where manuscript-scale logic is appropriate.
+
+Long-form evaluation may use story-scale continuity and broader manuscript structure, but the output still must distinguish evidence-backed findings from cautions, unknowns, and author-review items.
+
+### `long_form_multi_layer_evaluation`
+
+Used when the full multi-layer long-form analysis path is active.
+
+This mode may activate governed Story Ledger, DREAM long-form report synthesis, WAVE-informed diagnosis where applicable, and benchmarked ledger completeness obligations.
 
 ---
 
-## Mode 3 — Long-form multi-layer evaluation
+## Benchmark authority boundaries
 
-**Canonical label:** `long_form_multi_layer_evaluation`  
-**Typical threshold:** 25,000+ words plus multi-layer/multi-voice complexity  
-**Route:** `LONG_FORM`  
-**Output mode:** `multi_layer_long_form`
+RevisionGrade-native benchmark families are allowed to define the quality bar for evaluation output, but they do not replace the runtime mode system.
 
-Long-form multi-layer evaluation is the deepest evaluation mode. It is used when a manuscript contains multiple timelines, voice lanes, symbolic systems, doctrine/canon layers, identity systems, research-heavy ambiguity, structural paratext, or other architecture that would be flattened by a standard long-form report.
+Native benchmark families include:
 
-### Existing DREAM authority
-
-RevisionGrade already has DREAM long-form specifications and governed-ledger templates. This contract does not replace them. It names the product-facing mode and clarifies that DREAM/governed-ledger material belongs specifically to long-form multi-layer evaluation unless a standard long-form manuscript materially requires a compact version of a ledger.
-
-Existing DREAM templates/specs remain authoritative for:
-
-- governed ledger requirements;
-- layer-aware long-form completeness;
-- Story Ledger / Review Gate behavior where applicable;
-- protected WAVE/governance boundaries;
-- DREAM benchmark addenda.
-
-### Required output surfaces
-
-- All standard long-form surfaces.
-- Story Ledger / layer-aware architecture map where applicable.
-- Review Gate readiness surfaces where applicable.
-- Governed ledgers proving character, relationship, symbol, sensory/emotional, integrity, and evidence-distribution coverage where applicable.
-- Cross-layer synthesis.
-- Layer-aware revision sequencing.
-- Golden Spine / WAVE-informed readiness findings where appropriate, rendered in plain editorial language.
-- Long-form continuity and coverage proof.
-- Download/print versions that show all surfaced criterion opportunities and diagnostic details.
-
-### Explicit boundary
-
-Long-form multi-layer evaluation does not perform revision. It prepares the diagnosis, evidence, ledgers, and prioritized targets that later feed Revise Queue or TrustedPath.
-
----
-
-## Benchmark and corpus normalization rule
-
-Benchmark and corpus files must identify the evaluation mode they represent.
-
-Native RevisionGrade benchmarks should use one of:
-
-- `short_form_evaluation`
-- `long_form_evaluation`
-- `long_form_multi_layer_evaluation`
+```text
+docs/benchmarks/froggin-noggin-dream.md
+docs/benchmarks/froggin-noggin-dream-v2-governed-ledger-addendum.md
+docs/benchmarks/cartel-babies-dream.md
+docs/benchmarks/cartel-babies-dream-v2-governed-ledger-addendum.md
+docs/benchmarks/let-the-river-decide-dream.md
+docs/benchmarks/let-the-river-decide-dream-v2-governed-ledger-addendum.md
+```
 
 Public-domain calibration artifacts remain `runtime-authority: false` unless explicitly promoted through a later governance decision. They may teach calibration behavior, but they must not replace RevisionGrade-native gold standards.
 
@@ -166,3 +92,11 @@ docs/templates/evaluation/long-form-multi-layer-evaluation-template.md
 ```
 
 These templates define the expected public/report shape for each mode. Runtime code may render the same information differently, but the information hierarchy and boundaries must not contradict this contract.
+
+Seed-phase alignment must follow:
+
+```text
+docs/governance/seed-phase-template-alignment-contract.md
+```
+
+Seed scaffolds may align to these modes/templates but may not claim governing authority.

--- a/docs/governance/seed-phase-template-alignment-contract.md
+++ b/docs/governance/seed-phase-template-alignment-contract.md
@@ -1,0 +1,66 @@
+# Seed Phase Template Alignment Contract
+
+**Status:** Canonical documentation contract  
+**Owner:** Mmeraw  
+**Scope:** Seed-phase alignment to output-mode doctrine and templates  
+**Runtime impact:** Documentation only. No routing, scoring, gate, schema, database, or worker behavior changes in this contract slice.
+
+---
+
+## Purpose
+
+The seed phase may reduce cold-start extraction drift, but it must not invent parallel template logic.
+
+This contract binds seed behavior to the existing canonical output-mode system so seed artifacts align to the same mode doctrine used by evaluation.
+
+---
+
+## Canonical mode lock
+
+Seed-phase processing must classify and remain aligned to one of the existing canonical modes:
+
+- `short_form_evaluation`
+- `long_form_evaluation`
+- `long_form_multi_layer_evaluation`
+
+Seed phase must not introduce alternative mode names or aliases.
+
+---
+
+## Template authority lock
+
+Seed-phase scaffold outputs must align to the canonical template authorities:
+
+- `docs/templates/evaluation/short-form-evaluation-template.md`
+- `docs/templates/evaluation/long-form-evaluation-template.md`
+- `docs/templates/evaluation/long-form-multi-layer-evaluation-template.md`
+
+Alignment means seed hypotheses and routing hints may reference template sections conceptually, but seed must not claim template completion as verified truth.
+
+---
+
+## Governance boundaries
+
+- Seed is scaffold-only and non-governing.
+- Seed may shape downstream work but may not authorize downstream truth.
+- `accepted_story_ledger_v1` remains the only governing story-understanding authority for Phase 2.
+- Seed phase must not bypass Review Gate or Approval Normalizer.
+- Seed phase must not emit A/B/C revision proposals into evaluation output.
+
+---
+
+## Evidence and handoff posture
+
+Seed artifacts are handoff inputs, not final report authority.
+
+They may be persisted for retrieval by later steps only under scaffold status semantics and must remain subject to downstream evidence confirmation, normalization, integrity gating, and author review.
+
+---
+
+## Acceptance criteria
+
+- docs-only changes;
+- no runtime trust-path changes;
+- no mode-name drift;
+- no template-name drift;
+- no authority leakage from seed to Phase 2 governance.

--- a/docs/phase-0-warmup/PHASE_0_WARMUP_BENCHMARK_MANIFEST.md
+++ b/docs/phase-0-warmup/PHASE_0_WARMUP_BENCHMARK_MANIFEST.md
@@ -1,0 +1,134 @@
+# Phase 0 Warmup Benchmark Manifest
+
+Status: canonical warmup packet v1  
+Audience: Phase 0, SEED generation, Phase 1A, Story Layer Quality Gate, Review Gate  
+Runtime role: compact manifest only. Do not mine GitHub PR history during evaluation runtime.
+
+## Purpose
+
+Phase 0 must load a compact, deterministic set of benchmark and governance references before SEED generation and Phase 1A work. The system must not search historical PRs live during an evaluation. PR history is raw ore. This manifest is the runtime map.
+
+## Runtime loading rule
+
+Load only the current canonical files listed here, by path and version/hash where available. Do not load hundreds of PRs, review comments, old branch notes, or stale implementation discussions during evaluation runtime.
+
+## Required Phase 0 warmup packet
+
+These files form the compact Phase 0 control packet:
+
+```text
+docs/phase-0-warmup/PHASE_0_WARMUP_BENCHMARK_MANIFEST.md
+docs/phase-0-warmup/WHAT_NOT_TO_DO.md
+docs/phase-0-warmup/STORY_LEDGER_LAYER_FAILURE_MODES.md
+docs/phase-0-warmup/REVISIONGRADE_FAIL_CLOSED_RULES.md
+docs/phase-0-warmup/SIPOC_INPUT_OUTPUT_QUALITY_GATES.md
+docs/phase-0-warmup/SEED_AND_PHASE_1A_GOVERNANCE.md
+```
+
+## Core long-form benchmark canon
+
+```text
+docs/benchmarks/DREAM_LONGFORM_BENCHMARK_INDEX.md
+docs/benchmarks/README.md
+docs/benchmarks/templates/dream-longform-layered-template.md
+docs/governance/DREAM_OUTPUT_LONG_FORM_SPEC.md
+```
+
+## Manuscript benchmark sets
+
+```text
+docs/benchmarks/cartel-babies-dream.md
+docs/benchmarks/cartel-babies-dream-v2-governed-ledger-addendum.md
+
+docs/benchmarks/froggin-noggin-dream.md
+docs/benchmarks/froggin-noggin-dream-v2-governed-ledger-addendum.md
+
+docs/benchmarks/let-the-river-decide-dream.md
+docs/benchmarks/let-the-river-decide-dream-v2-governed-ledger-addendum.md
+```
+
+## Public-domain calibration benchmarks
+
+```text
+docs/benchmarks/public-domain/dracula-dream-calibration.md
+docs/benchmarks/public-domain/great-expectations-dream-calibration.md
+docs/benchmarks/public-domain/pride-and-prejudice-dream-calibration.md
+docs/benchmarks/public-domain/the-awakening-dream-calibration.md
+docs/benchmarks/public-domain/the-awakening-dream-calibration-v2-governed-ledger-addendum.md
+```
+
+## Story Ledger benchmark answer keys
+
+These files define benchmark-quality nine-layer Story Ledger targets and should be used for SEED quality, Phase 1A Story Ledger extraction expectations, fit-gap reporting, and regression targets.
+
+```text
+docs/benchmarks/story-ledger/README.md
+
+docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_CARTEL_BABIES.md
+docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_FROGGIN_NOGGIN.md
+docs/benchmarks/story-ledger/IDEAL_STORY_LEDGER_9_LAYER_BENCHMARK_LET_THE_RIVER_DECIDE.md
+
+docs/benchmarks/story-ledger/FROGGIN_NOGGIN_9_LAYER_OPTIMIZATION_ADDENDUM.md
+docs/benchmarks/story-ledger/LET_THE_RIVER_DECIDE_9_LAYER_OPTIMIZATION_ADDENDUM.md
+```
+
+## Additional benchmark-related references
+
+```text
+docs/benchmarks/ancient-bloodlines-longform-layered-template.md
+docs/benchmarks/ancient-bloodlines-longform-layered.md
+docs/benchmarks/ancient-bloodlines-shortform-model.md
+docs/benchmarks/github-ancient-bloodlines-gold-standard-brief.md
+docs/benchmarks/BENCHMARK-CHARTER.md
+```
+
+## Runtime hierarchy
+
+```text
+Phase 0 warmup packet
+  ↓
+story_seed_v1 + evaluation_seed_v1
+  ↓
+Seed Completeness Gate
+  ↓
+Phase 1A Story Ledger extraction
+  ↓
+Story Layer Quality Gate
+  ↓
+ledger_quality_report_v1
+  ↓
+Review Gate
+  ↓
+accepted_story_ledger_v1
+  ↓
+Phase 2 evaluation
+```
+
+## Authority hierarchy
+
+```text
+Benchmarks define target quality.
+SEED proposes baseline scaffolds.
+Phase 1A verifies against manuscript evidence.
+Story Layer Quality Gate classifies layer health.
+Author Review Gate authorizes accepted_story_ledger_v1.
+accepted_story_ledger_v1 governs Phase 2.
+```
+
+## Prohibited runtime behavior
+
+- Do not search GitHub PR history during evaluation runtime.
+- Do not load stale PR descriptions as live canon.
+- Do not load draft/do-not-merge PRs as authority.
+- Do not allow old PR doctrine to override current warmup files.
+- Do not let benchmark text replace manuscript evidence.
+- Do not let SEED become final truth.
+
+## Required runtime behavior
+
+- Load compact warmup files only.
+- Use benchmark files as quality targets, not manuscript evidence.
+- Record missing benchmark-required elements as fit-gaps.
+- Suppress/degrade/block substandard Story Ledger layers before Review Gate.
+- Use deterministic guardrails where possible.
+- Keep historical PR lessons distilled into canonical docs and tests.

--- a/docs/phase-0-warmup/REVISIONGRADE_FAIL_CLOSED_RULES.md
+++ b/docs/phase-0-warmup/REVISIONGRADE_FAIL_CLOSED_RULES.md
@@ -1,0 +1,279 @@
+# RevisionGrade Fail-Closed Rules
+
+Status: canonical warmup packet v1  
+Purpose: define the product-wide fail-closed doctrine for evaluation, Story Ledger, Review Gate, Revise, and downstream handoffs.
+
+## Core doctrine
+
+RevisionGrade must not convert uncertainty into authority.
+
+When required evidence, artifacts, validations, or benchmark minimums are missing, the system must block, retry, degrade with proof, suppress, or create a fit-gap report. It must not present incomplete or malformed output as valid author-facing truth.
+
+## Allowed failure responses
+
+```text
+block
+retry
+regenerate
+suppress
+degrade_with_caution
+create_fit_gap_report
+route_to_needs_targeting
+manual_review_required
+```
+
+## Prohibited failure response
+
+```text
+render_as_if_valid
+```
+
+---
+
+# Phase 0 fail-closed rules
+
+## Rule
+
+Phase 0 must load only compact canonical warmup files and benchmark references.
+
+## Fail closed when
+
+- Required warmup packet missing.
+- Benchmark manifest cannot be resolved.
+- Required phase-specific governance docs unavailable.
+- Runtime attempts to mine PR history instead of loading canonical docs.
+
+## Runtime consequence
+
+Block seed generation or continue only with explicitly degraded warmup status, never silent fallback to stale/default doctrine.
+
+---
+
+# SEED fail-closed rules
+
+## Rule
+
+Both required seeds must be complete:
+
+```text
+story_seed_v1
+evaluation_seed_v1
+```
+
+## Fail closed when
+
+- Either seed is missing.
+- Either seed is malformed.
+- Story seed lacks all nine layer scaffolds.
+- Story seed lacks candidate input collections.
+- Evaluation seed lacks manuscript profile.
+- Evaluation seed lacks short/long/multilayer template routing.
+- Evaluation seed lacks all 13 criterion scaffolds.
+- Seed includes final scores, final verdict, final canon IDs, or final layer truth.
+
+## Runtime consequence
+
+Create:
+
+```text
+seed_fit_gap_report_v1
+```
+
+Block with:
+
+```text
+SEED_FIT_GAP_BLOCKED
+```
+
+Do not start Phase 1A.
+
+---
+
+# Phase 1A Story Ledger fail-closed rules
+
+## Rule
+
+Phase 1A must use SEED as baseline scaffold and verify against manuscript evidence.
+
+## Fail closed when
+
+- Manuscript text unavailable.
+- Source scope unresolved.
+- Required governing layer cannot be built.
+- Layer output is malformed.
+- Benchmark-required governing entities or systems are missing.
+- Layer emits machine locators as author-facing evidence.
+- Layer claims validity without evidence anchors.
+
+## Runtime consequence
+
+Create or update:
+
+```text
+ledger_quality_report_v1
+```
+
+Layer status must be one of:
+
+```text
+valid
+degraded_with_caution
+suppressed_insufficient_evidence
+suppressed_conflicting_signals
+failed_benchmark_minimum
+```
+
+Do not render failed layers as author-approvable truth.
+
+---
+
+# Review Gate fail-closed rules
+
+## Rule
+
+Review Gate opens only when the Story Ledger is valid, safely degraded with proof, or safely suppressed with explanation.
+
+## Fail closed when
+
+- ledger_quality_report_v1 missing.
+- A required governing layer has failed_benchmark_minimum.
+- A layer has raw malformed content.
+- A layer includes unresolved identity blockers that contaminate dependent layers.
+- Review payload uses invalid status vocabulary.
+- Required comments are missing for comment/reject states.
+
+## Runtime consequence
+
+Do not create accepted_story_ledger_v1.
+Do not start Phase 2.
+Show controlled author-safe explanation or require regeneration.
+
+---
+
+# accepted_story_ledger_v1 fail-closed rules
+
+## Rule
+
+accepted_story_ledger_v1 is the governing story artifact for Phase 2.
+
+## Fail closed when
+
+- Artifact missing.
+- Artifact malformed.
+- Artifact lacks normalized layer decisions.
+- Artifact lacks expected job/manuscript binding.
+- Artifact was derived from unapproved failed layers.
+
+## Runtime consequence
+
+Phase 2 must refuse to start.
+
+---
+
+# Phase 2 evaluation fail-closed rules
+
+## Rule
+
+Phase 2 must evaluate craft against accepted story authority, not raw seed or dirty extraction.
+
+## Fail closed when
+
+- accepted_story_ledger_v1 missing.
+- pass12_handoff_v1 missing when required.
+- Required benchmark context unavailable.
+- Evaluation route unknown: short-form, long-form, or long-form multi-layer.
+- Evidence anchors missing for criterion claims.
+
+## Runtime consequence
+
+Block Phase 2 or mark job failed/degraded with explicit reason.
+
+---
+
+# Revise / Revise Queue fail-closed rules
+
+## Rule
+
+Revise must consume evidence-anchored revision_opportunity_ledger_v1. It must not re-diagnose the manuscript as a separate evaluation.
+
+## Fail closed when
+
+- revision_opportunity_ledger_v1 missing.
+- Opportunity lacks exact anchor.
+- Operation type is unknown.
+- candidate_text is missing where required.
+- candidate_text contains meta-commentary rather than manuscript content.
+- Opportunity has no manuscript_id/job_id binding.
+- Opportunity is vague advice rather than surgical operation.
+
+## Runtime consequence
+
+Do not place item in Revise Queue.
+Route to:
+
+```text
+Needs Targeting
+```
+
+or suppress until regenerated.
+
+---
+
+# TrustedPath fail-closed rules
+
+## Rule
+
+TrustedPath may apply recommended Option A only from trusted, ledger-backed, evidence-anchored revision opportunities.
+
+## Fail closed when
+
+- Opportunity is not from revision_opportunity_ledger_v1.
+- Option A is missing or malformed.
+- Anchor missing.
+- Operation type unknown.
+- No rollback/versioning path exists.
+
+## Runtime consequence
+
+Do not auto-apply. Require manual Revise Queue or regeneration.
+
+---
+
+# Author-facing display fail-closed rules
+
+## Rule
+
+The author must never see internal machine implementation details as if they are manuscript location or editorial evidence.
+
+## Fail closed when author-facing output contains
+
+- chunk IDs
+- raw internal artifact IDs as evidence
+- unparsed JSON
+- stack traces
+- model prompt fragments
+- unnormalized internal status vocabulary
+- unsupported machine coordinates without manuscript-native display location
+
+## Runtime consequence
+
+Block render or sanitize before display.
+
+---
+
+# Runtime hierarchy
+
+```text
+Missing required input → block or fit-gap
+Malformed artifact → block
+Unverified seed truth → verify before authority
+Dirty layer → suppress/degrade/block
+Failed benchmark minimum → do not open Review Gate
+No accepted ledger → do not start Phase 2
+No anchor → no Revise opportunity
+No rollback → no TrustedPath auto-apply
+```
+
+## Product trust sentence
+
+RevisionGrade may be uncertain. It may be incomplete. It may ask for regeneration. It may suppress a layer. It may block a phase. It must never pretend uncertain or malformed output is valid author-facing truth.

--- a/docs/phase-0-warmup/SEED_AND_PHASE_1A_GOVERNANCE.md
+++ b/docs/phase-0-warmup/SEED_AND_PHASE_1A_GOVERNANCE.md
@@ -1,0 +1,274 @@
+# SEED and Phase 1A Governance
+
+Status: canonical warmup packet v1  
+Purpose: define the exact relationship between Phase 0 warmup, SEED artifacts, Phase 1A Story Ledger extraction, Story Layer Quality Gate, Review Gate, and Phase 2.
+
+## Core doctrine
+
+```text
+Seed proposes.
+Phase 1A must use seed as baseline.
+Phase 1A verifies against manuscript evidence.
+Reducer normalizes.
+Story Layer Quality Gate validates.
+Author Review Gate authorizes.
+accepted_story_ledger_v1 governs Phase 2.
+```
+
+## What SEED is
+
+SEED is a provisional scaffold. It reduces cold-start drift and gives downstream extraction a map of what to look for.
+
+SEED is not truth.
+
+## Required SEED artifacts
+
+```text
+story_seed_v1
+evaluation_seed_v1
+```
+
+## story_seed_v1 purpose
+
+The story seed is the complete provisional Story Ledger scaffold.
+
+It must include all nine Story Ledger layer scaffolds:
+
+```text
+source_integrity_layer
+pov_structure_layer
+canonical_identity_layer
+cast_role_tier_layer
+identity_pronoun_layer
+relationship_network_layer
+object_symbol_layer
+location_timeline_worldstate_layer
+threat_antagonist_ending_layer
+```
+
+It must include candidate inputs:
+
+```text
+candidate_entity_registry
+candidate_alias_map
+candidate_pov_map
+candidate_relationship_map
+candidate_pressure_map
+candidate_object_shortlist
+candidate_location_map
+candidate_timeline_hypotheses
+uncertainty_flags
+```
+
+## evaluation_seed_v1 purpose
+
+The evaluation seed is the complete provisional evaluation scaffold.
+
+It must include:
+
+```text
+manuscript_profile
+word_count_tier
+evaluation_mode
+reporting_template_path
+short_form_template
+long_form_template
+long_form_multilayer_template
+criterion_scaffolds for all 13 criteria
+```
+
+## Evaluation routing
+
+```text
+under 25,000 words → short_form_evaluation
+25,000+ words → long_form_evaluation
+long / complex / layered manuscript → long_form_multi_layer_evaluation
+```
+
+Short-form evaluations use the 13 story criteria only. They do not receive Golden Spine / WAVE-level long-form governance.
+
+Long-form evaluations activate manuscript-scale logic.
+
+Long-form multi-layer evaluations activate the deeper layered/canonical path.
+
+## What SEED may do
+
+SEED may:
+
+- propose likely entities
+- propose likely aliases
+- propose likely POV/focalization owners
+- propose likely pressure systems
+- propose likely object/symbol candidates
+- propose likely locations/timeline hypotheses
+- propose evaluation route
+- propose reporting template path
+- propose criterion scaffolds
+- mark uncertainty flags
+
+## What SEED must not do
+
+SEED must not:
+
+- create final canon IDs
+- verify relationships
+- create final Story Ledger truth
+- create final craft scores
+- create final executive verdict
+- authorize Phase 2
+- replace manuscript evidence
+- bypass Review Gate
+
+## Artifact state vs claim state
+
+SEED artifact lifecycle and claim verification state must remain separate.
+
+Artifact state answers:
+
+```text
+Does the seed artifact exist and meet shape/completeness requirements?
+```
+
+Claim state answers:
+
+```text
+Has this specific seeded claim been verified, corrected, rejected, or left unresolved by manuscript evidence?
+```
+
+Do not collapse a partially useful seed into all-or-nothing truth.
+
+## Phase 1A obligation
+
+Phase 1A must use SEED as a baseline scaffold.
+
+That means Phase 1A starts from the seed’s layer scaffolds and candidate inputs, then verifies, corrects, rejects, or expands them from manuscript evidence.
+
+Phase 1A must not wander through the manuscript blindly when a complete seed exists.
+
+Phase 1A must also not trust the seed blindly.
+
+## Phase 1A claim resolution states
+
+Seeded claims should be resolved into states such as:
+
+```text
+verified_from_manuscript
+corrected_by_manuscript
+rejected_by_manuscript
+unresolved_insufficient_evidence
+conflicting_signals
+not_applicable
+```
+
+## Required Phase 1A output
+
+```text
+pass1a_story_layer_v1
+```
+
+This output must include all nine Story Ledger layers, unless a layer is intentionally suppressed/degraded with a quality report explanation.
+
+## Story Layer Quality Gate
+
+After Phase 1A, before Review Gate rendering, generated layers must pass the Story Layer Quality Gate.
+
+The gate must classify each layer:
+
+```text
+valid
+degraded_with_caution
+suppressed_insufficient_evidence
+suppressed_conflicting_signals
+failed_benchmark_minimum
+```
+
+The gate produces:
+
+```text
+ledger_quality_report_v1
+```
+
+## Review Gate
+
+Review Gate may open only when visible layers are valid, safely degraded, or safely suppressed with explanation.
+
+Review Gate must not open for raw failed layers.
+
+Author decisions create:
+
+```text
+accepted_story_ledger_v1
+```
+
+## Phase 2 authority
+
+Phase 2 may use:
+
+```text
+accepted_story_ledger_v1
+```
+
+Phase 2 must not use:
+
+```text
+raw seed as authority
+raw failed Story Ledger layers
+unapproved Phase 1A extraction
+```
+
+## Benchmark relationship
+
+Benchmark files are quality targets and known-answer keys. They are not manuscript evidence.
+
+During benchmark runs, missing benchmark-required structures should produce fit-gap or quality-report failures.
+
+During ordinary user manuscript runs, benchmark docs guide shape, completeness, and failure classification, but all claims must be verified against the user manuscript.
+
+## Display rules
+
+Author-facing Story Ledger output must use manuscript-native locators:
+
+```text
+chapter
+scene
+paragraph
+page
+quoted evidence anchor
+```
+
+Never show:
+
+```text
+chunk IDs
+raw internal coordinates
+unparsed JSON
+model prompt fragments
+stack traces
+```
+
+## Runtime anti-patterns
+
+Do not:
+
+- load PR history live during runtime
+- let seed bypass manuscript evidence
+- let seed bypass Review Gate
+- let incomplete seed start Phase 1A
+- let dirty Story Ledger layers render as truth
+- let failed layers become accepted_story_ledger_v1
+- let Phase 2 start without accepted_story_ledger_v1
+
+## Success condition
+
+The successful path is:
+
+```text
+Phase 0 loaded compact warmup packet.
+Both seed artifacts complete.
+Phase 1A used seed as baseline.
+Phase 1A verified against manuscript evidence.
+Story Layer Quality Gate classified every layer.
+Review Gate displayed only valid/degraded/suppressed-safe layers.
+Author decisions created accepted_story_ledger_v1.
+Phase 2 evaluated against accepted_story_ledger_v1.
+```

--- a/docs/phase-0-warmup/SIPOC_INPUT_OUTPUT_QUALITY_GATES.md
+++ b/docs/phase-0-warmup/SIPOC_INPUT_OUTPUT_QUALITY_GATES.md
@@ -1,0 +1,304 @@
+# SIPOC Input / Output Quality Gates
+
+Status: canonical warmup packet v1  
+Purpose: map each major RevisionGrade process step to required suppliers, inputs, process outputs, customers, and quality gates.
+
+## Core principle
+
+Every phase must declare its minimum usable input and its minimum acceptable output. If a phase cannot produce the required output, it must fail closed, create a fit-gap/quality report, or degrade with proof.
+
+---
+
+# SIPOC summary
+
+| Phase / Process | Supplier | Input | Process | Output | Customer |
+|---|---|---|---|---|---|
+| Phase 0 Warmup | Canon docs / benchmarks | Manifest + what-not-to-do + benchmark refs | Load compact doctrine | Warmup context | SEED generation |
+| SEED | Warmup + manuscript metadata | Manuscript profile + benchmark targets | Build provisional scaffolds | story_seed_v1 + evaluation_seed_v1 | Phase 1A |
+| Seed Completeness Gate | SEED | Two seed artifacts | Validate completeness | seed_fit_gap_report_v1 | Phase 1A or regeneration |
+| Phase 1A | Manuscript + seeds | Text + seed baselines | Extract nine Story Ledger layers | pass1a_story_layer_v1 | Story Layer Quality Gate |
+| Story Layer Quality Gate | Phase 1A | Generated layers + benchmarks | Validate per-layer quality | ledger_quality_report_v1 | Review Gate |
+| Review Gate | Author + quality report | Valid/degraded/suppressed layers | Author review/approval | accepted_story_ledger_v1 | Phase 2 |
+| Phase 2 | Accepted ledger | Accepted story authority + criteria | Craft evaluation | phase2/evaluation artifacts | Report / Revise handoff |
+| Revision Handoff | Evaluation | Anchored findings | Normalize operations | revision_opportunity_ledger_v1 | Revise Queue / TrustedPath |
+| Revise Queue | Revision ledger | Anchored operations | Author-controlled decisions | revision_ledger_decisions | Manuscript repair |
+
+---
+
+# Phase 0 Warmup quality gate
+
+## Required inputs
+
+- PHASE_0_WARMUP_BENCHMARK_MANIFEST.md
+- WHAT_NOT_TO_DO.md
+- STORY_LEDGER_LAYER_FAILURE_MODES.md
+- REVISIONGRADE_FAIL_CLOSED_RULES.md
+- SIPOC_INPUT_OUTPUT_QUALITY_GATES.md
+- SEED_AND_PHASE_1A_GOVERNANCE.md
+- Applicable benchmark docs
+
+## Required output
+
+- Compact warmup context.
+- Selected benchmark references.
+- Selected route: short-form, long-form, or long-form multi-layer where possible.
+- No live PR mining.
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| Manifest resolved | yes |
+| Required warmup docs available | yes |
+| PR history loaded at runtime | no |
+| Benchmark path list present | yes |
+| Fail-closed doctrine loaded | yes |
+
+---
+
+# SEED quality gate
+
+## Required inputs
+
+- Manuscript metadata.
+- Word count / scope estimate.
+- Warmup context.
+- Benchmark targets.
+
+## Required outputs
+
+```text
+story_seed_v1
+evaluation_seed_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| story_seed_v1 exists | yes |
+| evaluation_seed_v1 exists | yes |
+| all 9 Story Ledger layer scaffolds present | yes |
+| all candidate input collections present | yes |
+| all 13 criteria scaffolded | yes |
+| route selected | short / long / long-multilayer |
+| final scores in seed | no |
+| final verdict in seed | no |
+| seed authority | seed_only |
+
+---
+
+# Seed Completeness Gate
+
+## Required inputs
+
+- story_seed_v1
+- evaluation_seed_v1
+
+## Required output
+
+```text
+seed_fit_gap_report_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| Missing required seed sections detected | yes |
+| Fit-gap report persisted | yes |
+| Phase 1A blocked on incomplete seed | yes |
+| Error code on block | SEED_FIT_GAP_BLOCKED |
+
+---
+
+# Phase 1A Story Ledger extraction gate
+
+## Required inputs
+
+- Manuscript text.
+- Complete story_seed_v1.
+- Complete evaluation_seed_v1.
+- Benchmark context.
+
+## Required output
+
+```text
+pass1a_story_layer_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| 9 layer outputs attempted | yes |
+| seed used as baseline | yes |
+| manuscript evidence used to verify/correct/reject seed | yes |
+| machine chunk labels shown to author | no |
+| evidence anchors present | yes where claims are shown |
+| benchmark-required governing entities checked | yes |
+
+---
+
+# Story Layer Quality Gate
+
+## Required inputs
+
+- pass1a_story_layer_v1
+- benchmark targets
+- layer validators
+
+## Required output
+
+```text
+ledger_quality_report_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| every visible layer classified | yes |
+| failed_benchmark_minimum blocks approval | yes |
+| dirty layer suppressed/degraded | yes |
+| author-safe reason shown | yes |
+| valid empty pronoun state allowed | yes |
+| raw malformed layer rendered | no |
+
+Allowed statuses:
+
+```text
+valid
+degraded_with_caution
+suppressed_insufficient_evidence
+suppressed_conflicting_signals
+failed_benchmark_minimum
+```
+
+---
+
+# Review Gate quality gate
+
+## Required inputs
+
+- pass1a_story_layer_v1
+- ledger_quality_report_v1
+- author decisions / comments
+
+## Required output
+
+```text
+accepted_story_ledger_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| all visible layers reviewed | yes |
+| invalid status vocabulary normalized/rejected | yes |
+| comments required for correction/reject states | yes |
+| failed layers excluded from approval | yes |
+| accepted_story_ledger_v1 persisted | yes |
+
+---
+
+# Phase 2 quality gate
+
+## Required inputs
+
+- accepted_story_ledger_v1
+- evaluation route
+- criteria scaffolds
+- manuscript evidence
+
+## Required output
+
+- Criterion evaluation artifacts.
+- Evidence-backed craft diagnosis.
+- No seed-as-authority leakage.
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| accepted_story_ledger_v1 present | yes |
+| seed used as authority | no |
+| all applicable criteria addressed | yes |
+| short-form under 25k uses 13 story criteria only | yes |
+| long-form 25k+ uses manuscript-scale logic | yes |
+| long-form multilayer uses layered/canonical analysis | yes |
+| unanchored diagnosis | no |
+
+---
+
+# Revision Opportunity Ledger gate
+
+## Required inputs
+
+- Evaluation findings.
+- Accepted story authority.
+- Evidence anchors.
+
+## Required output
+
+```text
+revision_opportunity_ledger_v1
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| every opportunity has anchor | yes |
+| operation type locked | yes |
+| candidate_text present when required | yes |
+| forbidden meta-commentary absent | yes |
+| no anchor = no opportunity | enforced |
+| vague advice routed to Needs Targeting | yes |
+
+---
+
+# Revise Queue / TrustedPath gate
+
+## Required inputs
+
+- revision_opportunity_ledger_v1
+- operation labels
+- author decision state
+
+## Required outputs
+
+```text
+revision_ledger_decisions
+```
+
+## Quality metrics
+
+| Metric | Minimum |
+|---|---|
+| queue consumes ledger-backed opportunities | yes |
+| author can accept/reject/defer/customize | yes |
+| TrustedPath applies only trusted Option A | yes |
+| versioning/rollback path exists for auto-apply | required before auto-apply |
+| Revise re-diagnoses manuscript independently | no |
+
+---
+
+# Quality score dimensions
+
+Each gate should be measured against:
+
+| Dimension | Meaning |
+|---|---|
+| Completeness | Required fields/sections/entities exist |
+| Correctness | Claims match manuscript evidence |
+| Authority | Artifact is allowed to govern downstream phase |
+| Traceability | Evidence/source location exists |
+| Display safety | Author sees clean human-readable output |
+| Latency discipline | Runtime loads compact canon, not PR history |
+| Fail-closed behavior | Missing/dirty output blocks, suppresses, degrades, or fit-gaps |
+
+## Bottom line
+
+SIPOC is not paperwork. It is the minimum-quality contract for every handoff. If an output does not meet its customer’s minimum input quality, the next phase must not start cleanly.

--- a/docs/phase-0-warmup/STORY_LEDGER_LAYER_FAILURE_MODES.md
+++ b/docs/phase-0-warmup/STORY_LEDGER_LAYER_FAILURE_MODES.md
@@ -1,0 +1,290 @@
+# Story Ledger Layer Failure Modes
+
+Status: canonical warmup packet v1  
+Purpose: define how each of the nine Story Ledger layers may fail, how the system should classify the failure, and what the UI/runtime may render.
+
+## Core rule
+
+Story Ledger layers may not fail open.
+
+If a layer does not meet benchmark minimums or does not have sufficient verified manuscript evidence, RevisionGrade must render a controlled degraded/suppressed state or block Review Gate. It must not ask the author to approve substandard extraction as story truth.
+
+## Layer health statuses
+
+```text
+valid
+degraded_with_caution
+suppressed_insufficient_evidence
+suppressed_conflicting_signals
+failed_benchmark_minimum
+```
+
+## Author-facing rendering rule
+
+When a layer is not safe to present, render a concise human-readable reason:
+
+```text
+Layer not presented.
+RevisionGrade detected incomplete, conflicting, or insufficiently verified story signals for this layer.
+This layer did not meet the benchmark standard for author review.
+```
+
+Do not expose machine chunk IDs.
+
+---
+
+# 1. Source Integrity
+
+## Valid when
+
+- Submission scope is clear.
+- Manuscript text is available.
+- Word count / route / short-vs-long-form mode is known.
+- Extraction coverage can be assessed.
+- Known source risks are listed.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Manuscript text missing or unreadable | failed_benchmark_minimum | Block Phase 1A |
+| Scope unknown | suppressed_insufficient_evidence | Request regeneration or human review |
+| Major source contamination | suppressed_conflicting_signals | Block Review Gate until resolved |
+| Coverage too narrow for full manuscript | degraded_with_caution or failed_benchmark_minimum | Do not treat output as complete |
+| Internal machine labels exposed | failed_benchmark_minimum | Block author rendering |
+
+## Never do
+
+- Do not claim full-manuscript confidence from partial evidence.
+- Do not show internal chunk labels.
+- Do not treat package/metadata defects as story defects unless evidence supports it.
+
+---
+
+# 2. POV Structure
+
+## Valid when
+
+- Narrative camera/focalization owners are identified or a valid non-focal structure is proven.
+- Omniscient narration is distinguished from absence of POV.
+- Benchmark-required focal centers are represented where applicable.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Says “No POV characters identified” despite obvious focal centers | failed_benchmark_minimum | Suppress layer and regenerate |
+| Confuses role importance with focalization | degraded_with_caution | Show caution or regenerate |
+| Omits benchmark-required POV lane | failed_benchmark_minimum | Block Review Gate for benchmark run |
+| Treats omniscience as no POV | failed_benchmark_minimum | Suppress raw layer |
+
+## Never do
+
+- Do not render “No POV characters identified” for full novels with clear cameras.
+- Do not confuse protagonist role with POV ownership.
+- Do not flatten multi-lane narration into generic third person.
+
+---
+
+# 3. Canonical Identity
+
+## Valid when
+
+- Major named characters and required structural entities are captured.
+- Aliases, titles, roles, name states, and collectives are separated.
+- Merge/split risks are explicitly tracked.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Required benchmark entity missing | failed_benchmark_minimum | Block or fit-gap |
+| Titles split into fake characters | degraded_with_caution or failed_benchmark_minimum | Normalize before Review Gate |
+| Distinct characters merged incorrectly | failed_benchmark_minimum | Suppress layer |
+| Collectives treated as individuals without evidence | degraded_with_caution | Review before approval |
+| Name-state transformation omitted | failed_benchmark_minimum when structural | Fit-gap/regenerate |
+
+## Never do
+
+- Do not collapse aliases and identity transformations into generic names.
+- Do not invent final canon IDs from seed alone.
+- Do not merge collectives, institutions, objects, and people into one entity type.
+
+---
+
+# 4. Cast / Role Tier
+
+## Valid when
+
+- Characters are ranked by structural function.
+- Individual, collective, institutional, animal, symbolic, and environmental forces are separated.
+- Role tier reflects actual story work, not name frequency alone.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Primary/major structural force omitted | failed_benchmark_minimum | Block benchmark Review Gate |
+| Animal/symbolic/institutional force misclassified | degraded_with_caution | Render with caution or regenerate |
+| Minor walk-on promoted to major without evidence | degraded_with_caution | Require evidence |
+| Role tier based only on mentions | degraded_with_caution | Reclassify from plot function |
+
+## Never do
+
+- Do not treat all named characters as equal.
+- Do not treat structural animals as objects.
+- Do not treat institutions or symbolic systems as ordinary cast unless clearly framed.
+
+---
+
+# 5. Pronoun Transitions
+
+## Valid when
+
+- Only reviewable pronoun-family transitions or identity-signal ambiguities are shown.
+- Stable pronoun use is normalized and hidden from author review.
+- Empty state is allowed when no reviewable transitions exist.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Shows stable pronoun usage as review burden | failed_benchmark_minimum | Suppress or regenerate |
+| Treats titles/species/personification as pronoun transition | failed_benchmark_minimum | Suppress raw layer |
+| Misses real cross-family transition | degraded_with_caution or failed_benchmark_minimum | Review/regenerate |
+
+## Valid empty state
+
+```text
+No reviewable pronoun-family transitions detected.
+Stable pronoun usage is normalized and hidden from review.
+```
+
+## Never do
+
+- Do not show stable he/him, she/her, they/them as author tasks.
+- Do not mistake species labels, titles, royal terms, or symbolic personification for pronoun transition.
+
+---
+
+# 6. Relationship Network
+
+## Valid when
+
+- Sustained named relationships are represented.
+- Character-system relationships are allowed when structurally necessary.
+- Group/institution/environment relationships are clearly labeled as systems.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Benchmark-required relationship missing | failed_benchmark_minimum | Fit-gap/regenerate |
+| Named relationship collapsed into generic pressure | failed_benchmark_minimum | Suppress or degrade |
+| One-off encounter treated as major relationship | degraded_with_caution | Require evidence |
+| Unnamed group treated like named relationship without role stability | degraded_with_caution | Route to pressure/system |
+
+## Never do
+
+- Do not reduce relationships to generic “pressure” when named relational arcs exist.
+- Do not ignore animal/human, character/object, character/institution, or character/place relationships when structurally active.
+
+---
+
+# 7. Object / Symbol
+
+## Valid when
+
+- Story-bearing objects and motifs are tracked with lifecycle.
+- Physical objects, symbolic systems, beliefs, artifacts, places, and props are separated.
+- Objects that drive identity, pressure, plot, or closure are not treated as scenery.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Required benchmark object missing | failed_benchmark_minimum | Fit-gap/regenerate |
+| Dialogue classified as object | degraded_with_caution | Correct classification |
+| Doctrine treated as physical object | degraded_with_caution | Split doctrine/object |
+| Story-bearing object treated as scenery | failed_benchmark_minimum when structural | Suppress/regenerate |
+| Object lifecycle missing final meaning | degraded_with_caution | Render with caution |
+
+## Never do
+
+- Do not classify animals as objects.
+- Do not classify abstract doctrine as a physical object.
+- Do not miss objects that carry ending accountability.
+
+---
+
+# 8. Timeline / Location / Worldstate
+
+## Valid when
+
+- The story’s key temporal and spatial movement is represented.
+- Active scene locations are distinguished from backstory, myth, research, or reference locations.
+- World rules are captured.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| Full novel collapsed to opening/middle/end only | degraded_with_caution or failed_benchmark_minimum | Regenerate for coverage |
+| Benchmark-required transit/location chain omitted | failed_benchmark_minimum | Fit-gap |
+| Backstory location treated as active scene | degraded_with_caution | Correct classification |
+| World rules omitted | degraded_with_caution | Degrade layer |
+| Machine chunk labels shown | failed_benchmark_minimum | Block rendering |
+
+## Never do
+
+- Do not use chunk IDs as author-facing location.
+- Do not collapse all settings into generic place categories.
+- Do not ignore transit chains when they carry plot, identity, or safety meaning.
+
+---
+
+# 9. Threat / Pressure / Ending
+
+## Valid when
+
+- Individual, institutional, environmental, relational, symbolic, biological, social, and internal pressures are separated.
+- Ending accountability is explicit.
+- Closure debts are tracked.
+
+## Failure modes
+
+| Failure | Status | Runtime consequence |
+|---|---|---|
+| All pressure reduced to one villain | failed_benchmark_minimum | Regenerate |
+| Ending treated as mood only | failed_benchmark_minimum | Suppress/degrade |
+| Unresolved ending misreported as clean closure | failed_benchmark_minimum | Regenerate |
+| Major pressure system omitted | failed_benchmark_minimum | Fit-gap |
+| Consequences missing from terminal states | degraded_with_caution | Render with caution or regenerate |
+
+## Never do
+
+- Do not treat endings as complete just because the manuscript stops.
+- Do not omit consequences for benchmark-required relationships, objects, and pressures.
+- Do not flatten systemic, environmental, institutional, or symbolic pressure into a single antagonist.
+
+---
+
+# Review Gate rule
+
+Review Gate may open only when every visible layer is one of:
+
+```text
+valid
+degraded_with_caution with proof
+suppressed_insufficient_evidence with author-safe explanation
+suppressed_conflicting_signals with author-safe explanation
+```
+
+Review Gate must not allow approval of:
+
+```text
+failed_benchmark_minimum
+raw malformed layer
+raw unverified seed output
+machine-locator-heavy output
+```

--- a/docs/phase-0-warmup/WHAT_NOT_TO_DO.md
+++ b/docs/phase-0-warmup/WHAT_NOT_TO_DO.md
@@ -1,0 +1,191 @@
+# What Not To Do — Phase 0 Runtime Doctrine Map
+
+Status: canonical warmup packet v1  
+Purpose: compact map of known failure classes, enforcement locations, benchmark references, and runtime consequences.
+
+This file is not a replacement for code guardrails. It is the operating map that tells Phase 0 which hard rules, benchmark targets, and quality gates must be respected before SEED, Phase 1A, Review Gate, and Phase 2.
+
+## Core principle
+
+Do not fail open.
+
+If an artifact, layer, handoff, or revision operation does not meet its required contract, RevisionGrade must block, suppress, degrade with proof, or kick back for regeneration. It must not render substandard output as author-approvable truth.
+
+---
+
+# 1. Seed authority failures
+
+## Do not treat SEED as authority
+
+- Rule: SEED proposes baseline scaffolds only.
+- Enforced by: seed artifact contracts, seedCompletenessGuard, accepted_story_ledger_v1 requirement.
+- Runtime consequence: seed claims must remain proposed/unverified until Phase 1A verifies against manuscript evidence and Review Gate authorizes.
+- Never do: persist seed facts as governing story truth.
+
+## Do not start Phase 1A with incomplete seed artifacts
+
+- Rule: both story_seed_v1 and evaluation_seed_v1 must be complete.
+- Enforced by: seedCompletenessGuard / phase1aSeedRuntimeGate.
+- Runtime consequence: create seed_fit_gap_report_v1 and block with SEED_FIT_GAP_BLOCKED.
+- Never do: run chunk extraction from generic seed claims or partial template routing.
+
+## Do not allow seed to contain final scores or verdicts
+
+- Rule: seed may scaffold criteria and report shape, but may not produce final craft scores or executive verdicts.
+- Enforced by: evaluation_seed_v1 contract and seedCompletenessGuard.
+- Runtime consequence: fail seed fit-gap if final-score/final-verdict fields appear.
+
+---
+
+# 2. Story Ledger rendering failures
+
+## Do not render dirty Story Ledger layers
+
+- Rule: Story Ledger layers are not allowed to fail open.
+- Enforced by: Story Layer Quality Gate.
+- Benchmark references: docs/benchmarks/story-ledger/.
+- Runtime consequence: valid, degraded_with_caution, suppressed_insufficient_evidence, suppressed_conflicting_signals, or failed_benchmark_minimum.
+- Never do: render weak extraction as author-approvable truth.
+
+## Do not open Review Gate with failed benchmark-minimum layers
+
+- Rule: author approval must not be requested for layers that fail governing benchmark minimums.
+- Enforced by: ledger_quality_report_v1 and Review Gate readiness.
+- Runtime consequence: block Review Gate or show controlled suppressed/degraded state.
+
+## Do not claim “No POV characters identified” when focal centers exist
+
+- Rule: empty POV is valid only when evidence supports an intentionally non-focal structure.
+- Enforced by: POV layer validator, benchmark minimums, regression tests.
+- Runtime consequence: suppress/degrade POV Structure if obvious focal centers are missing.
+
+## Do not show stable pronoun use as reviewable pronoun transition
+
+- Rule: stable he/him, she/her, they/them usage belongs in hidden normalization, not author burden.
+- Enforced by: pronoun layer validator.
+- Runtime consequence: render valid empty state: “No reviewable pronoun-family transitions detected.”
+
+## Do not collapse named relationships into generic pressure
+
+- Rule: sustained named relationships must remain visible in Relationship Network.
+- Enforced by: benchmark-specific Story Ledger checks.
+- Runtime consequence: fit-gap if benchmark-required relationships are missing.
+
+## Do not treat story-bearing objects as scenery
+
+- Rule: objects that drive identity, pressure, plot, symbolism, or ending accountability belong in Object / Symbol.
+- Enforced by: benchmark-specific object requirements and Story Layer Quality Gate.
+- Runtime consequence: degrade or block Object / Symbol if required objects are omitted.
+
+## Do not show machine chunk labels to authors
+
+- Rule: machine locators are private traceability only.
+- Enforced by: display locator sanitizer and UI renderer.
+- Runtime consequence: use chapter, scene, paragraph, page, or quoted evidence anchor.
+
+---
+
+# 3. Phase handoff failures
+
+## Do not start Phase 2 without accepted_story_ledger_v1
+
+- Rule: Phase 2 story authority is accepted_story_ledger_v1.
+- Enforced by: Phase 2 handoff guard.
+- Runtime consequence: refuse Phase 2 until Review Gate completes or documented degraded authority is accepted by policy.
+
+## Do not use Golden Record as separate persisted artifact unless mapped to accepted_story_ledger_v1
+
+- Rule: “Golden Record” is doctrine language only unless explicitly mapped.
+- Enforced by: artifact registry and handoff docs.
+- Runtime consequence: avoid terminology split-brain.
+
+## Do not trust half-written artifacts
+
+- Rule: downstream phases require complete artifacts with expected type, version, content, status, and source hash.
+- Enforced by: artifact validators and handoff guards.
+- Runtime consequence: block, retry, or create fit-gap report.
+
+---
+
+# 4. Revision / Revise Queue failures
+
+## Do not create revision opportunities without anchors
+
+- Rule: no anchor = no opportunity.
+- Enforced by: revision_opportunity_ledger_v1 writer.
+- Runtime consequence: route to Needs Targeting, not Revise Queue.
+
+## Do not let Revise re-diagnose the manuscript independently
+
+- Rule: Revise consumes revision_opportunity_ledger_v1 and accepted ledger context; it does not invent a new evaluation.
+- Enforced by: workbench ingestion and TrustedPath ledger-backed flow.
+- Runtime consequence: block or ignore untrusted candidate-only findings.
+
+## Do not render generic advice as a surgical revision operation
+
+- Rule: Revise Queue requires a locked operation type, target, evidence, and candidate text.
+- Enforced by: Revise Card Contract / operation validator.
+- Runtime consequence: kick vague advice to Needs Targeting.
+
+## Do not use forbidden meta-commentary as candidate_text
+
+- Rule: candidate_text must be actual manuscript replacement/addition/deletion content, not “consider revising...” commentary.
+- Enforced by: forbidden-phrase filter.
+- Runtime consequence: block opportunity from queue.
+
+---
+
+# 5. Benchmark-specific completeness failures
+
+## Do not treat benchmark files as evidence
+
+- Rule: benchmark docs are quality targets and known-answer keys, not proof that a new manuscript contains the same facts.
+- Enforced by: Phase 0 manifest and Story Layer Quality Gate.
+- Runtime consequence: compare shape/completeness, then verify against uploaded manuscript.
+
+## Do not omit benchmark-required entities in benchmark runs
+
+Examples:
+
+- Cartel Babies must not miss Cobra, Diego, El Tomatero, Paolito/Paul, Benjamin’s family/church/school pressure, Canadian Embassy identity changes, radio-channel punishment, and transit chain.
+- Froggin Noggin must not miss Maximilian, Beiana, Lacerta, Twillow, Hyla council, Dead Zone, shard dependency, and unresolved ending escalation.
+- Let the River Decide must not treat Fritz and Schultz as decorative pets, must not miss William/Esmé/Nila/Anthony/Leanna, and must not flatten the river into setting.
+
+Runtime consequence: seed_fit_gap_report_v1 or ledger_quality_report_v1 must identify the missing benchmark target.
+
+---
+
+# 6. Latency and runtime discipline failures
+
+## Do not mine PR history during runtime
+
+- Rule: PRs are raw ore, not runtime canon.
+- Enforced by: Phase 0 manifest.
+- Runtime consequence: load compact warmup docs only.
+
+## Do not load stale branch notes as canon
+
+- Rule: current canonical docs and merged/current PR files govern.
+- Runtime consequence: old PR descriptions may inform offline doctrine mining only.
+
+## Do not expand Phase 0 into a huge prompt bundle
+
+- Rule: warmup must be compact, deterministic, and phase-specific.
+- Runtime consequence: manifest selects only the needed files; no broad repo scan.
+
+---
+
+# Enforcement summary
+
+| Rule class | Primary enforcement |
+|---|---|
+| Hard safety / sequencing | Code guardrail + regression test |
+| Benchmark completeness | Benchmark docs + fit-gap report + Story Layer Quality Gate |
+| Judgment doctrine | Phase 0 warmup packet |
+| Historical PR lessons | Offline mining into canonical docs |
+| Author-facing display | Renderer/UI sanitizer |
+| Downstream authority | Artifact handoff guards |
+
+## Bottom line
+
+Guardrails enforce the dangerous “do nots.” Benchmarks define quality and completeness. This file tells Phase 0 what not to do and where enforcement lives.

--- a/lib/evaluation/artifacts/artifactRegistry.ts
+++ b/lib/evaluation/artifacts/artifactRegistry.ts
@@ -7,6 +7,7 @@ import {
 const CONTRACT_DOC = 'docs/canon/STORY_LAYER_CONTRACT_V1.md';
 const SUPPORT_CONTRACT_DOC = 'docs/canon/SUPPORTING_SIGNAL_ARTIFACTS_CONTRACT_V1.md';
 const PROVIDER_VERIFICATION_CONTRACT_DOC = 'docs/canon/EVAL2_PROVIDER_VERIFICATION_CONTRACT_V1.md';
+const SEED_CONTRACT_DOC = 'docs/phase-0-warmup/SEED_AND_PHASE_1A_GOVERNANCE.md';
 
 export const ARTIFACT_REGISTRY: Record<CanonicalEvaluationArtifactType, ArtifactRegistryEntry> = {
   dream_calibration_packet_v1: {
@@ -18,6 +19,39 @@ export const ARTIFACT_REGISTRY: Record<CanonicalEvaluationArtifactType, Artifact
     phase: 'phase_0_calibration',
     phase2StoryAuthority: false,
     supportArtifact: false,
+    createsStoryLayer: false,
+  },
+  story_seed_v1: {
+    artifactType: 'story_seed_v1',
+    artifactVersion: 'v1',
+    schemaPath: null,
+    contractDocPath: SEED_CONTRACT_DOC,
+    authority: 'seed_baseline',
+    phase: 'seed_baseline',
+    phase2StoryAuthority: false,
+    supportArtifact: true,
+    createsStoryLayer: false,
+  },
+  evaluation_seed_v1: {
+    artifactType: 'evaluation_seed_v1',
+    artifactVersion: 'v1',
+    schemaPath: null,
+    contractDocPath: SEED_CONTRACT_DOC,
+    authority: 'seed_baseline',
+    phase: 'seed_baseline',
+    phase2StoryAuthority: false,
+    supportArtifact: true,
+    createsStoryLayer: false,
+  },
+  seed_fit_gap_report_v1: {
+    artifactType: 'seed_fit_gap_report_v1',
+    artifactVersion: 'v1',
+    schemaPath: null,
+    contractDocPath: SEED_CONTRACT_DOC,
+    authority: 'seed_fit_gap',
+    phase: 'seed_baseline',
+    phase2StoryAuthority: false,
+    supportArtifact: true,
     createsStoryLayer: false,
   },
   factual_anomalies_detected_v1: {

--- a/lib/evaluation/artifacts/artifactTypes.ts
+++ b/lib/evaluation/artifacts/artifactTypes.ts
@@ -4,9 +4,11 @@
  * Scope: shape-only registry support for STORY_LAYER_CONTRACT_V1.
  * Do not import runtime pipeline, worker, route, prompt, OpenAI, or Supabase modules here.
  */
-
 export const CANONICAL_EVALUATION_ARTIFACT_TYPES = [
   'dream_calibration_packet_v1',
+  'story_seed_v1',
+  'evaluation_seed_v1',
+  'seed_fit_gap_report_v1',
   'factual_anomalies_detected_v1',
   'pass1a_story_layer_v1',
   'ledger_quality_report_v1',
@@ -58,6 +60,8 @@ export type RuntimeArtifactEnvelope = {
 };
 
 export type ArtifactAuthority =
+  | 'seed_baseline'
+  | 'seed_fit_gap'
   | 'governing_story_understanding'
   | 'gate_verdict'
   | 'review_trace'
@@ -72,6 +76,7 @@ export type ArtifactAuthority =
 
 export type ArtifactPhase =
   | 'phase_0_calibration'
+  | 'seed_baseline'
   | 'phase_1a_story_layer'
   | 'review_gate'
   | 'approval_normalizer'

--- a/lib/evaluation/seed/phase1aSeedRuntimeGate.ts
+++ b/lib/evaluation/seed/phase1aSeedRuntimeGate.ts
@@ -4,6 +4,18 @@ import { countWords } from '@/lib/evaluation/pipeline/submissionScope';
 import { buildSeedFitGapReport, type SeedFitGapReportV1 } from '@/lib/evaluation/seed/seedCompletenessGuard';
 import { buildCompleteEvaluationSeedV1, buildCompleteStorySeedV1 } from '@/lib/evaluation/seed/seedScaffoldFactory';
 
+type PersistableSeedArtifactType = 'story_seed_v1' | 'evaluation_seed_v1' | 'seed_fit_gap_report_v1';
+
+const persistSeedArtifact = upsertEvaluationArtifact as unknown as (params: {
+  supabase: SupabaseClient<any, any, any>;
+  jobId: string;
+  manuscriptId: number;
+  artifactType: PersistableSeedArtifactType;
+  artifactVersion: string;
+  sourceHash: string;
+  content: unknown;
+}) => Promise<string>;
+
 export type Phase1aSeedGateResult = {
   ok: true;
   storySeed: unknown;
@@ -47,7 +59,7 @@ export async function ensureCompleteSeedsBeforePhase1a(args: {
   let storySeed = existing.get('story_seed_v1');
   if (!storySeed) {
     storySeed = buildCompleteStorySeedV1({ generatedAt: now });
-    await upsertEvaluationArtifact({
+    await persistSeedArtifact({
       supabase: args.supabase,
       jobId: args.jobId,
       manuscriptId: args.manuscriptId,
@@ -72,7 +84,7 @@ export async function ensureCompleteSeedsBeforePhase1a(args: {
       wordCount: countWords(args.manuscriptText),
       workType: args.workType,
     });
-    await upsertEvaluationArtifact({
+    await persistSeedArtifact({
       supabase: args.supabase,
       jobId: args.jobId,
       manuscriptId: args.manuscriptId,
@@ -92,7 +104,7 @@ export async function ensureCompleteSeedsBeforePhase1a(args: {
 
   const fitGapReport = buildSeedFitGapReport({ storySeed, evaluationSeed, generatedAt: now });
 
-  await upsertEvaluationArtifact({
+  await persistSeedArtifact({
     supabase: args.supabase,
     jobId: args.jobId,
     manuscriptId: args.manuscriptId,

--- a/lib/evaluation/seed/phase1aSeedRuntimeGate.ts
+++ b/lib/evaluation/seed/phase1aSeedRuntimeGate.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { stableSourceHash, upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+import { countWords } from '@/lib/evaluation/pipeline/submissionScope';
+import { buildSeedFitGapReport, type SeedFitGapReportV1 } from '@/lib/evaluation/seed/seedCompletenessGuard';
+import { buildCompleteEvaluationSeedV1, buildCompleteStorySeedV1 } from '@/lib/evaluation/seed/seedScaffoldFactory';
+
+export type Phase1aSeedGateResult = {
+  ok: true;
+  storySeed: unknown;
+  evaluationSeed: unknown;
+  fitGapReport: SeedFitGapReportV1;
+} | {
+  ok: false;
+  error_code: 'SEED_FIT_GAP_BLOCKED';
+  error_message: string;
+  fitGapReport: SeedFitGapReportV1;
+};
+
+export async function ensureCompleteSeedsBeforePhase1a(args: {
+  supabase: SupabaseClient<any, any, any>;
+  jobId: string;
+  manuscriptId: number;
+  userId: string;
+  manuscriptText: string;
+  workType?: string | null;
+}): Promise<Phase1aSeedGateResult> {
+  const now = new Date().toISOString();
+  const seedTypes = ['story_seed_v1', 'evaluation_seed_v1'] as const;
+
+  const { data: existingRows, error: readError } = await args.supabase
+    .from('evaluation_artifacts')
+    .select('artifact_type, content')
+    .eq('job_id', args.jobId)
+    .in('artifact_type', [...seedTypes]);
+
+  if (readError) {
+    throw new Error(`SEED_ARTIFACT_READ_FAILED: ${readError.message}`);
+  }
+
+  const existing = new Map<string, unknown>();
+  for (const row of existingRows ?? []) {
+    if (row && typeof row === 'object' && typeof (row as { artifact_type?: unknown }).artifact_type === 'string') {
+      existing.set((row as { artifact_type: string }).artifact_type, (row as { content?: unknown }).content);
+    }
+  }
+
+  let storySeed = existing.get('story_seed_v1');
+  if (!storySeed) {
+    storySeed = buildCompleteStorySeedV1({ generatedAt: now });
+    await upsertEvaluationArtifact({
+      supabase: args.supabase,
+      jobId: args.jobId,
+      manuscriptId: args.manuscriptId,
+      artifactType: 'story_seed_v1',
+      artifactVersion: 'story_seed_v1',
+      sourceHash: stableSourceHash({
+        jobId: args.jobId,
+        manuscriptId: args.manuscriptId,
+        userId: args.userId,
+        manuscriptText: args.manuscriptText,
+        promptVersion: 'story_seed_v1:complete_scaffold',
+        model: 'seed_scaffold_factory',
+      }),
+      content: storySeed,
+    });
+  }
+
+  let evaluationSeed = existing.get('evaluation_seed_v1');
+  if (!evaluationSeed) {
+    evaluationSeed = buildCompleteEvaluationSeedV1({
+      generatedAt: now,
+      wordCount: countWords(args.manuscriptText),
+      workType: args.workType,
+    });
+    await upsertEvaluationArtifact({
+      supabase: args.supabase,
+      jobId: args.jobId,
+      manuscriptId: args.manuscriptId,
+      artifactType: 'evaluation_seed_v1',
+      artifactVersion: 'evaluation_seed_v1',
+      sourceHash: stableSourceHash({
+        jobId: args.jobId,
+        manuscriptId: args.manuscriptId,
+        userId: args.userId,
+        manuscriptText: args.manuscriptText,
+        promptVersion: 'evaluation_seed_v1:complete_scaffold',
+        model: 'seed_scaffold_factory',
+      }),
+      content: evaluationSeed,
+    });
+  }
+
+  const fitGapReport = buildSeedFitGapReport({ storySeed, evaluationSeed, generatedAt: now });
+
+  await upsertEvaluationArtifact({
+    supabase: args.supabase,
+    jobId: args.jobId,
+    manuscriptId: args.manuscriptId,
+    artifactType: 'seed_fit_gap_report_v1',
+    artifactVersion: 'seed_fit_gap_report_v1',
+    sourceHash: stableSourceHash({
+      jobId: args.jobId,
+      manuscriptId: args.manuscriptId,
+      userId: args.userId,
+      manuscriptText: args.manuscriptText,
+      promptVersion: 'seed_fit_gap_report_v1:phase1a_gate',
+      model: 'seed_completeness_guard',
+    }),
+    content: fitGapReport,
+  });
+
+  if (fitGapReport.status === 'blocked') {
+    return {
+      ok: false,
+      error_code: 'SEED_FIT_GAP_BLOCKED',
+      error_message: `Seed fit-gap blocked Phase 1A: ${fitGapReport.gaps.length} required section(s) missing.`,
+      fitGapReport,
+    };
+  }
+
+  return { ok: true, storySeed, evaluationSeed, fitGapReport };
+}

--- a/lib/evaluation/seed/seedCompletenessGuard.ts
+++ b/lib/evaluation/seed/seedCompletenessGuard.ts
@@ -1,5 +1,9 @@
 import { CRITERIA_KEYS, type CriterionKey } from '@/schemas/criteria-keys';
-import { STORY_LAYER_KEYS, type StoryLayerCoreLayerKey } from '@/lib/evaluation/artifacts/artifactTypes';
+import {
+  STORY_LAYER_COUNT,
+  STORY_LAYER_KEYS,
+  type StoryLayerCoreLayerKey,
+} from '@/lib/evaluation/artifacts/artifactTypes';
 
 export const SEED_FIT_GAP_REPORT_TYPE = 'seed_fit_gap_report_v1' as const;
 
@@ -16,11 +20,27 @@ export type SeedFitGap = {
 
 export type SeedFitGapReportV1 = {
   artifact_type: typeof SEED_FIT_GAP_REPORT_TYPE;
-  status: 'blocked' | 'passed';
+  status: 'blocked' | 'passed' | 'passed_with_warnings';
   generated_at: string;
   doctrine: 'complete_seed_artifacts_required_before_phase_1a';
   gaps: SeedFitGap[];
 };
+
+export class SeedFitGapBlockedError extends Error {
+  readonly code = 'SEED_FIT_GAP_BLOCKED';
+  readonly report: SeedFitGapReportV1;
+
+  constructor(report: SeedFitGapReportV1) {
+    const summary = report.gaps
+      .filter((gap) => gap.severity === 'blocker')
+      .map((gap) => `${gap.artifact_type}:${gap.section}`)
+      .join(', ');
+
+    super(`SEED_FIT_GAP_BLOCKED: ${summary}`);
+    this.name = 'SeedFitGapBlockedError';
+    this.report = report;
+  }
+}
 
 export type StorySeedV1Minimum = {
   artifact_type: 'story_seed_v1';
@@ -73,6 +93,8 @@ export type EvaluationSeedV1Minimum = {
   };
 };
 
+type CandidateInputKind = 'array' | 'record';
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -81,46 +103,78 @@ function hasOwn(record: unknown, key: string): boolean {
   return isRecord(record) && Object.prototype.hasOwnProperty.call(record, key);
 }
 
-function pushGap(gaps: SeedFitGap[], artifact_type: SeedArtifactType, section: string, message: string, required_action: string): void {
-  gaps.push({ artifact_type, section, severity: 'blocker', message, required_action });
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasFiniteNumber(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonEmptyRecord(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && Object.keys(value).length > 0;
+}
+
+function candidateInputMatchesKind(value: unknown, kind: CandidateInputKind): boolean {
+  if (kind === 'array') return Array.isArray(value);
+  return isRecord(value);
+}
+
+function pushGap(
+  gaps: SeedFitGap[],
+  artifact_type: SeedArtifactType,
+  section: string,
+  message: string,
+  required_action: string,
+  severity: SeedGapSeverity = 'blocker',
+): void {
+  gaps.push({ artifact_type, section, severity, message, required_action });
 }
 
 export function validateStorySeedCompleteness(seed: unknown): SeedFitGap[] {
   const gaps: SeedFitGap[] = [];
-  const artifact = seed as Partial<StorySeedV1Minimum> | null;
 
   if (!isRecord(seed)) {
     pushGap(gaps, 'story_seed_v1', 'artifact', 'story_seed_v1 is missing or not an object.', 'Regenerate a complete story_seed_v1.');
     return gaps;
   }
 
+  const artifact = seed as Partial<StorySeedV1Minimum>;
+
   if (artifact.artifact_type !== 'story_seed_v1') pushGap(gaps, 'story_seed_v1', 'artifact_type', 'Wrong or missing artifact_type.', 'Set artifact_type to story_seed_v1.');
   if (artifact.authority !== 'seed_only') pushGap(gaps, 'story_seed_v1', 'authority', 'Seed authority must be seed_only.', 'Regenerate with authority=seed_only.');
+  if (!hasNonEmptyString(artifact.artifact_status)) pushGap(gaps, 'story_seed_v1', 'artifact_status', 'Missing artifact_status.', 'Set artifact_status to a non-empty lifecycle value.');
 
   if (!isRecord(artifact.layer_scaffolds)) {
-    pushGap(gaps, 'story_seed_v1', 'layer_scaffolds', 'Missing complete Story Ledger layer scaffolds.', 'Create scaffolds for all 9 Story Ledger layers.');
+    pushGap(gaps, 'story_seed_v1', 'layer_scaffolds', 'Missing complete Story Ledger layer scaffolds.', `Create scaffolds for all ${STORY_LAYER_COUNT} Story Ledger layers.`);
   } else {
     for (const layerKey of STORY_LAYER_KEYS) {
       if (!hasOwn(artifact.layer_scaffolds, layerKey)) {
         pushGap(gaps, 'story_seed_v1', `layer_scaffolds.${layerKey}`, `Missing scaffold for ${layerKey}.`, 'Seed must include every Story Ledger layer before Phase 1A.');
+      } else if (!isNonEmptyRecord(artifact.layer_scaffolds[layerKey])) {
+        pushGap(gaps, 'story_seed_v1', `layer_scaffolds.${layerKey}`, `Scaffold for ${layerKey} is empty or malformed.`, 'Seed scaffold must be a non-empty object with baseline expectations, risks, or required verification targets.');
       }
     }
   }
 
   const inputs = artifact.global_candidate_inputs;
-  const requiredInputs = [
-    'candidate_entity_registry',
-    'candidate_alias_map',
-    'candidate_pov_map',
-    'candidate_relationship_map',
-    'candidate_pressure_map',
-    'candidate_object_shortlist',
-    'candidate_location_map',
-    'candidate_timeline_hypotheses',
-    'uncertainty_flags',
+  const requiredInputs: Array<{ key: keyof NonNullable<StorySeedV1Minimum['global_candidate_inputs']>; kind: CandidateInputKind }> = [
+    { key: 'candidate_entity_registry', kind: 'array' },
+    { key: 'candidate_alias_map', kind: 'record' },
+    { key: 'candidate_pov_map', kind: 'array' },
+    { key: 'candidate_relationship_map', kind: 'array' },
+    { key: 'candidate_pressure_map', kind: 'array' },
+    { key: 'candidate_object_shortlist', kind: 'array' },
+    { key: 'candidate_location_map', kind: 'array' },
+    { key: 'candidate_timeline_hypotheses', kind: 'array' },
+    { key: 'uncertainty_flags', kind: 'array' },
   ];
-  for (const key of requiredInputs) {
-    if (!hasOwn(inputs, key)) pushGap(gaps, 'story_seed_v1', `global_candidate_inputs.${key}`, `Missing ${key}.`, 'Regenerate story seed with all candidate input collections.');
+  for (const { key, kind } of requiredInputs) {
+    if (!hasOwn(inputs, key)) {
+      pushGap(gaps, 'story_seed_v1', `global_candidate_inputs.${key}`, `Missing ${key}.`, 'Regenerate story seed with all candidate input collections.');
+    } else if (!candidateInputMatchesKind(inputs?.[key], kind)) {
+      pushGap(gaps, 'story_seed_v1', `global_candidate_inputs.${key}`, `${key} has the wrong shape.`, `Expected ${kind === 'array' ? 'an array' : 'an object'} for ${key}.`);
+    }
   }
 
   const rail = artifact.governance_rail;
@@ -134,28 +188,43 @@ export function validateStorySeedCompleteness(seed: unknown): SeedFitGap[] {
 
 export function validateEvaluationSeedCompleteness(seed: unknown): SeedFitGap[] {
   const gaps: SeedFitGap[] = [];
-  const artifact = seed as Partial<EvaluationSeedV1Minimum> | null;
 
   if (!isRecord(seed)) {
     pushGap(gaps, 'evaluation_seed_v1', 'artifact', 'evaluation_seed_v1 is missing or not an object.', 'Regenerate a complete evaluation_seed_v1.');
     return gaps;
   }
 
+  const artifact = seed as Partial<EvaluationSeedV1Minimum>;
+
   if (artifact.artifact_type !== 'evaluation_seed_v1') pushGap(gaps, 'evaluation_seed_v1', 'artifact_type', 'Wrong or missing artifact_type.', 'Set artifact_type to evaluation_seed_v1.');
   if (artifact.authority !== 'seed_only') pushGap(gaps, 'evaluation_seed_v1', 'authority', 'Seed authority must be seed_only.', 'Regenerate with authority=seed_only.');
+  if (!hasNonEmptyString(artifact.artifact_status)) pushGap(gaps, 'evaluation_seed_v1', 'artifact_status', 'Missing artifact_status.', 'Set artifact_status to a non-empty lifecycle value.');
 
   const profile = artifact.manuscript_profile;
-  for (const key of ['word_count', 'word_count_tier', 'evaluation_mode', 'work_type']) {
-    if (!hasOwn(profile, key)) pushGap(gaps, 'evaluation_seed_v1', `manuscript_profile.${key}`, `Missing ${key}.`, 'Evaluation seed must route short/long/multilayer mode before Phase 1A.');
+  if (!hasFiniteNumber(profile?.word_count)) pushGap(gaps, 'evaluation_seed_v1', 'manuscript_profile.word_count', 'Missing or invalid word_count.', 'Evaluation seed must include a finite numeric word_count.');
+  for (const key of ['word_count_tier', 'evaluation_mode', 'work_type'] as const) {
+    if (!hasNonEmptyString(profile?.[key])) pushGap(gaps, 'evaluation_seed_v1', `manuscript_profile.${key}`, `Missing ${key}.`, 'Evaluation seed must route short/long/multilayer mode before Phase 1A.');
   }
 
   const templates = artifact.reporting_template_path;
-  for (const key of ['selected_template', 'short_form_template', 'long_form_template', 'long_form_multilayer_template']) {
-    if (!hasOwn(templates, key)) pushGap(gaps, 'evaluation_seed_v1', `reporting_template_path.${key}`, `Missing ${key}.`, 'Evaluation seed must carry polished short and long-form template paths.');
+  for (const key of ['selected_template', 'short_form_template', 'long_form_template', 'long_form_multilayer_template'] as const) {
+    if (!hasNonEmptyString(templates?.[key])) pushGap(gaps, 'evaluation_seed_v1', `reporting_template_path.${key}`, `Missing ${key}.`, 'Evaluation seed must carry polished short and long-form template paths.');
   }
 
-  const criteria = Array.isArray(artifact.criterion_scaffolds) ? artifact.criterion_scaffolds : [];
-  const present = new Set(criteria.map((item) => item.criterion_key));
+  const criteria = Array.isArray(artifact.criterion_scaffolds)
+    ? artifact.criterion_scaffolds.filter(isRecord)
+    : [];
+  const malformedCriteria = Array.isArray(artifact.criterion_scaffolds)
+    ? artifact.criterion_scaffolds.length - criteria.length
+    : 0;
+
+  if (!Array.isArray(artifact.criterion_scaffolds)) {
+    pushGap(gaps, 'evaluation_seed_v1', 'criterion_scaffolds', 'criterion_scaffolds is missing or not an array.', 'Evaluation seed must scaffold all 13 criteria.');
+  } else if (malformedCriteria > 0) {
+    pushGap(gaps, 'evaluation_seed_v1', 'criterion_scaffolds.malformed', `${malformedCriteria} criterion scaffold item(s) are malformed.`, 'Every criterion scaffold must be an object with a criterion_key.');
+  }
+
+  const present = new Set(criteria.map((item) => item.criterion_key).filter(hasNonEmptyString));
   for (const key of CRITERIA_KEYS) {
     if (!present.has(key)) pushGap(gaps, 'evaluation_seed_v1', `criterion_scaffolds.${key}`, `Missing criterion scaffold for ${key}.`, 'Evaluation seed must scaffold all 13 criteria.');
   }
@@ -176,9 +245,10 @@ export function buildSeedFitGapReport(args: { storySeed: unknown; evaluationSeed
     ...validateStorySeedCompleteness(args.storySeed),
     ...validateEvaluationSeedCompleteness(args.evaluationSeed),
   ];
+  const hasBlockers = gaps.some((gap) => gap.severity === 'blocker');
   return {
     artifact_type: SEED_FIT_GAP_REPORT_TYPE,
-    status: gaps.length > 0 ? 'blocked' : 'passed',
+    status: hasBlockers ? 'blocked' : gaps.length > 0 ? 'passed_with_warnings' : 'passed',
     generated_at: args.generatedAt ?? new Date().toISOString(),
     doctrine: 'complete_seed_artifacts_required_before_phase_1a',
     gaps,
@@ -188,7 +258,6 @@ export function buildSeedFitGapReport(args: { storySeed: unknown; evaluationSeed
 export function assertSeedsCompleteForPhase1a(args: { storySeed: unknown; evaluationSeed: unknown }): void {
   const report = buildSeedFitGapReport(args);
   if (report.status === 'blocked') {
-    const summary = report.gaps.map((gap) => `${gap.artifact_type}:${gap.section}`).join(', ');
-    throw new Error(`SEED_FIT_GAP_BLOCKED: ${summary}`);
+    throw new SeedFitGapBlockedError(report);
   }
 }

--- a/lib/evaluation/seed/seedCompletenessGuard.ts
+++ b/lib/evaluation/seed/seedCompletenessGuard.ts
@@ -1,0 +1,194 @@
+import { CRITERIA_KEYS, type CriterionKey } from '@/schemas/criteria-keys';
+import { STORY_LAYER_KEYS, type StoryLayerCoreLayerKey } from '@/lib/evaluation/artifacts/artifactTypes';
+
+export const SEED_FIT_GAP_REPORT_TYPE = 'seed_fit_gap_report_v1' as const;
+
+export type SeedArtifactType = 'story_seed_v1' | 'evaluation_seed_v1';
+export type SeedGapSeverity = 'blocker' | 'warning';
+
+export type SeedFitGap = {
+  artifact_type: SeedArtifactType;
+  section: string;
+  severity: SeedGapSeverity;
+  message: string;
+  required_action: string;
+};
+
+export type SeedFitGapReportV1 = {
+  artifact_type: typeof SEED_FIT_GAP_REPORT_TYPE;
+  status: 'blocked' | 'passed';
+  generated_at: string;
+  doctrine: 'complete_seed_artifacts_required_before_phase_1a';
+  gaps: SeedFitGap[];
+};
+
+export type StorySeedV1Minimum = {
+  artifact_type: 'story_seed_v1';
+  authority: 'seed_only';
+  artifact_status: string;
+  layer_scaffolds?: Partial<Record<StoryLayerCoreLayerKey, unknown>>;
+  global_candidate_inputs?: {
+    candidate_entity_registry?: unknown;
+    candidate_alias_map?: unknown;
+    candidate_pov_map?: unknown;
+    candidate_relationship_map?: unknown;
+    candidate_pressure_map?: unknown;
+    candidate_object_shortlist?: unknown;
+    candidate_location_map?: unknown;
+    candidate_timeline_hypotheses?: unknown;
+    uncertainty_flags?: unknown;
+  };
+  governance_rail?: {
+    seed_must_be_used_as_phase1a_baseline?: unknown;
+    phase1a_must_verify_seed_against_manuscript_evidence?: unknown;
+    seed_may_authorize_downstream_truth?: unknown;
+    accepted_story_ledger_required_for_phase2?: unknown;
+  };
+};
+
+export type EvaluationSeedV1Minimum = {
+  artifact_type: 'evaluation_seed_v1';
+  authority: 'seed_only';
+  artifact_status: string;
+  manuscript_profile?: {
+    word_count?: unknown;
+    word_count_tier?: unknown;
+    evaluation_mode?: unknown;
+    work_type?: unknown;
+  };
+  reporting_template_path?: {
+    selected_template?: unknown;
+    short_form_template?: unknown;
+    long_form_template?: unknown;
+    long_form_multilayer_template?: unknown;
+  };
+  criterion_scaffolds?: Array<{ criterion_key?: CriterionKey | string }>;
+  governance_rail?: {
+    seed_must_be_used_as_phase1a_evaluation_baseline?: unknown;
+    phase1a_must_verify_seed_against_manuscript_evidence?: unknown;
+    seed_may_authorize_downstream_truth?: unknown;
+    final_craft_scores_forbidden?: unknown;
+    final_executive_verdict_forbidden?: unknown;
+    accepted_story_ledger_required_for_phase2?: unknown;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(record: unknown, key: string): boolean {
+  return isRecord(record) && Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function pushGap(gaps: SeedFitGap[], artifact_type: SeedArtifactType, section: string, message: string, required_action: string): void {
+  gaps.push({ artifact_type, section, severity: 'blocker', message, required_action });
+}
+
+export function validateStorySeedCompleteness(seed: unknown): SeedFitGap[] {
+  const gaps: SeedFitGap[] = [];
+  const artifact = seed as Partial<StorySeedV1Minimum> | null;
+
+  if (!isRecord(seed)) {
+    pushGap(gaps, 'story_seed_v1', 'artifact', 'story_seed_v1 is missing or not an object.', 'Regenerate a complete story_seed_v1.');
+    return gaps;
+  }
+
+  if (artifact.artifact_type !== 'story_seed_v1') pushGap(gaps, 'story_seed_v1', 'artifact_type', 'Wrong or missing artifact_type.', 'Set artifact_type to story_seed_v1.');
+  if (artifact.authority !== 'seed_only') pushGap(gaps, 'story_seed_v1', 'authority', 'Seed authority must be seed_only.', 'Regenerate with authority=seed_only.');
+
+  if (!isRecord(artifact.layer_scaffolds)) {
+    pushGap(gaps, 'story_seed_v1', 'layer_scaffolds', 'Missing complete Story Ledger layer scaffolds.', 'Create scaffolds for all 9 Story Ledger layers.');
+  } else {
+    for (const layerKey of STORY_LAYER_KEYS) {
+      if (!hasOwn(artifact.layer_scaffolds, layerKey)) {
+        pushGap(gaps, 'story_seed_v1', `layer_scaffolds.${layerKey}`, `Missing scaffold for ${layerKey}.`, 'Seed must include every Story Ledger layer before Phase 1A.');
+      }
+    }
+  }
+
+  const inputs = artifact.global_candidate_inputs;
+  const requiredInputs = [
+    'candidate_entity_registry',
+    'candidate_alias_map',
+    'candidate_pov_map',
+    'candidate_relationship_map',
+    'candidate_pressure_map',
+    'candidate_object_shortlist',
+    'candidate_location_map',
+    'candidate_timeline_hypotheses',
+    'uncertainty_flags',
+  ];
+  for (const key of requiredInputs) {
+    if (!hasOwn(inputs, key)) pushGap(gaps, 'story_seed_v1', `global_candidate_inputs.${key}`, `Missing ${key}.`, 'Regenerate story seed with all candidate input collections.');
+  }
+
+  const rail = artifact.governance_rail;
+  if (rail?.seed_must_be_used_as_phase1a_baseline !== true) pushGap(gaps, 'story_seed_v1', 'governance_rail.seed_must_be_used_as_phase1a_baseline', 'Story seed must be mandatory Phase 1A baseline.', 'Set true and enforce before chunk extraction.');
+  if (rail?.phase1a_must_verify_seed_against_manuscript_evidence !== true) pushGap(gaps, 'story_seed_v1', 'governance_rail.phase1a_must_verify_seed_against_manuscript_evidence', 'Phase 1A verification must be mandatory.', 'Set true and record claim resolution.');
+  if (rail?.seed_may_authorize_downstream_truth !== false) pushGap(gaps, 'story_seed_v1', 'governance_rail.seed_may_authorize_downstream_truth', 'Seed must never authorize downstream truth.', 'Set false.');
+  if (rail?.accepted_story_ledger_required_for_phase2 !== true) pushGap(gaps, 'story_seed_v1', 'governance_rail.accepted_story_ledger_required_for_phase2', 'Phase 2 must require accepted_story_ledger_v1.', 'Set true and enforce Phase 2 gate.');
+
+  return gaps;
+}
+
+export function validateEvaluationSeedCompleteness(seed: unknown): SeedFitGap[] {
+  const gaps: SeedFitGap[] = [];
+  const artifact = seed as Partial<EvaluationSeedV1Minimum> | null;
+
+  if (!isRecord(seed)) {
+    pushGap(gaps, 'evaluation_seed_v1', 'artifact', 'evaluation_seed_v1 is missing or not an object.', 'Regenerate a complete evaluation_seed_v1.');
+    return gaps;
+  }
+
+  if (artifact.artifact_type !== 'evaluation_seed_v1') pushGap(gaps, 'evaluation_seed_v1', 'artifact_type', 'Wrong or missing artifact_type.', 'Set artifact_type to evaluation_seed_v1.');
+  if (artifact.authority !== 'seed_only') pushGap(gaps, 'evaluation_seed_v1', 'authority', 'Seed authority must be seed_only.', 'Regenerate with authority=seed_only.');
+
+  const profile = artifact.manuscript_profile;
+  for (const key of ['word_count', 'word_count_tier', 'evaluation_mode', 'work_type']) {
+    if (!hasOwn(profile, key)) pushGap(gaps, 'evaluation_seed_v1', `manuscript_profile.${key}`, `Missing ${key}.`, 'Evaluation seed must route short/long/multilayer mode before Phase 1A.');
+  }
+
+  const templates = artifact.reporting_template_path;
+  for (const key of ['selected_template', 'short_form_template', 'long_form_template', 'long_form_multilayer_template']) {
+    if (!hasOwn(templates, key)) pushGap(gaps, 'evaluation_seed_v1', `reporting_template_path.${key}`, `Missing ${key}.`, 'Evaluation seed must carry polished short and long-form template paths.');
+  }
+
+  const criteria = Array.isArray(artifact.criterion_scaffolds) ? artifact.criterion_scaffolds : [];
+  const present = new Set(criteria.map((item) => item.criterion_key));
+  for (const key of CRITERIA_KEYS) {
+    if (!present.has(key)) pushGap(gaps, 'evaluation_seed_v1', `criterion_scaffolds.${key}`, `Missing criterion scaffold for ${key}.`, 'Evaluation seed must scaffold all 13 criteria.');
+  }
+
+  const rail = artifact.governance_rail;
+  if (rail?.seed_must_be_used_as_phase1a_evaluation_baseline !== true) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.seed_must_be_used_as_phase1a_evaluation_baseline', 'Evaluation seed must be mandatory Phase 1A baseline.', 'Set true and enforce before evaluation evidence extraction.');
+  if (rail?.phase1a_must_verify_seed_against_manuscript_evidence !== true) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.phase1a_must_verify_seed_against_manuscript_evidence', 'Phase 1A verification must be mandatory.', 'Set true and record fit-gap.');
+  if (rail?.seed_may_authorize_downstream_truth !== false) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.seed_may_authorize_downstream_truth', 'Seed must never authorize downstream truth.', 'Set false.');
+  if (rail?.final_craft_scores_forbidden !== true) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.final_craft_scores_forbidden', 'Seed must not contain final craft scores.', 'Set true and reject scored seed artifacts.');
+  if (rail?.final_executive_verdict_forbidden !== true) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.final_executive_verdict_forbidden', 'Seed must not contain final executive verdict.', 'Set true and reject verdict-bearing seed artifacts.');
+  if (rail?.accepted_story_ledger_required_for_phase2 !== true) pushGap(gaps, 'evaluation_seed_v1', 'governance_rail.accepted_story_ledger_required_for_phase2', 'Phase 2 must require accepted_story_ledger_v1.', 'Set true and enforce Phase 2 gate.');
+
+  return gaps;
+}
+
+export function buildSeedFitGapReport(args: { storySeed: unknown; evaluationSeed: unknown; generatedAt?: string }): SeedFitGapReportV1 {
+  const gaps = [
+    ...validateStorySeedCompleteness(args.storySeed),
+    ...validateEvaluationSeedCompleteness(args.evaluationSeed),
+  ];
+  return {
+    artifact_type: SEED_FIT_GAP_REPORT_TYPE,
+    status: gaps.length > 0 ? 'blocked' : 'passed',
+    generated_at: args.generatedAt ?? new Date().toISOString(),
+    doctrine: 'complete_seed_artifacts_required_before_phase_1a',
+    gaps,
+  };
+}
+
+export function assertSeedsCompleteForPhase1a(args: { storySeed: unknown; evaluationSeed: unknown }): void {
+  const report = buildSeedFitGapReport(args);
+  if (report.status === 'blocked') {
+    const summary = report.gaps.map((gap) => `${gap.artifact_type}:${gap.section}`).join(', ');
+    throw new Error(`SEED_FIT_GAP_BLOCKED: ${summary}`);
+  }
+}

--- a/lib/evaluation/seed/seedScaffoldFactory.ts
+++ b/lib/evaluation/seed/seedScaffoldFactory.ts
@@ -1,0 +1,257 @@
+import { CRITERIA_KEYS, type CriterionKey } from '@/schemas/criteria-keys';
+import { STORY_LAYER_KEYS, type StoryLayerCoreLayerKey } from '@/lib/evaluation/artifacts/artifactTypes';
+
+export type SeedAuthority = 'seed_only';
+export type SeedClaimStatus = 'proposed_unverified';
+export type SeedEvaluationMode = 'short_form_evaluation' | 'long_form_evaluation' | 'long_form_multi_layer_evaluation';
+export type SeedWordCountTier = 'short_under_25k' | 'long_25k_plus' | 'long_multilayer_75k_plus';
+
+export type StorySeedLayerScaffold = {
+  layer_key: StoryLayerCoreLayerKey;
+  claim_status: SeedClaimStatus;
+  baseline_rule: 'phase_1a_must_use_as_story_layer_creation_baseline';
+  required_sections: string[];
+  phase1a_must_fill: string[];
+  phase1a_must_verify: string[];
+  mistake_proofing: string[];
+};
+
+export type CompleteStorySeedV1 = {
+  artifact_type: 'story_seed_v1';
+  artifact_status: 'created';
+  authority: SeedAuthority;
+  generated_at: string;
+  seed_contract_version: 'seed_scaffold_complete_v1';
+  doctrine: 'complete_story_ledger_seed_required_before_phase_1a';
+  layer_scaffolds: Record<StoryLayerCoreLayerKey, StorySeedLayerScaffold>;
+  global_candidate_inputs: {
+    candidate_entity_registry: unknown[];
+    candidate_alias_map: Record<string, unknown>;
+    candidate_pov_map: unknown[];
+    candidate_relationship_map: unknown[];
+    candidate_pressure_map: unknown[];
+    candidate_object_shortlist: unknown[];
+    candidate_location_map: unknown[];
+    candidate_timeline_hypotheses: unknown[];
+    uncertainty_flags: string[];
+  };
+  governance_rail: {
+    seed_must_be_used_as_phase1a_baseline: true;
+    phase1a_must_verify_seed_against_manuscript_evidence: true;
+    phase1a_must_record_claim_resolution: true;
+    seed_may_authorize_downstream_truth: false;
+    accepted_story_ledger_required_for_phase2: true;
+  };
+};
+
+export type CompleteEvaluationSeedV1 = {
+  artifact_type: 'evaluation_seed_v1';
+  artifact_status: 'created';
+  authority: SeedAuthority;
+  generated_at: string;
+  seed_contract_version: 'evaluation_seed_complete_v1';
+  doctrine: 'complete_evaluation_template_seed_required_before_phase_1a';
+  manuscript_profile: {
+    word_count: number;
+    word_count_tier: SeedWordCountTier;
+    evaluation_mode: SeedEvaluationMode;
+    work_type: string;
+    likely_narrative_complexity: 'unknown' | 'low' | 'moderate' | 'high';
+    genre_classification: string[];
+  };
+  reporting_template_path: {
+    selected_template: string;
+    short_form_template: 'templates/evaluation/short-form-13-criteria-v1';
+    long_form_template: 'templates/evaluation/long-form-v1';
+    long_form_multilayer_template: 'templates/evaluation/long-form-multilayer-v1';
+  };
+  criterion_scaffolds: Array<{
+    criterion_key: CriterionKey;
+    claim_status: SeedClaimStatus;
+    short_form_template_sections: string[];
+    long_form_template_sections: string[];
+    phase1a_must_collect: string[];
+    mistake_proofing: string[];
+  }>;
+  hotspot_hypotheses: unknown[];
+  revise_density_profile: {
+    expected_revision_density: 'unknown' | 'low' | 'moderate' | 'high';
+    likely_revision_clusters: string[];
+  };
+  governance_rail: {
+    seed_must_be_used_as_phase1a_evaluation_baseline: true;
+    phase1a_must_verify_seed_against_manuscript_evidence: true;
+    seed_may_authorize_downstream_truth: false;
+    final_craft_scores_forbidden: true;
+    final_executive_verdict_forbidden: true;
+    accepted_story_ledger_required_for_phase2: true;
+  };
+};
+
+const commonDisplayMistakeProofing = [
+  'Do not show machine chunk labels to authors.',
+  'Use manuscript-native display locators: chapter, scene, paragraph, page, or quoted evidence anchor.',
+  'Keep machine locators private for traceability only.',
+];
+
+const storyLayerDefinitions: Record<StoryLayerCoreLayerKey, Omit<StorySeedLayerScaffold, 'layer_key' | 'claim_status' | 'baseline_rule'>> = {
+  source_integrity_layer: {
+    required_sections: ['manuscript_health', 'submission_scope', 'author_context_requests', 'hard_fail_triggers'],
+    phase1a_must_fill: ['source sufficiency', 'scope confidence', 'extraction risk flags'],
+    phase1a_must_verify: ['text availability', 'word count', 'scope classification'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+  pov_structure_layer: {
+    required_sections: ['candidate_pov_owners', 'narration_mode', 'focalization_pattern', 'pov_uncertainty_flags'],
+    phase1a_must_fill: ['POV owners', 'narrative camera', 'shift pattern'],
+    phase1a_must_verify: ['POV evidence anchors', 'omniscient or limited mode', 'rotating focalization'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+  canonical_identity_layer: {
+    required_sections: ['candidate_entities', 'candidate_aliases', 'name_state_warnings', 'merge_split_risks'],
+    phase1a_must_fill: ['entity registry', 'alias map', 'merge/split decisions'],
+    phase1a_must_verify: ['character existence', 'alias linkage', 'role/name-state boundary'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+  cast_role_tier_layer: {
+    required_sections: ['protagonists', 'co_protagonists', 'antagonists', 'major_secondary', 'minor_or_background', 'collectives'],
+    phase1a_must_fill: ['role tier', 'structural weight', 'individual versus collective classification'],
+    phase1a_must_verify: ['recurrence', 'plot function', 'pressure function'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+  identity_pronoun_layer: {
+    required_sections: ['reviewable_pronoun_transitions', 'identity_signal_uncertainties', 'stable_registry_hidden'],
+    phase1a_must_fill: ['only transitioning or ambiguous pronoun-family signals'],
+    phase1a_must_verify: ['cross-family transition', 'identity transition signal', 'no stable-registry author burden'],
+    mistake_proofing: [...commonDisplayMistakeProofing, 'If no reviewable transitions exist, display only a no-reviewable-transition message.'],
+  },
+  relationship_network_layer: {
+    required_sections: ['named_relationships', 'role_stable_unnamed_relationships', 'group_pressures_routed_elsewhere'],
+    phase1a_must_fill: ['sustained named-character bonds', 'relationship arc', 'first evidence anchor'],
+    phase1a_must_verify: ['named bond', 'sustained recurrence', 'unnamed/group reclassification'],
+    mistake_proofing: [...commonDisplayMistakeProofing, 'Do not present one-off unnamed encounters as normal named relationships.'],
+  },
+  object_symbol_layer: {
+    required_sections: ['high_value_symbols', 'scene_props', 'motif_systems', 'ownership_or_association'],
+    phase1a_must_fill: ['symbolic weight', 'object trajectory', 'holder/association logic'],
+    phase1a_must_verify: ['physical object versus motif', 'symbol recurrence', 'final meaning'],
+    mistake_proofing: [...commonDisplayMistakeProofing, 'Do not classify dialogue, evaluation artifacts, or abstract doctrine as physical objects.'],
+  },
+  location_timeline_worldstate_layer: {
+    required_sections: ['canonical_locations', 'movement_paths', 'timeline_sequence', 'world_state_rules'],
+    phase1a_must_fill: ['location normalization', 'movement paths', 'active scene versus backstory'],
+    phase1a_must_verify: ['duplicate locations', 'scene order', 'environmental rules'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+  threat_antagonist_ending_layer: {
+    required_sections: ['individual_antagonists', 'group_pressures', 'environmental_pressures', 'biological_pressures', 'internal_pressures', 'terminal_states', 'ending_accountability'],
+    phase1a_must_fill: ['pressure systems', 'threat vectors', 'terminal states', 'ending accountability'],
+    phase1a_must_verify: ['individual versus system pressure', 'terminal state evidence', 'unresolved consequences'],
+    mistake_proofing: commonDisplayMistakeProofing,
+  },
+};
+
+export function deriveSeedEvaluationMode(wordCount: number, forceMultiLayer = false): SeedEvaluationMode {
+  if (forceMultiLayer || wordCount >= 75000) return 'long_form_multi_layer_evaluation';
+  if (wordCount >= 25000) return 'long_form_evaluation';
+  return 'short_form_evaluation';
+}
+
+export function deriveSeedWordCountTier(wordCount: number, forceMultiLayer = false): SeedWordCountTier {
+  if (forceMultiLayer || wordCount >= 75000) return 'long_multilayer_75k_plus';
+  if (wordCount >= 25000) return 'long_25k_plus';
+  return 'short_under_25k';
+}
+
+export function buildCompleteStorySeedV1(args: { generatedAt?: string }): CompleteStorySeedV1 {
+  const layer_scaffolds = Object.fromEntries(STORY_LAYER_KEYS.map((layer_key) => [
+    layer_key,
+    {
+      layer_key,
+      claim_status: 'proposed_unverified' as const,
+      baseline_rule: 'phase_1a_must_use_as_story_layer_creation_baseline' as const,
+      ...storyLayerDefinitions[layer_key],
+    },
+  ])) as Record<StoryLayerCoreLayerKey, StorySeedLayerScaffold>;
+
+  return {
+    artifact_type: 'story_seed_v1',
+    artifact_status: 'created',
+    authority: 'seed_only',
+    generated_at: args.generatedAt ?? new Date().toISOString(),
+    seed_contract_version: 'seed_scaffold_complete_v1',
+    doctrine: 'complete_story_ledger_seed_required_before_phase_1a',
+    layer_scaffolds,
+    global_candidate_inputs: {
+      candidate_entity_registry: [],
+      candidate_alias_map: {},
+      candidate_pov_map: [],
+      candidate_relationship_map: [],
+      candidate_pressure_map: [],
+      candidate_object_shortlist: [],
+      candidate_location_map: [],
+      candidate_timeline_hypotheses: [],
+      uncertainty_flags: [],
+    },
+    governance_rail: {
+      seed_must_be_used_as_phase1a_baseline: true,
+      phase1a_must_verify_seed_against_manuscript_evidence: true,
+      phase1a_must_record_claim_resolution: true,
+      seed_may_authorize_downstream_truth: false,
+      accepted_story_ledger_required_for_phase2: true,
+    },
+  };
+}
+
+export function buildCompleteEvaluationSeedV1(args: { wordCount: number; workType?: string | null; generatedAt?: string; forceMultiLayer?: boolean }): CompleteEvaluationSeedV1 {
+  const evaluationMode = deriveSeedEvaluationMode(args.wordCount, args.forceMultiLayer);
+  const selected_template = evaluationMode === 'short_form_evaluation'
+    ? 'templates/evaluation/short-form-13-criteria-v1'
+    : evaluationMode === 'long_form_evaluation'
+      ? 'templates/evaluation/long-form-v1'
+      : 'templates/evaluation/long-form-multilayer-v1';
+
+  return {
+    artifact_type: 'evaluation_seed_v1',
+    artifact_status: 'created',
+    authority: 'seed_only',
+    generated_at: args.generatedAt ?? new Date().toISOString(),
+    seed_contract_version: 'evaluation_seed_complete_v1',
+    doctrine: 'complete_evaluation_template_seed_required_before_phase_1a',
+    manuscript_profile: {
+      word_count: args.wordCount,
+      word_count_tier: deriveSeedWordCountTier(args.wordCount, args.forceMultiLayer),
+      evaluation_mode: evaluationMode,
+      work_type: args.workType?.trim() || 'unknown',
+      likely_narrative_complexity: 'unknown',
+      genre_classification: [],
+    },
+    reporting_template_path: {
+      selected_template,
+      short_form_template: 'templates/evaluation/short-form-13-criteria-v1',
+      long_form_template: 'templates/evaluation/long-form-v1',
+      long_form_multilayer_template: 'templates/evaluation/long-form-multilayer-v1',
+    },
+    criterion_scaffolds: CRITERIA_KEYS.map((criterion_key) => ({
+      criterion_key,
+      claim_status: 'proposed_unverified',
+      short_form_template_sections: ['evidence', 'diagnosis', 'reader_effect', 'repair_direction'],
+      long_form_template_sections: ['evidence', 'diagnosis', 'cross_layer_dependency', 'revision_opportunity_seed', 'readiness_implication'],
+      phase1a_must_collect: ['quoted evidence anchor', 'manuscript-native location', 'criterion-specific signal'],
+      mistake_proofing: ['No final score in seed.', 'No final verdict in seed.', 'No unanchored craft diagnosis in seed.'],
+    })),
+    hotspot_hypotheses: [],
+    revise_density_profile: {
+      expected_revision_density: 'unknown',
+      likely_revision_clusters: [],
+    },
+    governance_rail: {
+      seed_must_be_used_as_phase1a_evaluation_baseline: true,
+      phase1a_must_verify_seed_against_manuscript_evidence: true,
+      seed_may_authorize_downstream_truth: false,
+      final_craft_scores_forbidden: true,
+      final_executive_verdict_forbidden: true,
+      accepted_story_ledger_required_for_phase2: true,
+    },
+  };
+}

--- a/lib/evaluation/stage-machine/hardStopGuards.ts
+++ b/lib/evaluation/stage-machine/hardStopGuards.ts
@@ -12,6 +12,8 @@ export type SupportArtifactRef = {
 };
 
 export type ArtifactSet = {
+  story_seed_v1?: ArtifactRef;
+  evaluation_seed_v1?: ArtifactRef;
   pass1a_story_layer_v1?: ArtifactRef;
   ledger_quality_report_v1?: ArtifactRef;
   pass3_preflight_draft_v1?: ArtifactRef;
@@ -204,6 +206,12 @@ export function forbidPhase2WithoutAcceptedLedger(set: ArtifactSet): GuardResult
     return ok();
   }
 
+  if (hasArtifactRef(set.story_seed_v1) || hasArtifactRef(set.evaluation_seed_v1)) {
+    return fail(
+      'Phase 2 cannot consume seed artifacts (story_seed_v1/evaluation_seed_v1); accepted_story_ledger_v1 is required',
+    );
+  }
+
   if (hasArtifactRef(set.pass1a_story_layer_v1)) {
     return fail('Phase 2 cannot consume raw pass1a_story_layer_v1; accepted_story_ledger_v1 is required');
   }
@@ -236,29 +244,4 @@ export function checkSupportArtifactFreshness(set: ArtifactSet): GuardResult {
   }
 
   return ok();
-}
-
-export function forbidLayer9(layerKeys: readonly string[]): GuardResult {
-  const allowed = new Set<string>(STORY_LAYER_KEYS);
-  const unexpected = layerKeys.filter((key) => !allowed.has(key));
-
-  if (unexpected.length > 0) {
-    return fail(`Story Layer contains non-canonical layer key(s): ${unexpected.join(', ')}`);
-  }
-
-  const missing = STORY_LAYER_KEYS.filter((key) => !layerKeys.includes(key));
-  if (missing.length > 0) {
-    return fail(`Story Layer is missing canonical layer key(s): ${missing.join(', ')}`);
-  }
-
-  const uniqueLayerCount = new Set(layerKeys).size;
-  if (uniqueLayerCount !== STORY_LAYER_KEYS.length || layerKeys.length !== STORY_LAYER_KEYS.length) {
-    return fail(`Story Layer must contain exactly ${STORY_LAYER_KEYS.length} canonical layers`);
-  }
-
-  return ok();
-}
-
-export function canonicalLayerKeys(): readonly StoryLayerCoreLayerKey[] {
-  return STORY_LAYER_KEYS;
 }


### PR DESCRIPTION
## Summary

Adds the seed mistake-proofing guard needed before Phase 1A can run.

This PR introduces `seedCompletenessGuard.ts`, which validates the two required seed artifacts:

1. `story_seed_v1` — complete provisional Story Ledger layer scaffold
2. `evaluation_seed_v1` — complete provisional evaluation scaffold for short/long/multilayer routing

If either seed is incomplete, the guard produces `seed_fit_gap_report_v1` and blocks downstream processing.

## Doctrine

- Seed 1 is the Story Ledger baseline scaffold.
- Seed 2 is the evaluation-template baseline scaffold.
- Both seeds must be complete before Phase 1A.
- Phase 1A must use seed as the baseline for Story Ledger layer creation.
- Phase 1A must verify seed against manuscript evidence.
- Seed remains non-authoritative.
- `accepted_story_ledger_v1` remains the Phase 2 authority.

## Mistake-proofing behavior

If a seed is missing, malformed, generic, or incomplete:

- do not start Phase 1A chunk extraction
- do not build `pass1a_story_layer_v1`
- create `seed_fit_gap_report_v1`
- block with `SEED_FIT_GAP_BLOCKED`
- kick the fit-gap back to the seed generator / ChatGPT repair path

## Files

- `lib/evaluation/seed/seedCompletenessGuard.ts`
- `lib/evaluation/artifacts/artifactTypes.ts`

## Acceptance criteria

- story seed requires all 9 Story Ledger layer scaffolds
- story seed requires all candidate input collections
- evaluation seed requires manuscript profile and template routing
- evaluation seed requires all 13 criterion scaffolds
- seed fit-gap report is first-class
- seed cannot authorize downstream truth
- Phase 2 remains locked behind `accepted_story_ledger_v1`

## Follow-up required

Wire this guard into the processor before Phase 1A chunk work so incomplete seeds block runtime execution.