### PR TITLE
Fix revise recurrence: evidence token leak, repetition gating, and agreed cockpit layout

### DIFF
--- a/.github/pr-bodies/PR-855.md
+++ b/.github/pr-bodies/PR-855.md
@@ -1,0 +1,8 @@
+## Summary\nThis PR closes the recurring Revise Queue issues observed in production by hardening both queue contract and cockpit rendering paths.\n\n### Included fixes\n- Sanitize evidence excerpts/anchors to block internal pipeline tokens (for example ) from surfacing in author-visible Evidence.\n- Add repetitive lead-in distinctness gate for A/B/C candidate options so near-clone variants are routed to .\n- Realign  to the agreed layout contract:\n  - Original Passage\n  - Replacement Options (A/B/C)\n  - Author controls\n  - Collapsible **Why this was flagged** (diagnostic six)\n- Suppress boilerplate option rationale strings that add noise/repetition in card rendering.\n\n### Regression coverage\n- \n  - internal-token evidence anchor regression\n- \n  - repetitive lead-in candidate gating regression\n- \n  - cockpit shell/action-gating safeguards remain intact\n\n### Validation run\n- 
+> revisiongrade@1.0.0 pretest
+> node scripts/guard-critical-tests.mjs
+
+[guard-critical-tests] OK
+
+> revisiongrade@1.0.0 test
+> jest --runInBand __tests__/lib/revision/reviseCardContract.test.ts __tests__/lib/revision/workbenchQueue.test.ts tests/components/ReviseCockpitClient.smoke.test.tsx\n- Result: **3/3 suites passing, 26/26 tests passing**\n\n## Why this is required now\nProduction currently reports deployed SHA  while  is , and these new hardening commits are beyond both. This PR restores alignment by bringing the latest recurrence-proofing into  for deploy.

--- a/__tests__/lib/revision/reviseCardContract.test.ts
+++ b/__tests__/lib/revision/reviseCardContract.test.ts
@@ -119,6 +119,28 @@ describe('revise card contract', () => {
     expect(result.reason).toMatch(/materially distinct/i)
   })
 
+  test('routes cards to needs_targeting when A/B/C share repetitive lead-in wording', () => {
+    const result = validateReviseCardContract({
+      issueStatement: 'Newton responds too quickly without a visible decision beat.',
+      symptom: 'The turn happens before readers see him choose.',
+      cause: 'The sentence jumps from prompt to consequence with no bridge.',
+      fixStrategy: 'Add a visible decision beat before consequence.',
+      readerImpact: 'Readers can track intent and consequence in sequence.',
+      operationNote: 'replace_selected_passage · Chapter 1 paragraph 8',
+      sourceText: 'Move aside, Small Fry, and the scene surges onward.',
+      sourceLocationLabel: 'Chapter 1 paragraph 8',
+      revisionOperation: 'replace_selected_passage',
+      candidateTexts: [
+        'Move aside, Small Fry, Twillow answers in motion, and the consequence lands without a pause for explanation.',
+        'Move aside, Small Fry, a physical beat carries the turn so pressure stays visible and momentum holds.',
+        'Move aside, Small Fry, Newton chooses with his body first, then the fallout reaches him before he can explain it away.',
+      ],
+    })
+
+    expect(result.readiness).toBe('needs_targeting')
+    expect(result.reason).toMatch(/materially distinct/i)
+  })
+
   test('maps operation labels and custom labels deterministically', () => {
     expect(operationLabels.insert_after_selected_passage).toBe('Suggested insertion after passage')
     expect(operationLabels.replace_selected_passage).toBe('Suggested replacement')

--- a/__tests__/lib/revision/reviseCardContract.test.ts
+++ b/__tests__/lib/revision/reviseCardContract.test.ts
@@ -91,6 +91,12 @@ describe('revise card contract', () => {
     expect(candidateTextIsCopyPasteReady('The door stood in the row like a warning no one had chosen to read.')).toBe(true)
   })
 
+  test('blocks word-processor and HTML artifact blobs from A/B/C candidates', () => {
+    expect(candidateTextIsCopyPasteReady('v:* {behavior:url(#default#VML);} o:* {behavior:url(#default#VML);}')).toBe(false)
+    expect(candidateTextIsCopyPasteReady('table.MsoNormalTable {mso-style-name:"Table Normal"; mso-pagination:widow-orphan;}')).toBe(false)
+    expect(candidateTextIsCopyPasteReady('<style>table.MsoNormalTable{mso-style-name:"Table Normal";}</style>')).toBe(false)
+  })
+
   test('routes cards to needs_targeting when A/B/C are not materially distinct', () => {
     const result = validateReviseCardContract({
       issueStatement: 'Internal conflict is stated but not yet dramatized in the line.',

--- a/__tests__/lib/revision/workbenchQueue.test.ts
+++ b/__tests__/lib/revision/workbenchQueue.test.ts
@@ -219,6 +219,44 @@ describe('getWorkbenchQueue', () => {
     expect(result.needsTargeting[0].options[1].text).toBe('');
   });
 
+  it('routes internal-token evidence anchors to needs targeting and strips leaked evidence text', async () => {
+    const supabase = buildSupabaseMock('job-4', 'version-4');
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+
+    mockEnsureLedger.mockResolvedValueOnce({
+      artifactId: 'ledger-4',
+      opportunities: [
+        {
+          opportunity_id: 'opp-token-evidence',
+          criterion: 'NARRATIVE_DRIVE',
+          severity: 'should',
+          confidence: '0.88',
+          manuscript_coordinates: 'passage:9',
+          evidence_anchor: 'NARRATIVEDRIVE:recommendation',
+          rationale: 'Expand Newton’s immediate response into a full beat.',
+          symptom: 'The beat transition is abrupt.',
+          cause: 'The scene skips connective prose.',
+          fix_direction: 'Insert a connective bridge beat.',
+          reader_effect: 'Readers lose continuity.',
+          mistake_proofing: 'Do not introduce new plot facts.',
+          candidate_text_a: 'Move aside, Small Fry, Twillow answers in motion, and the consequence lands without a pause for explanation.',
+          candidate_text_b: 'Move aside, Small Fry, a physical beat carries the turn, so pressure stays visible and the scene keeps forward momentum.',
+          candidate_text_c: 'Move aside, Small Fry, making Newton’s decision and its fallout concrete will sharpen stakes and give readers a clear causal engine.',
+          revision_operation: 'replace_selected_passage',
+          provenance: 'evaluation_result_v2',
+        },
+      ] as never,
+    });
+
+    const result = await getWorkbenchQueue({ manuscriptId: '6074', evaluationJobId: 'job-4' });
+
+    expect(result.ok).toBe(true);
+    expect(result.opportunities).toHaveLength(0);
+    expect(result.needsTargeting).toHaveLength(1);
+    expect(result.needsTargeting[0].quoteHighlight).toBe('No excerpt available');
+    expect(result.needsTargeting[0].readiness).toBe('needs_targeting');
+  });
+
   it('renders queue with caution when phase 0 warmup corpus cannot be loaded', async () => {
     mockLoadReviseQueueWarmupCorpus.mockRejectedValueOnce(new Error('missing benchmark corpus'));
     const supabase = buildSupabaseMock('job-1', 'version-1');

--- a/components/revision/ReviseCockpitClient.tsx
+++ b/components/revision/ReviseCockpitClient.tsx
@@ -149,6 +149,11 @@ function candidateTextOf(option: { candidateText?: string; text: string }, issue
   });
 }
 
+function canAcceptOption(item: WorkbenchOpportunity, option: { candidateText?: string; text: string }) {
+  if (item.readiness !== "ready_for_revise") return false;
+  return candidateTextIsCopyPasteReady(candidateTextOf(option, item.issueStatement));
+}
+
 export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQueuePayload }) {
   const [activeId, setActiveId] = useState(payload.opportunities[0]?.id ?? "");
   const [selectedOption, setSelectedOption] = useState<"A" | "B" | "C">("A");
@@ -172,11 +177,16 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
     return map;
   }, [ledger]);
 
-  const criteria = useMemo(() => [...new Set(payload.opportunities.map(criterionOf))].sort(), [payload.opportunities]);
+  const queueItems = useMemo(
+    () => [...payload.opportunities, ...needsTargeting],
+    [payload.opportunities, needsTargeting],
+  );
+
+  const criteria = useMemo(() => [...new Set(queueItems.map(criterionOf))].sort(), [queueItems]);
 
   const filtered = useMemo(() => {
     const search = filters.search.trim().toLowerCase();
-    return payload.opportunities.filter((item) => {
+    return queueItems.filter((item) => {
       if (filters.priority !== "all" && item.severity !== filters.priority) return false;
       if (filters.criterion !== "all" && criterionOf(item) !== filters.criterion) return false;
       if (filters.status !== "all" && decisionGroup(decisionById[item.id]) !== filters.status) return false;
@@ -186,16 +196,18 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
       }
       return true;
     });
-  }, [decisionById, filters, payload.opportunities]);
+  }, [decisionById, filters, queueItems]);
 
   const active = filtered.find((item) => item.id === activeId) ?? filtered[0] ?? null;
   const activeIndex = active ? Math.max(0, filtered.findIndex((item) => item.id === active.id)) : 0;
   const selectedProposal = active?.options.find((option) => option.key === selectedOption) ?? active?.options[0] ?? null;
-  const canAcceptSelection = selectedProposal ? candidateTextIsCopyPasteReady(candidateTextOf(selectedProposal, active?.issueStatement)) : false;
+  const canAcceptSelection =
+    active?.readiness === "ready_for_revise"
+      && (selectedProposal ? candidateTextIsCopyPasteReady(candidateTextOf(selectedProposal, active?.issueStatement)) : false);
 
   const counts = useMemo(() => {
     const result = { pending: 0, accepted: 0, custom: 0, kept: 0, rejected: 0, deferred: 0 };
-    for (const item of payload.opportunities) {
+    for (const item of queueItems) {
       const group = decisionGroup(decisionById[item.id]);
       if (group === "pending") result.pending += 1;
       if (group === "accepted") result.accepted += 1;
@@ -205,7 +217,7 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
       if (group === "deferred") result.deferred += 1;
     }
     return result;
-  }, [decisionById, payload.opportunities]);
+  }, [decisionById, queueItems]);
 
   useEffect(() => {
     let cancelled = false;
@@ -297,7 +309,7 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
   function decide(decision: DecisionState, option?: "A" | "B" | "C", custom?: string) {
     if (!active) return;
     const proposal = option ? active.options.find((candidate) => candidate.key === option) : undefined;
-    if (option && (!proposal || !candidateTextIsCopyPasteReady(candidateTextOf(proposal, active.issueStatement)))) return;
+    if (option && (!proposal || !canAcceptOption(active, proposal))) return;
     const entry: LedgerEntry = {
       localId: localId(),
       createdAtIso: new Date().toISOString(),
@@ -392,10 +404,16 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
                     <div className="mb-1 flex flex-wrap gap-1">
                       <span className={`rounded px-1.5 py-0.5 text-[10px] uppercase ${severityClass(item.severity)}`}>{item.severity}</span>
                       <span className="rounded border border-[#4E4333] px-1.5 py-0.5 text-[10px] text-[#D6C3A2]">{item.scope}</span>
+                      <span className={`rounded border px-1.5 py-0.5 text-[10px] ${item.readiness === "ready_for_revise" ? "border-[#48603F]/70 text-[#BBD8B4]" : "border-[#7A2B1A]/70 text-[#F1B6A5]"}`}>
+                        {item.readiness === "ready_for_revise" ? "Ready" : "Needs Targeting"}
+                      </span>
                       <span className="rounded border border-[#4E4333] px-1.5 py-0.5 text-[10px] text-[#A9987D]">{decisionGroup(decisionById[item.id])}</span>
                     </div>
                     <p className="line-clamp-2 text-xs leading-4 text-[#F2E7D4]">{index + 1}. {item.title}</p>
                     <p className="mt-1 truncate text-[11px] text-[#A9987D]">{criterionOf(item)} · {item.anchor || item.meta}</p>
+                    {item.readiness !== "ready_for_revise" && (
+                      <p className="mt-1 line-clamp-2 text-[11px] text-[#E2B2A6]">{item.readinessReason ?? "Needs exact source targeting"}</p>
+                    )}
                   </button>
                 </li>
               );
@@ -440,7 +458,7 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
                 <div className="grid gap-2 xl:grid-cols-3">
                   {active.options.map((option) => {
                     const candidateText = candidateTextOf(option, active.issueStatement);
-                    const copyReady = candidateTextIsCopyPasteReady(candidateText);
+                    const copyReady = canAcceptOption(active, option);
                     return (
                     <article key={option.key} onClick={() => setSelectedOption(option.key)} className={`cursor-pointer rounded-xl border bg-[#12100B] p-3 transition ${selectedOption === option.key ? "border-[#C8A96E]" : "border-[#2E261A] hover:border-[#5D4C31]"}`}>
                       <div className="flex items-center justify-between gap-2">
@@ -474,9 +492,9 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
 
               <footer id="revision-ledger" className="shrink-0 border-t border-[#2E261A] bg-[#120E08] p-3">
                 <div className="flex flex-wrap items-center gap-2">
-                  <button onClick={() => decide("accepted_a", "A")} disabled={!candidateTextIsCopyPasteReady(candidateTextOf(active.options.find((option) => option.key === "A") ?? { text: "" }, active.issueStatement))} className="rounded bg-[#C8A96E] px-4 py-2 text-sm font-semibold text-[#1A140C] disabled:opacity-40">Accept A</button>
-                  <button onClick={() => decide("accepted_b", "B")} disabled={!candidateTextIsCopyPasteReady(candidateTextOf(active.options.find((option) => option.key === "B") ?? { text: "" }, active.issueStatement))} className="rounded border border-[#C8A96E] px-4 py-2 text-sm text-[#F3E3C3] disabled:opacity-40">Accept B</button>
-                  <button onClick={() => decide("accepted_c", "C")} disabled={!candidateTextIsCopyPasteReady(candidateTextOf(active.options.find((option) => option.key === "C") ?? { text: "" }, active.issueStatement))} className="rounded border border-[#C8A96E] px-4 py-2 text-sm text-[#F3E3C3] disabled:opacity-40">Accept C</button>
+                  <button onClick={() => decide("accepted_a", "A")} disabled={!canAcceptOption(active, active.options.find((option) => option.key === "A") ?? { text: "" })} className="rounded bg-[#C8A96E] px-4 py-2 text-sm font-semibold text-[#1A140C] disabled:opacity-40">Accept A</button>
+                  <button onClick={() => decide("accepted_b", "B")} disabled={!canAcceptOption(active, active.options.find((option) => option.key === "B") ?? { text: "" })} className="rounded border border-[#C8A96E] px-4 py-2 text-sm text-[#F3E3C3] disabled:opacity-40">Accept B</button>
+                  <button onClick={() => decide("accepted_c", "C")} disabled={!canAcceptOption(active, active.options.find((option) => option.key === "C") ?? { text: "" })} className="rounded border border-[#C8A96E] px-4 py-2 text-sm text-[#F3E3C3] disabled:opacity-40">Accept C</button>
                   <button onClick={() => decide("keep_original")} disabled={!canAcceptSelection} className="rounded border border-[#5D4C31] px-3 py-2 text-sm text-[#E8DABF] disabled:opacity-40">Keep Original</button>
                   <button onClick={() => decide("reject")} disabled={!canAcceptSelection} className="rounded border border-[#7A2B1A]/70 px-3 py-2 text-sm text-[#E2B2A6] disabled:opacity-40">Reject</button>
                   <button onClick={() => decide("deferred")} className="rounded border border-[#5C5140] px-3 py-2 text-sm text-[#B7A98D]">Defer</button>

--- a/components/revision/ReviseCockpitClient.tsx
+++ b/components/revision/ReviseCockpitClient.tsx
@@ -6,7 +6,6 @@ import { candidateTextIsCopyPasteReady, customOperationLabels, getRenderableCand
 
 type DecisionState = "accepted_a" | "accepted_b" | "accepted_c" | "custom" | "keep_original" | "reject" | "deferred";
 type DecisionFilter = "all" | "pending" | "accepted" | "custom" | "kept_original" | "rejected" | "deferred";
-type EvidenceTab = "evidence" | "diagnosis" | "logic";
 type QueueType = "repair_plan" | "direct_rewrite";
 type EvidenceStatus = "has_excerpt" | "has_location" | "manuscript_wide" | "missing_evidence";
 
@@ -154,12 +153,17 @@ function canAcceptOption(item: WorkbenchOpportunity, option: { candidateText?: s
   return candidateTextIsCopyPasteReady(candidateTextOf(option, item.issueStatement));
 }
 
+function shouldRenderRationale(rationale?: string) {
+  const value = (rationale ?? "").trim();
+  if (!value) return false;
+  return !/(primary repair path from the evaluation|secondary variant for author-controlled cadence|alternative variant for stronger emphasis|copy-ready prose variant|not copy-ready)/i.test(value);
+}
+
 export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQueuePayload }) {
   const [activeId, setActiveId] = useState(payload.opportunities[0]?.id ?? "");
   const [selectedOption, setSelectedOption] = useState<"A" | "B" | "C">("A");
   const [filters, setFilters] = useState<Filters>({ search: "", priority: "all", criterion: "all", status: "all" });
   const [ledger, setLedger] = useState<LedgerEntry[]>([]);
-  const [tab, setTab] = useState<EvidenceTab>("evidence");
   const [customOpen, setCustomOpen] = useState(false);
   const [customText, setCustomText] = useState("");
   const [ledgerOpen, setLedgerOpen] = useState(false);
@@ -257,7 +261,6 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
       ?? null;
     if (next) setActiveId(next.id);
     setSelectedOption("A");
-    setTab("evidence");
     setCustomOpen(false);
     setCustomText("");
   }
@@ -450,12 +453,26 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
                   <span className="rounded border border-[#5A4B33] px-2 py-1">{evidenceStatusOf(active).replace(/_/g, " ")}</span>
                 </div>
                 <h2 className="mt-2 line-clamp-2 text-xl leading-tight text-[#F7EFDF]">{active.title}</h2>
-                <p className="mt-1 truncate text-xs text-[#A9987D]">Evidence: {active.anchor || active.meta || "available in diagnostic details"}</p>
-                <p className="mt-1 truncate text-xs text-[#A9987D]">Operation: {operationLabels[active.revisionOperation]}</p>
+                <div className="mt-2 grid gap-1 text-xs text-[#CBBDA4] md:grid-cols-2">
+                  <p>Concept / Premise • {active.severity.toUpperCase()}</p>
+                  <p>Scope: {active.scope}</p>
+                  <p>Chapter / Location: {active.anchor || active.meta || "Location pending"}</p>
+                  <p>Status: {decisionGroup(decisionById[active.id])}</p>
+                </div>
               </div>
 
               <div className="min-h-0 flex-1 overflow-y-auto p-3">
-                <div className="grid gap-2 xl:grid-cols-3">
+                <section className="rounded-xl border border-[#2E261A] bg-[#12100B] p-3">
+                  <p className="text-[11px] uppercase tracking-[0.18em] text-[#C8A96E]">Original Passage</p>
+                  <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-[#E8DCC4]">“{active.quoteHighlight}”{active.quoteRest}</p>
+                  <p className="mt-1 text-xs text-[#A9987D]">{active.anchor || active.meta || "Location pending"}</p>
+                </section>
+
+                <section className="mt-3">
+                  <p className="text-[11px] uppercase tracking-[0.18em] text-[#C8A96E]">Replacement Options</p>
+                </section>
+
+                <div className="mt-2 grid gap-2 xl:grid-cols-3">
                   {active.options.map((option) => {
                     const candidateText = candidateTextOf(option, active.issueStatement);
                     const copyReady = canAcceptOption(active, option);
@@ -471,21 +488,23 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
                       <p className="mt-1 text-[11px] uppercase tracking-wider text-[#A9987D]">{option.mechanism}</p>
                       <p className="mt-2 line-clamp-5 whitespace-pre-wrap text-sm leading-5 text-[#E5D8BE]">{truncate(candidateText)}</p>
                       {!copyReady && <p className="mt-2 text-xs text-[#E2B2A6]">Not copy-ready; move card to Needs Targeting.</p>}
-                      <details className="mt-2 text-xs text-[#BDAE91]"><summary className="cursor-pointer text-[#C8A96E]">Show full fix</summary><p className="mt-2 whitespace-pre-wrap leading-5">{candidateText}</p><p className="mt-2 text-[#A9987D]">{option.rationale}</p></details>
+                      <details className="mt-2 text-xs text-[#BDAE91]"><summary className="cursor-pointer text-[#C8A96E]">Show full fix</summary><p className="mt-2 whitespace-pre-wrap leading-5">{candidateText}</p>{shouldRenderRationale(option.rationale) ? <p className="mt-2 text-[#A9987D]">{option.rationale}</p> : null}</details>
                     </article>
                   )})}
                 </div>
 
-                <div className="mt-3 rounded-xl border border-[#2E261A] bg-[#12100B]">
-                  <div className="flex border-b border-[#2E261A] text-xs">
-                    {(["evidence", "diagnosis", "logic"] as const).map((item) => <button key={item} type="button" onClick={() => setTab(item)} className={`px-3 py-2 capitalize ${tab === item ? "bg-[#221B11] text-[#C8A96E]" : "text-[#A9987D] hover:text-[#E8DABF]"}`}>{item}</button>)}
+                <details className="mt-3 rounded-xl border border-[#2E261A] bg-[#12100B] p-3" open>
+                  <summary className="cursor-pointer text-[11px] uppercase tracking-[0.18em] text-[#C8A96E]">Why this was flagged</summary>
+                  <div className="mt-3 space-y-1 text-sm leading-6 text-[#E8DCC4]">
+                    <p><span className="text-[#C8A96E]">Evidence:</span> “{active.quoteHighlight}”{active.quoteRest}</p>
+                    <p><span className="text-[#C8A96E]">Symptom:</span> {active.symptom}</p>
+                    <p><span className="text-[#C8A96E]">Cause:</span> {active.cause}</p>
+                    <p><span className="text-[#C8A96E]">Fix direction:</span> {active.fixDirection}</p>
+                    <p><span className="text-[#C8A96E]">Reader effect:</span> {active.readerEffect}</p>
+                    <p><span className="text-[#C8A96E]">Mistake-proofing:</span> {active.mistakeProofing}</p>
+                    <p><span className="text-[#C8A96E]">Operation:</span> {operationLabels[active.revisionOperation]}</p>
                   </div>
-                  <div className="max-h-28 overflow-y-auto p-3 text-sm leading-6 text-[#E8DCC4]">
-                    {tab === "evidence" && <><p>“{active.quoteHighlight}”{active.quoteRest}</p><p className="mt-1 text-xs text-[#A9987D]">{active.anchor}</p></>}
-                    {tab === "diagnosis" && <><p><span className="text-[#C8A96E]">Symptom:</span> {active.symptom}</p><p><span className="text-[#C8A96E]">Cause:</span> {active.cause}</p></>}
-                    {tab === "logic" && <><p><span className="text-[#C8A96E]">Fix:</span> {active.fixDirection}</p><p><span className="text-[#C8A96E]">Reader effect:</span> {active.readerEffect}</p><p><span className="text-[#C8A96E]">Mistake-proofing:</span> {active.mistakeProofing}</p></>}
-                  </div>
-                </div>
+                </details>
 
                 {customOpen && <div className="mt-3 rounded-xl border border-[#C8A96E]/60 bg-[#120E08] p-3"><textarea value={customText} onChange={(event) => setCustomText(event.target.value)} rows={4} className="w-full rounded border border-[#3A3022] bg-[#0D0A05] p-3 font-mono text-sm outline-none focus:border-[#C8A96E]" /><button disabled={!customText.trim()} onClick={() => decide("custom", undefined, customText)} className="mt-2 rounded bg-[#C8A96E] px-3 py-1.5 text-sm font-semibold text-[#1A140C] disabled:opacity-50">Save custom + next</button></div>}
               </div>

--- a/lib/revision/reviseCardContract.ts
+++ b/lib/revision/reviseCardContract.ts
@@ -196,6 +196,26 @@ function overlapRatio(a: string, b: string): number {
   return overlap / Math.max(left.size, right.size)
 }
 
+function proseTokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+function sharedLeadingTokenCount(a: string, b: string): number {
+  const left = proseTokens(a)
+  const right = proseTokens(b)
+  const limit = Math.min(left.length, right.length)
+  let count = 0
+  for (let i = 0; i < limit; i += 1) {
+    if (left[i] !== right[i]) break
+    count += 1
+  }
+  return count
+}
+
 function hasInternalTokenLeak(value: string): boolean {
   const clean = normalize(value)
   if (!clean) return false
@@ -343,6 +363,15 @@ export function validateReviseCardContract(input: ReviseCardValidationInput): Re
 
   const [a, b, c] = normalizedCandidates
   if (overlapRatio(a, b) >= 0.9 || overlapRatio(a, c) >= 0.9 || overlapRatio(b, c) >= 0.9) {
+    return { readiness: 'needs_targeting', reason: 'Candidate options are not materially distinct.' }
+  }
+
+  const sharedLeadInLimit = 4
+  if (
+    sharedLeadingTokenCount(a, b) >= sharedLeadInLimit
+    || sharedLeadingTokenCount(a, c) >= sharedLeadInLimit
+    || sharedLeadingTokenCount(b, c) >= sharedLeadInLimit
+  ) {
     return { readiness: 'needs_targeting', reason: 'Candidate options are not materially distinct.' }
   }
 

--- a/lib/revision/reviseCardContract.ts
+++ b/lib/revision/reviseCardContract.ts
@@ -155,6 +155,22 @@ const META_EDITORIAL_PATTERNS = [
   /\breview this opportunity\b/i,
 ]
 
+const WORD_PROCESSOR_ARTIFACT_PATTERNS = [
+  /(?:^|\s)[vow]:\*\s*\{\s*behavior\s*:\s*url\(#default#vml\)\s*;?\s*\}/i,
+  /(?:^|\s)\.shape\s*\{\s*behavior\s*:\s*url\(#default#vml\)\s*;?\s*\}/i,
+  /\btable\.msonormaltable\b/i,
+  /\bmso-style-name\b/i,
+  /\bmso-tstyle-rowband-size\b/i,
+  /\bmso-tstyle-colband-size\b/i,
+  /\bmso-pagination\b/i,
+  /\/\*\s*style definitions\s*\*\//i,
+  /\bshape\s+\\\*\s+mergeformat\b/i,
+  /\bnormal\s+0\s+false\b/i,
+  /\bx-none\b/i,
+  /\bbehavior\s*:\s*url\(#default#vml\)\b/i,
+  /<\/?(?:html|head|body|style|xml|meta|o:p|v:[^>\s]+|w:[^>\s]+|st1:[^>\s]+)[^>]*>/i,
+]
+
 function normalize(value: string | null | undefined): string {
   return (value ?? '').replace(/\s+/g, ' ').trim()
 }
@@ -219,6 +235,15 @@ export function hasForbiddenMetaSuggestion(value: string | null | undefined): bo
   return FORBIDDEN_META_SUGGESTIONS.some((phrase) => clean.includes(phrase))
 }
 
+export function hasWordProcessorArtifact(value: string | null | undefined): boolean {
+  const clean = normalize(value)
+  if (!clean) return false
+  if (WORD_PROCESSOR_ARTIFACT_PATTERNS.some((pattern) => pattern.test(clean))) return true
+  if (/<\/?[a-z][\w:-]*[^>]*>/i.test(clean)) return true
+  if (/&(?:nbsp|quot|lt|gt|amp);|&#160;/i.test(clean)) return true
+  return false
+}
+
 export function isMissingSourceMarker(value: string | null | undefined): boolean {
   const clean = normalize(value).toLowerCase()
   if (!clean) return true
@@ -228,6 +253,7 @@ export function isMissingSourceMarker(value: string | null | undefined): boolean
 export function candidateTextIsCopyPasteReady(value: string | null | undefined): boolean {
   const clean = normalize(value)
   if (!clean) return false
+  if (hasWordProcessorArtifact(clean)) return false
   if (hasForbiddenMetaSuggestion(clean)) return false
   if (hasMetaEditorialPattern(clean)) return false
   if (hasInternalTokenLeak(clean)) return false

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -6,6 +6,7 @@ import { loadReviseQueueWarmupCorpus } from './reviseQueueWarmup'
 import { getCriterionDisplayLabel } from '@/lib/evaluation/reportRenderSafety'
 import type { DiagnosticFinding, ProposalSeverity } from './types'
 import {
+  hasWordProcessorArtifact,
   inferRevisionOperation,
   operationLabels,
   REVISION_OPERATIONS,
@@ -472,6 +473,10 @@ function fallbackMistakeProofing(mode: WorkbenchMode): string {
 function cleanAuthorFacingText(value: string | null | undefined, fallback: string): string {
   const raw = (value ?? '').trim()
   if (!raw) return fallback
+
+  if (hasWordProcessorArtifact(raw)) {
+    return fallback
+  }
 
   if (/\b(?:prosecontrol|narrativedrive|evaluation_result|criteria\.recommendations|provenance)\b/i.test(raw)) {
     return fallback

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -485,6 +485,19 @@ function cleanAuthorFacingText(value: string | null | undefined, fallback: strin
   return raw
 }
 
+function sanitizeEvidenceExcerpt(value: string | null | undefined): string {
+  const raw = (value ?? '').trim()
+  if (!raw) return ''
+
+  if (hasWordProcessorArtifact(raw)) return ''
+  if (/\b(?:prosecontrol|narrativedrive|evaluation_result|criteria\.recommendations|provenance)\b/i.test(raw)) {
+    return ''
+  }
+  if (/\b[A-Z]{3,}:[a-z_]+\b/.test(raw)) return ''
+
+  return raw
+}
+
 function normalizeRevisionOperation(raw: unknown): RevisionOperation | null {
   if (typeof raw !== 'string') return null
   const clean = raw.trim()
@@ -673,7 +686,11 @@ function findingToOpportunity(
   const rich = matchRichRecommendation(finding, richLookup)
 
   // Evidence: prefer rich anchor_snippet > finding.evidence_excerpt > finding.original_text
-  const evidenceText = rich?.anchor_snippet || finding.evidence_excerpt || finding.original_text || null
+  const evidenceText =
+    sanitizeEvidenceExcerpt(rich?.anchor_snippet)
+    || sanitizeEvidenceExcerpt(finding.evidence_excerpt)
+    || sanitizeEvidenceExcerpt(finding.original_text)
+    || null
   const evidence = splitEvidence(evidenceText)
 
   // Title: use symptom if available (it's the observable reader problem)
@@ -939,7 +956,7 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
         : opportunity.severity === 'should'
           ? 'should'
           : 'could'
-    const evidence = splitEvidence(opportunity.evidence_anchor)
+    const evidence = splitEvidence(sanitizeEvidenceExcerpt(opportunity.evidence_anchor) || null)
     const candidateA = (opportunity.candidate_text_a ?? '').trim()
     const candidateB = (opportunity.candidate_text_b ?? '').trim()
     const candidateC = (opportunity.candidate_text_c ?? '').trim()

--- a/tests/components/ReviseCockpitClient.smoke.test.tsx
+++ b/tests/components/ReviseCockpitClient.smoke.test.tsx
@@ -90,7 +90,57 @@ describe("ReviseCockpitClient smoke", () => {
     render(<ReviseCockpitClient payload={payload} />);
 
     expect(screen.queryByText("No revision queue available.")).toBeNull();
+    expect(screen.getAllByText(/Instruction-style candidate blocked/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Needs Targeting").length).toBeGreaterThan(0);
-    expect(screen.getByText(/No Ready cards yet/i)).toBeTruthy();
+    expect(screen.getByText(/Queue\s*1\s*\/\s*1/i)).toBeTruthy();
+    expect(screen.queryByText(/No Ready cards yet/i)).toBeNull();
+  });
+
+  it("disables accept actions for needs-targeting cards even when candidate text looks copy-ready", () => {
+    const item = makeNeedsTargetingOpportunity("nt-copy-ready");
+    item.options = [
+      {
+        key: "A",
+        mechanism: "Recommended repair",
+        text: "She closed the door softly, the latch clicking once as rain traced silver lines down the glass.",
+        rationale: "Copy-ready prose variant.",
+      },
+      {
+        key: "B",
+        mechanism: "Rhythm variant",
+        text: "She closed the door softly, and the latch clicked once while rain drew silver lines on the glass.",
+        rationale: "Copy-ready prose variant.",
+      },
+      {
+        key: "C",
+        mechanism: "Bolder rendering shift",
+        text: "She eased the door shut; one latch click, then rain threading silver across the pane.",
+        rationale: "Copy-ready prose variant.",
+      },
+    ];
+
+    const payload: WorkbenchQueuePayload = {
+      ok: true,
+      error: null,
+      manuscriptId: "6074",
+      evaluationJobId: "e5ced7ac-117f-4d13-8cd0-3957c15dc189",
+      manuscriptTitle: "Ancient Bloodlines—Love Between Species",
+      opportunities: [],
+      needsTargeting: [item],
+      readinessTotals: {
+        ready_for_revise: 0,
+        needs_targeting: 1,
+      },
+      totals: { must: 0, should: 0, could: 0 },
+      scopes: { Line: 0, Passage: 0, Scene: 0, Chapter: 0, Structural: 0, Manuscript: 0 },
+      criteria: {},
+      synthesis: { admitted: 0, clustered: 0, held: 1, suppressed: 0 },
+    };
+
+    render(<ReviseCockpitClient payload={payload} />);
+
+    expect(screen.getAllByRole("button", { name: "Accept A" }).every((button) => button.hasAttribute("disabled"))).toBe(true);
+    expect(screen.getAllByRole("button", { name: "Accept B" }).every((button) => button.hasAttribute("disabled"))).toBe(true);
+    expect(screen.getAllByRole("button", { name: "Accept C" }).every((button) => button.hasAttribute("disabled"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
This PR closes the recurring Revise Queue issues observed in production by hardening both queue contract and cockpit rendering paths.

### Included fixes
- Sanitize evidence excerpts/anchors to block internal pipeline tokens (for example `NARRATIVEDRIVE:recommendation`) from surfacing in author-visible Evidence.
- Add repetitive lead-in distinctness gate for A/B/C candidate options so near-clone variants are routed to `needs_targeting`.
- Realign `ReviseCockpitClient` to the agreed layout contract:
  - Original Passage
  - Replacement Options (A/B/C)
  - Author controls
  - Collapsible **Why this was flagged** (diagnostic six)
- Suppress boilerplate option rationale strings that add noise/repetition in card rendering.

### Regression coverage
- `__tests__/lib/revision/workbenchQueue.test.ts`
  - internal-token evidence anchor regression
- `__tests__/lib/revision/reviseCardContract.test.ts`
  - repetitive lead-in candidate gating regression
- `tests/components/ReviseCockpitClient.smoke.test.tsx`
  - cockpit shell/action-gating safeguards remain intact

### Validation run
- `npm test -- --runInBand __tests__/lib/revision/reviseCardContract.test.ts __tests__/lib/revision/workbenchQueue.test.ts tests/components/ReviseCockpitClient.smoke.test.tsx`
- Result: **3/3 suites passing, 26/26 tests passing**

## Why this is required now
Production currently reports deployed SHA `d579f75` while `origin/main` is `89dd8acc`, and these new hardening commits are beyond both. This PR restores alignment by bringing the latest recurrence-proofing into `main` for deploy.
