### PR TITLE
[P4/#859] Add Phase 0.5 ChatGPT Story Map Seed (story_map_seed_v1)

### DIFF
--- a/.github/pr-bodies/PR-869.md
+++ b/.github/pr-bodies/PR-869.md
@@ -1,0 +1,1 @@
+Dedicated one-issue/one-PR draft lane for #859.\n\nThis PR currently contains scaffold tracking only and will be updated with full implementation + test evidence before ready-for-review.\n\nRefs #859

--- a/docs/pr-tracking/issue-859.md
+++ b/docs/pr-tracking/issue-859.md
@@ -1,0 +1,15 @@
+# Issue #859 PR Scaffold
+
+Issue title: [P4] Add Phase 0.5 ChatGPT Story Map Seed (story_map_seed_v1)
+
+## Purpose
+This draft PR is a dedicated lane for issue #859 under the 10-PR execution policy.
+
+## Required implementation checklist
+- [ ] implement issue scope in production code
+- [ ] add or update focused tests
+- [ ] run evidence-producing test command(s)
+- [ ] update issue with proof links
+
+## Status
+Draft scaffold created to reserve one-issue/one-PR review boundary.


### PR DESCRIPTION
Dedicated one-issue/one-PR draft lane for #859.

This PR contained scaffold tracking only and is now superseded by the merged rescue/implementation path in PR #885 and follow-up PR #886. It was never ready-for-review and should not be merged from its stacked scaffold branch.

Closed to reduce stale PR noise and avoid accidental scaffold merges.

Refs #859