### PR TITLE
[P8/#863] Update downstream evaluation handoff to verified story artifact

### DIFF
--- a/.github/pr-bodies/PR-873.md
+++ b/.github/pr-bodies/PR-873.md
@@ -1,0 +1,1 @@
+Dedicated one-issue/one-PR draft lane for #863.\n\nThis PR currently contains scaffold tracking only and will be updated with full implementation + test evidence before ready-for-review.\n\nRefs #863

--- a/docs/pr-tracking/issue-863.md
+++ b/docs/pr-tracking/issue-863.md
@@ -1,0 +1,15 @@
+# Issue #863 PR Scaffold
+
+Issue title: [P8] Update downstream evaluation handoff to verified story artifact
+
+## Purpose
+This draft PR is a dedicated lane for issue #863 under the 10-PR execution policy.
+
+## Required implementation checklist
+- [ ] implement issue scope in production code
+- [ ] add or update focused tests
+- [ ] run evidence-producing test command(s)
+- [ ] update issue with proof links
+
+## Status
+Draft scaffold created to reserve one-issue/one-PR review boundary.


### PR DESCRIPTION
Dedicated one-issue/one-PR draft lane for issue 863.

This PR contained scaffold tracking only and is now superseded by the merged rescue/implementation path in PR #885 and follow-up PR #886. It was never ready-for-review and should not be merged from its stacked scaffold branch.

Closed to reduce stale PR noise and avoid accidental scaffold merges.

Refs issue 863