### PR TITLE
[P9/#864] Retire old nine-layer author approval click-through flow

### DIFF
--- a/.github/pr-bodies/PR-874.md
+++ b/.github/pr-bodies/PR-874.md
@@ -1,0 +1,1 @@
+Dedicated one-issue/one-PR draft lane for #864.\n\nThis PR currently contains scaffold tracking only and will be updated with full implementation + test evidence before ready-for-review.\n\nRefs #864

--- a/docs/pr-tracking/issue-864.md
+++ b/docs/pr-tracking/issue-864.md
@@ -1,0 +1,15 @@
+# Issue #864 PR Scaffold
+
+Issue title: [P9] Retire old nine-layer author approval click-through flow
+
+## Purpose
+This draft PR is a dedicated lane for issue #864 under the 10-PR execution policy.
+
+## Required implementation checklist
+- [ ] implement issue scope in production code
+- [ ] add or update focused tests
+- [ ] run evidence-producing test command(s)
+- [ ] update issue with proof links
+
+## Status
+Draft scaffold created to reserve one-issue/one-PR review boundary.


### PR DESCRIPTION
Dedicated one-issue/one-PR draft lane for issue 864.

This PR contained scaffold tracking only and is now superseded by the merged rescue/implementation path in PR #885 and follow-up PR #886. It was never ready-for-review and should not be merged from its stacked scaffold branch.

Closed to reduce stale PR noise and avoid accidental scaffold merges.

Refs issue 864