### PR TITLE
[P12] Add evaluation/revise checklist-as-code matrix

### DIFF
--- a/.github/pr-bodies/PR-877.md
+++ b/.github/pr-bodies/PR-877.md
@@ -1,0 +1,52 @@
+## Summary
+
+Adds the first implementation slice for checklist-as-code enforcement across the evaluation/revise pipeline.
+
+This PR introduces:
+
+- `lib/evaluation/phase-architecture-v2/checklistMatrix.ts`
+- `lib/evaluation/phase-architecture-v2/checklistEnforcer.ts`
+- `__tests__/evaluation/checklistEnforcer.test.ts`
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## Authority-proof requirement
+
+- Use the Phase 0 Authority Registry or the canonical loader that resolves it.
+- Do not add a separate warmup/canon loader.
+- Do not add a divergent authority path list.
+- Persist `phase0_authority_proof_v1` before Phase 0.5A/0.5B seed generation.
+- Record loaded paths, missing paths, and checksums.
+- Degrade or stop with proof if required authority is unavailable.
+
+## Doctrine enforced
+
+- No valid inputs, no phase start.
+- No valid outputs, no publish.
+- No resume-safe artifact, no resume.
+- Phase 0.5A and Phase 0.5B require `phase0_authority_proof_v1`.
+- Resume selection uses the last valid and resume-safe artifact, not the newest artifact.
+
+## Scope
+
+Initial enforcement slice only.
+
+This PR adds the matrix and pure enforcer helpers with focused tests. Runtime wiring into phase entry, artifact publication, and resume routes should follow in the next implementation PR once this contract is reviewed.
+
+## Tests
+
+Added targeted tests for:
+
+- Phase 0.5A blocking without `phase0_authority_proof_v1`
+- Phase 0.5B blocking without `phase0_authority_proof_v1`
+- Phase 1A blocking without `story_map_seed_v1`
+- Phase 2 blocking without `accepted_story_context_v1`
+- degraded artifacts requiring reason codes
+- resume choosing last valid resume-safe artifact, not newest artifact
+- usable but non-resume-safe artifacts not being resume points

--- a/__tests__/evaluation/checklistEnforcer.test.ts
+++ b/__tests__/evaluation/checklistEnforcer.test.ts
@@ -1,4 +1,8 @@
 import {
+  CHECKLIST_MATRIX,
+  SIPOC_STAGE_REFS,
+} from '../../lib/evaluation/phase-architecture-v2/checklistMatrix';
+import {
   assertChecklistPhaseMayStart,
   isArtifactResumeSafe,
   selectLastResumeSafeArtifact,
@@ -16,6 +20,30 @@ const valid = (artifact_type: ChecklistArtifactState['artifact_type']): Checklis
 });
 
 describe('Phase Architecture v2 checklist-as-code enforcer', () => {
+  it('binds every checklist row to an allowed SIPOC stage reference', () => {
+    const allowed = new Set<string>(SIPOC_STAGE_REFS);
+
+    expect(CHECKLIST_MATRIX.length).toBeGreaterThan(0);
+    for (const row of CHECKLIST_MATRIX) {
+      expect(allowed.has(row.sipoc_stage_ref)).toBe(true);
+    }
+  });
+
+  it('keeps Phase 0.5 and Revise/WAVE rows adjacent rather than pretending they are certified S01-S11 spine stages', () => {
+    expect(CHECKLIST_MATRIX.find((row) => row.phase_id === 'phase_0_5a')?.sipoc_stage_ref).toBe(
+      'ADJACENT_PHASE_0_5A',
+    );
+    expect(CHECKLIST_MATRIX.find((row) => row.phase_id === 'phase_0_5b')?.sipoc_stage_ref).toBe(
+      'ADJACENT_PHASE_0_5B',
+    );
+    expect(CHECKLIST_MATRIX.find((row) => row.phase_id === 'revise_admission')?.sipoc_stage_ref).toBe(
+      'ADJACENT_REVISE',
+    );
+    expect(CHECKLIST_MATRIX.find((row) => row.phase_id === 'wave')?.sipoc_stage_ref).toBe(
+      'ADJACENT_WAVE',
+    );
+  });
+
   it('blocks Phase 0.5A without phase0_authority_proof_v1', () => {
     const result = assertChecklistPhaseMayStart('phase_0_5a', {});
 

--- a/__tests__/evaluation/checklistEnforcer.test.ts
+++ b/__tests__/evaluation/checklistEnforcer.test.ts
@@ -1,0 +1,108 @@
+import {
+  assertChecklistPhaseMayStart,
+  isArtifactResumeSafe,
+  selectLastResumeSafeArtifact,
+  checklistRowsRequiringAuthorityProof,
+  type ChecklistArtifactState,
+} from '../../lib/evaluation/phase-architecture-v2/checklistEnforcer';
+
+const valid = (artifact_type: ChecklistArtifactState['artifact_type']): ChecklistArtifactState => ({
+  artifact_type,
+  artifact_id: `${artifact_type}-id`,
+  schema_valid: true,
+  semantic_status: 'valid',
+  is_resume_safe: true,
+  checksum: `${artifact_type}-checksum`,
+});
+
+describe('Phase Architecture v2 checklist-as-code enforcer', () => {
+  it('blocks Phase 0.5A without phase0_authority_proof_v1', () => {
+    const result = assertChecklistPhaseMayStart('phase_0_5a', {});
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+    expect(result.missing_inputs).toContain('phase0_authority_proof_v1');
+  });
+
+  it('blocks Phase 0.5B without phase0_authority_proof_v1', () => {
+    const result = assertChecklistPhaseMayStart('phase_0_5b', {});
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+    expect(result.missing_inputs).toContain('phase0_authority_proof_v1');
+  });
+
+  it('allows Phase 0.5A when authority proof is valid', () => {
+    const result = assertChecklistPhaseMayStart('phase_0_5a', {
+      phase0_authority_proof_v1: valid('phase0_authority_proof_v1'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('CHECKLIST_PHASE_MAY_START');
+  });
+
+  it('blocks Phase 1A without story_map_seed_v1', () => {
+    const result = assertChecklistPhaseMayStart('phase_1a', {
+      phase0_authority_proof_v1: valid('phase0_authority_proof_v1'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.missing_inputs).toContain('story_map_seed_v1');
+  });
+
+  it('blocks Phase 2 without accepted_story_context_v1', () => {
+    const result = assertChecklistPhaseMayStart('phase_2', {});
+
+    expect(result.ok).toBe(false);
+    expect(result.missing_inputs).toContain('accepted_story_context_v1');
+  });
+
+  it('requires degraded artifacts to carry reason codes before use', () => {
+    const degradedWithoutProof: ChecklistArtifactState = {
+      artifact_type: 'phase0_authority_proof_v1',
+      artifact_id: 'authority-id',
+      schema_valid: true,
+      semantic_status: 'degraded_with_reasons',
+      is_resume_safe: true,
+      blocking_reason_codes: [],
+    };
+
+    const result = assertChecklistPhaseMayStart('phase_0_5a', {
+      phase0_authority_proof_v1: degradedWithoutProof,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_INVALID');
+  });
+
+  it('selects the last valid resume-safe artifact, not the newest artifact', () => {
+    const older = valid('pass12_handoff_v1');
+    const newestInvalid: ChecklistArtifactState = {
+      artifact_type: 'evaluation_result_v2',
+      artifact_id: 'evaluation-result-id',
+      schema_valid: false,
+      semantic_status: 'valid',
+      is_resume_safe: true,
+    };
+
+    expect(selectLastResumeSafeArtifact([older, newestInvalid])).toBe(older);
+  });
+
+  it('does not treat usable but non-resume-safe artifacts as resume points', () => {
+    const usableButNotResumeSafe: ChecklistArtifactState = {
+      ...valid('evaluation_result_v2'),
+      is_resume_safe: false,
+    };
+
+    expect(isArtifactResumeSafe(usableButNotResumeSafe)).toBe(false);
+    expect(selectLastResumeSafeArtifact([usableButNotResumeSafe])).toBeNull();
+  });
+
+  it('declares only Phase 0.5 seed rows as authority-proof required in the initial slice', () => {
+    expect(checklistRowsRequiringAuthorityProof().map((row) => row.phase_id)).toEqual([
+      'phase_0_5a',
+      'phase_0_5b',
+      'phase_1a',
+    ]);
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/checklistEnforcer.ts
+++ b/lib/evaluation/phase-architecture-v2/checklistEnforcer.ts
@@ -1,0 +1,140 @@
+import {
+  CHECKLIST_MATRIX,
+  getChecklistRow,
+  type ChecklistArtifactType,
+  type ChecklistPhaseId,
+  type ChecklistMatrixRow,
+} from './checklistMatrix';
+
+export type ChecklistArtifactState = {
+  artifact_type: ChecklistArtifactType;
+  artifact_id?: string | null;
+  schema_valid?: boolean | null;
+  semantic_status?: 'valid' | 'degraded_with_reasons' | 'blocked' | 'failed' | 'unknown' | null;
+  is_resume_safe?: boolean | null;
+  blocking_reason_codes?: readonly string[] | null;
+  checksum?: string | null;
+};
+
+export type ChecklistArtifactMap = Partial<Record<ChecklistArtifactType, ChecklistArtifactState | null | undefined>>;
+
+export type ChecklistDecision = {
+  ok: boolean;
+  code: string;
+  reason: string;
+  phase_id: ChecklistPhaseId;
+  required_inputs: readonly ChecklistArtifactType[];
+  missing_inputs: ChecklistArtifactType[];
+  invalid_inputs: ChecklistArtifactType[];
+};
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasReasonCodes(value: unknown): boolean {
+  return Array.isArray(value) && value.some(hasText);
+}
+
+export function isArtifactUsableForPhaseInput(artifact: ChecklistArtifactState | null | undefined): boolean {
+  if (!artifact) return false;
+  if (!hasText(artifact.artifact_id)) return false;
+  if (artifact.schema_valid !== true) return false;
+
+  if (artifact.semantic_status === 'valid') return true;
+
+  if (artifact.semantic_status === 'degraded_with_reasons') {
+    return hasReasonCodes(artifact.blocking_reason_codes);
+  }
+
+  return false;
+}
+
+export function isArtifactResumeSafe(artifact: ChecklistArtifactState | null | undefined): boolean {
+  return isArtifactUsableForPhaseInput(artifact) && artifact?.is_resume_safe === true;
+}
+
+export function assertChecklistPhaseMayStart(
+  phaseId: ChecklistPhaseId,
+  artifacts: ChecklistArtifactMap = {},
+): ChecklistDecision {
+  const row = getChecklistRow(phaseId);
+  const missingInputs: ChecklistArtifactType[] = [];
+  const invalidInputs: ChecklistArtifactType[] = [];
+
+  for (const requiredType of row.required_inputs) {
+    const artifact = artifacts[requiredType];
+    if (!artifact) {
+      missingInputs.push(requiredType);
+      continue;
+    }
+
+    if (!isArtifactUsableForPhaseInput(artifact)) {
+      invalidInputs.push(requiredType);
+    }
+  }
+
+  if (row.required_authority_proof) {
+    const authority = artifacts.phase0_authority_proof_v1;
+    if (!authority) {
+      if (!missingInputs.includes('phase0_authority_proof_v1')) {
+        missingInputs.push('phase0_authority_proof_v1');
+      }
+    } else if (!isArtifactUsableForPhaseInput(authority)) {
+      if (!invalidInputs.includes('phase0_authority_proof_v1')) {
+        invalidInputs.push('phase0_authority_proof_v1');
+      }
+    }
+  }
+
+  if (missingInputs.length > 0) {
+    return {
+      ok: false,
+      code: 'CHECKLIST_REQUIRED_INPUT_MISSING',
+      reason: `Phase ${phaseId} cannot start: missing required artifact(s): ${missingInputs.join(', ')}.`,
+      phase_id: phaseId,
+      required_inputs: row.required_inputs,
+      missing_inputs: missingInputs,
+      invalid_inputs: invalidInputs,
+    };
+  }
+
+  if (invalidInputs.length > 0) {
+    return {
+      ok: false,
+      code: 'CHECKLIST_REQUIRED_INPUT_INVALID',
+      reason: `Phase ${phaseId} cannot start: invalid required artifact(s): ${invalidInputs.join(', ')}.`,
+      phase_id: phaseId,
+      required_inputs: row.required_inputs,
+      missing_inputs: missingInputs,
+      invalid_inputs: invalidInputs,
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'CHECKLIST_PHASE_MAY_START',
+    reason: `Phase ${phaseId} may start: checklist inputs satisfied.`,
+    phase_id: phaseId,
+    required_inputs: row.required_inputs,
+    missing_inputs: [],
+    invalid_inputs: [],
+  };
+}
+
+export function selectLastResumeSafeArtifact(
+  artifactsInPublicationOrder: readonly ChecklistArtifactState[],
+): ChecklistArtifactState | null {
+  for (let index = artifactsInPublicationOrder.length - 1; index >= 0; index -= 1) {
+    const artifact = artifactsInPublicationOrder[index];
+    if (isArtifactResumeSafe(artifact)) {
+      return artifact;
+    }
+  }
+
+  return null;
+}
+
+export function checklistRowsRequiringAuthorityProof(): ChecklistMatrixRow[] {
+  return CHECKLIST_MATRIX.filter((row) => row.required_authority_proof);
+}

--- a/lib/evaluation/phase-architecture-v2/checklistMatrix.ts
+++ b/lib/evaluation/phase-architecture-v2/checklistMatrix.ts
@@ -1,0 +1,209 @@
+export const CHECKLIST_ARTIFACT_TYPES = [
+  'phase0_authority_proof_v1',
+  'story_map_seed_v1',
+  'evaluation_seed_v1',
+  'revise_opportunity_seed_v1',
+  'story_map_verification_v1',
+  'seed_contradiction_report_v1',
+  'evidence_index_v1',
+  'verified_story_layer_handoff_v1',
+  'semantic_gate_result_v1',
+  'accepted_story_context_v1',
+  'criteria_evaluation_v1',
+  'criteria_recommendation_contract_v1',
+  'pass12_handoff_v1',
+  'evaluation_synthesis_v1',
+  'evaluation_result_v2',
+  'llr_quality_gate_result_v1',
+  'llr_recovery_checkpoint_v1',
+  'wave_readiness_analysis_v1',
+  'wave_revision_guidance_v1',
+  'revise_admission_result_v1',
+  'revise_candidate_validation_v1',
+  'revise_queue_package_v1',
+  'report_render_manifest_v1',
+  'job_checkpoint_manifest_v1',
+] as const;
+
+export type ChecklistArtifactType = (typeof CHECKLIST_ARTIFACT_TYPES)[number];
+
+export const CHECKLIST_PHASE_IDS = [
+  'phase_0',
+  'phase_0_5a',
+  'phase_0_5b',
+  'phase_1a',
+  'pass_3a',
+  'semantic_gate',
+  'phase_2',
+  'phase_3',
+  'llr_quality_gate',
+  'wave',
+  'revise_admission',
+  'revise_queue_package',
+  'final_render',
+] as const;
+
+export type ChecklistPhaseId = (typeof CHECKLIST_PHASE_IDS)[number];
+
+export type ChecklistRuntimePhase =
+  | 'phase_0'
+  | 'phase_1a'
+  | 'pass_3a'
+  | 'review_gate'
+  | 'phase_2'
+  | 'phase_3'
+  | 'wave'
+  | 'revise'
+  | 'final_render';
+
+export type ChecklistMatrixRow = {
+  readonly phase_id: ChecklistPhaseId;
+  readonly runtime_phase: ChecklistRuntimePhase;
+  readonly required_inputs: readonly ChecklistArtifactType[];
+  readonly required_authority_proof: boolean;
+  readonly output_artifacts: readonly ChecklistArtifactType[];
+  readonly validator: string;
+  readonly publish_gate: string;
+  readonly resume_rule: string;
+};
+
+export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
+  {
+    phase_id: 'phase_0',
+    runtime_phase: 'phase_0',
+    required_inputs: [],
+    required_authority_proof: false,
+    output_artifacts: ['phase0_authority_proof_v1'],
+    validator: 'assertPhase0AuthorityRegistryMayLoad',
+    publish_gate: 'phase0_authority_proof_schema_and_checksum_gate',
+    resume_rule: 'resume_from_phase0_authority_proof_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'phase_0_5a',
+    runtime_phase: 'phase_1a',
+    required_inputs: ['phase0_authority_proof_v1'],
+    required_authority_proof: true,
+    output_artifacts: ['story_map_seed_v1', 'evaluation_seed_v1'],
+    validator: 'assertStoryMapSeedMayStart',
+    publish_gate: 'seed_schema_authority_and_checksum_gate',
+    resume_rule: 'resume_from_story_map_seed_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'phase_0_5b',
+    runtime_phase: 'revise',
+    required_inputs: ['phase0_authority_proof_v1'],
+    required_authority_proof: true,
+    output_artifacts: ['revise_opportunity_seed_v1'],
+    validator: 'assertReviseOpportunitySeedMayStart',
+    publish_gate: 'revise_seed_schema_authority_and_checksum_gate',
+    resume_rule: 'resume_from_revise_opportunity_seed_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'phase_1a',
+    runtime_phase: 'phase_1a',
+    required_inputs: ['phase0_authority_proof_v1', 'story_map_seed_v1'],
+    required_authority_proof: true,
+    output_artifacts: ['story_map_verification_v1', 'seed_contradiction_report_v1', 'evidence_index_v1'],
+    validator: 'assertPhase1aSeedVerificationMayStart',
+    publish_gate: 'seed_verification_evidence_gate',
+    resume_rule: 'resume_from_story_map_verification_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'pass_3a',
+    runtime_phase: 'pass_3a',
+    required_inputs: ['story_map_verification_v1', 'evidence_index_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['verified_story_layer_handoff_v1'],
+    validator: 'assertPass3aNormalizationMayStart',
+    publish_gate: 'verified_story_layer_handoff_gate',
+    resume_rule: 'resume_from_verified_story_layer_handoff_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'semantic_gate',
+    runtime_phase: 'review_gate',
+    required_inputs: ['verified_story_layer_handoff_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['semantic_gate_result_v1', 'accepted_story_context_v1'],
+    validator: 'assertSemanticGateMayStart',
+    publish_gate: 'accepted_story_context_semantic_gate',
+    resume_rule: 'resume_from_accepted_story_context_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'phase_2',
+    runtime_phase: 'phase_2',
+    required_inputs: ['accepted_story_context_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['criteria_evaluation_v1', 'criteria_recommendation_contract_v1', 'pass12_handoff_v1'],
+    validator: 'assertPhase2ChecklistPreconditions',
+    publish_gate: 'criteria_evaluation_and_pass12_handoff_gate',
+    resume_rule: 'resume_from_pass12_handoff_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'phase_3',
+    runtime_phase: 'phase_3',
+    required_inputs: ['pass12_handoff_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['evaluation_synthesis_v1', 'evaluation_result_v2'],
+    validator: 'assertPhase3SynthesisMayStart',
+    publish_gate: 'evaluation_result_v2_publication_gate',
+    resume_rule: 'resume_from_evaluation_result_v2_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'llr_quality_gate',
+    runtime_phase: 'phase_3',
+    required_inputs: ['evaluation_result_v2'],
+    required_authority_proof: false,
+    output_artifacts: ['llr_quality_gate_result_v1', 'llr_recovery_checkpoint_v1'],
+    validator: 'assertLlrQualityGateMayStart',
+    publish_gate: 'llr_quality_or_recovery_checkpoint_gate',
+    resume_rule: 'resume_from_llr_recovery_checkpoint_v1_when_blocked_or_evaluation_result_v2_when_valid',
+  },
+  {
+    phase_id: 'wave',
+    runtime_phase: 'wave',
+    required_inputs: ['evaluation_result_v2', 'accepted_story_context_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['wave_readiness_analysis_v1', 'wave_revision_guidance_v1'],
+    validator: 'assertWaveMayStart',
+    publish_gate: 'wave_readiness_publication_gate',
+    resume_rule: 'resume_from_wave_readiness_analysis_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'revise_admission',
+    runtime_phase: 'revise',
+    required_inputs: ['revise_opportunity_seed_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['revise_admission_result_v1', 'revise_candidate_validation_v1'],
+    validator: 'assertReviseAdmissionMayStart',
+    publish_gate: 'revise_admission_and_candidate_validation_gate',
+    resume_rule: 'resume_from_revise_admission_result_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'revise_queue_package',
+    runtime_phase: 'revise',
+    required_inputs: ['revise_admission_result_v1', 'revise_candidate_validation_v1'],
+    required_authority_proof: false,
+    output_artifacts: ['revise_queue_package_v1'],
+    validator: 'assertReviseQueuePackageMayStart',
+    publish_gate: 'author_facing_revise_queue_package_gate',
+    resume_rule: 'resume_from_revise_queue_package_v1_when_valid_and_resume_safe',
+  },
+  {
+    phase_id: 'final_render',
+    runtime_phase: 'final_render',
+    required_inputs: ['evaluation_result_v2'],
+    required_authority_proof: false,
+    output_artifacts: ['report_render_manifest_v1', 'job_checkpoint_manifest_v1'],
+    validator: 'assertFinalRenderMayStart',
+    publish_gate: 'report_render_manifest_gate',
+    resume_rule: 'resume_render_from_evaluation_result_v2_not_full_pipeline',
+  },
+] as const;
+
+export function getChecklistRow(phaseId: ChecklistPhaseId): ChecklistMatrixRow {
+  const row = CHECKLIST_MATRIX.find((entry) => entry.phase_id === phaseId);
+  if (!row) {
+    throw new Error(`Unknown checklist phase: ${phaseId}`);
+  }
+  return row;
+}

--- a/lib/evaluation/phase-architecture-v2/checklistMatrix.ts
+++ b/lib/evaluation/phase-architecture-v2/checklistMatrix.ts
@@ -45,6 +45,30 @@ export const CHECKLIST_PHASE_IDS = [
 
 export type ChecklistPhaseId = (typeof CHECKLIST_PHASE_IDS)[number];
 
+export const SIPOC_STAGE_REFS = [
+  'S01_INTAKE',
+  'S02_QUEUE',
+  'S03_CLAIM',
+  'S04_ROUTING_CHUNKING',
+  'S05_PASS1',
+  'S06_PASS2',
+  'S07_PASS3',
+  'S08_ER2_NORMALIZATION',
+  'S09_QUALITYGATEV2',
+  'S10_PERSISTENCE',
+  'S11_RENDERER',
+  'ADJACENT_PHASE_0',
+  'ADJACENT_PHASE_0_5A',
+  'ADJACENT_PHASE_0_5B',
+  'ADJACENT_PASS_3A',
+  'ADJACENT_SEMANTIC_GATE',
+  'ADJACENT_LLR',
+  'ADJACENT_REVISE',
+  'ADJACENT_WAVE',
+] as const;
+
+export type SipocStageRef = (typeof SIPOC_STAGE_REFS)[number];
+
 export type ChecklistRuntimePhase =
   | 'phase_0'
   | 'phase_1a'
@@ -59,6 +83,7 @@ export type ChecklistRuntimePhase =
 export type ChecklistMatrixRow = {
   readonly phase_id: ChecklistPhaseId;
   readonly runtime_phase: ChecklistRuntimePhase;
+  readonly sipoc_stage_ref: SipocStageRef;
   readonly required_inputs: readonly ChecklistArtifactType[];
   readonly required_authority_proof: boolean;
   readonly output_artifacts: readonly ChecklistArtifactType[];
@@ -71,6 +96,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_0',
     runtime_phase: 'phase_0',
+    sipoc_stage_ref: 'ADJACENT_PHASE_0',
     required_inputs: [],
     required_authority_proof: false,
     output_artifacts: ['phase0_authority_proof_v1'],
@@ -81,6 +107,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_0_5a',
     runtime_phase: 'phase_1a',
+    sipoc_stage_ref: 'ADJACENT_PHASE_0_5A',
     required_inputs: ['phase0_authority_proof_v1'],
     required_authority_proof: true,
     output_artifacts: ['story_map_seed_v1', 'evaluation_seed_v1'],
@@ -91,6 +118,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_0_5b',
     runtime_phase: 'revise',
+    sipoc_stage_ref: 'ADJACENT_PHASE_0_5B',
     required_inputs: ['phase0_authority_proof_v1'],
     required_authority_proof: true,
     output_artifacts: ['revise_opportunity_seed_v1'],
@@ -101,6 +129,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_1a',
     runtime_phase: 'phase_1a',
+    sipoc_stage_ref: 'ADJACENT_PHASE_0_5A',
     required_inputs: ['phase0_authority_proof_v1', 'story_map_seed_v1'],
     required_authority_proof: true,
     output_artifacts: ['story_map_verification_v1', 'seed_contradiction_report_v1', 'evidence_index_v1'],
@@ -111,6 +140,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'pass_3a',
     runtime_phase: 'pass_3a',
+    sipoc_stage_ref: 'ADJACENT_PASS_3A',
     required_inputs: ['story_map_verification_v1', 'evidence_index_v1'],
     required_authority_proof: false,
     output_artifacts: ['verified_story_layer_handoff_v1'],
@@ -121,6 +151,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'semantic_gate',
     runtime_phase: 'review_gate',
+    sipoc_stage_ref: 'ADJACENT_SEMANTIC_GATE',
     required_inputs: ['verified_story_layer_handoff_v1'],
     required_authority_proof: false,
     output_artifacts: ['semantic_gate_result_v1', 'accepted_story_context_v1'],
@@ -131,6 +162,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_2',
     runtime_phase: 'phase_2',
+    sipoc_stage_ref: 'S08_ER2_NORMALIZATION',
     required_inputs: ['accepted_story_context_v1'],
     required_authority_proof: false,
     output_artifacts: ['criteria_evaluation_v1', 'criteria_recommendation_contract_v1', 'pass12_handoff_v1'],
@@ -141,6 +173,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'phase_3',
     runtime_phase: 'phase_3',
+    sipoc_stage_ref: 'S07_PASS3',
     required_inputs: ['pass12_handoff_v1'],
     required_authority_proof: false,
     output_artifacts: ['evaluation_synthesis_v1', 'evaluation_result_v2'],
@@ -151,6 +184,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'llr_quality_gate',
     runtime_phase: 'phase_3',
+    sipoc_stage_ref: 'ADJACENT_LLR',
     required_inputs: ['evaluation_result_v2'],
     required_authority_proof: false,
     output_artifacts: ['llr_quality_gate_result_v1', 'llr_recovery_checkpoint_v1'],
@@ -161,6 +195,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'wave',
     runtime_phase: 'wave',
+    sipoc_stage_ref: 'ADJACENT_WAVE',
     required_inputs: ['evaluation_result_v2', 'accepted_story_context_v1'],
     required_authority_proof: false,
     output_artifacts: ['wave_readiness_analysis_v1', 'wave_revision_guidance_v1'],
@@ -171,6 +206,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'revise_admission',
     runtime_phase: 'revise',
+    sipoc_stage_ref: 'ADJACENT_REVISE',
     required_inputs: ['revise_opportunity_seed_v1'],
     required_authority_proof: false,
     output_artifacts: ['revise_admission_result_v1', 'revise_candidate_validation_v1'],
@@ -181,6 +217,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'revise_queue_package',
     runtime_phase: 'revise',
+    sipoc_stage_ref: 'ADJACENT_REVISE',
     required_inputs: ['revise_admission_result_v1', 'revise_candidate_validation_v1'],
     required_authority_proof: false,
     output_artifacts: ['revise_queue_package_v1'],
@@ -191,6 +228,7 @@ export const CHECKLIST_MATRIX: readonly ChecklistMatrixRow[] = [
   {
     phase_id: 'final_render',
     runtime_phase: 'final_render',
+    sipoc_stage_ref: 'S11_RENDERER',
     required_inputs: ['evaluation_result_v2'],
     required_authority_proof: false,
     output_artifacts: ['report_render_manifest_v1', 'job_checkpoint_manifest_v1'],


### PR DESCRIPTION
## Summary

Adds the first implementation slice for checklist-as-code enforcement across the evaluation/revise pipeline.

This PR introduces:

- `lib/evaluation/phase-architecture-v2/checklistMatrix.ts`
- `lib/evaluation/phase-architecture-v2/checklistEnforcer.ts`
- `__tests__/evaluation/checklistEnforcer.test.ts`

## SIPOC posture

This PR does **not** replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

The checklist matrix is an executable enforcement companion to SIPOC. It must reference SIPOC stage identifiers and may not create a parallel SIPOC universe.

Canonical S01-S11 identifiers remain unchanged. Phase 0.5A, Phase 0.5B, Revise, WAVE, LLR, Pass 3A, and Semantic Gate are represented as adjacent tracks until explicitly promoted by a SIPOC certification update.

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## Authority-proof requirement

- Use the Phase 0 Authority Registry or the canonical loader that resolves it.
- Do not add a separate warmup/canon loader.
- Do not add a divergent authority path list.
- Persist `phase0_authority_proof_v1` before Phase 0.5A/0.5B seed generation.
- Record loaded paths, missing paths, and checksums.
- Degrade or stop with proof if required authority is unavailable.

## Doctrine enforced

- No valid inputs, no phase start.
- No valid outputs, no publish.
- No resume-safe artifact, no resume.
- Phase 0.5A and Phase 0.5B require `phase0_authority_proof_v1`.
- Resume selection uses the last valid and resume-safe artifact, not the newest artifact.
- Every checklist row must bind to an allowed SIPOC stage reference.
- Adjacent tracks must not pretend to be certified S01-S11 spine stages.

## Scope

Initial enforcement slice only.

This PR adds the matrix and pure enforcer helpers with focused tests. Runtime wiring into phase entry, artifact publication, and resume routes should follow in the next implementation PR once this contract is reviewed.

## Tests

Added targeted tests for:

- every checklist row binding to an allowed SIPOC stage reference
- Phase 0.5 / Revise / WAVE rows remaining adjacent rather than certified S01-S11 spine stages
- Phase 0.5A blocking without `phase0_authority_proof_v1`
- Phase 0.5B blocking without `phase0_authority_proof_v1`
- Phase 1A blocking without `story_map_seed_v1`
- Phase 2 blocking without `accepted_story_context_v1`
- degraded artifacts requiring reason codes
- resume choosing last valid resume-safe artifact, not newest artifact
- usable but non-resume-safe artifacts not being resume points