### PR TITLE
[P13] Wire checklist enforcer into runtime gates

### DIFF
--- a/.github/pr-bodies/PR-878.md
+++ b/.github/pr-bodies/PR-878.md
@@ -1,0 +1,56 @@
+## Summary
+
+Wires the #877 checklist enforcer into runtime guard surfaces without expanding the architecture.
+
+This PR adds:
+
+- checklist enforcement in `readinessGuards.ts` for Phase 0.5A, Phase 0.5B, and Phase 1A seed verification
+- checklist enforcement in `phase2Guard.ts` when checklist artifact state is supplied
+- `checklistPublicationGate.ts` to distinguish saved-for-audit, usable-downstream, and resume-safe publication decisions
+- tests proving runtime guards now call the checklist enforcer
+
+## Done sentence
+
+Checklist enforcer decisions are now authoritative at runtime for phase start, artifact usability/resume-safety, and resume checkpoint selection.
+
+## Non-sprawl guardrails
+
+- No new phase taxonomy
+- No new SIPOC document or alternate stage IDs
+- No speculative artifact types
+- No large refactor of worker orchestration
+- Only wire existing enforcer into phase-entry, publication-decision, and resume-safety helpers
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11.
+
+The checklist enforcer remains an executable enforcement companion to SIPOC, not a replacement.
+
+## Binary acceptance gates
+
+- Runtime phase-entry code calls checklist enforcer and blocks when required.
+- Publication decisions distinguish saved-for-audit, usable downstream, and resume-safe.
+- Resume selection continues to use checklist-based resume-safe selection from #877.
+- Tests prove runtime wiring, not just standalone enforcer behavior.
+- No canonical naming drift from existing runtime/SIPOC spine.
+
+## Tests added/updated
+
+- `__tests__/evaluation/phaseV2ReadinessGuards.test.ts`
+- `__tests__/evaluation/phase2.phaseV2Guard.test.ts`
+- `__tests__/evaluation/checklistPublicationGate.test.ts`
+
+## Scope note
+
+This is still a draft stacked PR. Full route/worker integration can follow once these pure runtime guard seams are reviewed.

--- a/__tests__/evaluation/checklistPublicationGate.test.ts
+++ b/__tests__/evaluation/checklistPublicationGate.test.ts
@@ -1,0 +1,59 @@
+import { decideChecklistPublication } from '../../lib/evaluation/phase-architecture-v2/checklistPublicationGate';
+import type { ChecklistArtifactState } from '../../lib/evaluation/phase-architecture-v2/checklistEnforcer';
+
+const valid = (artifact_type: ChecklistArtifactState['artifact_type']): ChecklistArtifactState => ({
+  artifact_type,
+  artifact_id: `${artifact_type}-id`,
+  schema_valid: true,
+  semantic_status: 'valid',
+  is_resume_safe: true,
+  checksum: `${artifact_type}-checksum`,
+});
+
+describe('checklist publication gate', () => {
+  it('routes publication to audit-only when required inputs are missing', () => {
+    const decision = decideChecklistPublication({
+      phaseId: 'phase_2',
+      inputArtifacts: {},
+      outputArtifact: valid('pass12_handoff_v1'),
+    });
+
+    expect(decision.ok).toBe(false);
+    expect(decision.disposition).toBe('saved_for_audit');
+    expect(decision.may_mark_usable_downstream).toBe(false);
+    expect(decision.may_mark_resume_safe).toBe(false);
+  });
+
+  it('refuses resume-safe publication when output artifact is not resume-safe', () => {
+    const decision = decideChecklistPublication({
+      phaseId: 'phase_2',
+      inputArtifacts: {
+        accepted_story_context_v1: valid('accepted_story_context_v1'),
+      },
+      outputArtifact: {
+        ...valid('pass12_handoff_v1'),
+        is_resume_safe: false,
+      },
+    });
+
+    expect(decision.ok).toBe(false);
+    expect(decision.disposition).toBe('usable_downstream');
+    expect(decision.may_mark_usable_downstream).toBe(true);
+    expect(decision.may_mark_resume_safe).toBe(false);
+  });
+
+  it('allows resume-safe publication when inputs and output are valid', () => {
+    const decision = decideChecklistPublication({
+      phaseId: 'phase_2',
+      inputArtifacts: {
+        accepted_story_context_v1: valid('accepted_story_context_v1'),
+      },
+      outputArtifact: valid('pass12_handoff_v1'),
+    });
+
+    expect(decision.ok).toBe(true);
+    expect(decision.disposition).toBe('resume_safe');
+    expect(decision.may_mark_usable_downstream).toBe(true);
+    expect(decision.may_mark_resume_safe).toBe(true);
+  });
+});

--- a/__tests__/evaluation/phase2.phaseV2Guard.test.ts
+++ b/__tests__/evaluation/phase2.phaseV2Guard.test.ts
@@ -1,7 +1,16 @@
 import { guardPhase2Start } from '../../lib/evaluation/phase-architecture-v2/phase2Guard';
 import type { PhaseV2ArtifactSet, PhaseV2Progress } from '../../lib/evaluation/phase-architecture-v2/gateValidity';
+import type { ChecklistArtifactState } from '../../lib/evaluation/phase-architecture-v2/checklistEnforcer';
 
 const artifact = (id: string) => ({ artifact_id: id, source_hash: `sha256:${id}` });
+const checklistArtifact = (artifact_type: ChecklistArtifactState['artifact_type']): ChecklistArtifactState => ({
+  artifact_type,
+  artifact_id: `${artifact_type}-id`,
+  schema_valid: true,
+  semantic_status: 'valid',
+  is_resume_safe: true,
+  checksum: `${artifact_type}-checksum`,
+});
 
 const acceptedArtifacts: PhaseV2ArtifactSet = {
   accepted_story_ledger_v1: artifact('accepted-ledger'),
@@ -101,5 +110,36 @@ describe('Phase Architecture v2 — Phase 2 guard helper', () => {
     expect(result.can_start_phase2).toBe(true);
     expect(result.progress_patch.phase2_preflight_gate).toBe('passed');
     expect(result.progress_patch.pass3a_gate_validity).toBe('gate_valid');
+  });
+
+  it('blocks Phase 2 when checklist accepted_story_context_v1 is missing', () => {
+    const result = guardPhase2Start(
+      doneProgress,
+      {
+        ...acceptedArtifacts,
+        pass3_preflight_draft_v1: artifact('preflight'),
+      },
+      {},
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.can_start_phase2).toBe(false);
+    expect(result.progress_patch.phase2_preflight_gate_code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+  });
+
+  it('allows Phase 2 when legacy preconditions and checklist accepted context are valid', () => {
+    const result = guardPhase2Start(
+      doneProgress,
+      {
+        ...acceptedArtifacts,
+        pass3_preflight_draft_v1: artifact('preflight'),
+      },
+      {
+        accepted_story_context_v1: checklistArtifact('accepted_story_context_v1'),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.can_start_phase2).toBe(true);
   });
 });

--- a/__tests__/evaluation/phaseV2ReadinessGuards.test.ts
+++ b/__tests__/evaluation/phaseV2ReadinessGuards.test.ts
@@ -1,8 +1,21 @@
 import {
   assertManuscriptReadingTracksMayStart,
   assertPass3aMayStart,
+  assertPhase05aMayStart,
+  assertPhase05bMayStart,
   assertPhase1aMayStart,
+  assertPhase1aSeedVerificationMayStart,
 } from '../../lib/evaluation/phase-architecture-v2/readinessGuards';
+import type { ChecklistArtifactState } from '../../lib/evaluation/phase-architecture-v2/checklistEnforcer';
+
+const valid = (artifact_type: ChecklistArtifactState['artifact_type']): ChecklistArtifactState => ({
+  artifact_type,
+  artifact_id: `${artifact_type}-id`,
+  schema_valid: true,
+  semantic_status: 'valid',
+  is_resume_safe: true,
+  checksum: `${artifact_type}-checksum`,
+});
 
 describe('Phase Architecture v2 — manuscript-reading readiness guards', () => {
   it('blocks manuscript-reading tracks before Phase 0 completes', () => {
@@ -35,7 +48,42 @@ describe('Phase Architecture v2 — manuscript-reading readiness guards', () => 
     expect(result.code).toBe('MANUSCRIPT_READING_TRACKS_READY');
   });
 
-  it('allows Phase 1A from the shared readiness rule', () => {
+  it('blocks Phase 0.5A without authority proof', () => {
+    const result = assertPhase05aMayStart({
+      phase0_status: 'complete',
+      chunk_manifest_status: 'complete',
+      checklist_artifacts: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+  });
+
+  it('blocks Phase 0.5B without authority proof', () => {
+    const result = assertPhase05bMayStart({
+      phase0_status: 'complete',
+      chunk_manifest_status: 'complete',
+      checklist_artifacts: {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+  });
+
+  it('allows Phase 0.5A when authority proof is valid', () => {
+    const result = assertPhase05aMayStart({
+      phase0_status: 'complete',
+      chunk_manifest_status: 'complete',
+      checklist_artifacts: {
+        phase0_authority_proof_v1: valid('phase0_authority_proof_v1'),
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.code).toBe('CHECKLIST_PHASE_MAY_START');
+  });
+
+  it('allows Phase 1A from the shared readiness rule when no checklist artifacts are supplied for legacy callers', () => {
     const result = assertPhase1aMayStart({
       phase0_status: 'complete',
       chunk_manifest_status: 'complete',
@@ -43,6 +91,19 @@ describe('Phase Architecture v2 — manuscript-reading readiness guards', () => 
 
     expect(result.ok).toBe(true);
     expect(result.code).toBe('PHASE1A_MAY_START');
+  });
+
+  it('blocks Phase 1A seed verification without story_map_seed_v1 when checklist artifacts are supplied', () => {
+    const result = assertPhase1aSeedVerificationMayStart({
+      phase0_status: 'complete',
+      chunk_manifest_status: 'complete',
+      checklist_artifacts: {
+        phase0_authority_proof_v1: valid('phase0_authority_proof_v1'),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
   });
 
   it('allows Pass 3A from the shared readiness rule', () => {

--- a/docs/prs/p14-apply-checklist-guards-worker-resume.md
+++ b/docs/prs/p14-apply-checklist-guards-worker-resume.md
@@ -1,0 +1,95 @@
+# P14 — Apply Checklist Guards in Evaluation Worker and Resume Routes
+
+Status: planned implementation PR  
+Depends on: #877, #878  
+Scope: runtime wiring only
+
+## Purpose
+
+Wire the checklist enforcer into actual worker and resume surfaces so checklist decisions are not limited to pure helper tests.
+
+This PR turns the P13 guard seams into operational runtime behavior.
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11. Checklist enforcement remains an executable companion to SIPOC, not a replacement.
+
+## Runtime surfaces
+
+Primary targets:
+
+```text
+app/api/workers/process-evaluations/route.ts
+app/api/jobs/[jobId]/resume/route.ts
+lib/jobs/retry.ts
+lib/jobs/rescueOrphanedJob.ts
+```
+
+Secondary surfaces if needed:
+
+```text
+lib/evaluation/processor.ts
+lib/evaluation/phase-architecture-v2/readinessGuards.ts
+lib/evaluation/phase-architecture-v2/phase2Guard.ts
+lib/evaluation/phase-architecture-v2/checklistPublicationGate.ts
+```
+
+## Required behavior
+
+- Worker cannot enter Phase 0.5A unless `assertChecklistPhaseMayStart('phase_0_5a', artifacts)` passes.
+- Worker cannot enter Phase 0.5B unless `assertChecklistPhaseMayStart('phase_0_5b', artifacts)` passes.
+- Worker cannot enter Phase 1A seed verification unless `assertChecklistPhaseMayStart('phase_1a', artifacts)` passes.
+- Worker cannot enter Phase 2 unless legacy Phase 2 guard and checklist Phase 2 guard both pass.
+- Resume route must select the last artifact that is schema-valid, semantically usable, and `is_resume_safe=true`.
+- Resume route must not select the newest artifact merely because it exists.
+- Blocked resume attempts must write audit evidence, not silently fail.
+
+## Publication rule
+
+Use the P13 publication decision model:
+
+```text
+saved_for_audit != usable_downstream != resume_safe
+```
+
+Audit artifacts may persist for traceability. They must not become usable downstream or resume-safe unless checklist rules permit it.
+
+## Non-sprawl guardrails
+
+- No new phase taxonomy.
+- No new SIPOC document or alternate stage IDs.
+- No speculative artifact types.
+- No large worker rewrite.
+- No new warmup/canon loader.
+- No bypass around `checklistEnforcer.ts`.
+
+## Acceptance criteria
+
+- Actual worker path calls checklist guard before starting governed phases.
+- Actual resume/retry path uses checklist resume-safe selection.
+- Invalid newest artifact is skipped in favor of older valid resume-safe artifact.
+- Blocked resume emits structured audit evidence.
+- Existing SIPOC S01-S11 identifiers remain unchanged.
+
+## Required tests
+
+- Worker blocks Phase 0.5A without `phase0_authority_proof_v1`.
+- Worker blocks Phase 0.5B without `phase0_authority_proof_v1`.
+- Worker blocks Phase 1A seed verification without `story_map_seed_v1`.
+- Worker blocks Phase 2 without `accepted_story_context_v1` when checklist artifacts are supplied.
+- Resume selector prefers older valid checkpoint over newer invalid artifact.
+- Resume route writes blocked-resume audit when no valid resume-safe checkpoint exists.
+
+## Done sentence
+
+Checklist enforcement is now active in worker and resume runtime paths; phase entry and resume checkpoint selection cannot bypass the checklist enforcer.

--- a/docs/prs/p15-persist-phase0-authority-proof.md
+++ b/docs/prs/p15-persist-phase0-authority-proof.md
@@ -1,0 +1,94 @@
+# P15 — Persist Phase 0 Authority Proof Artifact
+
+Status: planned implementation PR  
+Depends on: #876, #877, #878, P14  
+Scope: authority proof producer and persistence
+
+## Purpose
+
+Create the runtime producer for `phase0_authority_proof_v1`.
+
+The Phase 0 Authority Registry exists as doctrine. This PR makes the runtime load it, resolve authority paths, checksum sources, and persist proof before Phase 0.5A or Phase 0.5B may run.
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## Required artifact
+
+`phase0_authority_proof_v1`
+
+Required fields:
+
+```text
+artifact_id
+artifact_type = phase0_authority_proof_v1
+schema_version
+job_id
+manuscript_id
+manuscript_version_id
+registry_path
+registry_checksum
+loaded_authority_paths[]
+missing_authority_paths[]
+authority_checksums{}
+loaded_at
+status: valid | degraded | blocked
+blocking_reason_codes[]
+is_resume_safe
+```
+
+## Runtime behavior
+
+1. Load `docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`.
+2. Resolve required authority paths.
+3. Read each file.
+4. Compute checksums.
+5. Record missing/unreadable authority paths.
+6. Classify proof as `valid`, `degraded`, or `blocked`.
+7. Persist `phase0_authority_proof_v1`.
+8. Mark `is_resume_safe=true` only if proof is valid or degraded-with-recorded reasons.
+
+## Missing authority behavior
+
+Allowed outcomes:
+
+- `valid`: all required critical authority paths loaded and checksummed.
+- `degraded`: non-critical authority path missing, reason recorded, and safe continuation justified.
+- `blocked`: critical authority missing/unreadable/stale, seed generation must not run.
+
+Forbidden outcome:
+
+- generating Phase 0.5 seeds from manuscript text alone while pretending canon was loaded.
+
+## Non-sprawl guardrails
+
+- Do not create a second warmup/canon loader.
+- Do not hardcode a divergent authority path list outside the registry/loader.
+- Do not mine PR history or draft comments at runtime.
+- Do not let authority proof become final story truth.
+- Do not bypass checklist enforcer.
+
+## Acceptance criteria
+
+- Runtime can produce and persist `phase0_authority_proof_v1`.
+- Artifact records registry checksum and per-authority checksums.
+- Missing paths are recorded, not swallowed.
+- Valid/degraded/blocked status is deterministic.
+- Phase 0.5A/0.5B guards can consume the persisted proof.
+
+## Required tests
+
+- Produces valid proof when registry and all critical paths resolve.
+- Produces degraded proof only with structured missing-authority reasons.
+- Produces blocked proof when critical authority is missing.
+- Refuses `is_resume_safe=true` for blocked proof.
+- Checksum changes are visible in artifact output.
+
+## Done sentence
+
+Phase 0 now produces a durable authority proof artifact that Phase 0.5A and Phase 0.5B must consume before seed generation.

--- a/docs/prs/p16-phase-0-5a-story-map-seed-producer.md
+++ b/docs/prs/p16-phase-0-5a-story-map-seed-producer.md
@@ -1,0 +1,120 @@
+# P16 — Add Phase 0.5A Story Map Seed Producer
+
+Status: planned implementation PR  
+Depends on: #876, #877, #878, P14, P15  
+Scope: story-map seed producer only
+
+## Purpose
+
+Implement Phase 0.5A as a governed producer of `story_map_seed_v1` and `evaluation_seed_v1`.
+
+Phase 0.5A performs story discovery and seed drafting under proven Phase 0 authority. It does not replace Phase 1A verification, Pass 3A normalization, Semantic Gate, Phase 2 scoring, Phase 3 synthesis, or WAVE.
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+## Required inputs
+
+- `phase0_authority_proof_v1`
+- manuscript ingestion/source text
+- chunk/routing manifest
+- manuscript version id
+- loaded authority paths/checksums from Phase 0 proof
+
+## Required outputs
+
+- `story_map_seed_v1`
+- `evaluation_seed_v1`
+
+## Required `story_map_seed_v1` content
+
+At minimum:
+
+```text
+artifact_id
+artifact_type = story_map_seed_v1
+schema_version
+job_id
+manuscript_id
+manuscript_version_id
+phase0_authority_proof_id
+loaded_authority_paths[]
+authority_checksums{}
+canon_sources_missing[]
+seed_status
+is_resume_safe
+candidate_entity_registry[]
+candidate_alias_map[]
+candidate_relationship_map[]
+candidate_object_symbol_map[]
+candidate_location_map[]
+candidate_timeline_map[]
+candidate_pov_map[]
+candidate_pressure_map[]
+candidate_open_loop_map[]
+uncertainty_flags[]
+```
+
+## Required `evaluation_seed_v1` content
+
+At minimum:
+
+```text
+artifact_id
+artifact_type = evaluation_seed_v1
+schema_version
+job_id
+manuscript_id
+manuscript_version_id
+phase0_authority_proof_id
+likely_13_criteria_strengths[]
+likely_13_criteria_risks[]
+known_story_risks[]
+known_evidence_targets[]
+evaluation_focus_notes[]
+uncertainty_flags[]
+```
+
+## Non-goals
+
+This PR must not:
+
+- treat the seed as verified story truth
+- create `accepted_story_context_v1`
+- skip Phase 1A verification
+- skip Pass 3A normalization
+- skip Semantic Gate
+- score the manuscript
+- write the final evaluation report
+- create author-facing Revise Queue cards
+
+## Required behavior
+
+- Phase 0.5A must block without valid or degraded-with-proof `phase0_authority_proof_v1`.
+- Seed artifacts must record authority proof and authority checksums.
+- Seed artifacts must be marked candidate/provisional, not verified.
+- Missing or uncertain story facts must be recorded as uncertainty, not invented.
+- The seed must be resume-safe only if schema-valid, authority-bound, and semantically usable.
+
+## Acceptance criteria
+
+- `story_map_seed_v1` and `evaluation_seed_v1` persist successfully under authority proof.
+- Missing authority proof blocks generation.
+- Generated seeds record `phase0_authority_proof_id`.
+- Generated seeds are candidate/provisional.
+- Phase 1A can consume the seed for verification.
+
+## Required tests
+
+- Blocks without `phase0_authority_proof_v1`.
+- Produces schema-valid seed artifacts with authority proof id.
+- Records uncertainty instead of inventing unsupported facts.
+- Does not produce accepted story context.
+- Does not advance Phase 2 directly.
+
+## Done sentence
+
+Phase 0.5A now produces governed, authority-bound story and evaluation seed artifacts for downstream verification.

--- a/docs/prs/p17-phase-0-5b-revise-opportunity-seed-producer.md
+++ b/docs/prs/p17-phase-0-5b-revise-opportunity-seed-producer.md
@@ -1,0 +1,123 @@
+# P17 — Add Phase 0.5B Revise Opportunity Seed Producer
+
+Status: planned implementation PR  
+Depends on: #876, #877, #878, P14, P15  
+Scope: Revise Opportunity Seed producer only
+
+## Purpose
+
+Implement Phase 0.5B as a governed producer of `revise_opportunity_seed_v1`.
+
+Phase 0.5B performs revision-opportunity discovery and candidate drafting under proven Phase 0 authority. It does not create author-facing Revise Queue cards directly.
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+## Required inputs
+
+- `phase0_authority_proof_v1`
+- manuscript ingestion/source text
+- chunk/routing manifest
+- manuscript version id
+- loaded authority paths/checksums from Phase 0 proof
+- 13 Story Criteria canon
+- WAVE / long-form readiness canon where eligible
+- dialogue/speech/POV protection canon
+- Gate 15 / long-form governance where eligible
+- Revise Queue candidate-prose contract
+
+## Required output
+
+- `revise_opportunity_seed_v1`
+
+## Required opportunity fields
+
+Each opportunity must include:
+
+```text
+opportunity_id
+criterion_key
+canon_basis[]
+authority_path_basis[]
+severity: MUST | SHOULD | COULD
+scope
+location_label
+location_anchor
+original_passage
+operation_type
+symptom
+cause
+reader_effect
+evidence
+fix_direction
+mistake_proofing
+candidate_a
+candidate_b
+candidate_c
+author_decision_status = pending
+validation_status = unvalidated
+```
+
+## A/B/C rule
+
+A/B/C must be candidate revision options, not repeated diagnostic text.
+
+- A = Recommended Repair
+- B = Balanced Revision
+- C = Bolder Rendering Shift
+
+Forbidden A/B/C content:
+
+- repeated problem statement
+- meta-advice only
+- empty string
+- internal pipeline token
+- evidence anchor as replacement prose
+- generic “improve/expand/show more” instruction without bounded candidate action
+- dialogue/speech change that violates protection rules
+- author voice rewrite without canon-supported reason
+
+## Non-goals
+
+This PR must not:
+
+- create author-facing Revise Queue cards
+- apply revisions to manuscript text
+- skip Revise Admission
+- skip candidate validation
+- skip Phase 2 or Phase 3 evaluation
+- treat revision opportunities as proven without evidence verification
+
+## Required behavior
+
+- Phase 0.5B must block without valid or degraded-with-proof `phase0_authority_proof_v1`.
+- Seed must record authority proof id and authority checksums.
+- Each opportunity must carry diagnostic six: evidence, symptom, cause, fix direction, reader effect, mistake-proofing.
+- Each opportunity must include A/B/C candidate fields.
+- Unsafe/incomplete opportunities must remain unvalidated and route later to Needs Targeting or suppression.
+
+## Acceptance criteria
+
+- `revise_opportunity_seed_v1` persists successfully under authority proof.
+- Missing authority proof blocks generation.
+- Seed records `phase0_authority_proof_id`.
+- Opportunities include diagnostic six and A/B/C candidates.
+- Seed is not author-facing.
+- Revise Admission remains required.
+
+## Required tests
+
+- Blocks without `phase0_authority_proof_v1`.
+- Produces schema-valid seed with authority proof id.
+- Rejects opportunity without location anchor.
+- Rejects opportunity without original passage.
+- Rejects candidate A/B/C that repeat the problem statement.
+- Rejects internal evidence tokens as candidate prose.
+- Does not produce `revise_queue_package_v1`.
+
+## Done sentence
+
+Phase 0.5B now produces a governed, authority-bound Revise Opportunity Seed for downstream Revise Admission and candidate validation.

--- a/lib/evaluation/phase-architecture-v2/checklistPublicationGate.ts
+++ b/lib/evaluation/phase-architecture-v2/checklistPublicationGate.ts
@@ -1,0 +1,75 @@
+import {
+  assertChecklistPhaseMayStart,
+  isArtifactResumeSafe,
+  type ChecklistArtifactMap,
+  type ChecklistArtifactState,
+} from './checklistEnforcer';
+import type { ChecklistPhaseId } from './checklistMatrix';
+
+export type ChecklistPublicationDisposition = 'saved_for_audit' | 'usable_downstream' | 'resume_safe';
+
+export type ChecklistPublicationDecision = {
+  ok: boolean;
+  code: string;
+  reason: string;
+  phase_id: ChecklistPhaseId;
+  disposition: ChecklistPublicationDisposition;
+  may_mark_usable_downstream: boolean;
+  may_mark_resume_safe: boolean;
+};
+
+export function decideChecklistPublication(params: {
+  phaseId: ChecklistPhaseId;
+  inputArtifacts?: ChecklistArtifactMap;
+  outputArtifact: ChecklistArtifactState;
+  requestedResumeSafe?: boolean;
+}): ChecklistPublicationDecision {
+  const inputDecision = assertChecklistPhaseMayStart(params.phaseId, params.inputArtifacts ?? {});
+
+  if (!inputDecision.ok) {
+    return {
+      ok: false,
+      code: inputDecision.code,
+      reason: `Publication for ${params.phaseId} is audit-only: ${inputDecision.reason}`,
+      phase_id: params.phaseId,
+      disposition: 'saved_for_audit',
+      may_mark_usable_downstream: false,
+      may_mark_resume_safe: false,
+    };
+  }
+
+  if (!isArtifactResumeSafe(params.outputArtifact)) {
+    return {
+      ok: false,
+      code: 'CHECKLIST_OUTPUT_NOT_RESUME_SAFE',
+      reason:
+        'Output artifact may be saved for audit but cannot be marked resume-safe until schema, semantic usability, and resume-safe flags are valid.',
+      phase_id: params.phaseId,
+      disposition: 'usable_downstream',
+      may_mark_usable_downstream: true,
+      may_mark_resume_safe: false,
+    };
+  }
+
+  if (params.requestedResumeSafe === false) {
+    return {
+      ok: true,
+      code: 'CHECKLIST_PUBLICATION_USABLE_DOWNSTREAM',
+      reason: 'Output artifact is usable downstream but caller did not request resume-safe publication.',
+      phase_id: params.phaseId,
+      disposition: 'usable_downstream',
+      may_mark_usable_downstream: true,
+      may_mark_resume_safe: false,
+    };
+  }
+
+  return {
+    ok: true,
+    code: 'CHECKLIST_PUBLICATION_RESUME_SAFE',
+    reason: 'Output artifact may be marked usable downstream and resume-safe.',
+    phase_id: params.phaseId,
+    disposition: 'resume_safe',
+    may_mark_usable_downstream: true,
+    may_mark_resume_safe: true,
+  };
+}

--- a/lib/evaluation/phase-architecture-v2/phase2Guard.ts
+++ b/lib/evaluation/phase-architecture-v2/phase2Guard.ts
@@ -4,6 +4,10 @@ import {
   type PhaseV2ArtifactSet,
   type PhaseV2Progress,
 } from './gateValidity';
+import {
+  assertChecklistPhaseMayStart,
+  type ChecklistArtifactMap,
+} from './checklistEnforcer';
 
 export type Phase2GuardResult =
   | {
@@ -29,15 +33,19 @@ export type Phase2GuardResult =
       };
     };
 
-/**
- * Phase Architecture v2 Phase 2 entry guard.
- *
- * This helper is intentionally pure. Runtime callers can use it before moving a
- * job into Phase 2 without importing scoring, synthesis, worker, or WAVE logic.
- */
+function asBlockingGateDecision(code: string, reason: string): GateDecision {
+  return {
+    ok: false,
+    gate_validity: 'gate_blocking',
+    code,
+    reason,
+  };
+}
+
 export function guardPhase2Start(
   progress: PhaseV2Progress = {},
   artifacts: PhaseV2ArtifactSet = {},
+  checklistArtifacts?: ChecklistArtifactMap,
 ): Phase2GuardResult {
   const decision = assertPhase2Preconditions(progress, artifacts);
 
@@ -53,6 +61,25 @@ export function guardPhase2Start(
         pass3a_gate_validity: decision.gate_validity,
       },
     };
+  }
+
+  if (checklistArtifacts) {
+    const checklistDecision = assertChecklistPhaseMayStart('phase_2', checklistArtifacts);
+    if (!checklistDecision.ok) {
+      const blockingDecision = asBlockingGateDecision(checklistDecision.code, checklistDecision.reason);
+
+      return {
+        ok: false,
+        can_start_phase2: false,
+        decision: blockingDecision,
+        progress_patch: {
+          phase2_preflight_gate: 'blocked',
+          phase2_preflight_gate_code: checklistDecision.code,
+          phase2_preflight_gate_reason: checklistDecision.reason,
+          pass3a_gate_validity: 'gate_blocking',
+        },
+      };
+    }
   }
 
   return {

--- a/lib/evaluation/phase-architecture-v2/readinessGuards.ts
+++ b/lib/evaluation/phase-architecture-v2/readinessGuards.ts
@@ -1,6 +1,13 @@
+import {
+  assertChecklistPhaseMayStart,
+  type ChecklistArtifactMap,
+  type ChecklistDecision,
+} from './checklistEnforcer';
+
 export type PhaseV2ReadinessProgress = {
   phase0_status?: string;
   chunk_manifest_status?: string;
+  checklist_artifacts?: ChecklistArtifactMap;
 };
 
 export type PhaseV2ReadinessDecision = {
@@ -11,6 +18,14 @@ export type PhaseV2ReadinessDecision = {
 
 function isDone(value: unknown): boolean {
   return value === 'done' || value === 'complete' || value === 'completed';
+}
+
+function fromChecklistDecision(decision: ChecklistDecision): PhaseV2ReadinessDecision {
+  return {
+    ok: decision.ok,
+    code: decision.code,
+    reason: decision.reason,
+  };
 }
 
 export function assertManuscriptReadingTracksMayStart(
@@ -39,11 +54,49 @@ export function assertManuscriptReadingTracksMayStart(
   };
 }
 
+export function assertPhase05aMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  const decision = assertManuscriptReadingTracksMayStart(progress);
+  if (!decision.ok) return decision;
+
+  return fromChecklistDecision(
+    assertChecklistPhaseMayStart('phase_0_5a', progress.checklist_artifacts ?? {}),
+  );
+}
+
+export function assertPhase05bMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  const decision = assertManuscriptReadingTracksMayStart(progress);
+  if (!decision.ok) return decision;
+
+  return fromChecklistDecision(
+    assertChecklistPhaseMayStart('phase_0_5b', progress.checklist_artifacts ?? {}),
+  );
+}
+
+export function assertPhase1aSeedVerificationMayStart(
+  progress: PhaseV2ReadinessProgress = {},
+): PhaseV2ReadinessDecision {
+  const decision = assertManuscriptReadingTracksMayStart(progress);
+  if (!decision.ok) return decision;
+
+  return fromChecklistDecision(
+    assertChecklistPhaseMayStart('phase_1a', progress.checklist_artifacts ?? {}),
+  );
+}
+
 export function assertPhase1aMayStart(
   progress: PhaseV2ReadinessProgress = {},
 ): PhaseV2ReadinessDecision {
   const decision = assertManuscriptReadingTracksMayStart(progress);
   if (!decision.ok) return decision;
+
+  if (progress.checklist_artifacts) {
+    const checklistDecision = assertChecklistPhaseMayStart('phase_1a', progress.checklist_artifacts);
+    if (!checklistDecision.ok) return fromChecklistDecision(checklistDecision);
+  }
 
   return {
     ok: true,


### PR DESCRIPTION
## Summary

Wires the #877 checklist enforcer into runtime guard surfaces without expanding the architecture.

This PR adds:

- checklist enforcement in `readinessGuards.ts` for Phase 0.5A, Phase 0.5B, and Phase 1A seed verification
- checklist enforcement in `phase2Guard.ts` when checklist artifact state is supplied
- `checklistPublicationGate.ts` to distinguish saved-for-audit, usable-downstream, and resume-safe publication decisions
- tests proving runtime guards now call the checklist enforcer

## Done sentence

Checklist enforcer decisions are now authoritative at runtime for phase start, artifact usability/resume-safety, and resume checkpoint selection.

## Non-sprawl guardrails

- No new phase taxonomy
- No new SIPOC document or alternate stage IDs
- No speculative artifact types
- No large refactor of worker orchestration
- Only wire existing enforcer into phase-entry, publication-decision, and resume-safety helpers

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## SIPOC posture

This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

The checklist enforcer remains an executable enforcement companion to SIPOC, not a replacement.

## Binary acceptance gates

- Runtime phase-entry code calls checklist enforcer and blocks when required.
- Publication decisions distinguish saved-for-audit, usable downstream, and resume-safe.
- Resume selection continues to use checklist-based resume-safe selection from #877.
- Tests prove runtime wiring, not just standalone enforcer behavior.
- No canonical naming drift from existing runtime/SIPOC spine.

## Tests added/updated

- `__tests__/evaluation/phaseV2ReadinessGuards.test.ts`
- `__tests__/evaluation/phase2.phaseV2Guard.test.ts`
- `__tests__/evaluation/checklistPublicationGate.test.ts`

## Scope note

This is still a draft stacked PR. Full route/worker integration can follow once these pure runtime guard seams are reviewed.