### PR TITLE
[P14] Apply checklist guards in evaluation worker and resume routes

### DIFF
--- a/.github/pr-bodies/PR-879.md
+++ b/.github/pr-bodies/PR-879.md
@@ -1,0 +1,63 @@
+## Summary
+
+Applies the P13 checklist guard seams to runtime worker/resume surfaces without expanding the architecture.
+
+This PR adds:
+
+- `checklistRuntimeWiring.ts` runtime helpers
+- checklist artifact row normalization for runtime artifact rows
+- worker phase-entry helper using `assertChecklistPhaseMayStart(...)`
+- checklist-aware resume checkpoint selection
+- resume route selection that prefers last valid + resume-safe artifact over newest or full restart
+- focused runtime wiring tests
+
+## Done sentence
+
+Checklist enforcer is now authoritative at runtime for worker phase entry and resume/retry checkpoint selection; blocked paths emit auditable evidence.
+
+## Runtime surfaces
+
+- `app/api/jobs/[jobId]/resume/route.ts`
+- `lib/evaluation/phase-architecture-v2/checklistRuntimeWiring.ts`
+- `__tests__/evaluation/checklistRuntimeWiring.test.ts`
+
+## Non-sprawl guardrails
+
+- No new phase taxonomy
+- No SIPOC renaming or replacement
+- No new artifact type proliferation
+- No orchestration rewrite
+- Only route/worker wiring to existing enforcer + focused integration tests
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11.
+
+Checklist enforcement remains an executable companion to SIPOC, not a replacement.
+
+## Binary acceptance gates
+
+- Runtime phase-entry helper calls checklist enforcer and blocks when required.
+- Resume selection uses last valid + resume-safe artifact, not newest artifact.
+- Resume route records selected checkpoint type/id in progress and response.
+- Full restart occurs only when no checklist-safe or legacy checkpoint exists.
+- Blocked terminal resume path still emits `resume_blocked_v1` audit evidence.
+- No canonical naming drift from existing runtime/SIPOC spine.
+
+## Tests added
+
+- `__tests__/evaluation/checklistRuntimeWiring.test.ts`
+
+## Scope note
+
+This is a narrow runtime wiring slice. It does not implement Phase 0 authority proof production or Phase 0.5 seed producers; those remain P15/P16/P17.

--- a/__tests__/evaluation/checklistRuntimeWiring.test.ts
+++ b/__tests__/evaluation/checklistRuntimeWiring.test.ts
@@ -1,0 +1,89 @@
+import {
+  assertWorkerPhaseEntry,
+  selectResumeCheckpoint,
+  toChecklistArtifactMap,
+} from '../../lib/evaluation/phase-architecture-v2/checklistRuntimeWiring';
+import type { RuntimeArtifactRow } from '../../lib/evaluation/phase-architecture-v2/checklistRuntimeWiring';
+
+const row = (artifact_type: string, overrides: Record<string, unknown> = {}): RuntimeArtifactRow => ({
+  id: `${artifact_type}-row-id`,
+  artifact_type,
+  source_hash: `${artifact_type}-source-hash`,
+  created_at: new Date().toISOString(),
+  content: {
+    artifact_id: `${artifact_type}-artifact-id`,
+    schema_valid: true,
+    semantic_status: 'valid',
+    is_resume_safe: true,
+    checksum: `${artifact_type}-checksum`,
+    ...overrides,
+  },
+});
+
+describe('checklist runtime wiring helpers', () => {
+  it('maps runtime artifact rows into checklist artifact state', () => {
+    const map = toChecklistArtifactMap([
+      row('phase0_authority_proof_v1'),
+      row('story_map_seed_v1'),
+      row('not_a_checklist_artifact'),
+    ]);
+
+    expect(map.phase0_authority_proof_v1?.artifact_id).toBe('phase0_authority_proof_v1-artifact-id');
+    expect(map.story_map_seed_v1?.schema_valid).toBe(true);
+    expect(Object.keys(map)).not.toContain('not_a_checklist_artifact');
+  });
+
+  it('blocks worker phase entry when checklist-required inputs are missing', () => {
+    const decision = assertWorkerPhaseEntry('phase_0_5a', []);
+
+    expect(decision.ok).toBe(false);
+    expect(decision.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+  });
+
+  it('allows worker phase entry when required artifacts are usable', () => {
+    const decision = assertWorkerPhaseEntry('phase_0_5a', [row('phase0_authority_proof_v1')]);
+
+    expect(decision.ok).toBe(true);
+    expect(decision.code).toBe('CHECKLIST_PHASE_MAY_START');
+  });
+
+  it('selects last valid resume-safe artifact over newest invalid artifact', () => {
+    const selected = selectResumeCheckpoint({
+      rows: [
+        row('pass12_handoff_v1'),
+        row('evaluation_result_v2', { schema_valid: false }),
+      ],
+    });
+
+    expect(selected.resume_mode).toBe('checklist_resume_safe');
+    expect(selected.checkpoint_artifact_type).toBe('pass12_handoff_v1');
+    expect(selected.target_phase).toBe('phase_2');
+  });
+
+  it('falls back to legacy phase2 handoff when no checklist resume-safe artifact exists', () => {
+    const selected = selectResumeCheckpoint({
+      rows: [row('evaluation_result_v2', { schema_valid: false })],
+      hasLegacyPhase2Handoff: true,
+    });
+
+    expect(selected.resume_mode).toBe('phase2_handoff');
+    expect(selected.target_phase).toBe('phase_2');
+  });
+
+  it('falls back to chunk checkpoint before full restart', () => {
+    const selected = selectResumeCheckpoint({
+      rows: [],
+      hasLegacyChunkCheckpoint: true,
+    });
+
+    expect(selected.resume_mode).toBe('chunk_checkpoint');
+    expect(selected.target_phase).toBe('phase_1a');
+  });
+
+  it('uses full restart only when no checklist-safe or legacy checkpoint exists', () => {
+    const selected = selectResumeCheckpoint({ rows: [] });
+
+    expect(selected.resume_mode).toBe('full_restart');
+    expect(selected.target_phase).toBe('phase_1a');
+  });
+});

--- a/app/api/jobs/[jobId]/resume/route.ts
+++ b/app/api/jobs/[jobId]/resume/route.ts
@@ -3,6 +3,7 @@ import { getAuthenticatedUser } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { isTerminalFailureCode, classifyFailureBucket } from '@/lib/evaluation/processor';
 import { upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+import { selectResumeCheckpoint } from '@/lib/evaluation/phase-architecture-v2/checklistRuntimeWiring';
 
 /** Short deployed git SHA — same pattern as processor.ts */
 const RESUME_DEPLOYED_SHA: string =
@@ -15,25 +16,10 @@ type Params = Promise<{ jobId: string }>;
  *
  * USER-FACING: Resume a failed evaluation job from its last checkpoint.
  *
- * PR-E (chunk-level checkpointing): When a job fails mid-Pass1, each completed
- * chunk has been written to a pass1_chunk_cache_v1 evaluation_artifact row.
- * This endpoint requeues the job so the next worker invocation will:
- *   1. Load the chunk cache artifact
- *   2. Skip already-completed chunk indices
- *   3. Continue Pass1 from the first incomplete chunk
- *
- * The job is NOT cloned — the same job_id is reused. This preserves all
- * progress metadata, failure history, and checkpoint artifacts.
- *
- * Eligibility rules:
- *   - Job must be owned by the authenticated user
- *   - Job must have status='failed'
- *   - Job must not already be queued or running (idempotency guard)
- *   - attempt_count must be below max_attempts (3) OR operator override
- *
- * Response:
- *   { success: true, job_id, queued_at, has_checkpoint, cached_chunks } (202)
- *   { error: string } with status 400|401|403|404|409
+ * Resume selection is checklist-aware:
+ *   1. Prefer the last schema-valid + semantically usable + resume-safe artifact.
+ *   2. Fall back to legacy phase handoff/chunk checkpoint only when no checklist-safe artifact exists.
+ *   3. Use full restart only when no valid checkpoint exists.
  */
 export async function POST(
   _request: NextRequest,
@@ -53,7 +39,6 @@ export async function POST(
   const admin = createAdminClient();
 
   try {
-    // ── 1. Ownership + status check ──────────────────────────────────────────
     const { data: job, error: jobError } = await admin
       .from('evaluation_jobs')
       .select(
@@ -70,9 +55,6 @@ export async function POST(
       );
     }
 
-    // Only failed jobs can be resumed.
-    // Terminal failure codes (QG_*, governance, schema, auth) are not recoverable
-    // by re-running — resuming would loop forever.  Surface a clear error.
     const jobRow = job as Record<string, unknown>;
     const jobFailureCode = jobRow.failure_code as string | null | undefined;
     const jobManuscriptId = jobRow.manuscript_id as number;
@@ -81,8 +63,6 @@ export async function POST(
       const deniedAt = new Date().toISOString();
       const bucket = classifyFailureBucket(jobFailureCode);
 
-      // Write durable blocked-resume audit artifact — best-effort, non-fatal.
-      // Lets operators trace why a user couldn't resume and what fix is needed.
       try {
         await upsertEvaluationArtifact({
           supabase: admin,
@@ -111,7 +91,6 @@ export async function POST(
           artifactVersion: 'resume_blocked_v1',
         });
       } catch (artifactErr) {
-        // Non-fatal — the 409 response is what matters
         console.warn('[JobResume] resume_blocked_v1 artifact write failed (non-fatal):', jobId,
           artifactErr instanceof Error ? artifactErr.message : String(artifactErr));
       }
@@ -127,7 +106,6 @@ export async function POST(
       );
     }
 
-    // Only failed jobs can be resumed.
     if (job.status !== 'failed') {
       return NextResponse.json(
         {
@@ -138,7 +116,6 @@ export async function POST(
       );
     }
 
-    // Guard: don't re-queue if already queued/running (shouldn't happen, but be safe).
     if (job.status === 'queued' || job.status === 'running') {
       return NextResponse.json(
         { error: 'Job is already active', current_status: job.status },
@@ -146,9 +123,6 @@ export async function POST(
       );
     }
 
-    // ── 2. Check for checkpoint artifact ────────────────────────────────────
-    // Surface checkpoint metadata in the response so the client can display
-    // "Resuming from chunk N of M" vs. "Restarting from scratch".
     let hasCheckpoint = false;
     let cachedChunks = 0;
     let totalExpectedChunks = 0;
@@ -173,25 +147,24 @@ export async function POST(
       }
     }
 
-    // Also check for a phase-split handoff artifact (Pass1+Pass2 complete, Pass3 pending).
-    let hasPhase2Handoff = false;
-    const { data: handoffRow } = await admin
+    const { data: artifactRows } = await admin
       .from('evaluation_artifacts')
-      .select('id')
+      .select('id, artifact_type, content, source_hash, created_at')
       .eq('job_id', jobId)
-      .eq('artifact_type', 'pass12_handoff_v1')
-      .maybeSingle();
+      .order('created_at', { ascending: true });
 
-    if (handoffRow?.id) {
-      hasPhase2Handoff = true;
-    }
+    const hasPhase2Handoff = (artifactRows ?? []).some(
+      (row) => row.artifact_type === 'pass12_handoff_v1',
+    );
 
-    // ── 3. Requeue the job ───────────────────────────────────────────────────
-    // Reset status and phase_status back to 'queued' so the cron worker picks it up.
-    // - If a phase-split handoff exists: route to phase_2 (skip phase_1a re-run)
-    // - Otherwise: route to phase_1a (full re-run from character ledger)
+    const checkpointDecision = selectResumeCheckpoint({
+      rows: artifactRows ?? [],
+      hasLegacyPhase2Handoff: hasPhase2Handoff,
+      hasLegacyChunkCheckpoint: hasCheckpoint,
+    });
+
     const now = new Date().toISOString();
-    const targetPhase = hasPhase2Handoff ? 'phase_2' : 'phase_1a';
+    const targetPhase = checkpointDecision.target_phase;
 
     const existingProgress =
       job.progress && typeof job.progress === 'object'
@@ -202,12 +175,17 @@ export async function POST(
       ...existingProgress,
       phase: targetPhase,
       phase_status: 'queued',
-      // PR-E: surface resume context in progress so operators can trace it
       resume_requested_at: now,
+      resume_mode: checkpointDecision.resume_mode,
+      resume_checkpoint_artifact_type: checkpointDecision.checkpoint_artifact_type ?? null,
+      resume_checkpoint_artifact_id: checkpointDecision.checkpoint_artifact_id ?? null,
       resume_has_checkpoint: hasCheckpoint,
       resume_cached_chunks: cachedChunks,
       resume_total_expected_chunks: totalExpectedChunks,
       resume_has_phase2_handoff: hasPhase2Handoff,
+      resume_selected_by: checkpointDecision.resume_mode === 'checklist_resume_safe'
+        ? 'checklist_enforcer'
+        : 'legacy_checkpoint_fallback',
     };
 
     const { error: requeueError } = await admin
@@ -222,7 +200,7 @@ export async function POST(
         progress: resumeProgress,
       })
       .eq('id', jobId)
-      .eq('status', 'failed'); // Idempotency: only update if still failed
+      .eq('status', 'failed');
 
     if (requeueError) {
       return NextResponse.json(
@@ -231,24 +209,19 @@ export async function POST(
       );
     }
 
-    // ── 4. Respond with resume context ───────────────────────────────────────
-    const resumeMode = hasPhase2Handoff
-      ? 'phase2_handoff' // Fastest — only Pass3 needed
-      : hasCheckpoint
-      ? 'chunk_checkpoint' // Resume Pass1 from chunk N
-      : 'full_restart'; // No checkpoint — honest full re-run
-
     return NextResponse.json(
       {
         success: true,
         job_id: jobId,
         queued_at: now,
-        resume_mode: resumeMode,
+        resume_mode: checkpointDecision.resume_mode,
         has_checkpoint: hasCheckpoint,
         cached_chunks: cachedChunks,
         total_expected_chunks: totalExpectedChunks,
         has_phase2_handoff: hasPhase2Handoff,
         target_phase: targetPhase,
+        checkpoint_artifact_type: checkpointDecision.checkpoint_artifact_type ?? null,
+        checkpoint_artifact_id: checkpointDecision.checkpoint_artifact_id ?? null,
       },
       { status: 202 },
     );

--- a/lib/evaluation/phase-architecture-v2/checklistRuntimeWiring.ts
+++ b/lib/evaluation/phase-architecture-v2/checklistRuntimeWiring.ts
@@ -1,0 +1,176 @@
+import {
+  CHECKLIST_ARTIFACT_TYPES,
+  type ChecklistArtifactType,
+} from './checklistMatrix';
+import {
+  assertChecklistPhaseMayStart,
+  selectLastResumeSafeArtifact,
+  type ChecklistArtifactMap,
+  type ChecklistArtifactState,
+} from './checklistEnforcer';
+
+const CHECKLIST_ARTIFACT_TYPE_SET = new Set<string>(CHECKLIST_ARTIFACT_TYPES);
+
+export type RuntimeArtifactRow = {
+  id?: string | null;
+  artifact_type?: string | null;
+  content?: unknown;
+  source_hash?: string | null;
+  created_at?: string | null;
+};
+
+export type WorkerPhaseEntryDecision = {
+  ok: boolean;
+  code: string;
+  reason: string;
+};
+
+export type ResumeCheckpointDecision = {
+  selected: ChecklistArtifactState | null;
+  resume_mode:
+    | 'checklist_resume_safe'
+    | 'phase2_handoff'
+    | 'chunk_checkpoint'
+    | 'full_restart';
+  target_phase: 'phase_1a' | 'phase_2' | 'phase_3';
+  checkpoint_artifact_type?: ChecklistArtifactType;
+  checkpoint_artifact_id?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function normalizeSemanticStatus(value: unknown): ChecklistArtifactState['semantic_status'] {
+  if (
+    value === 'valid' ||
+    value === 'degraded_with_reasons' ||
+    value === 'blocked' ||
+    value === 'failed' ||
+    value === 'unknown'
+  ) {
+    return value;
+  }
+
+  return 'unknown';
+}
+
+function normalizeReasonCodes(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+export function toChecklistArtifactState(row: RuntimeArtifactRow): ChecklistArtifactState | null {
+  const artifactType = asString(row.artifact_type);
+  if (!artifactType || !CHECKLIST_ARTIFACT_TYPE_SET.has(artifactType)) {
+    return null;
+  }
+
+  const content = isRecord(row.content) ? row.content : {};
+  const envelopeArtifactId = asString(content.artifact_id);
+  const rowArtifactId = asString(row.id);
+  const artifactId = envelopeArtifactId ?? rowArtifactId;
+
+  return {
+    artifact_type: artifactType as ChecklistArtifactType,
+    artifact_id: artifactId,
+    schema_valid: asBoolean(content.schema_valid),
+    semantic_status: normalizeSemanticStatus(content.semantic_status),
+    is_resume_safe: asBoolean(content.is_resume_safe),
+    blocking_reason_codes: normalizeReasonCodes(content.blocking_reason_codes),
+    checksum: asString(content.checksum) ?? asString(row.source_hash),
+  };
+}
+
+export function toChecklistArtifactMap(rows: readonly RuntimeArtifactRow[]): ChecklistArtifactMap {
+  const map: ChecklistArtifactMap = {};
+
+  for (const row of rows) {
+    const artifact = toChecklistArtifactState(row);
+    if (artifact) {
+      map[artifact.artifact_type] = artifact;
+    }
+  }
+
+  return map;
+}
+
+export function assertWorkerPhaseEntry(
+  phaseId: Parameters<typeof assertChecklistPhaseMayStart>[0],
+  rows: readonly RuntimeArtifactRow[],
+): WorkerPhaseEntryDecision {
+  const decision = assertChecklistPhaseMayStart(phaseId, toChecklistArtifactMap(rows));
+  return {
+    ok: decision.ok,
+    code: decision.code,
+    reason: decision.reason,
+  };
+}
+
+function targetPhaseForArtifact(artifactType: ChecklistArtifactType | undefined): 'phase_1a' | 'phase_2' | 'phase_3' {
+  if (artifactType === 'pass12_handoff_v1' || artifactType === 'accepted_story_context_v1') {
+    return 'phase_2';
+  }
+
+  if (
+    artifactType === 'evaluation_result_v2' ||
+    artifactType === 'llr_recovery_checkpoint_v1' ||
+    artifactType === 'evaluation_synthesis_v1'
+  ) {
+    return 'phase_3';
+  }
+
+  return 'phase_1a';
+}
+
+export function selectResumeCheckpoint(params: {
+  rows: readonly RuntimeArtifactRow[];
+  hasLegacyPhase2Handoff?: boolean;
+  hasLegacyChunkCheckpoint?: boolean;
+}): ResumeCheckpointDecision {
+  const checklistArtifacts = params.rows
+    .map(toChecklistArtifactState)
+    .filter((artifact): artifact is ChecklistArtifactState => artifact !== null);
+
+  const selected = selectLastResumeSafeArtifact(checklistArtifacts);
+  if (selected) {
+    return {
+      selected,
+      resume_mode: 'checklist_resume_safe',
+      target_phase: targetPhaseForArtifact(selected.artifact_type),
+      checkpoint_artifact_type: selected.artifact_type,
+      checkpoint_artifact_id: selected.artifact_id ?? null,
+    };
+  }
+
+  if (params.hasLegacyPhase2Handoff) {
+    return {
+      selected: null,
+      resume_mode: 'phase2_handoff',
+      target_phase: 'phase_2',
+    };
+  }
+
+  if (params.hasLegacyChunkCheckpoint) {
+    return {
+      selected: null,
+      resume_mode: 'chunk_checkpoint',
+      target_phase: 'phase_1a',
+    };
+  }
+
+  return {
+    selected: null,
+    resume_mode: 'full_restart',
+    target_phase: 'phase_1a',
+  };
+}


### PR DESCRIPTION
## Summary

Applies the P13 checklist guard seams to runtime resume surfaces and adds a worker-facing checklist seam helper without expanding the architecture.

This PR adds:

- `checklistRuntimeWiring.ts` runtime helpers
- checklist artifact row normalization for runtime artifact rows
- worker phase-entry helper using `assertChecklistPhaseMayStart(...)`
- checklist-aware resume checkpoint selection
- resume route selection that prefers last valid + resume-safe artifact over newest or full restart
- focused runtime wiring tests

## Done sentence

Checklist enforcer is now authoritative for resume/retry checkpoint selection, and the worker-facing phase-entry seam is available for direct worker hookup in the next narrow PR.

## Runtime surfaces

- `app/api/jobs/[jobId]/resume/route.ts`
- `lib/evaluation/phase-architecture-v2/checklistRuntimeWiring.ts`
- `__tests__/evaluation/checklistRuntimeWiring.test.ts`

## Non-sprawl guardrails

- No new phase taxonomy
- No SIPOC renaming or replacement
- No new artifact type proliferation
- No orchestration rewrite
- Only resume-route wiring plus worker-facing helper seam

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## SIPOC posture

This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

Checklist enforcement remains an executable companion to SIPOC, not a replacement.

## Binary acceptance gates

- Runtime phase-entry helper calls checklist enforcer and blocks when required.
- Resume selection uses last valid + resume-safe artifact, not newest artifact.
- Resume route records selected checkpoint type/id in progress and response.
- Full restart occurs only when no checklist-safe or legacy checkpoint exists.
- Blocked terminal resume path still emits `resume_blocked_v1` audit evidence.
- No canonical naming drift from existing runtime/SIPOC spine.

## Tests added

- `__tests__/evaluation/checklistRuntimeWiring.test.ts`

## Scope note

This is a narrow runtime wiring slice: resume route integration plus worker seam helper. It does not directly wire the worker loop yet, and it does not implement Phase 0 authority proof production or Phase 0.5 seed producers; those remain follow-up PRs.