### PR TITLE
[P15] Persist Phase 0 authority proof artifact

### DIFF
--- a/.github/pr-bodies/PR-880.md
+++ b/.github/pr-bodies/PR-880.md
@@ -1,0 +1,66 @@
+## Summary
+
+Adds the first runtime producer for `phase0_authority_proof_v1`.
+
+This PR makes the Phase 0 Authority Registry executable enough for downstream Phase 0.5 guards to consume a durable authority proof artifact.
+
+## What this adds
+
+- `lib/evaluation/phase-architecture-v2/phase0AuthorityProof.ts`
+- `__tests__/evaluation/phase0AuthorityProof.test.ts`
+- `phase0_authority_proof_v1` added to `ArtifactType`
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11.
+
+Phase 0 authority proof remains an adjacent authority track until explicitly promoted by SIPOC certification update.
+
+## Runtime behavior
+
+The producer:
+
+- accepts registry text
+- extracts authority file paths
+- loads authority file contents through an injected reader
+- computes registry checksum
+- computes per-authority checksums
+- records missing paths
+- classifies proof as `valid`, `degraded`, or `blocked`
+- marks blocked proof as not resume-safe
+- persists through `upsertEvaluationArtifact(...)`
+
+## Non-sprawl guardrails
+
+- No new phase taxonomy
+- No SIPOC renaming/replacement
+- No second warmup/canon loader
+- No PR-history mining at runtime
+- No Phase 0.5 seed generation in this PR
+- No worker orchestration rewrite
+
+## Acceptance gates
+
+- Produces valid proof when registry and authority paths resolve.
+- Produces degraded proof with structured reasons when authority paths are missing.
+- Produces blocked proof when registry is missing or empty.
+- Blocked proof cannot be resume-safe.
+- Proof records registry path, registry checksum, loaded paths, missing paths, and authority checksums.
+
+## Tests added
+
+- `__tests__/evaluation/phase0AuthorityProof.test.ts`
+
+## Done sentence
+
+Phase 0 now has a durable authority proof artifact producer that Phase 0.5A and Phase 0.5B can require before seed generation.

--- a/__tests__/evaluation/phase0AuthorityProof.test.ts
+++ b/__tests__/evaluation/phase0AuthorityProof.test.ts
@@ -1,0 +1,84 @@
+import {
+  buildPhase0AuthorityProofArtifact,
+  extractAuthorityPathsFromRegistry,
+  PHASE0_AUTHORITY_REGISTRY_PATH,
+} from '../../lib/evaluation/phase-architecture-v2/phase0AuthorityProof';
+
+const registry = `# Registry
+
+\`\`\`text
+docs/phase-0-warmup/WHAT_NOT_TO_DO.md
+docs/benchmarks/README.md
+\`\`\`
+`;
+
+describe('phase0 authority proof producer', () => {
+  it('extracts authority paths from registry text', () => {
+    expect(extractAuthorityPathsFromRegistry(registry)).toEqual([
+      'docs/phase-0-warmup/WHAT_NOT_TO_DO.md',
+      'docs/benchmarks/README.md',
+    ]);
+  });
+
+  it('produces valid proof when registry and authority paths resolve', async () => {
+    const proof = await buildPhase0AuthorityProofArtifact({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      manuscriptVersionId: 'mv-1',
+      registryText: registry,
+      now: '2026-05-31T00:00:00.000Z',
+      readAuthorityFile: async (path) => `content for ${path}`,
+    });
+
+    expect(proof.artifact_type).toBe('phase0_authority_proof_v1');
+    expect(proof.registry_path).toBe(PHASE0_AUTHORITY_REGISTRY_PATH);
+    expect(proof.status).toBe('valid');
+    expect(proof.semantic_status).toBe('valid');
+    expect(proof.is_resume_safe).toBe(true);
+    expect(proof.loaded_authority_paths).toHaveLength(2);
+    expect(proof.missing_authority_paths).toEqual([]);
+    expect(Object.keys(proof.authority_checksums)).toHaveLength(2);
+  });
+
+  it('produces degraded proof when non-empty registry has missing paths', async () => {
+    const proof = await buildPhase0AuthorityProofArtifact({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      registryText: registry,
+      readAuthorityFile: async (path) => path.includes('README') ? null : `content for ${path}`,
+    });
+
+    expect(proof.status).toBe('degraded');
+    expect(proof.semantic_status).toBe('degraded_with_reasons');
+    expect(proof.is_resume_safe).toBe(true);
+    expect(proof.blocking_reason_codes).toContain('PHASE0_AUTHORITY_PATHS_MISSING');
+    expect(proof.missing_authority_paths).toEqual(['docs/benchmarks/README.md']);
+  });
+
+  it('produces blocked proof when registry is missing', async () => {
+    const proof = await buildPhase0AuthorityProofArtifact({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      registryText: null,
+      readAuthorityFile: async () => 'never called',
+    });
+
+    expect(proof.status).toBe('blocked');
+    expect(proof.semantic_status).toBe('blocked');
+    expect(proof.is_resume_safe).toBe(false);
+    expect(proof.blocking_reason_codes).toContain('PHASE0_AUTHORITY_REGISTRY_MISSING');
+  });
+
+  it('produces blocked proof when registry contains no authority paths', async () => {
+    const proof = await buildPhase0AuthorityProofArtifact({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      registryText: '# Empty registry',
+      readAuthorityFile: async () => 'never called',
+    });
+
+    expect(proof.status).toBe('blocked');
+    expect(proof.is_resume_safe).toBe(false);
+    expect(proof.blocking_reason_codes).toContain('PHASE0_AUTHORITY_REGISTRY_EMPTY');
+  });
+});

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -16,6 +16,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 export type ArtifactType =
   | "evaluation_result_v1"
   | "evaluation_result_v2"
+  /** Phase 0 authority proof: registry path/checksum, loaded paths, missing paths, authority checksums. */
+  | "phase0_authority_proof_v1"
   /** Runtime SEED hypothesis artifact generated before Phase 1A. */
   | "story_seed_v1"
   /** Runtime evaluation-priority SEED hypothesis artifact generated before Phase 1A. */

--- a/lib/evaluation/phase-architecture-v2/phase0AuthorityProof.ts
+++ b/lib/evaluation/phase-architecture-v2/phase0AuthorityProof.ts
@@ -1,0 +1,164 @@
+import crypto from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sha256Hex, upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+
+export const PHASE0_AUTHORITY_REGISTRY_PATH = 'docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md';
+
+export type Phase0AuthorityProofStatus = 'valid' | 'degraded' | 'blocked';
+
+export type AuthorityFileReader = (path: string) => Promise<string | null | undefined>;
+
+export type Phase0AuthorityProofArtifact = {
+  artifact_id: string;
+  artifact_type: 'phase0_authority_proof_v1';
+  schema_version: 'phase0_authority_proof_v1';
+  job_id: string;
+  manuscript_id: number;
+  manuscript_version_id: string | null;
+  registry_path: typeof PHASE0_AUTHORITY_REGISTRY_PATH;
+  registry_checksum: string | null;
+  loaded_authority_paths: string[];
+  missing_authority_paths: string[];
+  authority_checksums: Record<string, string>;
+  loaded_at: string;
+  status: Phase0AuthorityProofStatus;
+  blocking_reason_codes: string[];
+  schema_valid: boolean;
+  semantic_status: 'valid' | 'degraded_with_reasons' | 'blocked';
+  is_resume_safe: boolean;
+};
+
+export type BuildPhase0AuthorityProofInput = {
+  jobId: string;
+  manuscriptId: number;
+  manuscriptVersionId?: string | null;
+  registryText: string | null | undefined;
+  readAuthorityFile: AuthorityFileReader;
+  now?: string;
+};
+
+export type PersistPhase0AuthorityProofInput = BuildPhase0AuthorityProofInput & {
+  supabase: SupabaseClient;
+};
+
+function isNonEmptyPath(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.startsWith('#')) return false;
+  if (trimmed.startsWith('```')) return false;
+  if (!trimmed.includes('/')) return false;
+  return trimmed.endsWith('.md') || trimmed.endsWith('.ts') || trimmed.endsWith('.tsx') || trimmed.endsWith('.json');
+}
+
+export function extractAuthorityPathsFromRegistry(registryText: string): string[] {
+  const paths = registryText
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(isNonEmptyPath)
+    .map((line) => line.replace(/^[-*]\s+/u, '').trim());
+
+  return Array.from(new Set(paths));
+}
+
+function buildArtifactId(params: { jobId: string; manuscriptId: number; registryChecksum: string | null }): string {
+  return sha256Hex(JSON.stringify({
+    artifact_type: 'phase0_authority_proof_v1',
+    job_id: params.jobId,
+    manuscript_id: params.manuscriptId,
+    registry_checksum: params.registryChecksum,
+  }));
+}
+
+export async function buildPhase0AuthorityProofArtifact(
+  input: BuildPhase0AuthorityProofInput,
+): Promise<Phase0AuthorityProofArtifact> {
+  const loadedAt = input.now ?? new Date().toISOString();
+  const registryText = typeof input.registryText === 'string' ? input.registryText : null;
+  const registryChecksum = registryText ? sha256Hex(registryText) : null;
+  const authorityPaths = registryText ? extractAuthorityPathsFromRegistry(registryText) : [];
+
+  const loadedAuthorityPaths: string[] = [];
+  const missingAuthorityPaths: string[] = [];
+  const authorityChecksums: Record<string, string> = {};
+
+  for (const authorityPath of authorityPaths) {
+    const authorityText = await input.readAuthorityFile(authorityPath);
+    if (typeof authorityText === 'string' && authorityText.length > 0) {
+      loadedAuthorityPaths.push(authorityPath);
+      authorityChecksums[authorityPath] = sha256Hex(authorityText);
+    } else {
+      missingAuthorityPaths.push(authorityPath);
+    }
+  }
+
+  const blockingReasonCodes: string[] = [];
+  if (!registryText) {
+    blockingReasonCodes.push('PHASE0_AUTHORITY_REGISTRY_MISSING');
+  }
+  if (authorityPaths.length === 0 && registryText) {
+    blockingReasonCodes.push('PHASE0_AUTHORITY_REGISTRY_EMPTY');
+  }
+  if (missingAuthorityPaths.length > 0) {
+    blockingReasonCodes.push('PHASE0_AUTHORITY_PATHS_MISSING');
+  }
+
+  const status: Phase0AuthorityProofStatus = !registryText || authorityPaths.length === 0
+    ? 'blocked'
+    : missingAuthorityPaths.length > 0
+    ? 'degraded'
+    : 'valid';
+
+  return {
+    artifact_id: buildArtifactId({
+      jobId: input.jobId,
+      manuscriptId: input.manuscriptId,
+      registryChecksum,
+    }),
+    artifact_type: 'phase0_authority_proof_v1',
+    schema_version: 'phase0_authority_proof_v1',
+    job_id: input.jobId,
+    manuscript_id: input.manuscriptId,
+    manuscript_version_id: input.manuscriptVersionId ?? null,
+    registry_path: PHASE0_AUTHORITY_REGISTRY_PATH,
+    registry_checksum: registryChecksum,
+    loaded_authority_paths: loadedAuthorityPaths,
+    missing_authority_paths: missingAuthorityPaths,
+    authority_checksums: authorityChecksums,
+    loaded_at: loadedAt,
+    status,
+    blocking_reason_codes: blockingReasonCodes,
+    schema_valid: true,
+    semantic_status: status === 'valid' ? 'valid' : status === 'degraded' ? 'degraded_with_reasons' : 'blocked',
+    is_resume_safe: status === 'valid' || status === 'degraded',
+  };
+}
+
+export async function persistPhase0AuthorityProofArtifact(
+  input: PersistPhase0AuthorityProofInput,
+): Promise<{ artifactId: string; proof: Phase0AuthorityProofArtifact }> {
+  const proof = await buildPhase0AuthorityProofArtifact(input);
+  const sourceHash = crypto
+    .createHash('sha256')
+    .update(JSON.stringify({
+      artifact_type: proof.artifact_type,
+      job_id: proof.job_id,
+      manuscript_id: proof.manuscript_id,
+      registry_checksum: proof.registry_checksum,
+      authority_checksums: proof.authority_checksums,
+      missing_authority_paths: proof.missing_authority_paths,
+      status: proof.status,
+    }), 'utf8')
+    .digest('hex');
+
+  const artifactId = await upsertEvaluationArtifact({
+    supabase: input.supabase,
+    jobId: input.jobId,
+    manuscriptId: input.manuscriptId,
+    artifactType: 'phase0_authority_proof_v1',
+    content: proof,
+    sourceHash,
+    artifactVersion: 'phase0_authority_proof_v1',
+  });
+
+  return { artifactId, proof };
+}


### PR DESCRIPTION
## Summary

Adds the first runtime producer for `phase0_authority_proof_v1`.

This PR makes the Phase 0 Authority Registry executable enough for downstream Phase 0.5 guards to consume a durable authority proof artifact.

## What this adds

- `lib/evaluation/phase-architecture-v2/phase0AuthorityProof.ts`
- `__tests__/evaluation/phase0AuthorityProof.test.ts`
- `phase0_authority_proof_v1` added to `ArtifactType`

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## SIPOC posture

This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

Phase 0 authority proof remains an adjacent authority track until explicitly promoted by SIPOC certification update.

## Runtime behavior

The producer:

- accepts registry text
- extracts authority file paths
- loads authority file contents through an injected reader
- computes registry checksum
- computes per-authority checksums
- records missing paths
- classifies proof as `valid`, `degraded`, or `blocked`
- marks blocked proof as not resume-safe
- persists through `upsertEvaluationArtifact(...)`

## Non-sprawl guardrails

- No new phase taxonomy
- No SIPOC renaming/replacement
- No second warmup/canon loader
- No PR-history mining at runtime
- No Phase 0.5 seed generation in this PR
- No worker orchestration rewrite

## Acceptance gates

- Produces valid proof when registry and authority paths resolve.
- Produces degraded proof with structured reasons when authority paths are missing.
- Produces blocked proof when registry is missing or empty.
- Blocked proof cannot be resume-safe.
- Proof records registry path, registry checksum, loaded paths, missing paths, and authority checksums.

## Tests added

- `__tests__/evaluation/phase0AuthorityProof.test.ts`

## Done sentence

Phase 0 now has a durable authority proof artifact producer that Phase 0.5A and Phase 0.5B can require before seed generation.