### PR TITLE
[P17] Add Phase 0.5B Revise Opportunity Seed producer

### DIFF
--- a/.github/pr-bodies/PR-882.md
+++ b/.github/pr-bodies/PR-882.md
@@ -1,0 +1,55 @@
+## Summary
+
+Adds the Phase 0.5B producer for governed, authority-bound `revise_opportunity_seed_v1` artifacts.
+
+This PR keeps Phase 0.5B provisional and non-author-facing. It creates a Revise Opportunity Seed only. It does not create Revise Queue cards, apply manuscript revisions, skip Revise Admission, or bypass candidate validation.
+
+## What this adds
+
+- `lib/evaluation/phase-architecture-v2/phase05bReviseOpportunitySeed.ts`
+- `__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts`
+- `revise_opportunity_seed_v1` added to `ArtifactType`
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11.
+
+Phase 0.5B remains an adjacent Revise track until explicitly promoted by SIPOC certification update.
+
+## Required behavior
+
+- Blocks without valid or degraded-with-reasons `phase0_authority_proof_v1`.
+- Produces `revise_opportunity_seed_v1` under authority proof.
+- Carries `phase0_authority_proof_id`, loaded authority paths, authority checksums, and missing canon sources.
+- Requires each opportunity to include Diagnostic Six fields.
+- Requires each opportunity to include A/B/C candidate revision options.
+- Rejects missing anchors/original passages.
+- Rejects A/B/C candidates that are repeated problem statements, internal tokens, or meta-advice instead of candidate revision prose.
+- Carries degraded authority status forward when applicable.
+
+## Non-goals
+
+- Does not create author-facing Revise Queue cards.
+- Does not apply manuscript revisions.
+- Does not skip Revise Admission.
+- Does not skip candidate validation.
+- Does not skip Phase 2 or Phase 3 evaluation.
+- Does not treat revision opportunities as final truth.
+
+## Tests added
+
+- `__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts`
+
+## Done sentence
+
+Phase 0.5B can now produce a governed, authority-bound provisional Revise Opportunity Seed for downstream Revise Admission and candidate validation.

--- a/__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts
+++ b/__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts
@@ -1,0 +1,174 @@
+import { buildPhase05bReviseOpportunitySeed, type ReviseOpportunitySeedEntry } from '../../lib/evaluation/phase-architecture-v2/phase05bReviseOpportunitySeed';
+import type { Phase0AuthorityProofArtifact } from '../../lib/evaluation/phase-architecture-v2/phase0AuthorityProof';
+
+const authorityProof = (overrides: Partial<Phase0AuthorityProofArtifact> = {}): Phase0AuthorityProofArtifact => ({
+  artifact_id: 'authority-proof-id',
+  artifact_type: 'phase0_authority_proof_v1',
+  schema_version: 'phase0_authority_proof_v1',
+  job_id: 'job-1',
+  manuscript_id: 123,
+  manuscript_version_id: 'mv-1',
+  registry_path: 'docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md',
+  registry_checksum: 'registry-checksum',
+  loaded_authority_paths: ['docs/dialogue-speech-pov-canon-enforcement.md'],
+  missing_authority_paths: [],
+  authority_checksums: {
+    'docs/dialogue-speech-pov-canon-enforcement.md': 'checksum',
+  },
+  loaded_at: '2026-05-31T00:00:00.000Z',
+  status: 'valid',
+  blocking_reason_codes: [],
+  schema_valid: true,
+  semantic_status: 'valid',
+  is_resume_safe: true,
+  ...overrides,
+});
+
+const opportunity = (overrides: Partial<ReviseOpportunitySeedEntry> = {}): ReviseOpportunitySeedEntry => ({
+  opportunity_id: 'opp-1',
+  criterion_key: 'narrativeClosure',
+  canon_basis: ['13 Story Criteria: narrativeClosure'],
+  authority_path_basis: ['docs/dialogue-speech-pov-canon-enforcement.md'],
+  severity: 'SHOULD',
+  scope: 'scene',
+  location_label: 'Chapter 1 confrontation',
+  location_anchor: 'chapter-1:move-aside-small-fry',
+  original_passage: 'Move aside, Small Fry.',
+  operation_type: 'suggested_replacement',
+  symptom: 'The beat raises a conflict that is not yet paid off clearly enough.',
+  cause: 'The scene moves on before Newton’s choice is rendered as an observable action.',
+  reader_effect: 'The reader gets a clearer cause-and-effect bridge into the next beat.',
+  evidence: 'Newton is challenged, but the immediate response remains compressed.',
+  fix_direction: 'Render the response as a concrete beat while preserving the author’s voice.',
+  mistake_proofing: 'Do not change dialogue ownership or rewrite the scene into a different tone.',
+  candidate_a: {
+    label: 'A',
+    role: 'recommended_repair',
+    text: 'Newton held his ground for one breath longer, then shifted just enough to make the choice visible.',
+  },
+  candidate_b: {
+    label: 'B',
+    role: 'balanced_revision',
+    text: 'Newton did not answer right away. He looked from Twillow to the path ahead and chose to stay where he was.',
+  },
+  candidate_c: {
+    label: 'C',
+    role: 'bolder_rendering_shift',
+    text: 'For the first time, Newton let the insult land without moving. The decision cost him, but he stayed planted.',
+  },
+  author_decision_status: 'pending',
+  validation_status: 'unvalidated',
+  ...overrides,
+});
+
+describe('Phase 0.5B Revise Opportunity Seed producer', () => {
+  it('blocks without authority proof', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      authorityProof: null,
+      opportunities: [opportunity()],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('PHASE05B_AUTHORITY_PROOF_MISSING_OR_INVALID');
+    }
+  });
+
+  it('produces a governed revise opportunity seed under valid authority proof', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      manuscriptVersionId: 'mv-1',
+      authorityProof: authorityProof(),
+      opportunities: [opportunity()],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.seed.artifact_type).toBe('revise_opportunity_seed_v1');
+      expect(result.seed.phase0_authority_proof_id).toBe('authority-proof-id');
+      expect(result.seed.opportunities).toHaveLength(1);
+      expect(result.seed.opportunities[0].candidate_a.role).toBe('recommended_repair');
+      expect(result.seed.opportunities[0].author_decision_status).toBe('pending');
+      expect(result.seed.opportunities[0].validation_status).toBe('unvalidated');
+      expect(result.seed.is_resume_safe).toBe(true);
+    }
+  });
+
+  it('rejects opportunity without location anchor', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      authorityProof: authorityProof(),
+      opportunities: [opportunity({ location_anchor: '' })],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('PHASE05B_OPPORTUNITY_CONTRACT_INVALID');
+      expect(result.opportunity_errors?.['opp-1']).toContain('location_anchor_missing');
+    }
+  });
+
+  it('rejects candidate A that repeats problem statement instead of revision prose', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      authorityProof: authorityProof(),
+      opportunities: [opportunity({
+        candidate_a: {
+          label: 'A',
+          role: 'recommended_repair',
+          text: 'The problem is that the scene needs more response.',
+        },
+      })],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.opportunity_errors?.['opp-1']).toContain('candidate_a_not_revision_prose');
+    }
+  });
+
+  it('rejects internal evidence tokens as candidate prose', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      authorityProof: authorityProof(),
+      opportunities: [opportunity({
+        candidate_b: {
+          label: 'B',
+          role: 'balanced_revision',
+          text: 'NARRATIVEDRIVE:recommendation',
+        },
+      })],
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.opportunity_errors?.['opp-1']).toContain('candidate_b_not_revision_prose');
+    }
+  });
+
+  it('carries degraded authority status forward', () => {
+    const result = buildPhase05bReviseOpportunitySeed({
+      jobId: 'job-1',
+      manuscriptId: 123,
+      authorityProof: authorityProof({
+        status: 'degraded',
+        semantic_status: 'degraded_with_reasons',
+        missing_authority_paths: ['docs/benchmarks/README.md'],
+        blocking_reason_codes: ['PHASE0_AUTHORITY_PATHS_MISSING'],
+      }),
+      opportunities: [opportunity()],
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.seed.semantic_status).toBe('degraded_with_reasons');
+      expect(result.seed.canon_sources_missing).toEqual(['docs/benchmarks/README.md']);
+    }
+  });
+});

--- a/lib/evaluation/artifactPersistence.ts
+++ b/lib/evaluation/artifactPersistence.ts
@@ -20,6 +20,8 @@ export type ArtifactType =
   | "phase0_authority_proof_v1"
   /** Phase 0.5A governed story-map seed. Candidate/provisional, not verified truth. */
   | "story_map_seed_v1"
+  /** Phase 0.5B governed revise opportunity seed. Not author-facing until admission/candidate validation. */
+  | "revise_opportunity_seed_v1"
   /** Runtime SEED hypothesis artifact generated before Phase 1A. */
   | "story_seed_v1"
   /** Runtime evaluation-priority SEED hypothesis artifact generated before Phase 1A. */

--- a/lib/evaluation/phase-architecture-v2/phase05bReviseOpportunitySeed.ts
+++ b/lib/evaluation/phase-architecture-v2/phase05bReviseOpportunitySeed.ts
@@ -1,0 +1,227 @@
+import crypto from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { upsertEvaluationArtifact } from '@/lib/evaluation/artifactPersistence';
+import type { Phase0AuthorityProofArtifact } from './phase0AuthorityProof';
+
+export type ReviseSeverity = 'MUST' | 'SHOULD' | 'COULD';
+export type ReviseValidationStatus = 'unvalidated';
+
+export type ReviseSeedCandidate = {
+  label: 'A' | 'B' | 'C';
+  role: 'recommended_repair' | 'balanced_revision' | 'bolder_rendering_shift';
+  text: string;
+};
+
+export type ReviseOpportunitySeedEntry = {
+  opportunity_id: string;
+  criterion_key: string;
+  canon_basis: string[];
+  authority_path_basis: string[];
+  severity: ReviseSeverity;
+  scope: 'manuscript' | 'act' | 'chapter' | 'scene' | 'paragraph' | 'sentence' | 'phrase';
+  location_label: string;
+  location_anchor: string;
+  original_passage: string;
+  operation_type: string;
+  symptom: string;
+  cause: string;
+  reader_effect: string;
+  evidence: string;
+  fix_direction: string;
+  mistake_proofing: string;
+  candidate_a: ReviseSeedCandidate;
+  candidate_b: ReviseSeedCandidate;
+  candidate_c: ReviseSeedCandidate;
+  author_decision_status: 'pending';
+  validation_status: ReviseValidationStatus;
+};
+
+export type ReviseOpportunitySeedArtifact = {
+  artifact_id: string;
+  artifact_type: 'revise_opportunity_seed_v1';
+  schema_version: 'revise_opportunity_seed_v1';
+  job_id: string;
+  manuscript_id: number;
+  manuscript_version_id: string | null;
+  source: 'phase_0_5b';
+  phase0_authority_proof_id: string;
+  loaded_authority_paths: string[];
+  authority_checksums: Record<string, string>;
+  canon_sources_missing: string[];
+  schema_valid: boolean;
+  semantic_status: 'valid' | 'degraded_with_reasons' | 'blocked';
+  is_resume_safe: boolean;
+  opportunities: ReviseOpportunitySeedEntry[];
+};
+
+export type BuildPhase05bReviseSeedInput = {
+  jobId: string;
+  manuscriptId: number;
+  manuscriptVersionId?: string | null;
+  authorityProof: Phase0AuthorityProofArtifact | null | undefined;
+  opportunities: ReviseOpportunitySeedEntry[];
+};
+
+export type PersistPhase05bReviseSeedInput = BuildPhase05bReviseSeedInput & {
+  supabase: SupabaseClient;
+};
+
+const FORBIDDEN_CANDIDATE_PATTERNS = [
+  /^(expand|improve|clarify|strengthen|show more)\b/i,
+  /^the problem is\b/i,
+  /^symptom:/i,
+  /^evidence:/i,
+  /NARRATIVEDRIVE:/i,
+  /recommendation/i,
+];
+
+function isAuthorityProofUsable(proof: Phase0AuthorityProofArtifact | null | undefined): proof is Phase0AuthorityProofArtifact {
+  return !!proof && proof.schema_valid === true && proof.is_resume_safe === true &&
+    (proof.semantic_status === 'valid' || proof.semantic_status === 'degraded_with_reasons');
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function candidateHasForbiddenShape(candidate: ReviseSeedCandidate): boolean {
+  const text = candidate.text.trim();
+  if (!text) return true;
+  return FORBIDDEN_CANDIDATE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function validateCandidate(candidate: ReviseSeedCandidate, role: ReviseSeedCandidate['role']): string[] {
+  const errors: string[] = [];
+  if (candidate.role !== role) errors.push(`candidate_${candidate.label.toLowerCase()}_role_invalid`);
+  if (!hasText(candidate.text)) errors.push(`candidate_${candidate.label.toLowerCase()}_text_missing`);
+  if (candidateHasForbiddenShape(candidate)) errors.push(`candidate_${candidate.label.toLowerCase()}_not_revision_prose`);
+  return errors;
+}
+
+function validateOpportunity(opportunity: ReviseOpportunitySeedEntry): string[] {
+  const errors: string[] = [];
+  const requiredTextFields: Array<keyof ReviseOpportunitySeedEntry> = [
+    'opportunity_id',
+    'criterion_key',
+    'location_label',
+    'location_anchor',
+    'original_passage',
+    'operation_type',
+    'symptom',
+    'cause',
+    'reader_effect',
+    'evidence',
+    'fix_direction',
+    'mistake_proofing',
+  ];
+
+  for (const field of requiredTextFields) {
+    if (!hasText(opportunity[field])) errors.push(`${String(field)}_missing`);
+  }
+
+  if (!Array.isArray(opportunity.canon_basis) || opportunity.canon_basis.length === 0) {
+    errors.push('canon_basis_missing');
+  }
+  if (!Array.isArray(opportunity.authority_path_basis) || opportunity.authority_path_basis.length === 0) {
+    errors.push('authority_path_basis_missing');
+  }
+
+  errors.push(...validateCandidate(opportunity.candidate_a, 'recommended_repair'));
+  errors.push(...validateCandidate(opportunity.candidate_b, 'balanced_revision'));
+  errors.push(...validateCandidate(opportunity.candidate_c, 'bolder_rendering_shift'));
+
+  if (opportunity.author_decision_status !== 'pending') errors.push('author_decision_status_must_be_pending');
+  if (opportunity.validation_status !== 'unvalidated') errors.push('validation_status_must_be_unvalidated');
+
+  return errors;
+}
+
+function stableArtifactId(payload: unknown): string {
+  return crypto.createHash('sha256').update(JSON.stringify(payload), 'utf8').digest('hex');
+}
+
+export function buildPhase05bReviseOpportunitySeed(input: BuildPhase05bReviseSeedInput): {
+  ok: true;
+  seed: ReviseOpportunitySeedArtifact;
+} | {
+  ok: false;
+  code: string;
+  reason: string;
+  opportunity_errors?: Record<string, string[]>;
+} {
+  if (!isAuthorityProofUsable(input.authorityProof)) {
+    return {
+      ok: false,
+      code: 'PHASE05B_AUTHORITY_PROOF_MISSING_OR_INVALID',
+      reason: 'Phase 0.5B Revise Opportunity Seed cannot be generated without a valid or degraded-with-reasons Phase 0 authority proof.',
+    };
+  }
+
+  const opportunityErrors: Record<string, string[]> = {};
+  for (const opportunity of input.opportunities) {
+    const errors = validateOpportunity(opportunity);
+    if (errors.length > 0) {
+      opportunityErrors[opportunity.opportunity_id || 'unknown_opportunity'] = errors;
+    }
+  }
+
+  if (Object.keys(opportunityErrors).length > 0) {
+    return {
+      ok: false,
+      code: 'PHASE05B_OPPORTUNITY_CONTRACT_INVALID',
+      reason: 'One or more revise opportunities failed the seed contract and must not be persisted as a ready seed.',
+      opportunity_errors: opportunityErrors,
+    };
+  }
+
+  const semanticStatus = input.authorityProof.semantic_status === 'degraded_with_reasons'
+    ? 'degraded_with_reasons'
+    : 'valid';
+
+  const base = {
+    job_id: input.jobId,
+    manuscript_id: input.manuscriptId,
+    manuscript_version_id: input.manuscriptVersionId ?? null,
+    source: 'phase_0_5b' as const,
+    phase0_authority_proof_id: input.authorityProof.artifact_id,
+    loaded_authority_paths: input.authorityProof.loaded_authority_paths,
+    authority_checksums: input.authorityProof.authority_checksums,
+    canon_sources_missing: input.authorityProof.missing_authority_paths,
+    schema_valid: true,
+    semantic_status: semanticStatus,
+    is_resume_safe: true,
+    opportunities: input.opportunities,
+  };
+
+  return {
+    ok: true,
+    seed: {
+      artifact_id: stableArtifactId({ artifact_type: 'revise_opportunity_seed_v1', ...base }),
+      artifact_type: 'revise_opportunity_seed_v1',
+      schema_version: 'revise_opportunity_seed_v1',
+      ...base,
+    },
+  };
+}
+
+export async function persistPhase05bReviseOpportunitySeed(input: PersistPhase05bReviseSeedInput): Promise<{
+  artifactId: string;
+  seed: ReviseOpportunitySeedArtifact;
+}> {
+  const built = buildPhase05bReviseOpportunitySeed(input);
+  if (!built.ok) {
+    throw new Error(`${built.code}: ${built.reason}`);
+  }
+
+  const artifactId = await upsertEvaluationArtifact({
+    supabase: input.supabase,
+    jobId: input.jobId,
+    manuscriptId: input.manuscriptId,
+    artifactType: 'revise_opportunity_seed_v1',
+    content: built.seed,
+    sourceHash: built.seed.artifact_id,
+    artifactVersion: 'revise_opportunity_seed_v1',
+  });
+
+  return { artifactId, seed: built.seed };
+}


### PR DESCRIPTION
## Summary

Adds the Phase 0.5B producer for governed, authority-bound `revise_opportunity_seed_v1` artifacts.

This PR keeps Phase 0.5B provisional and non-author-facing. It creates a Revise Opportunity Seed only. It does not create Revise Queue cards, apply manuscript revisions, skip Revise Admission, or bypass candidate validation.

## What this adds

- `lib/evaluation/phase-architecture-v2/phase05bReviseOpportunitySeed.ts`
- `__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts`
- `revise_opportunity_seed_v1` added to `ArtifactType`

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## SIPOC posture

This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

Phase 0.5B remains an adjacent Revise track until explicitly promoted by SIPOC certification update.

## Required behavior

- Blocks without valid or degraded-with-reasons `phase0_authority_proof_v1`.
- Produces `revise_opportunity_seed_v1` under authority proof.
- Carries `phase0_authority_proof_id`, loaded authority paths, authority checksums, and missing canon sources.
- Requires each opportunity to include Diagnostic Six fields.
- Requires each opportunity to include A/B/C candidate revision options.
- Rejects missing anchors/original passages.
- Rejects A/B/C candidates that are repeated problem statements, internal tokens, or meta-advice instead of candidate revision prose.
- Carries degraded authority status forward when applicable.

## Non-goals

- Does not create author-facing Revise Queue cards.
- Does not apply manuscript revisions.
- Does not skip Revise Admission.
- Does not skip candidate validation.
- Does not skip Phase 2 or Phase 3 evaluation.
- Does not treat revision opportunities as final truth.

## Tests added

- `__tests__/evaluation/phase05bReviseOpportunitySeed.test.ts`

## Done sentence

Phase 0.5B can now produce a governed, authority-bound provisional Revise Opportunity Seed for downstream Revise Admission and candidate validation.