### PR TITLE
[P14b] Add direct worker checklist entry hook

### DIFF
--- a/.github/pr-bodies/PR-883.md
+++ b/.github/pr-bodies/PR-883.md
@@ -1,0 +1,53 @@
+## Summary
+
+Adds the direct worker-loop checklist entry hook as a narrow follow-up to #879.
+
+#879 added resume-route integration plus the worker-facing checklist seam. This PR adds the worker entry gate helper that can be used before processing queued/running phase jobs.
+
+## What this adds
+
+- `lib/evaluation/phase-architecture-v2/workerChecklistEntryGate.ts`
+- `__tests__/evaluation/workerChecklistEntryGate.test.ts`
+
+## Required behavior
+
+- Blocks `phase_1a` when checklist-required inputs are missing.
+- Blocks `phase_2` when `accepted_story_context_v1` is missing.
+- Allows governed phases when checklist-required inputs are usable.
+- Writes structured blocked progress/failure data through the helper path.
+- Leaves non-governed phases alone.
+
+## Scope discipline
+
+This PR is deliberately small.
+
+- No new phase taxonomy.
+- No SIPOC renaming or replacement.
+- No orchestration rewrite.
+- No new artifact producers.
+- No Phase 0.5 seed generation.
+- No Revise Queue rendering.
+
+## Authority Registry
+
+This PR must comply with:
+
+`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`
+
+If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.
+
+## SIPOC posture
+
+This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.
+
+The existing SIPOC document remains the canonical runtime certification spine for S01-S11.
+
+Checklist enforcement remains an executable companion to SIPOC, not a replacement.
+
+## Tests added
+
+- `__tests__/evaluation/workerChecklistEntryGate.test.ts`
+
+## Done sentence
+
+The worker now has a direct checklist entry gate helper that blocks governed phase entry before processing can proceed.

--- a/__tests__/evaluation/workerChecklistEntryGate.test.ts
+++ b/__tests__/evaluation/workerChecklistEntryGate.test.ts
@@ -1,0 +1,115 @@
+import {
+  evaluateWorkerChecklistEntry,
+  processQueuedJobsWithChecklistEntryGate,
+  type WorkerChecklistCandidate,
+} from '../../lib/evaluation/phase-architecture-v2/workerChecklistEntryGate';
+import type { RuntimeArtifactRow } from '../../lib/evaluation/phase-architecture-v2/checklistRuntimeWiring';
+
+const candidate = (phase: WorkerChecklistCandidate['phase']): WorkerChecklistCandidate => ({
+  id: 'job-1',
+  phase,
+  status: 'queued',
+  progress: {},
+});
+
+const artifact = (artifact_type: string, overrides: Record<string, unknown> = {}): RuntimeArtifactRow => ({
+  id: `${artifact_type}-row-id`,
+  artifact_type,
+  source_hash: `${artifact_type}-source-hash`,
+  created_at: '2026-05-31T00:00:00.000Z',
+  content: {
+    artifact_id: `${artifact_type}-artifact-id`,
+    schema_valid: true,
+    semantic_status: 'valid',
+    is_resume_safe: true,
+    checksum: `${artifact_type}-checksum`,
+    ...overrides,
+  },
+});
+
+describe('worker checklist entry gate', () => {
+  it('blocks phase_1a without story_map_seed_v1', () => {
+    const block = evaluateWorkerChecklistEntry({
+      candidate: candidate('phase_1a'),
+      artifacts: [artifact('phase0_authority_proof_v1')],
+    });
+
+    expect(block).not.toBeNull();
+    expect(block?.phase).toBe('phase_1a');
+    expect(block?.code).toBe('CHECKLIST_REQUIRED_INPUT_MISSING');
+    expect(block?.reason).toContain('story_map_seed_v1');
+  });
+
+  it('allows phase_1a when authority proof and story map seed are usable', () => {
+    const block = evaluateWorkerChecklistEntry({
+      candidate: candidate('phase_1a'),
+      artifacts: [
+        artifact('phase0_authority_proof_v1'),
+        artifact('story_map_seed_v1'),
+      ],
+    });
+
+    expect(block).toBeNull();
+  });
+
+  it('blocks phase_2 without accepted_story_context_v1', () => {
+    const block = evaluateWorkerChecklistEntry({
+      candidate: candidate('phase_2'),
+      artifacts: [],
+    });
+
+    expect(block).not.toBeNull();
+    expect(block?.phase).toBe('phase_2');
+    expect(block?.reason).toContain('accepted_story_context_v1');
+  });
+
+  it('allows phase_2 when accepted_story_context_v1 is usable', () => {
+    const block = evaluateWorkerChecklistEntry({
+      candidate: candidate('phase_2'),
+      artifacts: [artifact('accepted_story_context_v1')],
+    });
+
+    expect(block).toBeNull();
+  });
+
+  it('ignores non-governed phases', () => {
+    const block = evaluateWorkerChecklistEntry({
+      candidate: candidate('phase_3'),
+      artifacts: [],
+    });
+
+    expect(block).toBeNull();
+  });
+
+  it('runs processQueuedJobs after checklist gate seam completes', async () => {
+    const calls: string[] = [];
+    const supabase = {
+      from: () => ({
+        select: () => ({
+          in: () => ({
+            in: () => ({
+              order: () => ({
+                limit: async () => ({ data: [], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    } as never;
+
+    const result = await processQueuedJobsWithChecklistEntryGate({
+      supabase,
+      workerId: 'worker-1',
+      batchSize: 1,
+      leaseMs: 1000,
+      processQueuedJobs: async () => {
+        calls.push('processQueuedJobs');
+        return { claimed: 0, processed: 0, succeeded: 0, failed: 0, errors: [] };
+      },
+    });
+
+    expect(calls).toEqual(['processQueuedJobs']);
+    expect(result.checklistGate.checked).toBe(0);
+    expect(result.checklistGate.blocked).toEqual([]);
+  });
+});

--- a/lib/evaluation/phase-architecture-v2/workerChecklistEntryGate.ts
+++ b/lib/evaluation/phase-architecture-v2/workerChecklistEntryGate.ts
@@ -1,0 +1,176 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { assertWorkerPhaseEntry, type RuntimeArtifactRow } from './checklistRuntimeWiring';
+import type { ChecklistPhaseId } from './checklistMatrix';
+
+type WorkerPhase = 'phase_1a' | 'phase_2';
+
+export type WorkerChecklistCandidate = {
+  id: string;
+  phase: WorkerPhase | string | null;
+  status: string | null;
+  progress?: Record<string, unknown> | null;
+};
+
+export type WorkerChecklistBlock = {
+  job_id: string;
+  phase: WorkerPhase;
+  code: string;
+  reason: string;
+};
+
+export type WorkerChecklistGateResult = {
+  checked: number;
+  blocked: WorkerChecklistBlock[];
+};
+
+export type ProcessQueuedJobsLike = (options: {
+  workerId: string;
+  batchSize: number;
+  leaseMs: number;
+}) => Promise<{
+  claimed: number;
+  processed: number;
+  succeeded: number;
+  failed: number;
+  errors: string[];
+  [key: string]: unknown;
+}>;
+
+function toChecklistPhaseId(phase: WorkerChecklistCandidate['phase']): ChecklistPhaseId | null {
+  if (phase === 'phase_1a') return 'phase_1a';
+  if (phase === 'phase_2') return 'phase_2';
+  return null;
+}
+
+export function evaluateWorkerChecklistEntry(params: {
+  candidate: WorkerChecklistCandidate;
+  artifacts: RuntimeArtifactRow[];
+}): WorkerChecklistBlock | null {
+  const checklistPhaseId = toChecklistPhaseId(params.candidate.phase);
+  if (!checklistPhaseId) return null;
+
+  const decision = assertWorkerPhaseEntry(checklistPhaseId, params.artifacts);
+  if (decision.ok) return null;
+
+  return {
+    job_id: params.candidate.id,
+    phase: params.candidate.phase as WorkerPhase,
+    code: decision.code,
+    reason: decision.reason,
+  };
+}
+
+async function fetchChecklistCandidateArtifacts(params: {
+  supabase: SupabaseClient;
+  jobId: string;
+}): Promise<RuntimeArtifactRow[]> {
+  const { data, error } = await params.supabase
+    .from('evaluation_artifacts')
+    .select('id, artifact_type, content, source_hash, created_at')
+    .eq('job_id', params.jobId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`WORKER_CHECKLIST_ARTIFACT_READ_FAILED: ${error.message}`);
+  }
+
+  return (data ?? []) as RuntimeArtifactRow[];
+}
+
+async function failBlockedCandidate(params: {
+  supabase: SupabaseClient;
+  candidate: WorkerChecklistCandidate;
+  block: WorkerChecklistBlock;
+}): Promise<void> {
+  const now = new Date().toISOString();
+  const progress = params.candidate.progress && typeof params.candidate.progress === 'object'
+    ? params.candidate.progress
+    : {};
+
+  const { error } = await params.supabase
+    .from('evaluation_jobs')
+    .update({
+      status: 'failed',
+      phase: params.block.phase,
+      phase_status: 'failed',
+      failure_code: params.block.code,
+      last_error: params.block.reason,
+      updated_at: now,
+      progress: {
+        ...progress,
+        phase: params.block.phase,
+        phase_status: 'failed',
+        checklist_entry_gate: 'blocked',
+        checklist_entry_gate_code: params.block.code,
+        checklist_entry_gate_reason: params.block.reason,
+        checklist_entry_gate_blocked_at: now,
+      },
+    })
+    .eq('id', params.candidate.id)
+    .in('status', ['queued', 'running']);
+
+  if (error) {
+    throw new Error(`WORKER_CHECKLIST_BLOCK_WRITE_FAILED: ${error.message}`);
+  }
+}
+
+export async function enforceWorkerChecklistEntryGate(params: {
+  supabase: SupabaseClient;
+  batchSize: number;
+}): Promise<WorkerChecklistGateResult> {
+  const { data, error } = await params.supabase
+    .from('evaluation_jobs')
+    .select('id, phase, status, progress')
+    .in('status', ['queued', 'running'])
+    .in('phase', ['phase_1a', 'phase_2'])
+    .order('updated_at', { ascending: true })
+    .limit(params.batchSize);
+
+  if (error) {
+    throw new Error(`WORKER_CHECKLIST_CANDIDATE_READ_FAILED: ${error.message}`);
+  }
+
+  const candidates = (data ?? []) as WorkerChecklistCandidate[];
+  const blocked: WorkerChecklistBlock[] = [];
+
+  for (const candidate of candidates) {
+    const artifacts = await fetchChecklistCandidateArtifacts({
+      supabase: params.supabase,
+      jobId: candidate.id,
+    });
+    const block = evaluateWorkerChecklistEntry({ candidate, artifacts });
+    if (!block) continue;
+
+    await failBlockedCandidate({ supabase: params.supabase, candidate, block });
+    blocked.push(block);
+  }
+
+  return {
+    checked: candidates.length,
+    blocked,
+  };
+}
+
+export async function processQueuedJobsWithChecklistEntryGate(params: {
+  supabase: SupabaseClient;
+  workerId: string;
+  batchSize: number;
+  leaseMs: number;
+  processQueuedJobs: ProcessQueuedJobsLike;
+}): Promise<Awaited<ReturnType<ProcessQueuedJobsLike>> & { checklistGate: WorkerChecklistGateResult }> {
+  const checklistGate = await enforceWorkerChecklistEntryGate({
+    supabase: params.supabase,
+    batchSize: params.batchSize,
+  });
+
+  const results = await params.processQueuedJobs({
+    workerId: params.workerId,
+    batchSize: params.batchSize,
+    leaseMs: params.leaseMs,
+  });
+
+  return {
+    ...results,
+    checklistGate,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the direct worker-loop checklist entry hook as a narrow follow-up to #879.

#879 added resume-route integration plus the worker-facing checklist seam. This PR adds the worker entry gate helper that can be used before processing queued/running phase jobs.

## What this adds

- `lib/evaluation/phase-architecture-v2/workerChecklistEntryGate.ts`
- `__tests__/evaluation/workerChecklistEntryGate.test.ts`

## Required behavior

- Blocks `phase_1a` when checklist-required inputs are missing.
- Blocks `phase_2` when `accepted_story_context_v1` is missing.
- Allows governed phases when checklist-required inputs are usable.
- Writes structured blocked progress/failure data through the helper path.
- Leaves non-governed phases alone.

## Scope discipline

This PR is deliberately small.

- No new phase taxonomy.
- No SIPOC renaming or replacement.
- No orchestration rewrite.
- No new artifact producers.
- No Phase 0.5 seed generation.
- No Revise Queue rendering.

## Authority Registry

This PR must comply with:

`docs/phase-0-warmup/PHASE_0_AUTHORITY_REGISTRY.md`

If there is ambiguity about canon, warmup, benchmark authority, WAVE, the 13 Story Criteria, Gate 15, dialogue/speech protection, Story Ledger standards, Revise Queue doctrine, or fail-closed behavior, this registry is the first source of truth.

## SIPOC posture

This PR does not replace `docs/SIPOC_EVALUATION_PROCESS.md`.

The existing SIPOC document remains the canonical runtime certification spine for S01-S11.

Checklist enforcement remains an executable companion to SIPOC, not a replacement.

## Tests added

- `__tests__/evaluation/workerChecklistEntryGate.test.ts`

## Done sentence

The worker now has a direct checklist entry gate helper that blocks governed phase entry before processing can proceed.