### PR TITLE
Fix report status copy and word count fallback

### DIFF
--- a/.github/pr-bodies/PR-886.md
+++ b/.github/pr-bodies/PR-886.md
@@ -1,0 +1,1 @@
+Small live-fix PR to remove the misleading queue wording and show manuscript word count from persisted manuscript data while evaluation is still starting.

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -224,6 +224,32 @@ async function getManuscriptTitleById(manuscriptId?: number): Promise<string | n
   }
 }
 
+async function getManuscriptWordCountById(manuscriptId?: number): Promise<number | null> {
+  if (!Number.isFinite(manuscriptId) || (manuscriptId as number) <= 0) {
+    return null;
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from("manuscripts")
+      .select("word_count")
+      .eq("id", manuscriptId)
+      .maybeSingle();
+
+    if (error) {
+      console.warn(`[getManuscriptWordCountById] Failed to load manuscript ${manuscriptId}:`, error.message);
+      return null;
+    }
+
+    const wordCount = data?.word_count;
+    return typeof wordCount === "number" && wordCount > 0 ? wordCount : null;
+  } catch (err) {
+    console.warn(`[getManuscriptWordCountById] Unexpected error for manuscript ${manuscriptId}:`, err);
+    return null;
+  }
+}
+
 
 async function getCurrentOwnerId(): Promise<string | null> {
   const sessionUser = await getAuthenticatedUser();
@@ -566,7 +592,8 @@ export default async function EvaluationReportPage({
   const manuscriptTitle =
     getRelatedManuscriptTitle(job) || (await getManuscriptTitleById(job.manuscript_id));
   const { displayTitle } = resolveReportTitle({ chapterTitle, manuscriptTitle });
-  const wordCount = artifact?.metrics?.manuscript?.word_count ?? null;
+  const manuscriptWordCount = await getManuscriptWordCountById(job.manuscript_id);
+  const wordCount = artifact?.metrics?.manuscript?.word_count ?? manuscriptWordCount ?? null;
   const isLongForm = typeof wordCount === "number" && wordCount >= DREAM_WORD_COUNT_THRESHOLD;
   const dreamDoc = isComplete && isLongForm ? await getDreamArtifact(jobId) : null;
   const hasDetectedMode = Boolean(artifact?.detected_mode);

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -525,7 +525,7 @@ export function EvaluationPoller({
   const isFinalComplete = job.status === 'complete' && (!isLongForm || hasNarrativeSynthesis) && !isCompletingAnimation;
 
   const statusLabel = {
-    queued: 'Waiting in queue',
+    queued: 'Preparing your evaluation',
     running: 'In progress',
     complete: isCompletingAnimation
       ? 'In progress'
@@ -636,7 +636,7 @@ export function EvaluationPoller({
                     ↻ Refresh
                   </button>
                   {job.status === 'queued' && pollCount > 5 && (
-                    <span className="text-xs text-gray-400">Still waiting to start?</span>
+                    <span className="text-xs text-gray-400">Still preparing?</span>
                   )}
                   {job.status === 'running' && pollCount > 10 && (
                     <span className="text-xs text-gray-400">Taking longer than expected?</span>


### PR DESCRIPTION
Small live-fix PR to remove the misleading queue wording and show manuscript word count from persisted manuscript data while evaluation is still starting.