### PR TITLE
fix: unblock short-form phase entry and redact operational job diagnostics

### DIFF
--- a/.github/pr-bodies/PR-889.md
+++ b/.github/pr-bodies/PR-889.md
@@ -1,0 +1,65 @@
+## Why
+Two production risks were identified:
+
+1. **Short-form evaluations (<25k words) could fail immediately at Phase 1A entry** with `PHASE_0_NOT_PROVEN` because intake seeded zero Phase 0 durations but omitted the explicit bypass marker required by the guard.
+2. **Operational diagnostics were visible to non-operator users** via `/api/jobs/[jobId]` and report/poller rendering paths.
+
+## What changed
+
+### Phase 0 fast-track contract normalization
+- In `app/api/jobs/route.ts`, short-form fast-track seeding now includes:
+  - `phase0_bypass_reason: "short_form_policy_fast_track"`
+- Existing fields are preserved:
+  - `phase0_fast_track: true`
+  - `phase0_fast_track_reason: "short_form_under_25000_words"`
+  - `phase0_proof_normalized: true`
+
+### Server-side operational redaction gate
+- Added `lib/auth/evaluationOperationalAccess.ts`
+  - Allows operational detail visibility when either:
+    - `app_metadata.role` is `admin` or `superadmin`, or
+    - email is in `EVALUATION_OPERATOR_EMAILS` (comma-separated env var)
+- In `app/api/jobs/[jobId]/route.ts`, non-operator callers are redacted **before JSON serialization**.
+  - Redacted for non-operators:
+    - `phase0_total_duration_ms`
+    - `phase0_calibration_word_count`
+    - `phase_message`
+    - `heartbeat_age_seconds`
+    - `retry_count`
+    - `is_stalled`
+    - `stalled_reason`
+    - `last_error`
+    - `failure_code`
+  - Added response fields:
+    - `can_view_operational_details`
+    - `public_status_message` (failed + non-operator)
+
+### UI gating
+- `components/EvaluationPoller.tsx`
+  - Raw error block shown only when `can_view_operational_details` is true.
+  - Non-operators see customer-safe failure message.
+- `components/evaluation/FailedJobRecovery.tsx`
+  - Non-operators no longer see checkpoint internals/recovery mode details.
+  - Public-safe message + `Start New Evaluation` CTA only.
+- `app/evaluate/[jobId]/page.tsx`
+  - Server-rendered failed state now role-gated.
+  - Non-operators get public-safe message; operators keep diagnostics.
+
+## Tests
+- Updated/added tests in:
+  - `tests/api/jobs-route-input-contract.test.ts` (fast-track bypass marker regression)
+  - `tests/api/jobs-endpoint.test.ts` (operator vs non-operator redaction assertions)
+
+Executed locally:
+- `npm test -- tests/api/jobs-endpoint.test.ts tests/api/jobs-route-input-contract.test.ts __tests__/lib/evaluation/phase0-proof-normalization.test.ts --runInBand`
+- Result: **29 passed, 0 failed**
+
+## Ops note
+Set this env var in Vercel for operator access by email:
+- `EVALUATION_OPERATOR_EMAILS=...`
+
+No emails are hard-coded in source.
+
+## Governance
+This PR hardens privacy/security and unblocks legal short-form pipeline entry.
+It does **not** itself close product E2E verification; a fresh production proof packet is still required.

--- a/app/api/jobs/[jobId]/route.ts
+++ b/app/api/jobs/[jobId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getJob } from "@/lib/jobs/store";
 import type { Job } from "@/lib/jobs/types";
 import { getAuthenticatedUser } from "@/lib/supabase/server";
+import { canViewEvaluationOperationalDetails } from "@/lib/auth/evaluationOperationalAccess";
 
 type Params = Promise<{ jobId: string }>;
 
@@ -93,6 +94,10 @@ type CanonicalJobResponse = {
   stalled_reason?: string | null;
   last_error?: string;
   failure_code?: string;
+  /** True when the caller is an operator/admin and operational details are included */
+  can_view_operational_details?: boolean;
+  /** Public-safe failure message for non-operator callers */
+  public_status_message?: string | null;
 };
 
 const NO_STORE_HEADERS = {
@@ -125,6 +130,7 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
 
     const sessionUser = await getAuthenticatedUser();
     const ownerId = sessionUser?.id ?? headerOwnerId;
+    const canSeeOperationalDetails = canViewEvaluationOperationalDetails(sessionUser);
 
     if (!ownerId) {
       return jsonNoStore(
@@ -223,10 +229,10 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
     if (stageTiming.pass3_completed_at !== undefined) {
       response.job.pass3_completed_at = stageTiming.pass3_completed_at;
     }
-    if (stageTiming.phase0_total_duration_ms !== undefined) {
+    if (canSeeOperationalDetails && stageTiming.phase0_total_duration_ms !== undefined) {
       response.job.phase0_total_duration_ms = stageTiming.phase0_total_duration_ms;
     }
-    if (stageTiming.phase0_calibration_word_count !== undefined) {
+    if (canSeeOperationalDetails && stageTiming.phase0_calibration_word_count !== undefined) {
       response.job.phase0_calibration_word_count = stageTiming.phase0_calibration_word_count;
     }
 
@@ -247,31 +253,43 @@ export async function GET(req: NextRequest, ctx: { params: Params }) {
     }
 
     // 6f) Surface operational visibility fields for explicit stuck-state UX.
-    const operationalSignal = extractOperationalSignal(job, canonicalPhase.phase);
-    if (operationalSignal.phase_message !== undefined) {
-      response.job.phase_message = operationalSignal.phase_message;
-    }
-    if (operationalSignal.heartbeat_age_seconds !== undefined) {
-      response.job.heartbeat_age_seconds = operationalSignal.heartbeat_age_seconds;
-    }
-    if (operationalSignal.retry_count !== undefined) {
-      response.job.retry_count = operationalSignal.retry_count;
-    }
-    if (operationalSignal.is_stalled !== undefined) {
-      response.job.is_stalled = operationalSignal.is_stalled;
-    }
-    if (operationalSignal.stalled_reason !== undefined) {
-      response.job.stalled_reason = operationalSignal.stalled_reason;
+    //     Only emitted to operators/admins — these fields contain pipeline internals.
+    if (canSeeOperationalDetails) {
+      const operationalSignal = extractOperationalSignal(job, canonicalPhase.phase);
+      if (operationalSignal.phase_message !== undefined) {
+        response.job.phase_message = operationalSignal.phase_message;
+      }
+      if (operationalSignal.heartbeat_age_seconds !== undefined) {
+        response.job.heartbeat_age_seconds = operationalSignal.heartbeat_age_seconds;
+      }
+      if (operationalSignal.retry_count !== undefined) {
+        response.job.retry_count = operationalSignal.retry_count;
+      }
+      if (operationalSignal.is_stalled !== undefined) {
+        response.job.is_stalled = operationalSignal.is_stalled;
+      }
+      if (operationalSignal.stalled_reason !== undefined) {
+        response.job.stalled_reason = operationalSignal.stalled_reason;
+      }
     }
 
-    // 7) Include last_error only on failure
-    if (job.status === "failed" && job.last_error) {
+    // 7) Include last_error only on failure, and only for operators/admins.
+    if (job.status === "failed" && job.last_error && canSeeOperationalDetails) {
       response.job.last_error = job.last_error;
     }
 
-    // 8) Include failure_code whenever available (including non-terminal degradation signals)
-    if (job.failure_code) {
+    // 8) Include failure_code for operators/admins only.
+    if (job.failure_code && canSeeOperationalDetails) {
       response.job.failure_code = job.failure_code;
+    }
+
+    // 9) Always emit the visibility flag so the client can branch its UI.
+    response.job.can_view_operational_details = canSeeOperationalDetails;
+
+    // 10) For failed jobs viewed by non-operators, emit a safe public message.
+    if (job.status === "failed" && !canSeeOperationalDetails) {
+      response.job.public_status_message =
+        "This evaluation could not be completed. Please start a new evaluation or contact support if the problem continues.";
     }
 
     return jsonNoStore(response);

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -113,6 +113,10 @@ async function seedJobIntakeProgress(params: {
       message: "Short-form evaluation queued — using short-form criteria policy fast path",
       phase0_fast_track: true,
       phase0_fast_track_reason: "short_form_under_25000_words",
+      // Phase 1A proof guard requires either real Phase 0 proof durations
+      // or an explicit bypass reason. Short-form policy intentionally bypasses
+      // Phase 0 warm-up, so this marker is mandatory for legal entry.
+      phase0_bypass_reason: "short_form_policy_fast_track",
       phase0_started_at: now,
       phase0_completed_at: now,
       phase0_total_duration_ms: 0,

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -31,6 +31,7 @@ import { resolveReportTitle } from "@/lib/evaluation/reportTitle";
 import { safeTruncateToWordBoundary } from "@/lib/evaluation/reportRenderSafety";
 import CriterionOpportunities from "@/components/evaluation/CriterionOpportunities";
 import { hasActiveSupportGrant, logSupportView } from "@/lib/support/checkSupportAccess";
+import { canViewEvaluationOperationalDetails } from "@/lib/auth/evaluationOperationalAccess";
 import type { LongformDreamDocument } from "@/lib/evaluation/pipeline/runPass3bLongform";
 
 type Job = {
@@ -484,6 +485,7 @@ export default async function EvaluationReportPage({
 
   const userRole = (sessionUser?.app_metadata as Record<string, unknown> | undefined)?.role;
   const isAdminRole = userRole === 'admin' || userRole === 'superadmin';
+    const canSeeOperationalDetails = canViewEvaluationOperationalDetails(sessionUser);
   const isOwner = job.user_id === ownerId;
   const activeGrant = isAdminRole ? await hasActiveSupportGrant(jobId) : null;
   const hasSupportAccess = isAdminRole && !!activeGrant;
@@ -569,7 +571,8 @@ export default async function EvaluationReportPage({
     // Seed unit counters for accurate early/late phase_1a label selection.
     ...(typeof job.total_units === 'number' ? { total_units: job.total_units } : {}),
     ...(typeof job.completed_units === 'number' ? { completed_units: job.completed_units } : {}),
-    ...(job.last_error ? { last_error: job.last_error } : {}),
+    ...(job.last_error && canSeeOperationalDetails ? { last_error: job.last_error } : {}),
+    can_view_operational_details: canSeeOperationalDetails,
     // Seed review-gate quality signal and word count for immediate correct display.
     ...(progressHardFail !== null ? { hard_fail_present: progressHardFail } : {}),
     ...(pollerWordCount !== null ? { manuscript_word_count: pollerWordCount } : {}),
@@ -673,19 +676,37 @@ export default async function EvaluationReportPage({
         />
       </section>
 
-      {job.status === "failed" && job.last_error ? (
-        <section className="rounded-lg border border-red-200 bg-red-50 p-5">
-          <h2 className="text-lg font-semibold text-red-900">Evaluation failed</h2>
-          <p className="mt-2 text-sm text-red-800">{job.last_error}</p>
-          <div className="mt-4">
-            <Link
-              href="/evaluate"
-              className="inline-flex rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-900"
-            >
-              Return to job list
-            </Link>
-          </div>
-        </section>
+      {job.status === "failed" ? (
+        canSeeOperationalDetails && job.last_error ? (
+          <section className="rounded-lg border border-red-200 bg-red-50 p-5">
+            <h2 className="text-lg font-semibold text-red-900">Evaluation failed</h2>
+            <p className="mt-2 text-sm text-red-800">{job.last_error}</p>
+            <div className="mt-4">
+              <Link
+                href="/evaluate"
+                className="inline-flex rounded-md border border-red-300 px-3 py-2 text-sm font-medium text-red-900"
+              >
+                Return to job list
+              </Link>
+            </div>
+          </section>
+        ) : (
+          <section className="rounded-lg border border-amber-200 bg-amber-50 p-5">
+            <h2 className="text-lg font-semibold text-amber-900">Evaluation needs attention</h2>
+            <p className="mt-2 text-sm text-amber-800">
+              This evaluation could not be completed. Please start a new evaluation or contact
+              support if the problem continues.
+            </p>
+            <div className="mt-4">
+              <Link
+                href="/evaluate"
+                className="inline-flex rounded-md border border-amber-300 px-3 py-2 text-sm font-medium text-amber-900"
+              >
+                Start New Evaluation
+              </Link>
+            </div>
+          </section>
+        )
       ) : !isComplete ? (
         job.phase === 'review_gate' ? (
           <section

--- a/components/EvaluationPoller.tsx
+++ b/components/EvaluationPoller.tsx
@@ -87,6 +87,10 @@ export interface JobState {
   hard_fail_present?: boolean | null;
   /** Manuscript word count from chunk_routing — available before completion */
   manuscript_word_count?: number | null;
+  /** True when the caller is an operator/admin and operational details are included in this response */
+  can_view_operational_details?: boolean;
+  /** Public-safe failure message shown to non-operator users when the job has failed */
+  public_status_message?: string | null;
 }
 
 function isLongFormJob(job: Pick<JobState, 'manuscript_word_count'> | null): boolean {
@@ -713,13 +717,20 @@ export function EvaluationPoller({
         {/* Failed-job recovery: checkpoint-aware resume button */}
         {job.status === 'failed' && (
           <div className="space-y-3">
-            {/* Surface the raw error detail above the recovery panel for transparency */}
-            {job.last_error && (
+            {/* Operational error detail — operators only */}
+            {job.can_view_operational_details && job.last_error ? (
               <div className="p-3 bg-red-50 border border-red-200 rounded">
                 <p className="text-xs font-semibold text-red-800 uppercase">Error</p>
                 <p className="text-sm text-red-700 mt-2">{formatUserSafeError(job.last_error)}</p>
               </div>
-            )}
+            ) : !job.can_view_operational_details ? (
+              <div className="p-3 bg-amber-50 border border-amber-200 rounded">
+                <p className="text-sm text-amber-800">
+                  {job.public_status_message ??
+                    'This evaluation could not be completed. Please start a new evaluation or contact support if the problem continues.'}
+                </p>
+              </div>
+            ) : null}
             <FailedJobRecovery
               jobId={jobId}
               checkpoint={checkpoint}
@@ -727,6 +738,7 @@ export function EvaluationPoller({
               resumeError={resumeError}
               resumed={resumed}
               onResume={handleResume}
+              showOperationalDetails={job.can_view_operational_details ?? false}
             />
           </div>
         )}

--- a/components/evaluation/FailedJobRecovery.tsx
+++ b/components/evaluation/FailedJobRecovery.tsx
@@ -161,6 +161,8 @@ type FailedJobRecoveryProps = {
   resumeError: string | null;
   resumed: boolean;
   onResume: () => void;
+  /** When false (non-operator), hides internal checkpoint detail and recovery mode pill */
+  showOperationalDetails?: boolean;
 };
 
 export function FailedJobRecovery({
@@ -168,8 +170,27 @@ export function FailedJobRecovery({
   resumeLoading,
   resumeError,
   onResume,
+  showOperationalDetails = false,
 }: FailedJobRecoveryProps) {
   const { hasPhase2Handoff, resumeMode, checked, cachedChunks, totalExpectedChunks } = checkpoint;
+
+  // Non-operators see only a public-safe message and a single CTA.
+  if (!showOperationalDetails) {
+    return (
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-5 space-y-4">
+        <p className="text-sm text-amber-800">
+          This evaluation could not be completed from the current saved state. Please start a new
+          evaluation.
+        </p>
+        <Link
+          href="/evaluate"
+          className="inline-flex items-center gap-2 rounded-md bg-amber-700 px-4 py-2 text-sm font-medium text-white hover:bg-amber-800 transition-colors"
+        >
+          Start New Evaluation
+        </Link>
+      </div>
+    );
+  }
 
   // full_restart = no checkpoint, SLA clock is already expired on this job ID.
   // Requeueing the same job will always be killed by the SLA watchdog before a
@@ -203,8 +224,8 @@ export function FailedJobRecovery({
         <p className="text-sm text-amber-800">{bodyText}</p>
       </div>
 
-      {/* Recovery mode pill — operator transparency */}
-      {checked && resumeMode && (
+      {/* Recovery mode pill — operator transparency only */}
+      {checked && resumeMode && showOperationalDetails && (
         <div className="flex items-center gap-2">
           <span className="text-xs text-amber-600 font-medium">Recovery mode:</span>
           <span

--- a/lib/auth/evaluationOperationalAccess.ts
+++ b/lib/auth/evaluationOperationalAccess.ts
@@ -1,0 +1,33 @@
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Returns true when the authenticated user is permitted to view operational
+ * evaluation details (raw errors, Phase 0 telemetry, heartbeat/retry fields,
+ * pipeline stage internals, failure codes).
+ *
+ * Gate logic (OR):
+ *  1. User role is "admin" or "superadmin" (app_metadata.role)
+ *  2. User email is in the EVALUATION_OPERATOR_EMAILS environment variable
+ *     (comma-separated list, case-insensitive)
+ *
+ * NEVER hard-code email addresses in source. Use the environment variable.
+ */
+export function canViewEvaluationOperationalDetails(
+  user: User | null | undefined,
+): boolean {
+  if (!user) return false;
+
+  const role = (user.app_metadata as Record<string, unknown> | undefined)
+    ?.role as string | undefined;
+  if (role === "admin" || role === "superadmin") return true;
+
+  const email = user.email?.trim().toLowerCase();
+  if (!email) return false;
+
+  const allowedEmails = (process.env.EVALUATION_OPERATOR_EMAILS ?? "")
+    .split(",")
+    .map((v) => v.trim().toLowerCase())
+    .filter(Boolean);
+
+  return allowedEmails.includes(email);
+}

--- a/tests/api/jobs-endpoint.test.ts
+++ b/tests/api/jobs-endpoint.test.ts
@@ -29,7 +29,7 @@ const mockGetJob = jobStore.getJob as unknown as {
 };
 const mockGetAuthenticatedUser =
   supabaseServer.getAuthenticatedUser as unknown as {
-    mockResolvedValue: (value: { id: string } | null) => void;
+    mockResolvedValue: (value: { id: string; email?: string; app_metadata?: Record<string, unknown> } | null) => void;
   };
 
 // Helper: build a mock Job object
@@ -87,6 +87,7 @@ describe("GET /api/jobs/[jobId]", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EVALUATION_OPERATOR_EMAILS = "";
     mockGetAuthenticatedUser.mockResolvedValue(null);
   });
 
@@ -252,10 +253,121 @@ describe("GET /api/jobs/[jobId]", () => {
       job: { status: string; last_error?: string; failure_code?: string };
     };
     expect(json.job.status).toBe("failed");
-    expect(json.job.last_error).toBe(
-      "Anchor offsets missing for accepted proposal"
-    );
-    expect(json.job.failure_code).toBe("ANCHOR_MISS");
+    // Non-operator callers must not receive operational diagnostics.
+    expect(json.job.last_error).toBeUndefined();
+    expect(json.job.failure_code).toBeUndefined();
+  });
+
+  test("redacts operational fields for non-operator caller", async () => {
+    const req = buildRequest({ jobId: "job-1", userId: "user-123" });
+    const job = buildJob({
+      status: "failed" as JobStatus,
+      failure_code: "PHASE_0_NOT_PROVEN",
+      last_error:
+        "Phase 0 calibration not proven (phase0_total_duration_ms=0ms, phase0_measured_duration_ms=0ms).",
+      progress: {
+        phase: "phase_1a",
+        phase_status: "failed",
+        total_units: 10,
+        completed_units: 1,
+        phase0_total_duration_ms: 0,
+        phase0_calibration_word_count: 4412,
+        message: "Phase 1A blocked by proof guard",
+        attempt_count: 3,
+      },
+    });
+    mockGetJob.mockResolvedValue(job);
+
+    const response = await GET(req, {
+      params: Promise.resolve({ jobId: "job-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      ok: boolean;
+      job: {
+        can_view_operational_details?: boolean;
+        public_status_message?: string | null;
+        last_error?: string;
+        failure_code?: string;
+        phase0_total_duration_ms?: number | null;
+        phase0_calibration_word_count?: number | null;
+        phase_message?: string | null;
+        heartbeat_age_seconds?: number | null;
+        retry_count?: number | null;
+        stalled_reason?: string | null;
+      };
+    };
+
+    expect(json.ok).toBe(true);
+    expect(json.job.can_view_operational_details).toBe(false);
+    expect(json.job.public_status_message).toContain("could not be completed");
+    expect(json.job.last_error).toBeUndefined();
+    expect(json.job.failure_code).toBeUndefined();
+    expect(json.job.phase0_total_duration_ms).toBeUndefined();
+    expect(json.job.phase0_calibration_word_count).toBeUndefined();
+    expect(json.job.phase_message).toBeUndefined();
+    expect(json.job.heartbeat_age_seconds).toBeUndefined();
+    expect(json.job.retry_count).toBeUndefined();
+    expect(json.job.stalled_reason).toBeUndefined();
+  });
+
+  test("includes operational fields for operator caller", async () => {
+    process.env.EVALUATION_OPERATOR_EMAILS = "operator@revisiongrade.com";
+
+    const req = buildRequest({ jobId: "job-1", userId: null });
+    mockGetAuthenticatedUser.mockResolvedValue({
+      id: "user-123",
+      email: "operator@revisiongrade.com",
+      app_metadata: {},
+    });
+
+    const job = buildJob({
+      status: "failed" as JobStatus,
+      failure_code: "PHASE_0_NOT_PROVEN",
+      last_error:
+        "Phase 0 calibration not proven (phase0_total_duration_ms=0ms, phase0_measured_duration_ms=0ms).",
+      progress: {
+        phase: "phase_1a",
+        phase_status: "failed",
+        total_units: 10,
+        completed_units: 1,
+        phase0_total_duration_ms: 0,
+        phase0_calibration_word_count: 4412,
+        message: "Phase 1A blocked by proof guard",
+        attempt_count: 3,
+      },
+    });
+    mockGetJob.mockResolvedValue(job);
+
+    const response = await GET(req, {
+      params: Promise.resolve({ jobId: "job-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      ok: boolean;
+      job: {
+        can_view_operational_details?: boolean;
+        public_status_message?: string | null;
+        last_error?: string;
+        failure_code?: string;
+        phase0_total_duration_ms?: number | null;
+        phase0_calibration_word_count?: number | null;
+        phase_message?: string | null;
+        retry_count?: number | null;
+      };
+    };
+
+    expect(json.ok).toBe(true);
+    expect(json.job.can_view_operational_details).toBe(true);
+    expect(json.job.public_status_message).toBeUndefined();
+    expect(json.job.last_error).toContain("Phase 0 calibration not proven");
+    expect(json.job.failure_code).toBe("PHASE_0_NOT_PROVEN");
+    expect(json.job.phase0_total_duration_ms).toBe(0);
+    expect(json.job.phase0_calibration_word_count).toBe(4412);
+    expect(json.job.phase_message).toBe("Phase 1A blocked by proof guard");
+    expect(json.job.retry_count).toBe(3);
   });
 
   test("does not include last_error when status === failed but last_error is null", async () => {

--- a/tests/api/jobs-route-input-contract.test.ts
+++ b/tests/api/jobs-route-input-contract.test.ts
@@ -105,14 +105,30 @@ describe("POST /api/jobs input contract", () => {
   });
 
   test("accepts text-only input and creates fresh manuscript-backed job", async () => {
+    const updateMock = jest.fn(() => ({
+      eq: jest.fn(async () => ({ error: null })),
+    }));
+
     const supabase = {
-      from: jest.fn(() => ({
-        insert: jest.fn(() => ({
-          select: () => ({
-            single: async () => ({ data: { id: 321 }, error: null }),
-          }),
-        })),
-      })),
+      from: jest.fn((table: string) => {
+        if (table === "manuscripts") {
+          return {
+            insert: jest.fn(() => ({
+              select: () => ({
+                single: async () => ({ data: { id: 321 }, error: null }),
+              }),
+            })),
+          };
+        }
+
+        if (table === "evaluation_jobs") {
+          return {
+            update: updateMock,
+          };
+        }
+
+        throw new Error(`Unexpected table in test mock: ${table}`);
+      }),
     };
 
     mockCreateAdminClient.mockReturnValue(supabase as never);
@@ -186,6 +202,40 @@ describe("POST /api/jobs input contract", () => {
   });
 
   test("accepts manuscript_id-only payload and does not create a new manuscript row", async () => {
+    const updateMock = jest.fn(() => ({
+      eq: jest.fn(async () => ({ error: null })),
+    }));
+
+    const insertMock = jest.fn(() => {
+      throw new Error("Unexpected manuscripts.insert in manuscript_id-only path");
+    });
+
+    const supabase = {
+      from: jest.fn((table: string) => {
+        if (table === "manuscripts") {
+          return {
+            insert: insertMock,
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                eq: jest.fn(() => ({
+                  maybeSingle: async () => ({ data: { word_count: 4412 }, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+
+        if (table === "evaluation_jobs") {
+          return {
+            update: updateMock,
+          };
+        }
+
+        throw new Error(`Unexpected table in test mock: ${table}`);
+      }),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
     mockCreateJob.mockResolvedValue({
       id: "job-1002",
       manuscript_id: 1002,
@@ -217,7 +267,70 @@ describe("POST /api/jobs input contract", () => {
         job_type: "evaluate_full",
       }),
     );
-    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test("seeds explicit phase0 bypass marker for short-form fast-track jobs", async () => {
+    const updateMock = jest.fn(() => ({
+      eq: jest.fn(async () => ({ error: null })),
+    }));
+
+    const supabase = {
+      from: jest.fn((table: string) => {
+        if (table === "manuscripts") {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                eq: jest.fn(() => ({
+                  maybeSingle: async () => ({ data: { word_count: 4412 }, error: null }),
+                })),
+              })),
+            })),
+          };
+        }
+
+        if (table === "evaluation_jobs") {
+          return {
+            update: updateMock,
+          };
+        }
+
+        throw new Error(`Unexpected table in test mock: ${table}`);
+      }),
+    };
+
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+    mockCreateJob.mockResolvedValue({
+      id: "job-fast-track",
+      manuscript_id: 1234,
+      job_type: "evaluate_full",
+      status: "queued",
+      progress: {},
+    } as never);
+    mockFetch.mockResolvedValue({ ok: true } as Response);
+
+    const req = new Request("https://example.test/api/jobs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        manuscript_id: 1234,
+        job_type: "evaluate_full",
+        processing_terms_accepted: true,
+      }),
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(201);
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        progress: expect.objectContaining({
+          phase0_fast_track: true,
+          phase0_fast_track_reason: "short_form_under_25000_words",
+          phase0_bypass_reason: "short_form_policy_fast_track",
+        }),
+      }),
+    );
   });
 
   test("returns 201 and logs a warning when worker kickoff fetch rejects", async () => {


### PR DESCRIPTION
## Why
Two production risks were identified:

1. **Short-form evaluations (<25k words) could fail immediately at Phase 1A entry** with `PHASE_0_NOT_PROVEN` because intake seeded zero Phase 0 durations but omitted the explicit bypass marker required by the guard.
2. **Operational diagnostics were visible to non-operator users** via `/api/jobs/[jobId]` and report/poller rendering paths.

## What changed

### Phase 0 fast-track contract normalization
- In `app/api/jobs/route.ts`, short-form fast-track seeding now includes:
  - `phase0_bypass_reason: "short_form_policy_fast_track"`
- Existing fields are preserved:
  - `phase0_fast_track: true`
  - `phase0_fast_track_reason: "short_form_under_25000_words"`
  - `phase0_proof_normalized: true`

### Server-side operational redaction gate
- Added `lib/auth/evaluationOperationalAccess.ts`
  - Allows operational detail visibility when either:
    - `app_metadata.role` is `admin` or `superadmin`, or
    - email is in `EVALUATION_OPERATOR_EMAILS` (comma-separated env var)
- In `app/api/jobs/[jobId]/route.ts`, non-operator callers are redacted **before JSON serialization**.
  - Redacted for non-operators:
    - `phase0_total_duration_ms`
    - `phase0_calibration_word_count`
    - `phase_message`
    - `heartbeat_age_seconds`
    - `retry_count`
    - `is_stalled`
    - `stalled_reason`
    - `last_error`
    - `failure_code`
  - Added response fields:
    - `can_view_operational_details`
    - `public_status_message` (failed + non-operator)

### UI gating
- `components/EvaluationPoller.tsx`
  - Raw error block shown only when `can_view_operational_details` is true.
  - Non-operators see customer-safe failure message.
- `components/evaluation/FailedJobRecovery.tsx`
  - Non-operators no longer see checkpoint internals/recovery mode details.
  - Public-safe message + `Start New Evaluation` CTA only.
- `app/evaluate/[jobId]/page.tsx`
  - Server-rendered failed state now role-gated.
  - Non-operators get public-safe message; operators keep diagnostics.

## Tests
- Updated/added tests in:
  - `tests/api/jobs-route-input-contract.test.ts` (fast-track bypass marker regression)
  - `tests/api/jobs-endpoint.test.ts` (operator vs non-operator redaction assertions)

Executed locally:
- `npm test -- tests/api/jobs-endpoint.test.ts tests/api/jobs-route-input-contract.test.ts __tests__/lib/evaluation/phase0-proof-normalization.test.ts --runInBand`
- Result: **29 passed, 0 failed**

## Ops note
Set this env var in Vercel for operator access by email:
- `EVALUATION_OPERATOR_EMAILS=...`

No emails are hard-coded in source.

## Governance
This PR hardens privacy/security and unblocks legal short-form pipeline entry.
It does **not** itself close product E2E verification; a fresh production proof packet is still required.