### PR TITLE
fix: Story Ledger user gate long-form only (>=25k words)

### DIFF
--- a/.github/pr-bodies/PR-890.md
+++ b/.github/pr-bodies/PR-890.md
@@ -1,0 +1,39 @@
+## Why
+Short-form/chapter evaluations were being forced into `review_gate / awaiting_approval` after Phase 1A, which is product-inappropriate for chapter-scale submissions (e.g. 4,412 words).
+
+Policy target:
+- Internal Story Layer artifact generation can remain enabled.
+- User-facing Story Ledger approval gate must be long-form only.
+
+## What changed
+
+### 1) Processor routing policy (hard gate)
+In `lib/evaluation/processor.ts`:
+- Added `STORY_LEDGER_USER_GATE_MIN_WORDS = 25_000`
+- Added `shouldRequireStoryLedgerReviewGate(manuscriptWords)` helper.
+- In Phase 1A handoff:
+  - If `manuscript_words < 25_000` and handoff readiness is valid:
+    - Skip user-facing Review Gate.
+    - Auto-write `accepted_story_ledger_v1` with governance rail marking short-form auto-approval.
+    - Transition directly to `phase_2 / queued`.
+  - If `manuscript_words >= 25_000`, keep existing Review Gate behavior.
+
+### 2) UX wording correction at 15–34%
+In `components/evaluation-poller-display.ts`:
+- Early phase_1a label changed from **"Reading your manuscript..."** to **"Diagnosing your manuscript..."**
+- Helper text now reflects diagnosis/analysis language.
+
+## Tests
+- Added threshold regression test in `__tests__/lib/evaluation/processor.test.ts`:
+  - `< 25,000` => no user-facing Story Ledger gate
+  - `>= 25,000` => user-facing Story Ledger gate required
+- Updated `tests/evaluation-poller-display.test.ts` label expectations.
+
+Run locally:
+- `npm test -- __tests__/lib/evaluation/processor.test.ts tests/evaluation-poller-display.test.ts --runInBand`
+- Result: **59 passed, 0 failed**
+
+## Expected product behavior after merge
+- 4.4k chapter evaluations no longer stop at `review_gate / awaiting_approval`.
+- They proceed directly into criteria diagnosis pipeline after internal checks.
+- Long-form evaluations (>=25k) still use user-facing Story Ledger gate.

--- a/__tests__/lib/evaluation/processor.test.ts
+++ b/__tests__/lib/evaluation/processor.test.ts
@@ -17,6 +17,7 @@ const {
   toPhaseV2ArtifactSet,
   derivePhaseV2ReviewGateProgress,
   shouldRequeueReviewGateBlock,
+  shouldRequireStoryLedgerReviewGate,
 } = require("../../../lib/evaluation/processor");
 const { CRITERIA_KEYS } = require("../../../schemas/criteria-keys");
 
@@ -407,6 +408,15 @@ describe("SLA helpers", () => {
 });
 
 describe("Review Gate wiring helpers", () => {
+  test("Story Ledger user-facing gate requires >= 25,000 words", () => {
+    expect(shouldRequireStoryLedgerReviewGate(4412)).toBe(false);
+    expect(shouldRequireStoryLedgerReviewGate(24999)).toBe(false);
+    expect(shouldRequireStoryLedgerReviewGate(25000)).toBe(true);
+    expect(shouldRequireStoryLedgerReviewGate(80000)).toBe(true);
+    expect(shouldRequireStoryLedgerReviewGate(null)).toBe(false);
+    expect(shouldRequireStoryLedgerReviewGate(undefined)).toBe(false);
+  });
+
   test("maps phase v2 artifact refs from evaluation_artifacts rows using content.artifact_id fallback to row id", () => {
     const refs = toPhaseV2ArtifactSet([
       {

--- a/components/evaluation-poller-display.ts
+++ b/components/evaluation-poller-display.ts
@@ -175,13 +175,13 @@ export function getProgressDisplay(
     const fraction = job.phase_unit_fraction ?? 1;
     const isEarly = fraction < 0.5;
     return {
-      label: isEarly ? "Reading your manuscript..." : "Understanding your story...",
+      label: isEarly ? "Diagnosing your manuscript..." : "Understanding your story...",
       valueLabel: isEarly ? "15%" : "35%",
       percentage: isEarly ? 15 : 35,
       color: "blue",
       hardStop: false,
       indeterminate: false,
-      helperText: "Getting to know your characters, setting, and narrative arc."
+      helperText: "Analyzing your manuscript's story, structure, and craft signals."
     };
   }
 
@@ -257,11 +257,11 @@ export function getProgressDisplay(
     const pct = elapsedDrift(job.phase1_started_at, rangeMin, rangeMax, _now);
     return {
       label: isEarly
-        ? "Reading your manuscript..."
+        ? "Diagnosing your manuscript..."
         : "Understanding your story...",
       valueLabel: `${pct}%`,
       helperText: isEarly
-        ? "Getting to know your manuscript."
+        ? "Analyzing your manuscript's story, structure, and craft signals."
         : "Exploring your characters, relationships, and narrative arc.",
       indeterminate: false,
       percentage: pct,
@@ -273,9 +273,9 @@ export function getProgressDisplay(
   if (job.phase === "phase_1a") {
     const pct = elapsedDrift(job.phase1_started_at, 15, 34, _now);
     return {
-      label: "Reading your manuscript...",
+      label: "Diagnosing your manuscript...",
       valueLabel: `${pct}%`,
-      helperText: "Getting to know your manuscript.",
+      helperText: "Analyzing your manuscript's story, structure, and craft signals.",
       indeterminate: false,
       percentage: pct,
       color: "blue",

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -171,6 +171,13 @@ import { getConfiguredAppBaseUrl } from '@/lib/jobs/triggerWorker';
 /** Minimum manuscript word count for WAVE eligibility */
 const WAVE_MIN_WORDS = 25_000;
 
+/**
+ * User-facing Story Ledger Review Gate is long-form only.
+ * Short-form/chapter evaluations may still build internal Story Layer artifacts,
+ * but must not block on author approval UI.
+ */
+const STORY_LEDGER_USER_GATE_MIN_WORDS = 25_000;
+
 /** Minimum per-criterion score (0-10) for WAVE eligibility — no red criteria */
 const WAVE_MIN_CRITERION_SCORE = 6.0;
 
@@ -262,6 +269,12 @@ export function getValidatedWorkerBatchSize(raw: unknown, fallback = 5): number 
   }
   const normalized = Math.trunc(parsed);
   return normalized >= 1 && normalized <= 5 ? normalized : fallback;
+}
+
+export function shouldRequireStoryLedgerReviewGate(manuscriptWords: number | null | undefined): boolean {
+  return typeof manuscriptWords === 'number'
+    && Number.isFinite(manuscriptWords)
+    && manuscriptWords >= STORY_LEDGER_USER_GATE_MIN_WORDS;
 }
 
 function isMissingColumnError(error: unknown, columnName: string): boolean {
@@ -6139,6 +6152,11 @@ export async function processEvaluationJob(
 
         // ── 7. Review Gate handoff (Phase Architecture v2 helper) ─────────
         const phase1aNow = new Date().toISOString();
+        const manuscriptWordCountForGate =
+          typeof chunkRouting.manuscript_words === 'number' && Number.isFinite(chunkRouting.manuscript_words)
+            ? chunkRouting.manuscript_words
+            : countWords(manuscriptWithContent.content || '');
+        const requireUserFacingReviewGate = shouldRequireStoryLedgerReviewGate(manuscriptWordCountForGate);
         const reviewGateArtifactTypes = [
           'pass1a_story_layer_v1',
           'ledger_quality_report_v1',
@@ -6167,6 +6185,160 @@ export async function processEvaluationJob(
           phaseV2Progress,
           phaseV2Artifacts,
         );
+
+        // Short-form policy: internal Story Layer artifacts are still generated,
+        // but user-facing Review Gate approval is long-form only.
+        if (!requireUserFacingReviewGate && reviewGateHandoffResult.ok) {
+          const autoApprovalAt = new Date().toISOString();
+          const sourceLayers =
+            storyLayerPayload && typeof storyLayerPayload === 'object' && 'layers' in storyLayerPayload
+              ? ((storyLayerPayload as { layers?: Record<string, Record<string, unknown>> }).layers ?? {})
+              : {};
+
+          const preferredLayerKeys = Object.keys(sourceLayers).filter((k) => k.trim().length > 0);
+          const canonicalFallbackLayerKeys = [
+            'canon_identity_core',
+            'relationship_network',
+            'timeline_and_causality',
+            'motivation_and_goal_pressure',
+            'stakes_and_threat_model',
+            'symbolic_systems',
+            'theme_and_argument',
+            'voice_register_and_pov',
+            'ending_and_accountability',
+          ];
+          const layerKeys = (preferredLayerKeys.length > 0 ? preferredLayerKeys : canonicalFallbackLayerKeys).slice(0, 9);
+
+          while (layerKeys.length < 9) {
+            layerKeys.push(`layer_${layerKeys.length + 1}`);
+          }
+
+          const autoLayerDecisions = Object.fromEntries(
+            layerKeys.map((key) => [
+              key,
+              {
+                status: 'accepted_without_changes',
+                comment: `Auto-approved by short-form policy (< ${STORY_LEDGER_USER_GATE_MIN_WORDS} words).`,
+              },
+            ]),
+          );
+
+          const acceptedLedgerPayload = {
+            job_id: String(job.id),
+            manuscript_id: Number(job.manuscript_id),
+            artifact_id: `accepted_story_ledger_v1:${randomUUID().slice(0, 16)}`,
+            artifact_type: 'accepted_story_ledger_v1',
+            artifact_version: 'v1',
+            source_hash: createHash('sha256')
+              .update(`${String(job.id)}:short_form_auto_accept:${manuscriptWordCountForGate}:${autoApprovalAt}`)
+              .digest('hex'),
+            generated_at: autoApprovalAt,
+            layers: sourceLayers,
+            governance_rail: {
+              approval_state: 'accepted',
+              approved_by: 'system:auto_short_form_policy',
+              approved_at: autoApprovalAt,
+              disposition: 'accepted_without_changes',
+              author_notes: null,
+              edit_requests: [],
+              unresolved_warnings_preserved: true,
+              dependency_warnings:
+                (qualityReport as { quality_report?: { layer_dependency_warnings?: unknown } })
+                  ?.quality_report?.layer_dependency_warnings ?? [],
+              contested_layer_count: 0,
+              layer_decisions: autoLayerDecisions,
+              auto_approved_short_form: true,
+              auto_approval_reason: 'short_form_under_25000_words',
+              manuscript_word_count: manuscriptWordCountForGate,
+            },
+          };
+
+          await upsertEvaluationArtifact({
+            supabase,
+            jobId: String(job.id),
+            manuscriptId: Number(job.manuscript_id),
+            artifactType: 'accepted_story_ledger_v1',
+            content: acceptedLedgerPayload,
+            sourceHash: acceptedLedgerPayload.source_hash,
+            artifactVersion: 'v1',
+          });
+
+          const phase2QueueAt = new Date().toISOString();
+          const phase2BypassProgress = {
+            ...progressState,
+            ...buildPhaseLogPatch(progressState, 'phase_1a', 'passed', phase2QueueAt),
+            total_units: 100,
+            completed_units: 55,
+            phase: 'phase_2',
+            phase_status: 'queued',
+            message: 'Phase 1A complete — short-form policy skipped Story Ledger approval and queued diagnosis',
+            phase1a_completed_at: phase2QueueAt,
+            gate_ready_status: 'auto_approved_short_form',
+            review_gate_ready: false,
+            hard_fail_present: qualityReport.hard_fail_present,
+            story_layer_artifact_id: storyLayerRefs.pass1a_story_layer_v1.artifact_id,
+            quality_report_artifact_id: storyLayerRefs.ledger_quality_report_v1.artifact_id,
+            pass3a_status: phaseV2Progress.pass3a_status,
+            pass3a_gate_validity: 'gate_valid',
+            pass3a_artifact_id: phaseV2Progress.pass3a_artifact_id,
+            pass3a_degraded_reason: phaseV2Progress.degraded_reason,
+            short_form_review_gate_bypassed: true,
+            short_form_review_gate_bypass_reason: 'manuscript_under_25000_words',
+            story_ledger_user_gate_required: false,
+            story_ledger_user_gate_min_words: STORY_LEDGER_USER_GATE_MIN_WORDS,
+            manuscript_word_count: manuscriptWordCountForGate,
+            phase1a_batch_state: {
+              ...((progressState.phase1a_batch_state as Record<string, unknown>) ?? {}),
+              ledger_assembly_status: 'COMPLETE',
+              preflight_status: 'DONE',
+            },
+            phase_log: [
+              ...((progressState.phase_log as unknown[]) ?? []),
+              { at: storyLayerPersistedAt, event: 'phase1a_story_layer_persisted', stage: 'phase_1a' },
+              {
+                at: phase2QueueAt,
+                event: 'review_gate_skipped_short_form',
+                stage: 'phase_1a',
+                manuscript_word_count: manuscriptWordCountForGate,
+                threshold_words: STORY_LEDGER_USER_GATE_MIN_WORDS,
+              },
+            ],
+          };
+
+          const { data: shortFormQueueRow, error: shortFormQueueErr } = await supabase
+            .from('evaluation_jobs')
+            .update({
+              status: JOB_STATUS.QUEUED,
+              phase: PHASES.PHASE_2,
+              phase_status: JOB_STATUS.QUEUED,
+              claimed_by: null,
+              claimed_at: null,
+              lease_token: null,
+              lease_until: null,
+              review_gate_passed_at: phase2QueueAt,
+              updated_at: phase2QueueAt,
+              progress: phase2BypassProgress,
+            })
+            .eq('id', job.id)
+            .eq('status', JOB_STATUS.RUNNING)
+            .select('id, status, phase, phase_status')
+            .single();
+
+          if (shortFormQueueErr) {
+            throw new Error(`Phase 1A short-form bypass transition failed: ${shortFormQueueErr.message}`);
+          }
+
+          console.log(
+            `[Processor] ${jobId}: short-form review gate skipped — queued phase_2 directly`,
+            {
+              manuscript_word_count: manuscriptWordCountForGate,
+              threshold_words: STORY_LEDGER_USER_GATE_MIN_WORDS,
+              status: shortFormQueueRow?.status,
+              phase: shortFormQueueRow?.phase,
+            },
+          );
+          return { success: true };
+        }
 
         if (reviewGateHandoffResult.ok === false) {
           const blocked = reviewGateHandoffResult.blocked;

--- a/tests/evaluation-poller-display.test.ts
+++ b/tests/evaluation-poller-display.test.ts
@@ -64,7 +64,7 @@ describe("getProgressDisplay: canonical state mapping", () => {
       phase_status: "running",
       phase_unit_fraction: 0.1,
     });
-    expect(pd!.label).toBe("Reading your manuscript...");
+    expect(pd!.label).toBe("Diagnosing your manuscript...");
     expect(pd!.percentage).toBe(15);
   });
 
@@ -85,7 +85,7 @@ describe("getProgressDisplay: canonical state mapping", () => {
       phase: "phase_1a",
       phase_status: "queued",
     });
-    expect(pd!.label).toBe("Reading your manuscript...");
+    expect(pd!.label).toBe("Diagnosing your manuscript...");
     expect(pd!.percentage).toBe(15);
   });
 


### PR DESCRIPTION
## Why
Short-form/chapter evaluations were being forced into `review_gate / awaiting_approval` after Phase 1A, which is product-inappropriate for chapter-scale submissions (e.g. 4,412 words).

Policy target:
- Internal Story Layer artifact generation can remain enabled.
- User-facing Story Ledger approval gate must be long-form only.

## What changed

### 1) Processor routing policy (hard gate)
In `lib/evaluation/processor.ts`:
- Added `STORY_LEDGER_USER_GATE_MIN_WORDS = 25_000`
- Added `shouldRequireStoryLedgerReviewGate(manuscriptWords)` helper.
- In Phase 1A handoff:
  - If `manuscript_words < 25_000` and handoff readiness is valid:
    - Skip user-facing Review Gate.
    - Auto-write `accepted_story_ledger_v1` with governance rail marking short-form auto-approval.
    - Transition directly to `phase_2 / queued`.
  - If `manuscript_words >= 25_000`, keep existing Review Gate behavior.

### 2) UX wording correction at 15–34%
In `components/evaluation-poller-display.ts`:
- Early phase_1a label changed from **"Reading your manuscript..."** to **"Diagnosing your manuscript..."**
- Helper text now reflects diagnosis/analysis language.

## Tests
- Added threshold regression test in `__tests__/lib/evaluation/processor.test.ts`:
  - `< 25,000` => no user-facing Story Ledger gate
  - `>= 25,000` => user-facing Story Ledger gate required
- Updated `tests/evaluation-poller-display.test.ts` label expectations.

Run locally:
- `npm test -- __tests__/lib/evaluation/processor.test.ts tests/evaluation-poller-display.test.ts --runInBand`
- Result: **59 passed, 0 failed**

## Expected product behavior after merge
- 4.4k chapter evaluations no longer stop at `review_gate / awaiting_approval`.
- They proceed directly into criteria diagnosis pipeline after internal checks.
- Long-form evaluations (>=25k) still use user-facing Story Ledger gate.
