### PR TITLE
fix(ui): render criterion score as explicit score out of ten

### DIFF
--- a/.github/pr-bodies/PR-906.md
+++ b/.github/pr-bodies/PR-906.md
@@ -1,0 +1,23 @@
+## Summary
+
+- Updates criterion score badges to render as an explicit editorial score: `Score: 8/10`.
+- Removes the cramped `8 / 10` badge style from criterion cards.
+- Keeps score presentation on the right side of the existing criterion header, alongside the confidence badge.
+
+## Why
+
+The criterion header should read professionally:
+
+- Left: criterion name only, for example `Concept`
+- Right: `Score: 8/10` plus the confidence badge, for example `High Confidence`
+
+This makes the score unambiguous and avoids the cramped `8.0 Concept High` / compact-badge look from the earlier report screenshot.
+
+## Scope
+
+- UI/report rendering only.
+- No scoring, confidence calculation, criteria ordering, pipeline, database, prompt, or artifact-generation logic changed.
+
+## Note
+
+The current evaluation page already places the criterion name on the left and the score/confidence badges on the right. This PR tightens the score wording to the requested `Score: 8/10` format. The existing confidence badge already expands the label beyond `High` to `High Confidence`.

--- a/lib/evaluation/reportCriterionDisplay.ts
+++ b/lib/evaluation/reportCriterionDisplay.ts
@@ -39,6 +39,14 @@ export function isCertifiedCriterion(criterion: RenderableCriterion): boolean {
   return typeof criterion.score_0_10 === "number";
 }
 
+function formatScoreOutOfTen(score: number | null | undefined): string {
+  if (typeof score !== "number" || !Number.isFinite(score)) {
+    return "Score: —/10";
+  }
+
+  return `Score: ${Math.round(score)}/10`;
+}
+
 export function getCriterionPrimaryBadge(criterion: RenderableCriterion): {
   label: string;
   classes: string;
@@ -63,7 +71,7 @@ export function getCriterionPrimaryBadge(criterion: RenderableCriterion): {
   const scoreValue = criterion.score_0_10;
   if (typeof scoreValue === "number" && scoreValue >= 8) {
     return {
-      label: `${Math.round(scoreValue)} / 10`,
+      label: formatScoreOutOfTen(scoreValue),
       classes: "bg-green-100 text-green-800",
       numeric: true,
     };
@@ -71,14 +79,14 @@ export function getCriterionPrimaryBadge(criterion: RenderableCriterion): {
 
   if (typeof scoreValue === "number" && scoreValue >= 6) {
     return {
-      label: `${Math.round(scoreValue)} / 10`,
+      label: formatScoreOutOfTen(scoreValue),
       classes: "bg-yellow-100 text-yellow-800",
       numeric: true,
     };
   }
 
   return {
-    label: `${typeof scoreValue === "number" ? Math.round(scoreValue) : "—"} / 10`,
+    label: formatScoreOutOfTen(scoreValue),
     classes: "bg-red-100 text-red-800",
     numeric: true,
   };
@@ -105,7 +113,7 @@ export function getCriterionSupportLabel(criterion: RenderableCriterion): string
 
 function repairTruncatedQuotes(text: string): string {
   return text.replace(
-    /[""\u201c]([^""\u201d]+)[""\u201d]/g,
+    /[""“]([^""”]+)[""”]/g,
     (match, inner: string) => {
       const content = inner.trimEnd();
       if (/[.!?]$/.test(content)) return match;
@@ -114,7 +122,7 @@ function repairTruncatedQuotes(text: string): string {
         const lastSpace = content.lastIndexOf(" ");
         if (lastSpace === -1) return match;
         const trimmed = content.slice(0, lastSpace).replace(/[,;:\s]+$/, "");
-        return `\u201c${trimmed}\u2026\u201d`;
+        return `“${trimmed}…”`;
       }
       return match;
     },


### PR DESCRIPTION
## Summary

- Updates criterion score badges to render as an explicit editorial score: `Score: 8/10`.
- Removes the cramped `8 / 10` badge style from criterion cards.
- Keeps score presentation on the right side of the existing criterion header, alongside the confidence badge.

## Why

The criterion header should read professionally:

- Left: criterion name only, for example `Concept`
- Right: `Score: 8/10` plus the confidence badge, for example `High Confidence`

This makes the score unambiguous and avoids the cramped `8.0 Concept High` / compact-badge look from the earlier report screenshot.

## Scope

- UI/report rendering only.
- No scoring, confidence calculation, criteria ordering, pipeline, database, prompt, or artifact-generation logic changed.

## Note

The current evaluation page already places the criterion name on the left and the score/confidence badges on the right. This PR tightens the score wording to the requested `Score: 8/10` format. The existing confidence badge already expands the label beyond `High` to `High Confidence`.