### PR TITLE
fix(ui): replace blocking confirmation dialogs causing INP warnings

### DIFF
--- a/.github/pr-bodies/PR-910.md
+++ b/.github/pr-bodies/PR-910.md
@@ -1,0 +1,24 @@
+## Summary
+
+- Replaces browser-blocking `window.confirm()` in **TrustedPath** with an inline confirmation panel.
+- Replaces browser-blocking saved-document **Delete** confirmation on `/evaluate` with an inline confirmation panel.
+- Keeps destructive delete actions red, while keeping productive TrustedPath confirmation in the existing gold/calm action style.
+
+## Why
+
+Chrome reported an INP warning because the Delete button click handler was blocked while a synchronous browser confirmation dialog was open. The same blocking pattern existed in TrustedPath and previously caused the same symptom there.
+
+Browser-native `window.confirm()` blocks the main thread and delays UI updates, so it is a poor fit for these flows. Inline confirmation keeps the UI responsive and avoids the bottom-right INP warning.
+
+## Scope
+
+- UI interaction/performance only.
+- No API contract changes.
+- No database/schema changes.
+- No evaluation, scoring, prompt, artifact, or TrustedPath server-route behavior changed.
+
+## Acceptance check
+
+- Clicking Delete should open an inline confirmation inside the saved-document card, not a browser modal.
+- Clicking TrustedPath should open an inline confirmation panel, not a browser modal.
+- Chrome should no longer report the blocking `window.confirm()` INP issue for these two flows.

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -116,6 +116,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const [isLoadingDashboard, setIsLoadingDashboard] = useState(true);
   const [isUploading, setIsUploading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pendingDeleteManuscriptId, setPendingDeleteManuscriptId] = useState(null);
   const [error, setError] = useState(null);
   const [processingTermsAccepted, setProcessingTermsAccepted] = useState(false);
 
@@ -149,22 +150,16 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     setDashboardManuscripts((prev) => prev.filter((doc) => doc.id !== manuscriptId));
     setHiddenManuscriptIds((prev) => prev.filter((id) => id !== manuscriptId));
     setSelectedManuscriptId((current) => (current === manuscriptId ? null : current));
+    setPendingDeleteManuscriptId((current) => (current === manuscriptId ? null : current));
   };
 
   const hideManuscriptHere = (manuscriptId) => {
     setHiddenManuscriptIds((prev) => (prev.includes(manuscriptId) ? prev : [...prev, manuscriptId]));
     setSelectedManuscriptId((current) => (current === manuscriptId ? null : current));
+    setPendingDeleteManuscriptId((current) => (current === manuscriptId ? null : current));
   };
 
-  const deleteManuscriptById = async (manuscriptId, confirmationLabel) => {
-    const target = dashboardManuscripts.find((doc) => doc.id === manuscriptId);
-    const label = target?.title || "this manuscript";
-    const confirmed = window.confirm(
-      confirmationLabel || `Delete ${label}? This permanently removes it from your dashboard and this window.`,
-    );
-
-    if (!confirmed) return;
-
+  const deleteManuscriptById = async (manuscriptId) => {
     setError(null);
 
     try {
@@ -186,6 +181,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const clearThisWindow = () => {
     setHiddenManuscriptIds(dashboardManuscripts.map((doc) => doc.id));
     setSelectedManuscriptId(null);
+    setPendingDeleteManuscriptId(null);
   };
 
   const restoreAllInThisWindow = () => {
@@ -221,6 +217,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
   const handleInputMethodChange = (methodId) => {
     setActiveInputMethod(methodId);
     setError(null);
+    setPendingDeleteManuscriptId(null);
 
     if (methodId === "paste") {
       setSelectedManuscriptId(null);
@@ -236,6 +233,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     if (!file) return;
     setIsUploading(true);
     setError(null);
+    setPendingDeleteManuscriptId(null);
 
     try {
       const form = new FormData();
@@ -270,6 +268,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
     setSelectedManuscriptId((current) => (current === manuscriptId ? null : manuscriptId));
     setManuscriptText("");
     setActiveInputMethod("saved");
+    setPendingDeleteManuscriptId(null);
   };
 
   const triggerDashboardUpload = () => uploadInputRef.current?.click();
@@ -297,6 +296,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
 
     setIsSubmitting(true);
     setError(null);
+    setPendingDeleteManuscriptId(null);
 
     try {
       const manuscriptSize = hasPastedText ? new Blob([manuscriptText]).size : undefined;
@@ -436,6 +436,7 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                     ) : (
                       visibleDashboardManuscripts.map((doc) => {
                         const isSelected = selectedManuscriptId === doc.id;
+                        const isConfirmingDelete = pendingDeleteManuscriptId === doc.id;
                         return (
                           <div
                             key={doc.id}
@@ -494,7 +495,8 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                                   onClick={(event) => {
                                     event.preventDefault();
                                     event.stopPropagation();
-                                    deleteManuscriptById(doc.id);
+                                    setError(null);
+                                    setPendingDeleteManuscriptId(doc.id);
                                   }}
                                   className="min-h-[38px] rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-100"
                                 >
@@ -502,6 +504,43 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess }) {
                                 </button>
                               </div>
                             </div>
+                            {isConfirmingDelete && (
+                              <div
+                                className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3"
+                                onClick={(event) => event.stopPropagation()}
+                              >
+                                <p className="text-sm font-semibold text-red-900">
+                                  Delete {doc.title || "this manuscript"} from your dashboard?
+                                </p>
+                                <p className="mt-1 text-sm text-red-800">
+                                  This permanently removes it from your dashboard and this window.
+                                </p>
+                                <div className="mt-3 flex flex-wrap justify-end gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      setPendingDeleteManuscriptId(null);
+                                    }}
+                                    className="min-h-[34px] rounded-md border border-stone-300 bg-white px-3 py-1.5 text-sm font-semibold text-stone-800 hover:bg-stone-50"
+                                  >
+                                    Cancel
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      void deleteManuscriptById(doc.id);
+                                    }}
+                                    className="min-h-[34px] rounded-md border border-red-700 bg-red-700 px-3 py-1.5 text-sm font-bold text-white hover:bg-red-800"
+                                  >
+                                    Confirm Delete
+                                  </button>
+                                </div>
+                              </div>
+                            )}
                           </div>
                         );
                       })

--- a/components/revision/TrustedPathWorkbenchButton.tsx
+++ b/components/revision/TrustedPathWorkbenchButton.tsx
@@ -11,15 +11,12 @@ type TrustedPathWorkbenchButtonProps = {
 export default function TrustedPathWorkbenchButton({ manuscriptId, evaluationJobId, disabled }: TrustedPathWorkbenchButtonProps) {
   const [running, setRunning] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
 
   async function runTrustedPath() {
     if (disabled || running || !manuscriptId || !evaluationJobId) return;
 
-    const confirmed = window.confirm(
-      "TrustedPath™ will accept Recommended Repair A for every copy-ready item in the current Revise Queue. Needs Targeting items remain untouched. You can still use Final Review before applying/exporting. Continue?",
-    );
-    if (!confirmed) return;
-
+    setConfirming(false);
     setRunning(true);
     setMessage("TrustedPath™ is moving Recommended Repair A decisions to the ledger…");
 
@@ -52,7 +49,11 @@ export default function TrustedPathWorkbenchButton({ manuscriptId, evaluationJob
     <div className="workbench-v2-trusted-path fixed right-[462px] top-[78px] z-50 text-center">
       <button
         type="button"
-        onClick={runTrustedPath}
+        onClick={() => {
+          if (isDisabled) return;
+          setMessage(null);
+          setConfirming(true);
+        }}
         disabled={isDisabled}
         className={`rounded border px-4 py-2 text-[12px] font-bold uppercase tracking-[0.08em] shadow-lg transition ${
           isDisabled
@@ -63,6 +64,30 @@ export default function TrustedPathWorkbenchButton({ manuscriptId, evaluationJob
       >
         {running ? "Running…" : "TrustedPath"}
       </button>
+      {confirming && !running && (
+        <div className="absolute right-0 mt-2 w-[390px] rounded border border-[#E0BF78] bg-[#120E08] px-3 py-3 text-left text-[11px] leading-4 text-[#CBBDA4] shadow-lg">
+          <p className="font-bold text-[#F4E3B0]">Confirm TrustedPath™</p>
+          <p className="mt-1">
+            TrustedPath™ will accept Recommended Repair A for every copy-ready item in the current Revise Queue. Needs Targeting items remain untouched. You can still use Final Review before applying/exporting.
+          </p>
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="rounded border border-[#3A3022] bg-[#171006] px-3 py-1.5 text-[11px] font-bold text-[#CBBDA4] hover:bg-[#21180E]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={runTrustedPath}
+              className="rounded border border-[#E0BF78] bg-[#D5B36C] px-3 py-1.5 text-[11px] font-bold text-[#171006] hover:bg-[#E4C982]"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      )}
       {message && (
         <p className="absolute right-0 mt-2 w-[360px] rounded border border-[#3A3022] bg-[#120E08] px-3 py-2 text-[11px] leading-4 text-[#CBBDA4] shadow-lg">
           {message}


### PR DESCRIPTION
## Summary

- Replaces browser-blocking `window.confirm()` in **TrustedPath** with an inline confirmation panel.
- Replaces browser-blocking saved-document **Delete** confirmation on `/evaluate` with an inline confirmation panel.
- Keeps destructive delete actions red, while keeping productive TrustedPath confirmation in the existing gold/calm action style.

## Why

Chrome reported an INP warning because the Delete button click handler was blocked while a synchronous browser confirmation dialog was open. The same blocking pattern existed in TrustedPath and previously caused the same symptom there.

Browser-native `window.confirm()` blocks the main thread and delays UI updates, so it is a poor fit for these flows. Inline confirmation keeps the UI responsive and avoids the bottom-right INP warning.

## Scope

- UI interaction/performance only.
- No API contract changes.
- No database/schema changes.
- No evaluation, scoring, prompt, artifact, or TrustedPath server-route behavior changed.

## Acceptance check

- Clicking Delete should open an inline confirmation inside the saved-document card, not a browser modal.
- Clicking TrustedPath should open an inline confirmation panel, not a browser modal.
- Chrome should no longer report the blocking `window.confirm()` INP issue for these two flows.