### PR TITLE
fix(ui): tighten landing page vertical spacing

### DIFF
--- a/.github/pr-bodies/PR-917.md
+++ b/.github/pr-bodies/PR-917.md
@@ -1,0 +1,22 @@
+## Summary
+
+- Tightens vertical spacing on the public landing page for a less airy mobile reading experience.
+- Reduces section padding, card padding, internal gaps, and paragraph/button margins across the home page.
+- Keeps the existing layout, copy, routes, colors, and conversion paths intact.
+
+## Why
+
+The landing page was reading too airy, especially on phones. This trims the vertical rhythm so users see more meaningful content per screen without changing the brand or page structure.
+
+## Scope
+
+- UI/spacing only.
+- No API changes.
+- No database/schema changes.
+- No evaluation, scoring, prompt, artifact, or pipeline behavior changed.
+
+## Acceptance check
+
+- Sections should feel closer together on mobile and desktop.
+- Cards should remain readable but consume less vertical space.
+- Existing CTAs and content order should remain unchanged.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,30 +99,30 @@ function SectionLabel({ children }: { children: ReactNode }) {
 export default function Home() {
   return (
     <div className="bg-rg-ink text-rg-cream">
-      <section className="mx-auto grid max-w-7xl items-center gap-8 px-6 py-12 lg:grid-cols-[1.04fr_0.96fr] lg:gap-12 lg:py-16">
+      <section className="mx-auto grid max-w-7xl items-center gap-6 px-6 py-9 lg:grid-cols-[1.04fr_0.96fr] lg:gap-8 lg:py-12">
         <div>
           <SectionLabel>RevisionGrade™ · WAVE Readiness System™</SectionLabel>
-          <h1 className="mt-6 max-w-5xl font-rg-serif text-5xl leading-[0.95] tracking-tight text-rg-cream md:text-7xl">
+          <h1 className="mt-4 max-w-5xl font-rg-serif text-5xl leading-[0.95] tracking-tight text-rg-cream md:text-7xl">
             Diagnose the manuscript. Then repair it through Revise.
           </h1>
-          <p className="mt-8 max-w-2xl text-lg leading-8 text-rg-cream2/90">
+          <p className="mt-5 max-w-2xl text-lg leading-8 text-rg-cream2/90">
             RevisionGrade is a manuscript-readiness and revision system. It evaluates the story across 13 criteria, builds evidence-backed diagnosis, and uses WAVE as a governed readiness layer before repair opportunities enter Revise without erasing the writer&apos;s voice.
           </p>
-          <div className="mt-10 flex flex-wrap gap-4">
+          <div className="mt-7 flex flex-wrap gap-3">
             <Link href="/evaluate" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">Begin Evaluation</Link>
             <Link href="/revise" className="border border-rg-cream2/30 px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-cream transition hover:border-rg-gold hover:text-rg-gold">See Revise</Link>
           </div>
         </div>
-        <div className="border border-rg-cream2/20 bg-rg-ink2/80 p-6 shadow-2xl shadow-black/30">
-          <div className="border border-rg-gold/35 p-6">
+        <div className="border border-rg-cream2/20 bg-rg-ink2/80 p-5 shadow-2xl shadow-black/30">
+          <div className="border border-rg-gold/35 p-5">
             <SectionLabel>The public promise</SectionLabel>
-            <h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">Diagnosis first. Governed repair second.</h2>
-            <p className="mt-4 text-base leading-8 text-rg-cream2/90">
+            <h2 className="mt-3 font-rg-serif text-3xl text-rg-cream">Diagnosis first. Governed repair second.</h2>
+            <p className="mt-3 text-base leading-7 text-rg-cream2/90">
               Story architecture is assessed before refinement. The 13 criteria establish narrative viability. WAVE is the protected readiness layer used before eligible repair opportunities enter Revise.
             </p>
-            <div className="mt-6 grid gap-3">
+            <div className="mt-5 grid gap-2.5">
               {["Story diagnosis", "13 criteria", "Evidence layer", "WAVE readiness", "Author approval"].map((item, index) => (
-                <div key={item} className="flex items-center gap-4 border border-rg-cream2/15 px-4 py-4">
+                <div key={item} className="flex items-center gap-4 border border-rg-cream2/15 px-4 py-3">
                   <span className="font-rg-mono text-sm text-rg-gold">0{index + 1}</span>
                   <span className="font-rg-mono text-sm uppercase tracking-[0.14em] text-rg-cream2/95">{item}</span>
                 </div>
@@ -133,52 +133,52 @@ export default function Home() {
       </section>
 
       <section className="border-y border-rg-cream2/10 bg-rg-ink2/50">
-        <div className="mx-auto grid max-w-7xl gap-8 px-6 py-10 md:grid-cols-3 lg:py-12">
+        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-8 md:grid-cols-3 lg:py-10">
           {revisionContrasts.map((item) => (
             <article key={item.title}>
               <SectionLabel>{item.title}</SectionLabel>
-              <h2 className="mt-4 font-rg-serif text-3xl text-rg-cream">{item.title === "Not a chatbot" ? "Governed diagnosis." : item.title === "Not cosmetic polish" ? "Structural repair first." : "Voice protected."}</h2>
-              <p className="mt-4 text-base leading-8 text-rg-cream2/90">{item.copy}</p>
+              <h2 className="mt-3 font-rg-serif text-3xl text-rg-cream">{item.title === "Not a chatbot" ? "Governed diagnosis." : item.title === "Not cosmetic polish" ? "Structural repair first." : "Voice protected."}</h2>
+              <p className="mt-3 text-base leading-7 text-rg-cream2/90">{item.copy}</p>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-12 lg:py-16">
+      <section className="mx-auto max-w-7xl px-6 py-9 lg:py-12">
         <div className="max-w-4xl">
           <SectionLabel>WAVE Readiness System™</SectionLabel>
-          <h2 className="mt-4 font-rg-serif text-4xl leading-tight text-rg-cream md:text-5xl">
+          <h2 className="mt-3 font-rg-serif text-4xl leading-tight text-rg-cream md:text-5xl">
             WAVE is the protected readiness layer inside evaluation.
           </h2>
-          <p className="mt-6 max-w-3xl text-lg leading-8 text-rg-cream2/90">
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-rg-cream2/90">
             The WAVE Readiness System™ is not a single rewrite command. It is a proprietary, sequenced readiness methodology that turns evidence-backed findings into governed manuscript interventions while protecting the author&apos;s voice.
           </p>
         </div>
-        <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
           {publicWaveSignals.map((signal) => (
-            <article key={signal.title} className="border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <article key={signal.title} className="border border-rg-cream2/15 bg-rg-ink2/70 p-4">
               <p className="font-rg-mono text-sm uppercase tracking-[0.16em] text-rg-gold md:text-xs">WAVE principle</p>
-              <h3 className="mt-4 font-rg-serif text-2xl text-rg-cream md:text-xl">{signal.title}</h3>
-              <p className="mt-3 text-base leading-7 text-rg-cream2/90">{signal.copy}</p>
+              <h3 className="mt-3 font-rg-serif text-2xl text-rg-cream md:text-xl">{signal.title}</h3>
+              <p className="mt-2 text-base leading-7 text-rg-cream2/90">{signal.copy}</p>
             </article>
           ))}
         </div>
       </section>
 
       <section className="bg-rg-cream text-rg-ink">
-        <div className="mx-auto grid max-w-7xl gap-8 px-6 py-12 lg:grid-cols-[0.9fr_1.1fr] lg:py-16">
+        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-9 lg:grid-cols-[0.9fr_1.1fr] lg:py-12">
           <div>
             <p className="font-rg-mono text-sm uppercase tracking-[0.2em] text-rg-gold md:text-xs md:tracking-[0.24em]">Thirteen story criteria</p>
-            <h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">
+            <h2 className="mt-3 font-rg-serif text-4xl leading-tight md:text-5xl">
               The criteria decide whether a manuscript is ready for WAVE-level readiness analysis.
             </h2>
-            <p className="mt-6 text-base leading-8 text-rg-ink/80">
+            <p className="mt-4 text-base leading-7 text-rg-ink/80">
               Short-form work is evaluated against the 13 criteria only. Long-form work can activate deeper manuscript-scale diagnosis and WAVE readiness when appropriate.
             </p>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-2.5 sm:grid-cols-2">
             {criteria.map((criterion) => (
-              <div key={criterion} className="border border-rg-ink/20 bg-white/60 px-5 py-5 font-rg-mono text-sm uppercase tracking-[0.14em] text-rg-ink/90">
+              <div key={criterion} className="border border-rg-ink/20 bg-white/60 px-4 py-4 font-rg-mono text-sm uppercase tracking-[0.14em] text-rg-ink/90">
                 {criterion}
               </div>
             ))}
@@ -186,35 +186,35 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-12 lg:py-16">
+      <section className="mx-auto max-w-7xl px-6 py-9 lg:py-12">
         <div className="max-w-3xl">
           <SectionLabel>How it works</SectionLabel>
-          <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl">
+          <h2 className="mt-3 font-rg-serif text-4xl text-rg-cream md:text-5xl">
             Evaluation first. WAVE readiness second. Revise with author control.
           </h2>
         </div>
-        <div className="mt-8 grid gap-4 lg:grid-cols-5">
+        <div className="mt-6 grid gap-3 lg:grid-cols-5">
           {workflow.map((item) => (
-            <article key={item.step} className="border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <article key={item.step} className="border border-rg-cream2/15 bg-rg-ink2/70 p-4">
               <p className="font-rg-mono text-sm text-rg-gold md:text-xs">{item.step}</p>
-              <h3 className="mt-4 font-rg-serif text-2xl text-rg-cream md:text-xl">{item.title}</h3>
-              <p className="mt-3 text-base leading-7 text-rg-cream2/90">{item.copy}</p>
+              <h3 className="mt-3 font-rg-serif text-2xl text-rg-cream md:text-xl">{item.title}</h3>
+              <p className="mt-2 text-base leading-7 text-rg-cream2/90">{item.copy}</p>
             </article>
           ))}
         </div>
       </section>
 
       <section className="bg-rg-cream text-rg-ink">
-        <div className="mx-auto grid max-w-7xl gap-8 px-6 py-12 lg:grid-cols-[0.9fr_1.1fr] lg:py-16">
+        <div className="mx-auto grid max-w-7xl gap-6 px-6 py-9 lg:grid-cols-[0.9fr_1.1fr] lg:py-12">
           <div>
             <p className="font-rg-mono text-sm uppercase tracking-[0.2em] text-rg-gold md:text-xs md:tracking-[0.24em]">Why this is different</p>
-            <h2 className="mt-4 font-rg-serif text-4xl leading-tight md:text-5xl">
+            <h2 className="mt-3 font-rg-serif text-4xl leading-tight md:text-5xl">
               The author does not need another opinion. The author needs a governed readiness path and repair workflow.
             </h2>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-2.5 sm:grid-cols-2">
             {proofPoints.map((point) => (
-              <div key={point} className="border border-rg-ink/20 bg-white/60 p-5 font-rg-mono text-sm uppercase tracking-[0.14em] text-rg-ink/90">
+              <div key={point} className="border border-rg-ink/20 bg-white/60 p-4 font-rg-mono text-sm uppercase tracking-[0.14em] text-rg-ink/90">
                 {point}
               </div>
             ))}
@@ -222,39 +222,39 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="mx-auto max-w-7xl px-6 py-12 lg:py-16">
-        <div className="grid gap-8 lg:grid-cols-[1fr_1fr]">
-          <div className="border border-rg-cream2/15 bg-rg-ink2/70 p-8">
+      <section className="mx-auto max-w-7xl px-6 py-9 lg:py-12">
+        <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
+          <div className="border border-rg-cream2/15 bg-rg-ink2/70 p-6">
             <SectionLabel>Revise Queue</SectionLabel>
-            <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">Manual repair, one opportunity at a time.</h2>
-            <p className="mt-5 text-base leading-8 text-rg-cream2/90">
+            <h2 className="mt-3 font-rg-serif text-4xl text-rg-cream">Manual repair, one opportunity at a time.</h2>
+            <p className="mt-4 text-base leading-7 text-rg-cream2/90">
               WAVE readiness findings can become RevisionOpportunity cards with evidence, severity, repair options, rationale, and explicit author decisions.
             </p>
-            <Link href="/workbench" className="mt-7 inline-block font-rg-mono text-sm uppercase tracking-[0.16em] text-rg-gold hover:text-rg-cream md:text-xs">Open Revise Queue →</Link>
+            <Link href="/workbench" className="mt-5 inline-block font-rg-mono text-sm uppercase tracking-[0.16em] text-rg-gold hover:text-rg-cream md:text-xs">Open Revise Queue →</Link>
           </div>
-          <div className="border border-rg-cream2/15 bg-rg-ink2/70 p-8">
+          <div className="border border-rg-cream2/15 bg-rg-ink2/70 p-6">
             <SectionLabel>TrustedPath™</SectionLabel>
-            <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream">One-click governed repair for eligible manuscripts.</h2>
-            <p className="mt-5 text-base leading-8 text-rg-cream2/90">
+            <h2 className="mt-3 font-rg-serif text-4xl text-rg-cream">One-click governed repair for eligible manuscripts.</h2>
+            <p className="mt-4 text-base leading-7 text-rg-cream2/90">
               TrustedPath™ applies eligible recommended repairs to a duplicate manuscript draft, preserves the original, and generates a change log so convenience does not become blind rewriting.
             </p>
-            <Link href="/revise" className="mt-7 inline-block font-rg-mono text-sm uppercase tracking-[0.16em] text-rg-gold hover:text-rg-cream md:text-xs">See Revise →</Link>
+            <Link href="/revise" className="mt-5 inline-block font-rg-mono text-sm uppercase tracking-[0.16em] text-rg-gold hover:text-rg-cream md:text-xs">See Revise →</Link>
           </div>
         </div>
       </section>
 
       <section className="border-t border-rg-cream2/10 bg-rg-ink2/50">
-        <div className="mx-auto max-w-7xl px-6 py-12 lg:py-16">
-          <div className="grid gap-8 lg:grid-cols-[1fr_1fr] lg:gap-10 items-start">
+        <div className="mx-auto max-w-7xl px-6 py-9 lg:py-12">
+          <div className="grid gap-6 lg:grid-cols-[1fr_1fr] lg:gap-8 items-start">
             <div>
               <SectionLabel>Agent Readiness Package™</SectionLabel>
-              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
+              <h2 className="mt-3 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
                 After readiness, build the submission package.
               </h2>
-              <p className="mt-6 text-base leading-8 text-rg-cream2/90">
+              <p className="mt-4 text-base leading-7 text-rg-cream2/90">
                 Generate your query letter, synopsis, query pitch, comparables, manuscript positioning, and author bio—then approve each section before export. Built for authors who have moved from diagnosis toward submission readiness.
               </p>
-              <div className="mt-8 flex flex-wrap gap-4">
+              <div className="mt-6 flex flex-wrap gap-3">
                 <Link href="/agent-readiness" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
                   Build My Package
                 </Link>
@@ -263,7 +263,7 @@ export default function Home() {
                 </Link>
               </div>
             </div>
-            <div className="grid gap-3">
+            <div className="grid gap-2.5">
               {[
                 ["01", "Query Letter", "Hook, metadata, comparables, differentiator, and bio. 450-word hard cap."],
                 ["02", "Synopsis", "Query (100–150 words), standard (250–500), or extended (700–1,000)."],
@@ -272,19 +272,19 @@ export default function Home() {
                 ["05", "Author Bio", "Third-person, professional. Author-supplied credentials only."],
                 ["06", "Package History / Export", "Approve all sections, then export as DOCX or copy."],
               ].map(([num, title, desc]) => (
-                <div key={num} className="flex items-start gap-4 border border-rg-cream2/15 bg-rg-ink px-4 py-4">
+                <div key={num} className="flex items-start gap-3 border border-rg-cream2/15 bg-rg-ink px-4 py-3">
                   <span className="font-rg-mono text-sm text-rg-gold shrink-0 mt-0.5 md:text-xs">{num}</span>
                   <div>
                     <p className="font-rg-mono text-sm uppercase tracking-[0.12em] text-rg-cream">{title}</p>
-                    <p className="mt-2 font-rg-mono text-sm text-rg-cream2/85 leading-6">{desc}</p>
+                    <p className="mt-1.5 font-rg-mono text-sm text-rg-cream2/85 leading-6">{desc}</p>
                   </div>
                 </div>
               ))}
-              <div className="flex items-start gap-4 border border-rg-cream2/15 bg-rg-ink px-4 py-4 opacity-90">
+              <div className="flex items-start gap-3 border border-rg-cream2/15 bg-rg-ink px-4 py-3 opacity-90">
                 <span className="font-rg-mono text-sm text-rg-gold shrink-0 mt-0.5 md:text-xs">07</span>
                 <div>
                   <p className="font-rg-mono text-sm uppercase tracking-[0.12em] text-rg-cream2/85">Agent Targeting™—Coming Next</p>
-                  <p className="mt-2 font-rg-mono text-sm text-rg-cream2/75 leading-6">Find target agents. Generate agent-specific query variants.</p>
+                  <p className="mt-1.5 font-rg-mono text-sm text-rg-cream2/75 leading-6">Find target agents. Generate agent-specific query variants.</p>
                 </div>
               </div>
             </div>
@@ -293,20 +293,20 @@ export default function Home() {
       </section>
 
       <section className="border-t border-rg-cream2/10">
-        <div className="mx-auto max-w-7xl px-6 py-12 lg:py-16">
-          <div className="grid gap-8 lg:grid-cols-[1fr_1fr] lg:gap-10 items-start">
+        <div className="mx-auto max-w-7xl px-6 py-9 lg:py-12">
+          <div className="grid gap-6 lg:grid-cols-[1fr_1fr] lg:gap-8 items-start">
             <div>
               <SectionLabel>Storygate Studio™</SectionLabel>
-              <h2 className="mt-4 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
+              <h2 className="mt-3 font-rg-serif text-4xl text-rg-cream md:text-5xl leading-tight">
                 A curated access layer for readiness-vetted manuscript projects.
               </h2>
-              <p className="mt-6 text-base leading-8 text-rg-cream2/90">
+              <p className="mt-4 text-base leading-7 text-rg-cream2/90">
                 Manuscript projects that clear the readiness threshold can enter Storygate Studio—a controlled environment where verified publishing professionals request access to creator-approved materials.
               </p>
-              <p className="mt-3 text-base leading-8 text-rg-cream2/80">
+              <p className="mt-2 text-base leading-7 text-rg-cream2/80">
                 No public marketplace. No cold outreach. Access is requested, approved by the creator, and logged.
               </p>
-              <div className="mt-8 flex flex-wrap gap-4">
+              <div className="mt-6 flex flex-wrap gap-3">
                 <Link href="/storygate-studio" className="border border-rg-gold bg-rg-gold px-5 py-3 font-rg-mono text-xs uppercase tracking-[0.18em] text-rg-ink transition hover:bg-transparent hover:text-rg-gold">
                   Learn About Storygate
                 </Link>
@@ -315,7 +315,7 @@ export default function Home() {
                 </Link>
               </div>
             </div>
-            <div className="grid gap-3">
+            <div className="grid gap-2.5">
               {[
                 ["Verified Access Only", "Publishing users are approved before viewing any project materials."],
                 ["Creator-Controlled Visibility", "Creators decide what is visible and to whom. Access requires their approval."],
@@ -323,9 +323,9 @@ export default function Home() {
                 ["Logged Activity", "All access events are recorded and append-only. No anonymous actions."],
                 ["Not a Marketplace", "No public search. No cold contact. No fee to submit your project."],
               ].map(([title, desc]) => (
-                <div key={title} className="border border-rg-cream2/15 bg-rg-ink2/70 px-5 py-4">
+                <div key={title} className="border border-rg-cream2/15 bg-rg-ink2/70 px-4 py-3">
                   <p className="font-rg-mono text-sm uppercase tracking-[0.12em] text-rg-gold md:text-xs">{title}</p>
-                  <p className="mt-2 text-base text-rg-cream2/85 leading-7">{desc}</p>
+                  <p className="mt-1.5 text-base text-rg-cream2/85 leading-7">{desc}</p>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Tightens vertical spacing on the public landing page for a less airy mobile reading experience.
- Reduces section padding, card padding, internal gaps, and paragraph/button margins across the home page.
- Keeps the existing layout, copy, routes, colors, and conversion paths intact.

## Why

The landing page was reading too airy, especially on phones. This trims the vertical rhythm so users see more meaningful content per screen without changing the brand or page structure.

## Scope

- UI/spacing only.
- No API changes.
- No database/schema changes.
- No evaluation, scoring, prompt, artifact, or pipeline behavior changed.

## Acceptance check

- Sections should feel closer together on mobile and desktop.
- Cards should remain readable but consume less vertical space.
- Existing CTAs and content order should remain unchanged.