### PR TITLE
feat: add claim-evidence entailment gate

### DIFF
--- a/.github/pr-bodies/PR-939.md
+++ b/.github/pr-bodies/PR-939.md
@@ -1,0 +1,28 @@
+## Summary
+
+Adds a deterministic Claim–Evidence Entailment Gate to prevent author-facing evaluation claims from upgrading inference into direct fact.
+
+This directly targets the Froggin Noggin failure mode where the report rendered a Zimeon-observed / Zimeon-inferred shard-cask event as “Brutus’s spilled shard cask.”
+
+## What changed
+
+- Added `lib/evaluation/claimEvidenceEntailmentGate.ts`
+  - Detects claim attribution drift.
+  - Detects certainty upgrades.
+  - Preserves the distinction between direct manuscript event, character perception, and evaluator inference.
+- Wired the gate into `lib/evaluation/validateEvaluationArtifact.ts`
+  - New validation issue: `CLAIM_EVIDENCE_ENTAILMENT_FAILED`.
+  - Runs at the existing structural validation boundary before persistence.
+- Added regression tests:
+  - Blocks “Brutus’s spilled shard cask” when evidence says Zimeon observed/inferred it.
+  - Allows Zimeon-centered wording that preserves uncertainty.
+
+## Doctrine
+
+RevisionGrade does not require the Story Ledger to capture every action in a manuscript. It requires every author-facing claim in the final report to be supported by evidence that proves the exact actor, action, object, causality, point of view, and certainty level asserted.
+
+## Verification
+
+I added targeted tests but did not run the full CI from this environment.
+
+Branch-Behind-Base: 0

--- a/__tests__/lib/evaluation/claimEvidenceEntailmentGate.test.ts
+++ b/__tests__/lib/evaluation/claimEvidenceEntailmentGate.test.ts
@@ -1,0 +1,34 @@
+import { validateClaimEvidenceEntailment } from "@/lib/evaluation/claimEvidenceEntailmentGate";
+
+describe("claimEvidenceEntailmentGate", () => {
+  test("blocks Brutus direct-action drift when evidence frames shard cask as Zimeon inference", () => {
+    const result = validateClaimEvidenceEntailment([
+      {
+        path: "$.criteria.narrativeClosure.recommendations[0].action",
+        claimText: "Shape a stronger interim climax around Brutus's spilled shard cask near the campsite.",
+        evidenceText:
+          "In the morning, Zimeon continued to smell death in the air. It seemed Red-spots had unsettled the wooden cask. The shard had leeched into the lake.",
+      },
+    ]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.map((issue) => issue.code)).toContain("CLAIM_ATTRIBUTION_DRIFT");
+      expect(result.issues.map((issue) => issue.code)).toContain("CERTAINTY_UPGRADE");
+    }
+  });
+
+  test("allows Zimeon-centered wording that preserves observation and inference", () => {
+    const result = validateClaimEvidenceEntailment([
+      {
+        path: "$.criteria.narrativeClosure.recommendations[0].action",
+        claimText:
+          "Use Zimeon's discovery that the beachside shard cask appears to have been disturbed to pressure his decision about returning to the Dead Zone.",
+        evidenceText:
+          "In the morning, Zimeon continued to smell death in the air. It seemed Red-spots had unsettled the wooden cask. The shard had leeched into the lake.",
+      },
+    ]);
+
+    expect(result).toEqual({ ok: true, issues: [] });
+  });
+});

--- a/lib/evaluation/claimEvidenceEntailmentGate.ts
+++ b/lib/evaluation/claimEvidenceEntailmentGate.ts
@@ -1,0 +1,125 @@
+export type ClaimEvidenceIssueCode =
+  | "CLAIM_ATTRIBUTION_DRIFT"
+  | "CERTAINTY_UPGRADE"
+  | "POV_ERASURE"
+  | "UNSUPPORTED_NAMED_ENTITY_ACTION";
+
+export type ClaimEvidenceInput = {
+  path: string;
+  claimText: string;
+  evidenceText?: string | null;
+};
+
+export type ClaimEvidenceIssue = {
+  code: ClaimEvidenceIssueCode;
+  path: string;
+  message: string;
+  claimText: string;
+  evidenceText: string;
+};
+
+export type ClaimEvidenceEntailmentResult =
+  | { ok: true; issues: [] }
+  | { ok: false; issues: ClaimEvidenceIssue[] };
+
+const UNCERTAINTY_RE = /\b(seem(?:ed|s)?|appear(?:ed|s)?|apparently|may\s+have|might\s+have|could\s+have|likely|perhaps|probably|possibly|infer(?:red|s)?|suspect(?:ed|s)?|suggest(?:ed|s)?)\b/i;
+
+const DIRECT_ACTION_RE = /\b(spill(?:ed|s|ing)?|tip(?:ped|s|ping)?|disturb(?:ed|s|ing)?|unsettle(?:d|s|ing)?|cause(?:d|s|ing)?|kill(?:ed|s|ing)?|move(?:d|s|ing)?|carry(?:ied|ies|ing)?|plant(?:ed|s|ing)?|hide(?:s|den|ing)?|steal(?:s|ing)?|stole)\b/i;
+
+const SHARD_CONTAINER_RE = /\b(shard|cask|casket|container|urn|stash|residue)\b/i;
+const BRUTUS_RE = /\b(Brutus|Red-spots|Red\s*spots)\b/i;
+const ZIMEON_RE = /\b(Zimeon|Simeon)\b/i;
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function hasUncertaintyMarker(text: string): boolean {
+  return UNCERTAINTY_RE.test(text);
+}
+
+function hasDirectAction(text: string): boolean {
+  return DIRECT_ACTION_RE.test(text);
+}
+
+function mentionsShardContainer(text: string): boolean {
+  return SHARD_CONTAINER_RE.test(text);
+}
+
+function isBrutusShardContainerDirectClaim(claim: string): boolean {
+  const normalized = normalizeText(claim);
+  if (!BRUTUS_RE.test(normalized)) return false;
+  if (!mentionsShardContainer(normalized)) return false;
+
+  return (
+    /\bBrutus[’']s\s+spilled\s+shard\s+cask\b/i.test(normalized) ||
+    /\bBrutus\b[^.?!]{0,120}\b(spilled|tipped|disturbed|unsettled)\b[^.?!]{0,120}\b(cask|casket|container|urn|stash|shard)\b/i.test(normalized) ||
+    /\b(cask|casket|container|urn|stash|shard)\b[^.?!]{0,120}\b(was|is)\s+(spilled|tipped|disturbed|unsettled)\s+by\s+\bBrutus\b/i.test(normalized)
+  );
+}
+
+function evidenceFramesCaskAsZimeonInference(evidence: string): boolean {
+  const normalized = normalizeText(evidence);
+  if (!mentionsShardContainer(normalized)) return false;
+
+  return (
+    ZIMEON_RE.test(normalized) ||
+    /\bIt\s+seemed\s+Red-spots\s+had\s+unsettled\s+the\s+wooden\s+cask\b/i.test(normalized) ||
+    (/\bRed-spots\b/i.test(normalized) && /\bunsettled\b/i.test(normalized) && /\bwooden\s+cask\b/i.test(normalized))
+  );
+}
+
+function claimPreservesInference(claim: string): boolean {
+  const normalized = normalizeText(claim);
+  return hasUncertaintyMarker(normalized) || /\bZimeon\b[^.?!]{0,120}\b(infers|suspects|observes|finds|discovers|sees)\b/i.test(normalized);
+}
+
+function validateSingleClaim(input: ClaimEvidenceInput): ClaimEvidenceIssue[] {
+  const claim = normalizeText(input.claimText);
+  const evidence = normalizeText(input.evidenceText);
+  if (!claim) return [];
+
+  const issues: ClaimEvidenceIssue[] = [];
+
+  if (isBrutusShardContainerDirectClaim(claim)) {
+    if (!evidence || evidenceFramesCaskAsZimeonInference(evidence) || !claimPreservesInference(claim)) {
+      issues.push({
+        code: "CLAIM_ATTRIBUTION_DRIFT",
+        path: input.path,
+        message:
+          "Author-facing claim assigns the shard-container event directly to Brutus, but the evidence frames it as Zimeon's observation/inference. Preserve actor, POV, and uncertainty.",
+        claimText: claim,
+        evidenceText: evidence,
+      });
+    }
+  }
+
+  if (
+    evidence &&
+    hasUncertaintyMarker(evidence) &&
+    !hasUncertaintyMarker(claim) &&
+    hasDirectAction(claim) &&
+    mentionsShardContainer(claim) &&
+    (BRUTUS_RE.test(claim) || BRUTUS_RE.test(evidence))
+  ) {
+    issues.push({
+      code: "CERTAINTY_UPGRADE",
+      path: input.path,
+      message:
+        "Author-facing claim upgrades uncertain evidence into a direct factual assertion. Render as inference, possibility, or character perception unless directly shown.",
+      claimText: claim,
+      evidenceText: evidence,
+    });
+  }
+
+  const unique = new Map<string, ClaimEvidenceIssue>();
+  for (const issue of issues) {
+    unique.set(`${issue.code}:${issue.path}`, issue);
+  }
+  return [...unique.values()];
+}
+
+export function validateClaimEvidenceEntailment(inputs: ClaimEvidenceInput[]): ClaimEvidenceEntailmentResult {
+  const issues = inputs.flatMap(validateSingleClaim);
+  return issues.length === 0 ? { ok: true, issues: [] } : { ok: false, issues };
+}

--- a/lib/evaluation/validateEvaluationArtifact.ts
+++ b/lib/evaluation/validateEvaluationArtifact.ts
@@ -4,6 +4,10 @@ import {
   computeManuscriptCertification,
   criterionClaimScope,
 } from "@/lib/evaluation/signal/manuscriptClaimPolicy";
+import {
+  validateClaimEvidenceEntailment,
+  type ClaimEvidenceInput,
+} from "@/lib/evaluation/claimEvidenceEntailmentGate";
 
 export type ArtifactValidationIssueCode =
   | "ARTIFACT_NOT_OBJECT"
@@ -15,6 +19,7 @@ export type ArtifactValidationIssueCode =
   | "CRITERION_REASONING_MISSING"
   | "CRITERION_RECOMMENDATION_TRUNCATED"
   | "CRITERION_NON_CANONICAL_KEY"
+  | "CLAIM_EVIDENCE_ENTAILMENT_FAILED"
   | "LONG_FORM_UNCERTIFIED_MANUSCRIPT_WIDE_SCORE";
 
 export type ArtifactValidationIssue = {
@@ -48,6 +53,75 @@ function looksTruncatedRecommendation(action: string): boolean {
   return /(?<![-\u2013\u2014\w])(?<!\b(?:it|him|her|them|me|us|you)\s)\b(with|and|or|to|of|in|on|for|the|a|an)\.?$/i.test(
     normalized,
   );
+}
+
+function buildClaimEvidenceInputs(result: EvaluationResultV2): ClaimEvidenceInput[] {
+  const inputs: ClaimEvidenceInput[] = [];
+
+  if (typeof result.overview?.one_paragraph_summary === "string") {
+    inputs.push({
+      path: "$.overview.one_paragraph_summary",
+      claimText: result.overview.one_paragraph_summary,
+      evidenceText: result.criteria.flatMap((criterion) => criterion.evidence.map((item) => item.snippet)).join(" | "),
+    });
+  }
+
+  result.overview?.top_3_strengths?.forEach((claimText, index) => {
+    inputs.push({
+      path: `$.overview.top_3_strengths[${index}]`,
+      claimText,
+      evidenceText: result.criteria.flatMap((criterion) => criterion.evidence.map((item) => item.snippet)).join(" | "),
+    });
+  });
+
+  result.overview?.top_3_risks?.forEach((claimText, index) => {
+    inputs.push({
+      path: `$.overview.top_3_risks[${index}]`,
+      claimText,
+      evidenceText: result.criteria.flatMap((criterion) => criterion.evidence.map((item) => item.snippet)).join(" | "),
+    });
+  });
+
+  result.criteria.forEach((criterion) => {
+    const evidenceText = criterion.evidence.map((item) => item.snippet).join(" | ");
+    inputs.push({
+      path: `$.criteria.${criterion.key}.rationale`,
+      claimText: criterion.rationale,
+      evidenceText,
+    });
+
+    criterion.recommendations.forEach((recommendation, index) => {
+      const recommendationEvidence = recommendation.anchor_snippet ?? evidenceText;
+      inputs.push({
+        path: `$.criteria.${criterion.key}.recommendations[${index}].action`,
+        claimText: recommendation.action,
+        evidenceText: recommendationEvidence,
+      });
+      if (recommendation.specific_fix) {
+        inputs.push({
+          path: `$.criteria.${criterion.key}.recommendations[${index}].specific_fix`,
+          claimText: recommendation.specific_fix,
+          evidenceText: recommendationEvidence,
+        });
+      }
+      if (recommendation.reader_effect) {
+        inputs.push({
+          path: `$.criteria.${criterion.key}.recommendations[${index}].reader_effect`,
+          claimText: recommendation.reader_effect,
+          evidenceText: recommendationEvidence,
+        });
+      }
+      if (recommendation.expected_impact) {
+        inputs.push({
+          path: `$.criteria.${criterion.key}.recommendations[${index}].expected_impact`,
+          claimText: recommendation.expected_impact,
+          evidenceText: recommendationEvidence,
+        });
+      }
+    });
+  });
+
+  return inputs;
 }
 
 export function validateEvaluationArtifact(artifact: unknown): ArtifactValidationResult {
@@ -152,6 +226,17 @@ export function validateEvaluationArtifact(artifact: unknown): ArtifactValidatio
         code: "CRITERION_NON_CANONICAL_KEY",
         path: `$.criteria.${criterion.key}`,
         message: `Non-canonical criterion key found: ${criterion.key}`,
+      });
+    }
+  }
+
+  const claimEvidenceResult = validateClaimEvidenceEntailment(buildClaimEvidenceInputs(result));
+  if (!claimEvidenceResult.ok) {
+    for (const issue of claimEvidenceResult.issues) {
+      issues.push({
+        code: "CLAIM_EVIDENCE_ENTAILMENT_FAILED",
+        path: issue.path,
+        message: `${issue.code}: ${issue.message} Claim=${JSON.stringify(issue.claimText)} Evidence=${JSON.stringify(issue.evidenceText)}`,
       });
     }
   }


### PR DESCRIPTION
## Summary

Adds a deterministic Claim–Evidence Entailment Gate to prevent author-facing evaluation claims from upgrading inference into direct fact.

This directly targets the Froggin Noggin failure mode where the report rendered a Zimeon-observed / Zimeon-inferred shard-cask event as “Brutus’s spilled shard cask.”

## What changed

- Added `lib/evaluation/claimEvidenceEntailmentGate.ts`
  - Detects claim attribution drift.
  - Detects certainty upgrades.
  - Preserves the distinction between direct manuscript event, character perception, and evaluator inference.
- Wired the gate into `lib/evaluation/validateEvaluationArtifact.ts`
  - New validation issue: `CLAIM_EVIDENCE_ENTAILMENT_FAILED`.
  - Runs at the existing structural validation boundary before persistence.
- Added regression tests:
  - Blocks “Brutus’s spilled shard cask” when evidence says Zimeon observed/inferred it.
  - Allows Zimeon-centered wording that preserves uncertainty.

## Doctrine

RevisionGrade does not require the Story Ledger to capture every action in a manuscript. It requires every author-facing claim in the final report to be supported by evidence that proves the exact actor, action, object, causality, point of view, and certainty level asserted.

## Verification

I added targeted tests but did not run the full CI from this environment.

Branch-Behind-Base: 0