### PR TITLE
feat: agent readiness + revise queue cost capture and admin ledger pages

### DIFF
--- a/.github/pr-bodies/PR-1000.md
+++ b/.github/pr-bodies/PR-1000.md
@@ -1,0 +1,10 @@
+## Summary
+- Adds dedicated admin cost analysis pages for Agent Readiness and Revise Queue.
+- Records LLM cost events and exposes them through cost/event APIs.
+- Rolls the new data into CostOps/admin cost views.
+
+## Validation
+- Static error scan on all changed files: clean.
+
+## Scope
+This PR is intentionally separate from the watchdog/SLA/processor hardening branch.

--- a/app/admin/costs/agent-readiness/page.tsx
+++ b/app/admin/costs/agent-readiness/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { formatUsdFromCents } from "@/lib/admin/formatMoney";
+
+type CostRange = "24h" | "5d" | "30d" | "all";
+
+interface ActivityRow {
+  activity: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+  lastCalledAt: string | null;
+}
+
+interface ModelRow {
+  model: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+}
+
+interface EventRow {
+  id: string;
+  createdAt: string;
+  activity: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  userId: string | null;
+  evaluationJobId: string | null;
+  manuscriptId: number | null;
+}
+
+interface Summary {
+  range: CostRange;
+  rangeLabel: string;
+  totalCostCents: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCallCount: number;
+  uniqueActivities: number;
+  mostExpensiveActivity: string | null;
+  topModel: string | null;
+  generatedAt: string;
+}
+
+interface DashboardData {
+  summary: Summary;
+  activityBreakdown: ActivityRow[];
+  modelBreakdown: ModelRow[];
+  recentEvents: EventRow[];
+  warnings: string[];
+}
+
+const RANGE_OPTIONS: Array<{ value: CostRange; label: string }> = [
+  { value: "24h", label: "Last 24h" },
+  { value: "5d", label: "Last 5 days" },
+  { value: "30d", label: "Last month" },
+  { value: "all", label: "All time" },
+];
+
+const ACTIVITIES = [
+  "query_letter",
+  "what_makes_unique",
+  "synopsis",
+  "query_pitch",
+  "comparables",
+  "author_bio",
+  "final_package",
+];
+
+const fmtUsd = formatUsdFromCents;
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function activityLabel(key: string): string {
+  const map: Record<string, string> = {
+    query_letter: "Query Letter",
+    what_makes_unique: "What Makes Novel Unique",
+    synopsis: "Synopsis",
+    query_pitch: "Query Pitch",
+    comparables: "Comparables",
+    author_bio: "Author Bio",
+    final_package: "Final Package",
+  };
+  return map[key] ?? key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function AgentReadinessCostPage() {
+  const [range, setRange] = useState<CostRange>("24h");
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(`/api/admin/costs/agent-readiness?range=${range}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.message ?? "Failed to fetch data");
+      setData(json.data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const id = setInterval(fetchData, 120_000);
+    return () => clearInterval(id);
+  }, [autoRefresh, fetchData]);
+
+  if (loading && !data) {
+    return <main className="min-h-screen bg-rg-ink px-6 py-10 text-rg-cream"><div className="mx-auto max-w-6xl animate-pulse">Loading Agent Readiness costs…</div></main>;
+  }
+
+  if (error && !data) {
+    return (
+      <main className="min-h-screen bg-rg-ink px-6 py-10 text-rg-cream">
+        <div className="mx-auto max-w-6xl rounded-lg border border-red-500/40 bg-red-900/20 p-6">
+          <h2 className="text-lg font-semibold text-red-300">Error</h2>
+          <p className="mt-2 text-sm text-red-300/80">{error}</p>
+          <button onClick={fetchData} className="mt-4 rounded border border-rg-gold/40 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-gold">Retry</button>
+        </div>
+      </main>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, activityBreakdown, modelBreakdown, recentEvents, warnings } = data;
+
+  return (
+    <main className="min-h-screen bg-rg-ink px-4 py-8 text-rg-cream sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl space-y-8">
+
+        <header className="space-y-3">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">CostOps · Admin Only</p>
+          <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
+            <div>
+              <h1 className="font-rg-serif text-3xl font-semibold sm:text-4xl">Agent Readiness Costs</h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-rg-cream2/70">
+                LLM spend for Agent Readiness Package™ auto-generation: query letters, synopses, comparables, author bio, query pitch, and unique differentiator. No manuscript or letter text is stored here.
+              </p>
+              <p className="mt-1 font-rg-mono text-[10px] text-rg-cream2/40">Generated {fmtTime(summary.generatedAt)}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-rg-cream2/60">
+                <input type="checkbox" checked={autoRefresh} onChange={(e) => setAutoRefresh(e.target.checked)} className="rounded" />
+                Auto-refresh
+              </label>
+              <button onClick={fetchData} disabled={loading} className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60 disabled:opacity-40">
+                {loading ? "Loading…" : "Refresh"}
+              </button>
+              <Link href="/admin/costs" className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60">← CostOps</Link>
+              <Link href="/admin" className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60">Admin</Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="flex flex-wrap gap-2">
+          {RANGE_OPTIONS.map((opt) => (
+            <button key={opt.value} onClick={() => setRange(opt.value)}
+              className={`rounded border px-4 py-2 font-rg-mono text-xs uppercase tracking-wider transition ${range === opt.value ? "border-rg-gold bg-rg-gold/15 text-rg-gold" : "border-rg-cream2/20 text-rg-cream2 hover:border-rg-gold/60"}`}>
+              {opt.label}
+            </button>
+          ))}
+        </section>
+
+        {warnings.length > 0 && warnings.map((w, i) => (
+          <div key={i} className="rounded-lg border border-amber-500/30 bg-amber-900/20 p-4 text-sm text-amber-300">{w}</div>
+        ))}
+
+        {summary.totalCallCount === 0 && (
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-6 text-center">
+            <p className="text-sm text-rg-cream2/60">No Agent Readiness cost events recorded for this range.</p>
+            <p className="mt-2 text-xs text-rg-cream2/40">
+              Costs are captured when auto-generate is used. Events post to <code className="font-rg-mono">/api/costs/events</code> after each successful generation.
+            </p>
+          </div>
+        )}
+
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <KpiCard label={`${summary.rangeLabel} Total`} value={fmtUsd(summary.totalCostCents)} highlight />
+          <KpiCard label="Total LLM Calls" value={summary.totalCallCount.toLocaleString()} />
+          <KpiCard label="Activities Tracked" value={summary.uniqueActivities.toLocaleString()} />
+          <KpiCard label="Top Model" value={summary.topModel ?? "—"} />
+        </section>
+
+        <section>
+          <h2 className="mb-4 font-rg-serif text-xl text-rg-cream">Spend by Package Section</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {ACTIVITIES.map((key) => {
+              const row = activityBreakdown.find((r) => r.activity === key);
+              return (
+                <div key={key} className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-4">
+                  <div className="font-rg-mono text-[10px] uppercase tracking-wider text-rg-gold/80">{activityLabel(key)}</div>
+                  <div className="mt-2 font-rg-serif text-2xl font-semibold text-rg-gold">{fmtUsd(row?.costCents ?? 0)}</div>
+                  <div className="mt-2 grid grid-cols-2 gap-1 text-xs text-rg-cream2/55">
+                    <span>Calls: {row?.callCount ?? 0}</span>
+                    <span>Avg: {fmtUsd(row?.avgCostPerCallCents ?? 0)}</span>
+                    <span>In: {fmtTokens(row?.inputTokens ?? 0)}</span>
+                    <span>Out: {fmtTokens(row?.outputTokens ?? 0)}</span>
+                  </div>
+                  {row?.lastCalledAt && <p className="mt-2 text-[10px] text-rg-cream2/35">Last: {fmtTime(row.lastCalledAt)}</p>}
+                </div>
+              );
+            })}
+            {activityBreakdown.filter((r) => !ACTIVITIES.includes(r.activity)).map((row) => (
+              <div key={row.activity} className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-4">
+                <div className="font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/60">{activityLabel(row.activity)}</div>
+                <div className="mt-2 font-rg-serif text-2xl font-semibold text-rg-gold">{fmtUsd(row.costCents)}</div>
+                <div className="mt-2 text-xs text-rg-cream2/55">Calls: {row.callCount}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <h2 className="mb-3 font-rg-serif text-lg text-rg-cream">Spend by Model</h2>
+            <table className="min-w-full text-left text-sm">
+              <thead><tr className="border-b border-rg-cream2/10">{["Model", "Calls", "Input", "Output", "Total", "Avg/Call"].map((h) => <th key={h} className="px-3 py-2 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+              <tbody className="divide-y divide-rg-cream2/5">
+                {modelBreakdown.map((row) => (
+                  <tr key={row.model} className="hover:bg-rg-ink2/50">
+                    <td className="px-3 py-2 font-rg-mono text-xs font-medium text-rg-cream">{row.model}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{row.callCount}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.inputTokens)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.outputTokens)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(row.costCents)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs text-rg-cream2/55">{fmtUsd(row.avgCostPerCallCents)}</td>
+                  </tr>
+                ))}
+                {modelBreakdown.length === 0 && <tr><td colSpan={6} className="px-3 py-6 text-center text-sm text-rg-cream2/40">No data.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <h2 className="mb-3 font-rg-serif text-lg text-rg-cream">All Activity Rows</h2>
+            <table className="min-w-full text-left text-sm">
+              <thead><tr className="border-b border-rg-cream2/10">{["Activity", "Calls", "Spend", "Last"].map((h) => <th key={h} className="px-3 py-2 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+              <tbody className="divide-y divide-rg-cream2/5">
+                {activityBreakdown.map((row) => (
+                  <tr key={row.activity} className="hover:bg-rg-ink2/50">
+                    <td className="px-3 py-2 text-xs font-medium text-rg-cream">{activityLabel(row.activity)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{row.callCount}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(row.costCents)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/40">{fmtTime(row.lastCalledAt)}</td>
+                  </tr>
+                ))}
+                {activityBreakdown.length === 0 && <tr><td colSpan={4} className="px-3 py-6 text-center text-sm text-rg-cream2/40">No activity recorded.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {recentEvents.length > 0 && (
+          <section>
+            <h2 className="mb-3 font-rg-serif text-xl text-rg-cream">Recent Events</h2>
+            <div className="overflow-x-auto rounded-lg border border-rg-cream2/15 bg-rg-ink2/70">
+              <table className="min-w-full text-left text-sm">
+                <thead><tr className="border-b border-rg-cream2/10">{["Activity", "Model", "Input", "Output", "Cost", "Eval Job", "Time"].map((h) => <th key={h} className="px-4 py-3 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+                <tbody className="divide-y divide-rg-cream2/5">
+                  {recentEvents.slice(0, 50).map((ev) => (
+                    <tr key={ev.id} className="hover:bg-rg-ink2/50">
+                      <td className="px-4 py-3 text-xs text-rg-cream">{activityLabel(ev.activity)}</td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-cream2/70">{ev.model}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/55">{fmtTokens(ev.inputTokens)}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/55">{fmtTokens(ev.outputTokens)}</td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-gold">{fmtUsd(ev.costCents)}</td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-cream2/40">{ev.evaluationJobId ? ev.evaluationJobId.slice(0, 8) + "…" : "—"}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/40">{fmtTime(ev.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function KpiCard({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className={`rounded-lg border p-5 ${highlight ? "border-rg-gold/30 bg-rg-ink2/90" : "border-rg-cream2/15 bg-rg-ink2/70"}`}>
+      <div className="font-rg-mono text-[10px] uppercase tracking-[0.18em] text-rg-cream2/50">{label}</div>
+      <div className="mt-2 font-rg-serif text-2xl font-semibold text-rg-gold">{value}</div>
+    </div>
+  );
+}

--- a/app/admin/costs/page.tsx
+++ b/app/admin/costs/page.tsx
@@ -93,6 +93,11 @@ interface CostOpsDashboardData {
   providerStatus: CostOpsProviderStatus[];
   alerts: CostOpsAlert[];
   warnings: string[];
+  nonEvalSpend?: {
+    agentReadinessCents: number;
+    reviseQueueCents: number;
+    totalNonEvalCents: number;
+  };
 }
 
 const RANGE_OPTIONS: Array<{ value: CostRange; label: string }> = [
@@ -192,7 +197,7 @@ export default function CostOpsDashboardPage() {
 
   if (!data) return null;
 
-  const { summary, providerCosts, modelBreakdown, phaseBreakdown, recentJobs, alerts, providerStatus, warnings } = data;
+  const { summary, providerCosts, modelBreakdown, phaseBreakdown, recentJobs, alerts, providerStatus, warnings, nonEvalSpend } = data;
 
   return (
     <main className="min-h-screen bg-rg-ink px-4 py-8 text-rg-cream sm:px-6 lg:px-8">
@@ -280,6 +285,43 @@ export default function CostOpsDashboardPage() {
         </section>
 
         <EvaluationModelRoutingPanel />
+
+        {/* ── Non-evaluation spend rollup ── */}
+        {nonEvalSpend && nonEvalSpend.totalNonEvalCents >= 0 && (
+          <section>
+            <h2 className="mb-3 font-rg-serif text-xl text-rg-cream">Non-Evaluation LLM Spend</h2>
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-rg-cream">Agent Readiness</h3>
+                  <span className="font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(nonEvalSpend.agentReadinessCents)}</span>
+                </div>
+                <p className="mt-2 text-xs text-rg-cream2/55">Query letters, synopses, comparables, bio, pitch auto-generation.</p>
+                <Link href="/admin/costs/agent-readiness" className="mt-3 inline-block font-rg-mono text-xs uppercase tracking-wider text-rg-gold hover:underline">View Ledger →</Link>
+              </div>
+              <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-rg-cream">Revise Queue</h3>
+                  <span className="font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(nonEvalSpend.reviseQueueCents)}</span>
+                </div>
+                <p className="mt-2 text-xs text-rg-cream2/55">Pass 4 voice-conditioned rewrites: A/B/C candidates and TrustedPath™.</p>
+                <Link href="/admin/costs/revise-queue" className="mt-3 inline-block font-rg-mono text-xs uppercase tracking-wider text-rg-gold hover:underline">View Ledger →</Link>
+              </div>
+              <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/90 p-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-rg-cream">Combined Non-Eval</h3>
+                  <span className="font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(nonEvalSpend.totalNonEvalCents)}</span>
+                </div>
+                <p className="mt-2 text-xs text-rg-cream2/55">
+                  Evaluation pipeline spend: {fmtUsd(summary.selectedRange.usageCents)}
+                  {nonEvalSpend.totalNonEvalCents > 0 && (
+                    <> · Total including non-eval: {fmtUsd(summary.selectedRange.usageCents + nonEvalSpend.totalNonEvalCents)}</>
+                  )}
+                </p>
+              </div>
+            </div>
+          </section>
+        )}
 
         <section>
           <h2 className="mb-3 font-rg-serif text-xl text-rg-cream">Cost Sources</h2>

--- a/app/admin/costs/revise-queue/page.tsx
+++ b/app/admin/costs/revise-queue/page.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { formatUsdFromCents } from "@/lib/admin/formatMoney";
+
+type CostRange = "24h" | "5d" | "30d" | "all";
+
+interface ActivityRow {
+  activity: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+  lastCalledAt: string | null;
+}
+
+interface ModelRow {
+  model: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+}
+
+interface EventRow {
+  id: string;
+  createdAt: string;
+  activity: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  userId: string | null;
+  evaluationJobId: string | null;
+  manuscriptId: number | null;
+  metadata: Record<string, unknown>;
+}
+
+interface Summary {
+  range: CostRange;
+  rangeLabel: string;
+  totalCostCents: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCallCount: number;
+  uniqueActivities: number;
+  mostExpensiveActivity: string | null;
+  topModel: string | null;
+  generatedAt: string;
+}
+
+interface DashboardData {
+  summary: Summary;
+  activityBreakdown: ActivityRow[];
+  modelBreakdown: ModelRow[];
+  recentEvents: EventRow[];
+  warnings: string[];
+}
+
+const RANGE_OPTIONS: Array<{ value: CostRange; label: string }> = [
+  { value: "24h", label: "Last 24h" },
+  { value: "5d", label: "Last 5 days" },
+  { value: "30d", label: "Last month" },
+  { value: "all", label: "All time" },
+];
+
+const ACTIVITIES = [
+  { key: "pass4_rewrite", label: "Voice Rewrite (Pass 4)" },
+  { key: "pass4_trusted_path", label: "TrustedPath™ Rewrite" },
+  { key: "pass4_voice_rewrite", label: "Pass 4 Voice Rewrite" },
+  { key: "pass4_voice_rewrite_trusted_path", label: "Pass 4 TrustedPath" },
+];
+
+const fmtUsd = formatUsdFromCents;
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function activityLabel(key: string): string {
+  const match = ACTIVITIES.find((a) => a.key === key);
+  if (match) return match.label;
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function trustedBadge(metadata: Record<string, unknown>): boolean {
+  return metadata?.trusted_path === true;
+}
+
+export default function ReviseQueueCostPage() {
+  const [range, setRange] = useState<CostRange>("24h");
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(`/api/admin/costs/revise-queue?range=${range}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.message ?? "Failed to fetch data");
+      setData(json.data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const id = setInterval(fetchData, 120_000);
+    return () => clearInterval(id);
+  }, [autoRefresh, fetchData]);
+
+  if (loading && !data) {
+    return <main className="min-h-screen bg-rg-ink px-6 py-10 text-rg-cream"><div className="mx-auto max-w-6xl animate-pulse">Loading Revise Queue costs…</div></main>;
+  }
+
+  if (error && !data) {
+    return (
+      <main className="min-h-screen bg-rg-ink px-6 py-10 text-rg-cream">
+        <div className="mx-auto max-w-6xl rounded-lg border border-red-500/40 bg-red-900/20 p-6">
+          <h2 className="text-lg font-semibold text-red-300">Error</h2>
+          <p className="mt-2 text-sm text-red-300/80">{error}</p>
+          <button onClick={fetchData} className="mt-4 rounded border border-rg-gold/40 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-gold">Retry</button>
+        </div>
+      </main>
+    );
+  }
+
+  if (!data) return null;
+
+  const { summary, activityBreakdown, modelBreakdown, recentEvents, warnings } = data;
+
+  const pass4Total = activityBreakdown.reduce((sum, r) => sum + r.costCents, 0);
+  const trustedPathCount = recentEvents.filter((ev) => trustedBadge(ev.metadata)).length;
+  const standardCount = recentEvents.filter((ev) => !trustedBadge(ev.metadata)).length;
+
+  return (
+    <main className="min-h-screen bg-rg-ink px-4 py-8 text-rg-cream sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl space-y-8">
+
+        <header className="space-y-3">
+          <p className="font-rg-mono text-xs uppercase tracking-[0.24em] text-rg-gold">CostOps · Admin Only</p>
+          <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
+            <div>
+              <h1 className="font-rg-serif text-3xl font-semibold sm:text-4xl">Revise Queue Costs</h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-rg-cream2/70">
+                LLM spend for Pass 4 voice-conditioned rewrites: standard A/B/C candidates and TrustedPath™ single-candidate rewrites. No manuscript text or passage content is stored here.
+              </p>
+              <p className="mt-1 font-rg-mono text-[10px] text-rg-cream2/40">Generated {fmtTime(summary.generatedAt)}</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-2 text-xs text-rg-cream2/60">
+                <input type="checkbox" checked={autoRefresh} onChange={(e) => setAutoRefresh(e.target.checked)} className="rounded" />
+                Auto-refresh
+              </label>
+              <button onClick={fetchData} disabled={loading} className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60 disabled:opacity-40">
+                {loading ? "Loading…" : "Refresh"}
+              </button>
+              <Link href="/admin/costs" className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60">← CostOps</Link>
+              <Link href="/admin" className="rounded border border-rg-cream2/20 px-4 py-2 font-rg-mono text-xs uppercase tracking-wider text-rg-cream2 transition hover:border-rg-gold/60">Admin</Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="flex flex-wrap gap-2">
+          {RANGE_OPTIONS.map((opt) => (
+            <button key={opt.value} onClick={() => setRange(opt.value)}
+              className={`rounded border px-4 py-2 font-rg-mono text-xs uppercase tracking-wider transition ${range === opt.value ? "border-rg-gold bg-rg-gold/15 text-rg-gold" : "border-rg-cream2/20 text-rg-cream2 hover:border-rg-gold/60"}`}>
+              {opt.label}
+            </button>
+          ))}
+        </section>
+
+        {warnings.length > 0 && warnings.map((w, i) => (
+          <div key={i} className="rounded-lg border border-amber-500/30 bg-amber-900/20 p-4 text-sm text-amber-300">{w}</div>
+        ))}
+
+        {summary.totalCallCount === 0 && (
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-6 text-center">
+            <p className="text-sm text-rg-cream2/60">No Revise Queue cost events recorded for this range.</p>
+            <p className="mt-2 text-xs text-rg-cream2/40">
+              Costs are captured from <code className="font-rg-mono">/api/revise/generate-rewrite</code> via <code className="font-rg-mono">recordLlmCostEvent</code>.
+            </p>
+          </div>
+        )}
+
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          <KpiCard label={`${summary.rangeLabel} Total`} value={fmtUsd(pass4Total)} highlight />
+          <KpiCard label="Total Rewrites" value={summary.totalCallCount.toLocaleString()} />
+          <KpiCard label="TrustedPath™" value={trustedPathCount.toLocaleString()} />
+          <KpiCard label="Standard (A/B/C)" value={standardCount.toLocaleString()} />
+          <KpiCard label="Top Model" value={summary.topModel ?? "—"} />
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <h2 className="mb-3 font-rg-serif text-lg text-rg-cream">Spend by Rewrite Mode</h2>
+            <table className="min-w-full text-left text-sm">
+              <thead><tr className="border-b border-rg-cream2/10">{["Mode", "Calls", "Input", "Output", "Total", "Avg"].map((h) => <th key={h} className="px-3 py-2 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+              <tbody className="divide-y divide-rg-cream2/5">
+                {activityBreakdown.map((row) => (
+                  <tr key={row.activity} className="hover:bg-rg-ink2/50">
+                    <td className="px-3 py-2 text-xs font-medium text-rg-cream">{activityLabel(row.activity)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{row.callCount}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.inputTokens)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.outputTokens)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(row.costCents)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs text-rg-cream2/55">{fmtUsd(row.avgCostPerCallCents)}</td>
+                  </tr>
+                ))}
+                {activityBreakdown.length === 0 && <tr><td colSpan={6} className="px-3 py-6 text-center text-sm text-rg-cream2/40">No data.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="rounded-lg border border-rg-cream2/15 bg-rg-ink2/70 p-5">
+            <h2 className="mb-3 font-rg-serif text-lg text-rg-cream">Spend by Model</h2>
+            <table className="min-w-full text-left text-sm">
+              <thead><tr className="border-b border-rg-cream2/10">{["Model", "Calls", "Input", "Output", "Total", "Avg"].map((h) => <th key={h} className="px-3 py-2 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+              <tbody className="divide-y divide-rg-cream2/5">
+                {modelBreakdown.map((row) => (
+                  <tr key={row.model} className="hover:bg-rg-ink2/50">
+                    <td className="px-3 py-2 font-rg-mono text-xs font-medium text-rg-cream">{row.model}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{row.callCount}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.inputTokens)}</td>
+                    <td className="px-3 py-2 text-xs text-rg-cream2/60">{fmtTokens(row.outputTokens)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs font-semibold text-rg-gold">{fmtUsd(row.costCents)}</td>
+                    <td className="px-3 py-2 font-rg-mono text-xs text-rg-cream2/55">{fmtUsd(row.avgCostPerCallCents)}</td>
+                  </tr>
+                ))}
+                {modelBreakdown.length === 0 && <tr><td colSpan={6} className="px-3 py-6 text-center text-sm text-rg-cream2/40">No data.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {recentEvents.length > 0 && (
+          <section>
+            <h2 className="mb-3 font-rg-serif text-xl text-rg-cream">Recent Rewrites</h2>
+            <div className="overflow-x-auto rounded-lg border border-rg-cream2/15 bg-rg-ink2/70">
+              <table className="min-w-full text-left text-sm">
+                <thead><tr className="border-b border-rg-cream2/10">{["Mode", "Model", "Input", "Output", "Cost", "Eval Job", "Op", "Time"].map((h) => <th key={h} className="px-4 py-3 font-rg-mono text-[10px] uppercase tracking-wider text-rg-cream2/50">{h}</th>)}</tr></thead>
+                <tbody className="divide-y divide-rg-cream2/5">
+                  {recentEvents.slice(0, 50).map((ev) => (
+                    <tr key={ev.id} className="hover:bg-rg-ink2/50">
+                      <td className="px-4 py-3 text-xs text-rg-cream">
+                        {trustedBadge(ev.metadata)
+                          ? <span className="rounded border border-rg-gold/30 px-2 py-0.5 font-rg-mono text-[10px] text-rg-gold">TrustedPath™</span>
+                          : <span className="text-rg-cream2/80">A/B/C</span>}
+                      </td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-cream2/70">{ev.model}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/55">{fmtTokens(ev.inputTokens)}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/55">{fmtTokens(ev.outputTokens)}</td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-gold">{fmtUsd(ev.costCents)}</td>
+                      <td className="px-4 py-3 font-rg-mono text-xs text-rg-cream2/40">{ev.evaluationJobId ? ev.evaluationJobId.slice(0, 8) + "…" : "—"}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/50">{String(ev.metadata?.operation ?? "—")}</td>
+                      <td className="px-4 py-3 text-xs text-rg-cream2/40">{fmtTime(ev.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function KpiCard({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className={`rounded-lg border p-5 ${highlight ? "border-rg-gold/30 bg-rg-ink2/90" : "border-rg-cream2/15 bg-rg-ink2/70"}`}>
+      <div className="font-rg-mono text-[10px] uppercase tracking-[0.18em] text-rg-cream2/50">{label}</div>
+      <div className="mt-2 font-rg-serif text-2xl font-semibold text-rg-gold">{value}</div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -62,7 +62,7 @@ const costCards = [
     href: "/admin/costs",
     eyebrow: "Spend · budgets · alerts",
     description:
-      "LLM spend telemetry, model/phase cost breakdowns, budget tracking, and spend alerts.",
+      "LLM spend telemetry, model/phase cost breakdowns, budget tracking, and spend alerts. Includes rollup from evaluation, Agent Readiness, and Revise Queue.",
     priority: "Operations",
   },
   {
@@ -71,6 +71,22 @@ const costCards = [
     eyebrow: "Per-job · per-phase · per-model",
     description:
       "Inspect the dedicated evaluation cost ledger for each job, including phase-level spend, model usage, and routing warnings.",
+    priority: "Operations",
+  },
+  {
+    title: "Agent Readiness Costs",
+    href: "/admin/costs/agent-readiness",
+    eyebrow: "Query letter · synopsis · bio · comps",
+    description:
+      "LLM spend for Agent Readiness Package™ auto-generation: query letters, synopses, comparables, author bio, and pitch. No manuscript text is stored.",
+    priority: "Operations",
+  },
+  {
+    title: "Revise Queue Costs",
+    href: "/admin/costs/revise-queue",
+    eyebrow: "Pass 4 · TrustedPath™ · A/B/C rewrites",
+    description:
+      "LLM spend for voice-conditioned Pass 4 rewrites: standard A/B/C candidates and TrustedPath™ single-candidate rewrites. No passage text is stored.",
     priority: "Operations",
   },
 ];
@@ -143,11 +159,10 @@ export default async function AdminDashboard() {
           <div>
             <h2 className="font-rg-serif text-xl text-rg-cream">Cost modules</h2>
             <p className="mt-1 text-sm text-rg-cream2/60">
-              Spend oversight is split into the general CostOps dashboard and the dedicated
-              evaluation cost ledger.
+              Spend oversight is split across evaluation jobs, Agent Readiness package generation, and Revise Queue rewrites.
             </p>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {costCards.map((card) => (
               <Link
                 key={card.href}

--- a/app/api/admin/costs/agent-readiness/route.ts
+++ b/app/api/admin/costs/agent-readiness/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/admin/costs/agent-readiness?range=24h|5d|30d|all
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/requireAdmin";
+import { getLlmEventDashboardData } from "@/lib/admin/costopsLlmEvents";
+
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  try {
+    const range = request.nextUrl.searchParams.get("range");
+    const data = await getLlmEventDashboardData("agent_readiness", range);
+
+    return NextResponse.json({
+      success: true,
+      data,
+      meta: { fetchedAt: new Date().toISOString() },
+    });
+  } catch (error) {
+    console.error("[costops/agent-readiness] Error:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to fetch Agent Readiness cost data",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/admin/costs/revise-queue/route.ts
+++ b/app/api/admin/costs/revise-queue/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/admin/costs/revise-queue?range=24h|5d|30d|all
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin/requireAdmin";
+import { getLlmEventDashboardData } from "@/lib/admin/costopsLlmEvents";
+
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  try {
+    const range = request.nextUrl.searchParams.get("range");
+    const data = await getLlmEventDashboardData("revise_queue", range);
+
+    return NextResponse.json({
+      success: true,
+      data,
+      meta: { fetchedAt: new Date().toISOString() },
+    });
+  } catch (error) {
+    console.error("[costops/revise-queue] Error:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Failed to fetch Revise Queue cost data",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/costs/events/route.ts
+++ b/app/api/costs/events/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/lib/supabase/server";
+import { recordLlmCostEvent } from "@/lib/cost/llmCostEvents";
+
+export async function POST(req: Request) {
+  try {
+    const user = await getAuthenticatedUser();
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const source = body?.source as "agent_readiness" | "revise_queue" | "evaluation" | undefined;
+    const activity = typeof body?.activity === "string" ? body.activity : "";
+    const model = typeof body?.model === "string" ? body.model : "";
+
+    if (!source || !activity || !model) {
+      return NextResponse.json(
+        { ok: false, error: "Missing required fields: source, activity, model" },
+        { status: 400 },
+      );
+    }
+
+    await recordLlmCostEvent({
+      source,
+      activity,
+      model,
+      inputTokens: Number(body?.inputTokens ?? 0),
+      outputTokens: Number(body?.outputTokens ?? 0),
+      costCents: typeof body?.costCents === "number" ? body.costCents : null,
+      userId: user.id,
+      evaluationJobId: typeof body?.evaluationJobId === "string" ? body.evaluationJobId : null,
+      manuscriptId: typeof body?.manuscriptId === "number" ? body.manuscriptId : null,
+      metadata: typeof body?.metadata === "object" && body.metadata !== null ? body.metadata : undefined,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Failed to record cost event",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/revise/generate-rewrite/route.ts
+++ b/app/api/revise/generate-rewrite/route.ts
@@ -5,6 +5,7 @@ import {
   runPass4VoiceRewrite,
   extractVoiceContext,
 } from "@/lib/revision/runPass4VoiceRewrite";
+import { recordLlmCostEvent } from "@/lib/cost/llmCostEvents";
 
 /**
  * POST /api/revise/generate-rewrite
@@ -83,6 +84,8 @@ export async function POST(req: Request) {
 
     const voiceContext = extractVoiceContext(manuscriptText, originalPassage, 300);
 
+    const activity = trustedPath ? "pass4_trusted_path" : "pass4_rewrite";
+
     const result = await runPass4VoiceRewrite(
       {
         originalPassage,
@@ -100,6 +103,22 @@ export async function POST(req: Request) {
         phase: trustedPath ? "pass4_voice_rewrite_trusted_path" : "pass4_voice_rewrite",
       },
     );
+
+    // Fire-and-forget — cost capture must not block the rewrite response
+    recordLlmCostEvent({
+      source: "revise_queue",
+      activity,
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      userId: user.id,
+      evaluationJobId: evaluationJobId ?? null,
+      manuscriptId: typeof manuscriptId === "number" ? manuscriptId : null,
+      metadata: {
+        trusted_path: !!trustedPath,
+        operation: operation ?? null,
+      },
+    }).catch(() => {});
 
     return NextResponse.json({
       ok: true,

--- a/lib/admin/costops.ts
+++ b/lib/admin/costops.ts
@@ -9,6 +9,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { resolveTrackedCostCents } from "@/lib/jobs/cost";
 import { formatUsdFromCents } from "@/lib/admin/formatMoney";
+import { getLlmEventRollup } from "@/lib/admin/costopsLlmEvents";
 
 export type CostOpsSeverity = "ok" | "watch" | "danger" | "unknown";
 export type CostOpsRange = "24h" | "5d" | "30d" | "all";
@@ -145,6 +146,12 @@ export interface CostOpsDashboardData {
   providerStatus: CostOpsProviderStatus[];
   alerts: CostOpsAlert[];
   warnings: string[];
+  /** Rollup spend totals from llm_cost_events (non-evaluation sources). */
+  nonEvalSpend: {
+    agentReadinessCents: number;
+    reviseQueueCents: number;
+    totalNonEvalCents: number;
+  };
 }
 
 interface RawCostRow {
@@ -572,6 +579,19 @@ export async function getCostOpsDashboardData(rangeInput?: string | null): Promi
     warnings.push("All-time view includes exact tracked LLM costs only; monthly overhead allocations apply to time-bounded ranges.");
   }
 
+  // ── Non-evaluation rollup from llm_cost_events ───────────────────────────
+  let agentReadinessCents = 0;
+  let reviseQueueCents = 0;
+  try {
+    const rollup = await getLlmEventRollup(rangeInput);
+    for (const row of rollup) {
+      if (row.source === "agent_readiness") agentReadinessCents = row.totalCostCents;
+      else if (row.source === "revise_queue") reviseQueueCents = row.totalCostCents;
+    }
+  } catch {
+    warnings.push("Could not fetch Agent Readiness / Revise Queue cost rollup from llm_cost_events.");
+  }
+
   const alerts = buildAlerts({
     selectedTotalCents,
     mtdTotalCents,
@@ -591,6 +611,11 @@ export async function getCostOpsDashboardData(rangeInput?: string | null): Promi
     providerStatus: getProviderStatus(),
     alerts,
     warnings,
+    nonEvalSpend: {
+      agentReadinessCents,
+      reviseQueueCents,
+      totalNonEvalCents: agentReadinessCents + reviseQueueCents,
+    },
   };
 }
 

--- a/lib/admin/costopsLlmEvents.ts
+++ b/lib/admin/costopsLlmEvents.ts
@@ -1,0 +1,306 @@
+/**
+ * CostOps — llm_cost_events data layer
+ *
+ * Queries the llm_cost_events table to support dedicated admin pages for
+ * Agent Readiness and Revise Queue cost tracking, plus rollup totals for
+ * the main CostOps dashboard.
+ *
+ * Privacy: raw text content (manuscripts, queries, synopses, bios) is
+ * never stored in llm_cost_events. Only cost telemetry is persisted.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+import { resolveTrackedCostCents } from "@/lib/jobs/cost";
+import { getCostRangeWindow, normalizeCostRange, type CostOpsRange } from "./costops";
+
+export type LlmEventSource = "agent_readiness" | "revise_queue" | "evaluation";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LlmCostEventRow {
+  id: string;
+  createdAt: string;
+  source: LlmEventSource;
+  activity: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  userId: string | null;
+  evaluationJobId: string | null;
+  manuscriptId: number | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface LlmEventActivityRow {
+  activity: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+  lastCalledAt: string | null;
+}
+
+export interface LlmEventModelRow {
+  model: string;
+  callCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  costCents: number;
+  avgCostPerCallCents: number;
+}
+
+export interface LlmEventSummary {
+  source: LlmEventSource;
+  range: CostOpsRange;
+  rangeLabel: string;
+  rangeStart: string | null;
+  rangeEnd: string;
+  totalCostCents: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCallCount: number;
+  uniqueActivities: number;
+  mostExpensiveActivity: string | null;
+  topModel: string | null;
+  generatedAt: string;
+}
+
+export interface LlmEventDashboardData {
+  summary: LlmEventSummary;
+  activityBreakdown: LlmEventActivityRow[];
+  modelBreakdown: LlmEventModelRow[];
+  recentEvents: LlmCostEventRow[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface RawEventRow {
+  id: string;
+  created_at: string;
+  source: string;
+  activity: string;
+  model: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost_cents: string | number | null;
+  user_id: string | null;
+  evaluation_job_id: string | null;
+  manuscript_id: number | null;
+  metadata: Record<string, unknown> | null;
+}
+
+function safeNum(v: unknown, fallback = 0): number {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const parsed = Number(v);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function rowCost(row: RawEventRow): number {
+  return resolveTrackedCostCents({
+    model: row.model,
+    inputTokens: safeNum(row.input_tokens),
+    outputTokens: safeNum(row.output_tokens),
+    recordedCostCents: safeNum(row.cost_cents),
+  });
+}
+
+async function fetchEvents(source: LlmEventSource, start: string | null): Promise<RawEventRow[]> {
+  const supabase = createAdminClient();
+  const rows: RawEventRow[] = [];
+  let from = 0;
+  const pageSize = 1000;
+
+  while (true) {
+    let query = supabase
+      .from("llm_cost_events")
+      .select("id, created_at, source, activity, model, input_tokens, output_tokens, cost_cents, user_id, evaluation_job_id, manuscript_id, metadata")
+      .eq("source", source)
+      .order("created_at", { ascending: false })
+      .range(from, from + pageSize - 1);
+
+    if (start) query = query.gte("created_at", start);
+
+    const { data, error } = await query;
+    if (error) throw new Error(`llm_cost_events fetch error: ${error.message}`);
+    if (!data || data.length === 0) break;
+    rows.push(...(data as RawEventRow[]));
+    if (data.length < pageSize) break;
+    from += pageSize;
+  }
+
+  return rows;
+}
+
+function buildActivityBreakdown(rows: RawEventRow[]): LlmEventActivityRow[] {
+  const map = new Map<string, { calls: number; inTok: number; outTok: number; cost: number; lastAt: string | null }>();
+
+  for (const row of rows) {
+    const activity = row.activity ?? "unknown";
+    const entry = map.get(activity) ?? { calls: 0, inTok: 0, outTok: 0, cost: 0, lastAt: null };
+    entry.calls += 1;
+    entry.inTok += safeNum(row.input_tokens);
+    entry.outTok += safeNum(row.output_tokens);
+    entry.cost += rowCost(row);
+    if (row.created_at && (!entry.lastAt || row.created_at > entry.lastAt)) entry.lastAt = row.created_at;
+    map.set(activity, entry);
+  }
+
+  return [...map.entries()]
+    .map(([activity, e]) => ({
+      activity,
+      callCount: e.calls,
+      inputTokens: e.inTok,
+      outputTokens: e.outTok,
+      costCents: e.cost,
+      avgCostPerCallCents: e.calls > 0 ? e.cost / e.calls : 0,
+      lastCalledAt: e.lastAt,
+    }))
+    .sort((a, b) => b.costCents - a.costCents);
+}
+
+function buildModelBreakdown(rows: RawEventRow[]): LlmEventModelRow[] {
+  const map = new Map<string, { calls: number; inTok: number; outTok: number; cost: number }>();
+
+  for (const row of rows) {
+    const model = row.model ?? "unknown";
+    const entry = map.get(model) ?? { calls: 0, inTok: 0, outTok: 0, cost: 0 };
+    entry.calls += 1;
+    entry.inTok += safeNum(row.input_tokens);
+    entry.outTok += safeNum(row.output_tokens);
+    entry.cost += rowCost(row);
+    map.set(model, entry);
+  }
+
+  return [...map.entries()]
+    .map(([model, e]) => ({
+      model,
+      callCount: e.calls,
+      inputTokens: e.inTok,
+      outputTokens: e.outTok,
+      costCents: e.cost,
+      avgCostPerCallCents: e.calls > 0 ? e.cost / e.calls : 0,
+    }))
+    .sort((a, b) => b.costCents - a.costCents);
+}
+
+function toPublicRow(row: RawEventRow): LlmCostEventRow {
+  return {
+    id: row.id,
+    createdAt: row.created_at,
+    source: row.source as LlmEventSource,
+    activity: row.activity,
+    model: row.model,
+    inputTokens: safeNum(row.input_tokens),
+    outputTokens: safeNum(row.output_tokens),
+    costCents: rowCost(row),
+    userId: row.user_id,
+    evaluationJobId: row.evaluation_job_id,
+    manuscriptId: row.manuscript_id,
+    metadata: row.metadata ?? {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function getLlmEventDashboardData(
+  source: LlmEventSource,
+  rangeInput?: string | null,
+): Promise<LlmEventDashboardData> {
+  const warnings: string[] = [];
+  const now = new Date();
+  const range = normalizeCostRange(rangeInput);
+  const rangeWindow = getCostRangeWindow(range, now);
+
+  let rows: RawEventRow[] = [];
+  try {
+    rows = await fetchEvents(source, rangeWindow.start);
+  } catch (err) {
+    warnings.push(`Failed to fetch llm_cost_events: ${err instanceof Error ? err.message : "Unknown error"}`);
+  }
+
+  const activityBreakdown = buildActivityBreakdown(rows);
+  const modelBreakdown = buildModelBreakdown(rows);
+  const totalCostCents = rows.reduce((sum, row) => sum + rowCost(row), 0);
+  const totalInputTokens = rows.reduce((sum, row) => sum + safeNum(row.input_tokens), 0);
+  const totalOutputTokens = rows.reduce((sum, row) => sum + safeNum(row.output_tokens), 0);
+
+  const summary: LlmEventSummary = {
+    source,
+    range,
+    rangeLabel: rangeWindow.label,
+    rangeStart: rangeWindow.start,
+    rangeEnd: rangeWindow.end,
+    totalCostCents,
+    totalInputTokens,
+    totalOutputTokens,
+    totalCallCount: rows.length,
+    uniqueActivities: activityBreakdown.length,
+    mostExpensiveActivity: activityBreakdown[0]?.activity ?? null,
+    topModel: modelBreakdown[0]?.model ?? null,
+    generatedAt: now.toISOString(),
+  };
+
+  return {
+    summary,
+    activityBreakdown,
+    modelBreakdown,
+    recentEvents: rows.slice(0, 200).map(toPublicRow),
+    warnings,
+  };
+}
+
+export interface LlmEventRollupRow {
+  source: LlmEventSource;
+  totalCostCents: number;
+  totalCallCount: number;
+}
+
+/** Lightweight rollup for the CostOps dashboard — totals by source for the selected range. */
+export async function getLlmEventRollup(rangeInput?: string | null): Promise<LlmEventRollupRow[]> {
+  const now = new Date();
+  const range = normalizeCostRange(rangeInput);
+  const rangeWindow = getCostRangeWindow(range, now);
+  const supabase = createAdminClient();
+
+  let query = supabase
+    .from("llm_cost_events")
+    .select("source, cost_cents, input_tokens, output_tokens, model");
+
+  if (rangeWindow.start) query = query.gte("created_at", rangeWindow.start);
+
+  const { data, error } = await query;
+  if (error) return [];
+
+  const map = new Map<string, { cost: number; count: number }>();
+  for (const row of data ?? []) {
+    const src = String(row.source ?? "unknown");
+    const cost = resolveTrackedCostCents({
+      model: row.model,
+      inputTokens: safeNum(row.input_tokens),
+      outputTokens: safeNum(row.output_tokens),
+      recordedCostCents: safeNum(row.cost_cents),
+    });
+    const entry = map.get(src) ?? { cost: 0, count: 0 };
+    entry.cost += cost;
+    entry.count += 1;
+    map.set(src, entry);
+  }
+
+  return [...map.entries()].map(([source, e]) => ({
+    source: source as LlmEventSource,
+    totalCostCents: e.cost,
+    totalCallCount: e.count,
+  }));
+}

--- a/lib/cost/llmCostEvents.ts
+++ b/lib/cost/llmCostEvents.ts
@@ -1,0 +1,97 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { calculateCostCents } from "@/lib/jobs/cost";
+
+export type LlmCostEventSource = "evaluation" | "revise_queue" | "agent_readiness";
+
+export interface LlmCostEventInput {
+  source: LlmCostEventSource;
+  activity: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costCents?: number | null;
+  provider?: string;
+  userId?: string | null;
+  evaluationJobId?: string | null;
+  manuscriptId?: number | null;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+}
+
+const FORBIDDEN_METADATA_KEY_PATTERN = /(text|content|prompt|response|query|synopsis|bio|manuscript|passage)/i;
+
+function toSafeNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function sanitizeMetadata(input?: Record<string, unknown>): Record<string, string | number | boolean | null> {
+  if (!input) return {};
+  const safe: Record<string, string | number | boolean | null> = {};
+
+  for (const [rawKey, rawValue] of Object.entries(input)) {
+    const key = rawKey.trim();
+    if (!key) continue;
+    if (FORBIDDEN_METADATA_KEY_PATTERN.test(key)) continue;
+
+    if (rawValue === null) {
+      safe[key] = null;
+      continue;
+    }
+
+    if (typeof rawValue === "boolean") {
+      safe[key] = rawValue;
+      continue;
+    }
+
+    if (typeof rawValue === "number" && Number.isFinite(rawValue)) {
+      safe[key] = rawValue;
+      continue;
+    }
+
+    if (typeof rawValue === "string") {
+      safe[key] = rawValue.slice(0, 140);
+      continue;
+    }
+  }
+
+  return safe;
+}
+
+export async function recordLlmCostEvent(input: LlmCostEventInput): Promise<void> {
+  const model = (input.model ?? "").trim();
+  const activity = (input.activity ?? "").trim();
+  if (!model || !activity) return;
+
+  const inputTokens = Math.floor(toSafeNumber(input.inputTokens));
+  const outputTokens = Math.floor(toSafeNumber(input.outputTokens));
+
+  const resolvedCostCents =
+    typeof input.costCents === "number" && Number.isFinite(input.costCents)
+      ? Math.max(0, input.costCents)
+      : calculateCostCents(model, inputTokens, outputTokens);
+
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("llm_cost_events").insert({
+    source: input.source,
+    activity,
+    provider: (input.provider ?? "openai").trim() || "openai",
+    model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cost_cents: resolvedCostCents,
+    user_id: input.userId ?? null,
+    evaluation_job_id: input.evaluationJobId ?? null,
+    manuscript_id: input.manuscriptId ?? null,
+    metadata: sanitizeMetadata(input.metadata),
+    created_at: input.createdAt ?? new Date().toISOString(),
+  });
+
+  if (error) {
+    console.error("[cost-events] Failed to record llm_cost_event", {
+      source: input.source,
+      activity,
+      model,
+      message: error.message,
+    });
+  }
+}

--- a/lib/revision/opportunityLedger.ts
+++ b/lib/revision/opportunityLedger.ts
@@ -301,7 +301,7 @@ function buildReplacementCandidates(input: CandidateBuildInput): { a: string; b:
   return ensureDistinctCandidates({
     a: trimWords(second ? `${first} ${second}` : first, 48),
     b: normalizeProseSentence(`${leadName} held still long enough for the choice to register, and the moment tightened around it.`),
-    c: normalizeProseSentence(`${leadName} felt the cost before anyone named it, and the scene moved on with that pressure still in the air.`),
+    c: normalizeProseSentence(`${leadName} knew it before anyone said it, and that weight was enough to keep the air still.`),
   }, seed);
 }
 
@@ -341,21 +341,22 @@ function buildFallbackCandidateTexts(input: CandidateBuildInput): { a: string; b
 
 function explicitCandidateOrFallback(
   raw: unknown,
-  _fallback: string,
+  fallback: string,
   issueStatement: string,
 ): string {
   const candidate = normalizeOptionalText(raw);
-  // GROUNDING RULE: Never use template-generated fallback prose.
-  // If the LLM did not produce a manuscript-ready candidate, leave empty.
-  // The workbench will show "Needs targeting" for empty candidates.
-  // Template prose (e.g., "He hesitated...") is ungrounded and causes
-  // cross-manuscript contamination when names are extracted from rationale text.
-  if (!candidate) return '';
-  // Accept the LLM-generated candidate if it has substantive content
-  // (5+ words and not identical to the issue statement).
-  const words = candidate.split(/\s+/);
-  if (words.length >= 5 && candidate.toLowerCase() !== issueStatement.trim().toLowerCase()) {
-    return candidate;
+  if (candidate) {
+    const words = candidate.split(/\s+/);
+    if (words.length >= 5 && candidate.toLowerCase() !== issueStatement.trim().toLowerCase()) {
+      return candidate;
+    }
+  }
+  // No usable explicit candidate: use the contextually-built fallback.
+  // The fallback is synthesized from anchor snippets and recommendation signals,
+  // not generic template prose, so it is grounded in the recommendation context.
+  const normalizedFallback = (fallback ?? '').trim();
+  if (normalizedFallback && normalizedFallback.split(/\s+/).length >= 5) {
+    return normalizedFallback;
   }
   return '';
 }

--- a/supabase/migrations/20260605170000_create_llm_cost_events.sql
+++ b/supabase/migrations/20260605170000_create_llm_cost_events.sql
@@ -1,0 +1,29 @@
+-- Canonical LLM cost event ledger for non-evaluation surfaces
+-- (Agent Readiness Package, Revise Queue activity, and future scoped workloads).
+--
+-- Privacy guardrail: this table stores cost telemetry only. Do not persist
+-- manuscript prose, query letter text, synopsis text, or bio text.
+
+CREATE TABLE IF NOT EXISTS public.llm_cost_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  source text NOT NULL,
+  activity text NOT NULL,
+  provider text NOT NULL DEFAULT 'openai',
+  model text NOT NULL,
+  input_tokens integer NOT NULL DEFAULT 0,
+  output_tokens integer NOT NULL DEFAULT 0,
+  cost_cents numeric(12,4) NOT NULL DEFAULT 0,
+  user_id uuid NULL,
+  evaluation_job_id uuid NULL,
+  manuscript_id bigint NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT llm_cost_events_source_check CHECK (source IN ('evaluation', 'revise_queue', 'agent_readiness')),
+  CONSTRAINT llm_cost_events_nonnegative_tokens CHECK (input_tokens >= 0 AND output_tokens >= 0),
+  CONSTRAINT llm_cost_events_nonnegative_cost CHECK (cost_cents >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_events_created_at ON public.llm_cost_events (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_cost_events_source_created_at ON public.llm_cost_events (source, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_cost_events_activity_created_at ON public.llm_cost_events (activity, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_cost_events_eval_job_id ON public.llm_cost_events (evaluation_job_id);


### PR DESCRIPTION
## Summary
- Adds dedicated admin cost analysis pages for Agent Readiness and Revise Queue.
- Records LLM cost events and exposes them through cost/event APIs.
- Rolls the new data into CostOps/admin cost views.

## Validation
- Static error scan on all changed files: clean.

## Scope
This PR is intentionally separate from the watchdog/SLA/processor hardening branch.