### PR TITLE
Add copyable report reference ID

### DIFF
--- a/.github/pr-bodies/PR-1005.md
+++ b/.github/pr-bodies/PR-1005.md
@@ -1,0 +1,9 @@
+## Summary
+- Show the job reference ID in the report and evaluation headers
+- Add a one-click copy button for support issue reporting
+
+## Validation
+- `get_errors` passed for the edited files
+
+## Notes
+- This PR only includes the report-reference change; unrelated local admin/billing edits remain uncommitted in the workspace.

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/schemas/criteria-keys";
 import { EvaluationPoller, type JobState } from "@/components/EvaluationPoller";
 import DownloadReportButton from "@/components/reports/DownloadReportButton";
+import CopyReferenceIdButton from "@/components/reports/CopyReferenceIdButton";
 import SupportAccessToggle from "@/components/reports/SupportAccessToggle";
 import ReportConcernForm from "@/components/reports/ReportConcernForm";
 import {
@@ -711,6 +712,14 @@ export default async function EvaluationReportPage({
             {manuscriptTitle && chapterTitle && manuscriptTitle !== chapterTitle && (
               <p className="mt-2 text-base font-medium text-stone-700">{manuscriptTitle}</p>
             )}
+            <p className="mt-2 text-sm text-stone-500">
+              <span className="font-medium text-stone-700">Reference ID:</span>{' '}
+              <span className="font-mono text-stone-900">{jobId}</span>{' '}
+              <CopyReferenceIdButton
+                value={jobId}
+                className="ml-2 inline-flex items-center rounded-md border border-stone-300 px-2.5 py-1 text-xs font-medium text-stone-700 transition hover:bg-stone-100"
+              />
+            </p>
             <dl className="mt-5 grid gap-x-6 gap-y-3 text-base sm:grid-cols-2">
               <div><dt className="font-semibold text-stone-950">Report Type</dt><dd className="mt-1 text-stone-700">{reportType}</dd></div>
               <div><dt className="font-semibold text-stone-950">Genre</dt><dd className="mt-1 capitalize text-stone-700">{genre}</dd></div>

--- a/app/reports/[jobId]/page.tsx
+++ b/app/reports/[jobId]/page.tsx
@@ -40,6 +40,7 @@ import type { LongformDreamDocument } from '@/lib/evaluation/pipeline/runPass3bL
 import { SynthesisPoller } from '@/components/evaluation/SynthesisPoller';
 import CriterionOpportunities from '@/components/reports/CriterionOpportunities';
 import DownloadReportButton from '@/components/reports/DownloadReportButton';
+import CopyReferenceIdButton from '@/components/reports/CopyReferenceIdButton';
 import AutoPrintOnLoad from '@/components/reports/AutoPrintOnLoad';
 import SupportAccessToggle from '@/components/reports/SupportAccessToggle';
 import LongformCharacterCoverageArcLedger from '@/components/reports/longform/LongformCharacterCoverageArcLedger';
@@ -404,6 +405,14 @@ export default async function ReportPage({
               )}
               <p className="mt-1 text-sm text-gray-500">
                 Generated {getDisplayDateTime(result.generated_at, "Unknown")}
+              </p>
+              <p className="mt-1 text-sm text-gray-500">
+                <span className="font-medium text-gray-700">Reference ID:</span>{' '}
+                <span className="font-mono text-gray-900">{params.jobId}</span>{' '}
+                <CopyReferenceIdButton
+                  value={params.jobId}
+                  className="ml-2 inline-flex items-center rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 transition hover:bg-gray-100"
+                />
               </p>
             </div>
             <div className="shrink-0 flex items-center gap-3 print-hidden">

--- a/components/reports/CopyReferenceIdButton.tsx
+++ b/components/reports/CopyReferenceIdButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+type CopyReferenceIdButtonProps = {
+  value: string;
+  className?: string;
+};
+
+export default function CopyReferenceIdButton({ value, className }: CopyReferenceIdButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleCopy()}
+      className={className}
+      aria-label={`Copy reference ID ${value}`}
+      title={copied ? "Copied" : "Copy reference ID"}
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Show the job reference ID in the report and evaluation headers
- Add a one-click copy button for support issue reporting

## Validation
- `get_errors` passed for the edited files

## Notes
- This PR only includes the report-reference change; unrelated local admin/billing edits remain uncommitted in the workspace.