### PR TITLE
Make evaluation kickoff async and defer analytics click handling

### DIFF
--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -14,7 +14,6 @@ import { getAuthenticatedUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { backpressureGuard } from "@/lib/jobs/backpressure";
 import { isTriggerWorkerFailure, triggerEvaluationWorker } from "@/lib/jobs/triggerWorker";
-import { failEvaluationJobTerminally } from "@/lib/jobs/failJobTerminal";
 import { resolveManuscriptTitle } from "@/lib/manuscripts/title";
 import { computeEnrichment, type EnrichmentResult } from "@/lib/evaluation/enrichment";
 import { routeNarrativeEvaluationPreflight } from "@/lib/evaluation/preflight/manuscriptTypeRouting";
@@ -763,51 +762,55 @@ export async function POST(req: Request) {
         phase0_fast_track: shouldFastTrackPhase0,
       },
     });
-    const kickoffResult = await triggerEvaluationWorker({
+    // Do not block the user-facing job creation response on worker kickoff.
+    // The evaluation page/poller can show queued/running state while the worker claims the job.
+    void triggerEvaluationWorker({
       req,
       jobId: job.id,
       trace_id,
       request_id,
       source: "api.jobs.create",
       kickoffDispatchStartedAt,
-    });
+    }).then((kickoffResult) => {
+      const targetClaimFailed = kickoffResult.ok && kickoffResult.targetClaimed === false;
+      const noJobsClaimed = kickoffResult.ok && kickoffResult.claimed !== null && kickoffResult.claimed < 1;
 
-    const targetClaimFailed = kickoffResult.ok && kickoffResult.targetClaimed === false;
-    const noJobsClaimed = kickoffResult.ok && kickoffResult.claimed !== null && kickoffResult.claimed < 1;
-    if (!kickoffResult.ok || targetClaimFailed || noJobsClaimed) {
-      const reason = isTriggerWorkerFailure(kickoffResult)
-        ? (kickoffResult.error ?? kickoffResult.reason)
-        : targetClaimFailed
-          ? "worker_did_not_claim_created_job"
-          : "worker_returned_zero_claims";
+      if (!kickoffResult.ok || targetClaimFailed || noJobsClaimed) {
+        const reason = isTriggerWorkerFailure(kickoffResult)
+          ? (kickoffResult.error ?? kickoffResult.reason)
+          : targetClaimFailed
+            ? "worker_did_not_claim_created_job"
+            : "worker_returned_zero_claims";
 
-      logger.error("Worker kickoff failed closed after job creation", {
+        logger.error("Worker kickoff failed after job creation", {
+          trace_id,
+          request_id,
+          event: "api.jobs.create.worker_kickoff_failed_async",
+          job_id: job.id,
+          reason,
+          worker_body: kickoffResult.ok ? kickoffResult.body : kickoffResult.body,
+        });
+
+        return;
+      }
+
+      logger.info("Worker kickoff accepted job asynchronously", {
         trace_id,
         request_id,
-        event: "api.jobs.create.worker_kickoff_failed_closed",
+        event: "api.jobs.create.worker_kickoff_async_ok",
         job_id: job.id,
-        reason,
-        worker_body: kickoffResult.ok ? kickoffResult.body : kickoffResult.body,
+      });
+    }).catch((error) => {
+      logger.error("Worker kickoff threw after job creation", {
+        trace_id,
+        request_id,
+        event: "api.jobs.create.worker_kickoff_async_exception",
+        job_id: job.id,
+        error: error instanceof Error ? error.message : String(error),
       });
 
-      await failEvaluationJobTerminally({
-        supabase: createAdminClient(),
-        jobId: job.id,
-        failureCode: "WORKER_KICKOFF_FAILED",
-        message: `Evaluation worker did not accept the job: ${reason}`,
-        source: "api.jobs.worker_kickoff_guard",
-      });
-
-      return NextResponse.json(
-        {
-          ok: false,
-          error: "Evaluation worker is temporarily unavailable. Please try again shortly.",
-          code: "WORKER_KICKOFF_FAILED",
-          trace_id,
-        },
-        { status: 503 },
-      );
-    }
+      return;
+    });
 
     logger.info("Job created successfully", {
       trace_id,

--- a/components/analytics/SiteAnalyticsTracker.jsx
+++ b/components/analytics/SiteAnalyticsTracker.jsx
@@ -91,8 +91,14 @@ export default function SiteAnalyticsTracker() {
 
   useEffect(() => {
     const handler = (event) => {
-      const inferred = clickEventFromElement(event.target);
-      if (inferred) track(inferred.eventName, inferred);
+      // Capture target synchronously (the element may be gone after the timeout),
+      // then yield to the browser before doing any analytics work so the click
+      // interaction can paint without being blocked by DOM traversal + fetch.
+      const target = event.target;
+      window.setTimeout(() => {
+        const inferred = clickEventFromElement(target);
+        if (inferred) track(inferred.eventName, inferred);
+      }, 0);
     };
     document.addEventListener("click", handler, true);
     return () => document.removeEventListener("click", handler, true);

--- a/tests/api/admin-proof-jobs-route-kickoff.test.ts
+++ b/tests/api/admin-proof-jobs-route-kickoff.test.ts
@@ -74,7 +74,10 @@ function buildRequest() {
 describe('POST /api/admin/proof/jobs kickoff behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.NODE_ENV = 'test';
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'test',
+      configurable: true,
+    });
     process.env.PROOF_RUN_SECRET = 'proof-secret';
     process.env.CRON_SECRET = 'cron-secret';
     mockCreateAdminClient.mockReturnValue(buildAdminClientMock() as never);


### PR DESCRIPTION
## Summary
- Make public evaluation job worker kickoff asynchronous so job creation is not blocked by worker claim timing.
- Log worker kickoff failures asynchronously without terminalizing the user-facing evaluation job from the create route.
- Defer analytics click handling with `setTimeout(..., 0)` to reduce click-handler INP blocking.

## Verification
- `npx tsc --noEmit`
- `npm test -- tests/api/admin-proof-jobs-route-kickoff.test.ts`