### PR TITLE
Add Revised Manuscript Package Export Standard

### DIFF
--- a/.github/pr-bodies/PR-1031.md
+++ b/.github/pr-bodies/PR-1031.md
@@ -1,0 +1,51 @@
+# PR: Add Revised Manuscript Package Export Standard
+
+## Summary
+This PR codifies the expected download package after a user completes Revise. It ensures RevisionGrade never silently presents a partially revised manuscript as fully complete.
+
+The export model distinguishes between:
+
+- **Applied Copy-Paste repairs** — safe TrustedPath/local edits applied to the manuscript.
+- **Author customizations** — user-entered revisions preserved in the revised file.
+- **Deferred or unresolved Strategy Cards** — visible in the Marked Manuscript as author-facing notes.
+- **Withheld/blocked cards** — never rendered in user-facing exports.
+
+## Product Rule
+TrustedPath may only execute cards classified as `copy_paste_rewrite`.
+
+Strategy cards are not auto-applied. If the author does not resolve them manually, the affected manuscript section remains unchanged and receives a visible RevisionGrade note in the Marked Manuscript.
+
+## Download Package
+The user should receive:
+
+1. **Clean Manuscript**  
+   Accepted TrustedPath/copy-paste edits applied.
+2. Author custom edits applied.
+3. No notes or markers.
+4. Unresolved sections remain unchanged.
+5. **Marked Manuscript**  
+   Accepted edits applied.
+6. Unresolved/deferred Strategy sections visibly marked.
+7. Notes must be distinguishable from manuscript prose.
+8. **Revision Log**  
+   Applied repairs count.
+9. Author customizations count.
+10. Deferred cards count.
+11. Strategy unresolved count.
+12. Withheld/blocked count only in admin/support context, not normal user export.
+
+## Required Inline Note
+For unresolved Strategy/deferred sections, insert:
+
+> [REVISIONGRADE NOTE — Strategy Card Unresolved]
+> This section requires your attention. TrustedPath did not modify this area because the necessary adjustments involve structural, voice, canon, metaphor, or downstream continuity concerns that require author oversight.
+
+## Acceptance Criteria
+
+- TrustedPath applies only `copy_paste_rewrite` cards.
+- Strategy cards are never silently treated as complete.
+- Deferred/rejected/unresolved Strategy sections remain visible in the Marked Manuscript.
+- Clean Manuscript contains no RevisionGrade notes.
+- Marked Manuscript clearly shows unresolved areas.
+- Withheld cards remain invisible to normal users.
+- Revision Log records applied, customized, deferred, and unresolved status counts.

--- a/__tests__/lib/revision/finalReviewRuntime.test.ts
+++ b/__tests__/lib/revision/finalReviewRuntime.test.ts
@@ -1,0 +1,212 @@
+import { applyFinalReviewDecisions, buildFinalReviewExport } from '@/lib/revision/finalReviewRuntime';
+import { createDerivedVersion } from '@/lib/manuscripts/versions';
+import { getWorkbenchQueue } from '@/lib/revision/workbenchQueue';
+import { resolveFinalReviewSourceText } from '@/lib/revision/finalReviewSourceText';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { getAuthenticatedUser } from '@/lib/supabase/server';
+
+jest.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: jest.fn(),
+}));
+
+jest.mock('@/lib/supabase/server', () => ({
+  getAuthenticatedUser: jest.fn(),
+}));
+
+jest.mock('@/lib/manuscripts/versions', () => ({
+  createDerivedVersion: jest.fn(),
+}));
+
+jest.mock('@/lib/revision/workbenchQueue', () => ({
+  getWorkbenchQueue: jest.fn(),
+}));
+
+jest.mock('@/lib/revision/finalReviewSourceText', () => {
+  const actual = jest.requireActual('@/lib/revision/finalReviewSourceText') as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveFinalReviewSourceText: jest.fn(),
+  };
+});
+
+const mockCreateAdminClient = createAdminClient as jest.MockedFunction<typeof createAdminClient>;
+const mockGetAuthenticatedUser = getAuthenticatedUser as jest.MockedFunction<typeof getAuthenticatedUser>;
+const mockCreateDerivedVersion = createDerivedVersion as jest.MockedFunction<typeof createDerivedVersion>;
+const mockGetWorkbenchQueue = getWorkbenchQueue as jest.MockedFunction<typeof getWorkbenchQueue>;
+const mockResolveFinalReviewSourceText = resolveFinalReviewSourceText as jest.MockedFunction<typeof resolveFinalReviewSourceText>;
+
+const SOURCE_TEXT = 'Alpha original safe. Beta original strategy. Gamma original withheld. Delta unchanged.';
+
+type MockQueryInput = {
+  single?: unknown;
+  list?: unknown[];
+  insertSpy?: jest.Mock;
+};
+
+function makeQuery(input: MockQueryInput = {}) {
+  const query = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    order: jest.fn(async () => ({ data: input.list ?? [], error: null })),
+    maybeSingle: jest.fn(async () => ({ data: input.single ?? null, error: null })),
+    insert: input.insertSpy ?? jest.fn(async () => ({ data: null, error: null })),
+  };
+  return query;
+}
+
+function decision(overrides: Partial<Record<string, unknown>>) {
+  return {
+    id: 'decision-1',
+    opportunity_id: 'copy-1',
+    opportunity_title: 'Safe copy repair',
+    decision: 'accepted_a',
+    selected_option: 'A',
+    custom_text: null,
+    selected_text: 'Alpha repaired safe.',
+    source_excerpt: 'Alpha original safe.',
+    source_location: 'chapter 1',
+    metadata: {},
+    created_at: '2026-06-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildSupabaseMock(decisions: Array<Record<string, unknown>>) {
+  const insertSpy = jest.fn(async () => ({ data: null, error: null }));
+
+  const tables: Record<string, ReturnType<typeof makeQuery>> = {
+    manuscripts: makeQuery({ single: { id: 6074, title: 'Sister', user_id: 'user-1' } }),
+    evaluation_jobs: makeQuery({ single: { id: 'job-1', status: 'complete', manuscript_id: 6074, manuscript_version_id: 'version-1' } }),
+    manuscript_versions: makeQuery({ single: { id: 'version-1', raw_text: SOURCE_TEXT } }),
+    revision_ledger_decisions: makeQuery({ list: decisions }),
+    final_review_apply_runs: makeQuery({ insertSpy }),
+  };
+
+  return {
+    insertSpy,
+    client: {
+      from: jest.fn((table: string) => {
+        const query = tables[table];
+        if (!query) throw new Error(`Unexpected table: ${table}`);
+        return query;
+      }),
+    },
+  };
+}
+
+function mockQueue() {
+  mockGetWorkbenchQueue.mockResolvedValue({
+    ok: true,
+    opportunities: [{ id: 'copy-1' }],
+    needsTargeting: [{ id: 'strategy-1', cardType: 'revision_strategy' }],
+    withheldUnsupported: [{ id: 'withheld-1' }],
+  } as never);
+}
+
+describe('final review runtime governance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthenticatedUser.mockResolvedValue({ id: 'user-1' } as never);
+    mockResolveFinalReviewSourceText.mockResolvedValue(SOURCE_TEXT);
+    mockCreateDerivedVersion.mockResolvedValue({ id: 'version-2' } as never);
+    mockQueue();
+  });
+
+  it('exports a semi-revised manuscript by applying only queue-visible copy-paste repairs', async () => {
+    const { client, insertSpy } = buildSupabaseMock([
+      decision({ id: 'decision-copy' }),
+      decision({
+        id: 'decision-strategy',
+        opportunity_id: 'strategy-1',
+        opportunity_title: 'Strategy card',
+        selected_text: 'Beta strategy replacement should not apply.',
+        source_excerpt: 'Beta original strategy.',
+        metadata: { cardType: 'revision_strategy', trustedPathStatus: 'manual_review' },
+      }),
+      decision({
+        id: 'decision-withheld',
+        opportunity_id: 'withheld-1',
+        opportunity_title: 'Withheld card',
+        selected_text: 'Gamma withheld replacement should not apply.',
+        source_excerpt: 'Gamma original withheld.',
+        metadata: { cardType: 'withheld', trustedPathStatus: 'blocked' },
+      }),
+      decision({
+        id: 'decision-stale-copy',
+        opportunity_id: 'stale-copy-1',
+        opportunity_title: 'Stale persisted copy-paste metadata',
+        selected_text: 'Delta stale replacement should not apply.',
+        source_excerpt: 'Delta unchanged.',
+        metadata: { cardType: 'copy_paste_rewrite', trustedPathStatus: 'eligible' },
+      }),
+    ]);
+    mockCreateAdminClient.mockReturnValue(client as never);
+
+    const exported = await buildFinalReviewExport({ manuscriptId: 6074, evaluationJobId: 'job-1', format: 'clean' });
+
+    expect(exported.filename).toBe('revisiongrade-sister-semi-revised-draft.txt');
+    expect(exported.content).toContain('Alpha repaired safe.');
+    expect(exported.content).toContain('Beta original strategy.');
+    expect(exported.content).toContain('Gamma original withheld.');
+    expect(exported.content).toContain('Delta unchanged.');
+    expect(exported.content).not.toContain('Beta strategy replacement should not apply.');
+    expect(exported.content).not.toContain('Gamma withheld replacement should not apply.');
+    expect(exported.content).not.toContain('Delta stale replacement should not apply.');
+
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'exported',
+      applied_decision_ids: ['decision-copy'],
+      skipped_decision_ids: ['decision-strategy', 'decision-withheld', 'decision-stale-copy'],
+      metadata: expect.objectContaining({
+        copy_paste_repair_count: 1,
+        strategy_card_count: 1,
+        withheld_blocked_count: 1,
+      }),
+    }));
+  });
+
+  it('reports copy-paste, strategy, and withheld counts in the changelog', async () => {
+    const { client } = buildSupabaseMock([
+      decision({ id: 'decision-copy' }),
+      decision({ id: 'decision-strategy', opportunity_id: 'strategy-1', metadata: { cardType: 'revision_strategy' } }),
+      decision({ id: 'decision-withheld', opportunity_id: 'withheld-1', metadata: { cardType: 'withheld' } }),
+    ]);
+    mockCreateAdminClient.mockReturnValue(client as never);
+
+    const exported = await buildFinalReviewExport({ manuscriptId: 6074, evaluationJobId: 'job-1', format: 'changelog' });
+
+    expect(exported.content).toContain('1 safe copy-paste repair applied or ready to apply.');
+    expect(exported.content).toContain('1 Strategy Card require author decision and were not applied.');
+    expect(exported.content).toContain('1 withheld/blocked card stayed invisible to the semi-revised manuscript.');
+    expect(exported.content).toContain('TrustedPath applies only safe, local copy-paste repairs.');
+  });
+
+  it('creates a derived manuscript version from safe copy-paste decisions only', async () => {
+    const { client, insertSpy } = buildSupabaseMock([
+      decision({ id: 'decision-copy' }),
+      decision({
+        id: 'decision-strategy',
+        opportunity_id: 'strategy-1',
+        selected_text: 'Beta strategy replacement should not apply.',
+        source_excerpt: 'Beta original strategy.',
+        metadata: { cardType: 'revision_strategy' },
+      }),
+    ]);
+    mockCreateAdminClient.mockReturnValue(client as never);
+
+    const result = await applyFinalReviewDecisions({ manuscriptId: 6074, evaluationJobId: 'job-1' });
+
+    expect(result).toEqual({ ok: true, revisedVersionId: 'version-2', appliedCount: 1 });
+    expect(mockCreateDerivedVersion).toHaveBeenCalledWith(expect.objectContaining({
+      manuscript_id: 6074,
+      source_version_id: 'version-1',
+      raw_text: 'Alpha repaired safe. Beta original strategy. Gamma original withheld. Delta unchanged.',
+      created_by: 'user-1',
+    }));
+    expect(insertSpy).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'applied',
+      applied_decision_ids: ['decision-copy'],
+      skipped_decision_ids: ['decision-strategy'],
+    }));
+  });
+});

--- a/app/api/revision-ledger/trusted-path/route.ts
+++ b/app/api/revision-ledger/trusted-path/route.ts
@@ -44,6 +44,7 @@ function candidateRepeatsSourceForInsertion(item: WorkbenchOpportunity, text: st
 
 function optionA(item: WorkbenchOpportunity): string {
   if (item.readiness !== "ready_for_revise") return "";
+  if (item.cardType !== "copy_paste_rewrite" || item.trustedPathStatus !== "eligible") return "";
   const option = item.options.find((entry) => entry.key === "A");
   if (!option) return "";
   const candidate = getRenderableCandidateText({
@@ -75,6 +76,9 @@ function buildEntry(item: WorkbenchOpportunity, selectedText: string, modeContra
       criterion: criterionOf(item),
       severity: item.severity,
       scope: item.scope,
+      cardType: item.cardType,
+      trustedPathStatus: item.trustedPathStatus,
+      executabilityReasons: item.executabilityReasons ?? [],
       modeContract: modeContractForMetadata(modeContract),
     },
   };

--- a/docs/templates/revise/revised-manuscript-package-template.md
+++ b/docs/templates/revise/revised-manuscript-package-template.md
@@ -1,0 +1,109 @@
+# Revised Manuscript Package Template
+**Status:** Canonical export template  
+**Applies to:** Revise, TrustedPath, manuscript downloads, semi-revised manuscript exports
+
+## Purpose
+The Revised Manuscript Package must show the author exactly what was changed, what was preserved, and what still requires author attention.
+
+RevisionGrade must never silently imply that a manuscript is fully revised when unresolved Strategy Cards, deferred cards, or author-skipped sections remain.
+
+## Package Contents
+
+### 1. Clean Manuscript
+The Clean Manuscript is the author’s production-facing revised file.
+
+It includes:
+
+- TrustedPath-applied copy-paste repairs
+- author-customized revisions
+- accepted manual revisions
+- all unchanged manuscript sections preserved exactly as submitted
+
+It must not include:
+
+- RevisionGrade notes
+- Strategy Card warnings
+- unresolved markers
+- admin/debug information
+- withheld card references
+
+### 2. Marked Manuscript
+The Marked Manuscript is the author-review version.
+
+It includes:
+
+- all applied revisions
+- unchanged sections
+- visible notes for unresolved Strategy Cards
+- visible notes for deferred author decisions
+- visible notes where TrustedPath could not safely apply a repair
+
+Required unresolved marker:
+
+> [REVISIONGRADE NOTE — Strategy Card Unresolved]
+> This section requires your attention. TrustedPath did not modify this area because the necessary adjustments involve structural, voice, canon, metaphor, or downstream continuity concerns that require author oversight.
+
+### 3. Revision Log
+The Revision Log is the decision record for the Revise session.
+
+It must include:
+
+| Status | Meaning |
+|---|---|
+| Applied via TrustedPath | Safe copy-paste card automatically applied |
+| Applied by Author | Author accepted or customized a revision |
+| Deferred | Author chose not to resolve the card during this session |
+| Strategy Unresolved | Card required author judgment and remains unresolved |
+| Withheld / Blocked | Excluded from user-facing output; admin/support only |
+
+## Card Export Rules
+
+### Copy-Paste Rewrite Card
+`cardType: copy_paste_rewrite`
+
+TrustedPath eligible.
+
+Export behavior:
+
+- Clean Manuscript: apply selected repair
+- Marked Manuscript: apply selected repair, optionally track change
+- Revision Log: count as applied
+
+### Revision Strategy Card
+`cardType: revision_strategy`
+
+TrustedPath ineligible.
+
+Export behavior:
+
+- Clean Manuscript: leave original manuscript text unchanged unless author manually customized it
+- Marked Manuscript: leave original manuscript text visible and add unresolved note
+- Revision Log: count as Strategy Unresolved or Author Applied
+
+### Withheld Card
+`cardType: withheld`
+
+Never user-facing.
+
+Export behavior:
+
+- Clean Manuscript: no marker
+- Marked Manuscript: no marker
+- Revision Log: admin/support only
+
+## Data Fields
+Recommended export fields:
+
+```yaml
+cardType: 'copy_paste_rewrite' | 'revision_strategy' | 'withheld'
+trustedPathStatus: 'eligible' | 'unavailable_author_review_required' | 'impossible'
+exportStatus:
+  | 'applied'
+  | 'author_customized'
+  | 'deferred'
+  | 'strategy_unresolved'
+  | 'withheld'
+```
+
+## Product Language
+TrustedPath has automatically applied safe, local copy-paste repairs to your manuscript. Complex revision opportunities have been preserved for author review in the Marked Manuscript. Sections requiring author judgment remain visible and clearly marked so RevisionGrade never silently presents unresolved work as complete.

--- a/lib/revision/finalReviewRuntime.ts
+++ b/lib/revision/finalReviewRuntime.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getAuthenticatedUser } from "@/lib/supabase/server";
 import { createDerivedVersion } from "@/lib/manuscripts/versions";
 import { resolveFinalReviewSourceText, scrubInternalReportLeakage } from "@/lib/revision/finalReviewSourceText";
+import { getWorkbenchQueue } from "@/lib/revision/workbenchQueue";
 
 export type FinalReviewExportFormat = "clean" | "marked" | "changelog";
 export type FinalReviewExportFile = "txt" | "pdf" | "docx";
@@ -20,6 +21,14 @@ type RuntimeContext = {
   sourceVersionId: string;
   sourceText: string;
   decisions: RuntimeDecision[];
+  queueSummary: RuntimeQueueSummary;
+};
+
+type RuntimeQueueSummary = {
+  copyPasteOpportunityIds: Set<string>;
+  copyPasteCount: number;
+  strategyCount: number;
+  withheldBlockedCount: number;
 };
 
 type RuntimeDecision = {
@@ -32,10 +41,18 @@ type RuntimeDecision = {
   selected_text: string | null;
   source_excerpt: string | null;
   source_location: string | null;
+  metadata: Record<string, unknown> | null;
   created_at: string;
 };
 
 const APPLICABLE = new Set(["accepted_a", "accepted_b", "accepted_c", "custom"]);
+
+const EMPTY_QUEUE_SUMMARY: RuntimeQueueSummary = {
+  copyPasteOpportunityIds: new Set(),
+  copyPasteCount: 0,
+  strategyCount: 0,
+  withheldBlockedCount: 0,
+};
 
 function safeFilename(title: string, suffix: string, ext: string): string {
   const base = title.replace(/[^a-z0-9]+/gi, "-").toLowerCase().replace(/^-|-$/g, "").slice(0, 50) || "manuscript";
@@ -84,7 +101,7 @@ async function loadRuntimeContext(input: FinalReviewRuntimeInput): Promise<Runti
 
   const { data: rows, error: ledgerError } = await supabase
     .from("revision_ledger_decisions")
-    .select("id, opportunity_id, opportunity_title, decision, selected_option, custom_text, selected_text, source_excerpt, source_location, created_at")
+    .select("id, opportunity_id, opportunity_title, decision, selected_option, custom_text, selected_text, source_excerpt, source_location, metadata, created_at")
     .eq("user_id", user.id)
     .eq("manuscript_id", manuscriptId)
     .eq("evaluation_job_id", input.evaluationJobId)
@@ -106,6 +123,23 @@ async function loadRuntimeContext(input: FinalReviewRuntimeInput): Promise<Runti
     fallbackRawText: version.raw_text ?? "",
   });
 
+  let queueSummary = EMPTY_QUEUE_SUMMARY;
+  const queuePayload = await getWorkbenchQueue({
+    manuscriptId: String(manuscriptId),
+    evaluationJobId: String(input.evaluationJobId),
+  });
+  if (queuePayload.ok) {
+    const copyPasteOpportunityIds = new Set(queuePayload.opportunities.map((opportunity) => opportunity.id));
+    const strategyCount = queuePayload.needsTargeting.filter((opportunity) => opportunity.cardType === "revision_strategy").length;
+    const withheldBlockedCount = queuePayload.withheldUnsupported.length + queuePayload.needsTargeting.filter((opportunity) => opportunity.cardType !== "revision_strategy").length;
+    queueSummary = {
+      copyPasteOpportunityIds,
+      copyPasteCount: copyPasteOpportunityIds.size,
+      strategyCount,
+      withheldBlockedCount,
+    };
+  }
+
   return {
     supabase,
     userId: user.id,
@@ -115,11 +149,17 @@ async function loadRuntimeContext(input: FinalReviewRuntimeInput): Promise<Runti
     sourceVersionId: job.manuscript_version_id,
     sourceText,
     decisions: [...latestByOpportunity.values()],
+    queueSummary,
   };
 }
 
-function applicableDecisions(decisions: RuntimeDecision[]): RuntimeDecision[] {
-  return decisions.filter((d) => APPLICABLE.has(d.decision));
+function isCopyPasteExecutableDecision(ctx: RuntimeContext, decision: RuntimeDecision): boolean {
+  if (!APPLICABLE.has(decision.decision)) return false;
+  return ctx.queueSummary.copyPasteOpportunityIds.has(decision.opportunity_id);
+}
+
+function applicableDecisions(ctx: RuntimeContext): RuntimeDecision[] {
+  return ctx.decisions.filter((decision) => isCopyPasteExecutableDecision(ctx, decision));
 }
 
 function decisionLabel(decision: RuntimeDecision): string {
@@ -140,6 +180,14 @@ function cleanLocation(value: string | null): string | null {
 
 function buildChangelog(ctx: RuntimeContext): string {
   const lines = ["RevisionGrade Final Review Changelog", `Manuscript: ${ctx.manuscriptTitle}`, ""];
+
+  const executable = applicableDecisions(ctx);
+  lines.push("TrustedPath summary");
+  lines.push(`${executable.length} safe copy-paste repair${executable.length === 1 ? "" : "s"} applied or ready to apply.`);
+  lines.push(`${ctx.queueSummary.strategyCount} Strategy Card${ctx.queueSummary.strategyCount === 1 ? "" : "s"} require author decision and were not applied.`);
+  lines.push(`${ctx.queueSummary.withheldBlockedCount} withheld/blocked card${ctx.queueSummary.withheldBlockedCount === 1 ? "" : "s"} stayed invisible to the semi-revised manuscript.`);
+  lines.push("TrustedPath applies only safe, local copy-paste repairs. More complex revision opportunities remain available as Strategy Cards for author review. Your downloaded semi-revised manuscript preserves all unchanged sections exactly as submitted.");
+  lines.push("");
 
   if (ctx.decisions.length === 0) {
     lines.push("No synced revision decisions were found.");
@@ -193,7 +241,7 @@ function applyTextSnapshots(ctx: RuntimeContext): { text: string; applied: Runti
     return { text: "", applied, blocked: ["Full manuscript source text is unavailable for this legacy evaluation."] };
   }
 
-  for (const decision of applicableDecisions(ctx.decisions)) {
+  for (const decision of applicableDecisions(ctx)) {
     const replacement = scrubInternalReportLeakage(decision.decision === "custom" ? decision.custom_text ?? "" : decision.selected_text ?? "");
     const source = scrubInternalReportLeakage(decision.source_excerpt ?? "");
 
@@ -251,7 +299,7 @@ export async function applyFinalReviewDecisions(input: FinalReviewRuntimeInput) 
     await recordRun(ctx, {
       status: "blocked",
       mode: "apply",
-      skippedDecisionIds: applicableDecisions(ctx.decisions).map((d) => d.id),
+      skippedDecisionIds: ctx.decisions.filter((decision) => APPLICABLE.has(decision.decision)).map((d) => d.id),
       blockedReason: result.blocked.join(" | ") || "No applicable accepted/custom decisions with persisted text snapshots.",
       metadata: { blocked: result.blocked },
     });
@@ -270,8 +318,13 @@ export async function applyFinalReviewDecisions(input: FinalReviewRuntimeInput) 
     mode: "apply",
     revisedVersionId: version.id,
     appliedDecisionIds: result.applied.map((d) => d.id),
-    skippedDecisionIds: ctx.decisions.filter((d) => !APPLICABLE.has(d.decision)).map((d) => d.id),
-    metadata: { applied_count: result.applied.length },
+    skippedDecisionIds: ctx.decisions.filter((decision) => !isCopyPasteExecutableDecision(ctx, decision)).map((d) => d.id),
+    metadata: {
+      applied_count: result.applied.length,
+      copy_paste_repair_count: ctx.queueSummary.copyPasteCount,
+      strategy_card_count: ctx.queueSummary.strategyCount,
+      withheld_blocked_count: ctx.queueSummary.withheldBlockedCount,
+    },
   });
 
   return { ok: true, revisedVersionId: version.id, appliedCount: result.applied.length };
@@ -299,16 +352,23 @@ export async function buildFinalReviewExport(input: FinalReviewRuntimeInput & { 
     } else {
       content = applied.text;
     }
-    suffix = "clean-draft";
+    suffix = "semi-revised-draft";
   }
 
   await recordRun(ctx, {
     status: "exported",
     mode: format === "clean" ? "export_clean" : format === "marked" ? "export_marked" : "export_changelog",
     appliedDecisionIds: applied.applied.map((d) => d.id),
-    skippedDecisionIds: ctx.decisions.filter((d) => !APPLICABLE.has(d.decision)).map((d) => d.id),
+    skippedDecisionIds: ctx.decisions.filter((decision) => !isCopyPasteExecutableDecision(ctx, decision)).map((d) => d.id),
     exportFormat: file,
-    metadata: { export_kind: format, requested_file: file, blocked: applied.blocked },
+    metadata: {
+      export_kind: format,
+      requested_file: file,
+      blocked: applied.blocked,
+      copy_paste_repair_count: ctx.queueSummary.copyPasteCount,
+      strategy_card_count: ctx.queueSummary.strategyCount,
+      withheld_blocked_count: ctx.queueSummary.withheldBlockedCount,
+    },
   });
 
   return {

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -23,6 +23,11 @@ import {
   type RevisionModeContract,
 } from './modeContract'
 import { runWorkbenchAdmissionGate } from './reviseAdmissionGate'
+import {
+  evaluateRecommendationExecutability,
+  type RecommendationCardType,
+  type TrustedPathStatus,
+} from './recommendationExecutability'
 
 export type WorkbenchSeverity = 'must' | 'should' | 'could'
 export type WorkbenchScope = 'Line' | 'Passage' | 'Scene' | 'Chapter' | 'Structural' | 'Manuscript'
@@ -74,6 +79,9 @@ export type WorkbenchOpportunity = {
   revisionOperation: RevisionOperation
   readiness: RevisionReadiness
   readinessReason: string | null
+  cardType?: RecommendationCardType
+  trustedPathStatus?: TrustedPathStatus
+  executabilityReasons?: string[]
   groundingStatus?: SlaeGroundingStatus
   groundingNote?: string | null
   contextQuality?: 'clean' | 'limited' | 'blocked'
@@ -95,6 +103,49 @@ function splitPreflightReasonsByClass(reasons: string[] | undefined): { hydratio
   const hydration = all.filter((reason) => reason.startsWith(HYDRATION_REASON_PREFIX))
   const res = all.filter((reason) => !reason.startsWith(HYDRATION_REASON_PREFIX))
   return { hydration, res }
+}
+
+function passageLengthForExecutability(scope: WorkbenchScope, sourceText: string): 'short' | 'moderate' | 'long' {
+  if (scope === 'Chapter' || scope === 'Structural' || scope === 'Manuscript') return 'long'
+  const words = sourceText.split(/\s+/).filter(Boolean).length
+  if (words <= 35) return 'short'
+  if (words <= 120) return 'moderate'
+  return 'long'
+}
+
+function hasReasonMatching(reasons: string[] | undefined, pattern: RegExp): boolean {
+  return (reasons ?? []).some((reason) => pattern.test(reason))
+}
+
+function classifyWorkbenchExecutability(opportunity: WorkbenchOpportunity) {
+  const sourceText = `${opportunity.quoteHighlight ?? ''}${opportunity.quoteRest ?? ''}`.trim()
+  const admission = runWorkbenchAdmissionGate(opportunity)
+  const preflightReasons = opportunity.preflightReasons ?? []
+  const scopeRequiresStrategy = opportunity.mode === 'repair-brief'
+  const hasEvidence = sourceText.length > 0 && !/no excerpt available/i.test(sourceText)
+
+  return evaluateRecommendationExecutability({
+    evidencePresent: hasEvidence,
+    contextPresent: opportunity.contextQuality === 'clean' && opportunity.preflightStatus === 'passed',
+    canonClear:
+      opportunity.contextQuality !== 'blocked' &&
+      !hasReasonMatching(preflightReasons, /canon|ledger_conflict|anchor_mismatch|testimony_fabrication/i),
+    diagnosisSupported:
+      (opportunity.groundingStatus === 'supported' || opportunity.groundingStatus === 'supported_after_relook') &&
+      opportunity.preflightStatus === 'passed',
+    anchorPrecise: !hasPlaceholderCoordinates(opportunity.anchor),
+    passageLength: passageLengthForExecutability(opportunity.scope, sourceText),
+    beforeAfterContextSufficient: hasEvidence && opportunity.contextQuality === 'clean',
+    ledgerConflictPossible: hasReasonMatching(preflightReasons, /ledger|anchor_mismatch|context_mismatch|canon/i),
+    canonConflict: hasReasonMatching(preflightReasons, /canon_authority_blocked|canon_conflict|canon_drift/i),
+    affectsSceneArchitecture: scopeRequiresStrategy,
+    affectsPOVVoiceCanonMetaphor: hasReasonMatching(preflightReasons, /voice|pov|metaphor|canon|testimony/i),
+    downstreamContinuityRisk: scopeRequiresStrategy || opportunity.scope === 'Scene',
+    voiceFingerprintStable: !hasReasonMatching(preflightReasons, /voice|pov|testimony_fabrication/i),
+    localOperation: opportunity.mode === 'direct-rewrite' && opportunity.revisionOperation !== 'needs_targeting',
+    passingCandidateCount: admission.passedCandidateCount,
+    candidateProseNarrativeSafe: admission.admission_status === 'admission_passed',
+  })
 }
 
 export type WorkbenchQueuePayload = {
@@ -1259,8 +1310,7 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
 
     const splitReasons = splitPreflightReasonsByClass(opportunity.preflight_reasons)
     const hydrationRepairNeeded = splitReasons.hydration.length > 0
-
-    return {
+    const baseOpportunity = {
       ...contracted,
       readinessReason: hydrationRepairNeeded
         ? 'Needs hydration repair'
@@ -1282,16 +1332,35 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
         : undefined,
       modeContract: modeContractForMetadata(modeContract),
     }
+    const executability = classifyWorkbenchExecutability(baseOpportunity)
+
+    return {
+      ...baseOpportunity,
+      cardType: executability.cardType,
+      trustedPathStatus: executability.trustedPathStatus,
+      executabilityReasons: executability.reasons,
+    }
   })
 
   const readyForRevise = opportunities.filter((opportunity) => opportunity.readiness === 'ready_for_revise')
-  const needsTargeting = opportunities.filter((opportunity) => opportunity.readiness === 'needs_targeting')
+  const strategyReadyForReview = readyForRevise.filter((opportunity) =>
+    isSupportedForUserQueue(opportunity) &&
+    opportunity.cardType === 'revision_strategy' &&
+    runWorkbenchAdmissionGate(opportunity).admission_status === 'admission_passed',
+  )
+  const needsTargeting = [
+    ...opportunities.filter((opportunity) => opportunity.readiness === 'needs_targeting'),
+    ...strategyReadyForReview,
+  ]
   const supportedReadyForRevise = readyForRevise.filter((opportunity) => {
     if (!isSupportedForUserQueue(opportunity)) return false
+    if (opportunity.cardType !== 'copy_paste_rewrite' || opportunity.trustedPathStatus !== 'eligible') return false
     return runWorkbenchAdmissionGate(opportunity).admission_status === 'admission_passed'
   })
   const withheldUnsupported = readyForRevise.filter((opportunity) => {
     if (!isSupportedForUserQueue(opportunity)) return true
+    if (opportunity.cardType === 'revision_strategy' && runWorkbenchAdmissionGate(opportunity).admission_status === 'admission_passed') return false
+    if (opportunity.cardType === 'withheld') return true
     return runWorkbenchAdmissionGate(opportunity).admission_status !== 'admission_passed'
   })
 


### PR DESCRIPTION
# PR: Add Revised Manuscript Package Export Standard

## Summary
This PR codifies the expected download package after a user completes Revise. It ensures RevisionGrade never silently presents a partially revised manuscript as fully complete.

The export model distinguishes between:

- **Applied Copy-Paste repairs** — safe TrustedPath/local edits applied to the manuscript.
- **Author customizations** — user-entered revisions preserved in the revised file.
- **Deferred or unresolved Strategy Cards** — visible in the Marked Manuscript as author-facing notes.
- **Withheld/blocked cards** — never rendered in user-facing exports.

## Product Rule
TrustedPath may only execute cards classified as `copy_paste_rewrite`.

Strategy cards are not auto-applied. If the author does not resolve them manually, the affected manuscript section remains unchanged and receives a visible RevisionGrade note in the Marked Manuscript.

## Download Package
The user should receive three grouped deliverables:

### 1. Clean Manuscript
- Accepted TrustedPath/copy-paste edits applied.
- Author custom edits applied.
- No notes or markers.
- Unresolved sections remain unchanged.

### 2. Marked Manuscript
- Accepted edits applied.
- Unresolved/deferred Strategy sections visibly marked.
- Notes must be distinguishable from manuscript prose.

### 3. Revision Log
- Applied repairs count.
- Author customizations count.
- Deferred cards count.
- Strategy unresolved count.
- Withheld/blocked count only in admin/support context, not normal user export.

## Required Inline Note
For unresolved Strategy/deferred sections, insert:

> [REVISIONGRADE NOTE — Strategy Card Unresolved]
> This section requires your attention. TrustedPath did not modify this area because the necessary adjustments involve structural, voice, canon, metaphor, or downstream continuity concerns that require author oversight.

## Acceptance Criteria

- TrustedPath applies only `copy_paste_rewrite` cards.
- Strategy cards are never silently treated as complete.
- Deferred/rejected/unresolved Strategy sections remain visible in the Marked Manuscript.
- Clean Manuscript contains no RevisionGrade notes.
- Marked Manuscript clearly shows unresolved areas.
- Withheld cards remain invisible to normal users.
- Revision Log records applied, customized, deferred, and unresolved status counts.
