### PR TITLE
Fix english_variant propagation across evaluation and revise prompts

### DIFF
--- a/.github/pr-bodies/PR-1048.md
+++ b/.github/pr-bodies/PR-1048.md
@@ -1,0 +1,14 @@
+## Summary
+- add a shared English variant normalization/prompt contract helper
+- persist the Evaluate-time english_variant through job creation and processing
+- inject the selected variant into Pass 1, Pass 2, Pass 3, Pass 3B/DREAM, Revise Queue hydration/enrichment, and TrustedPath rewrite prompts
+- preserve manuscript quotes/excerpts/evidence exactly while applying the variant only to generated editorial prose
+
+## Verification
+- static diagnostics clean for changed files
+- git diff --check
+- npm test -- --runInBand --runTestsByPath __tests__/lib/evaluation/englishVariantPropagation.test.ts __tests__/lib/evaluation/reportHeaderPolicy.test.ts __tests__/lib/revision/candidateHydration.test.ts lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts
+
+## Audit notes
+- grep audit confirms helper interpolation/pass-through for Pass 1, Pass 2, Pass 3, Pass 3B non-chunked, DREAM/chunked, Revise hydration, Revise enrichment, and Pass 4
+- remaining hard-coded english_variant: "us" occurrences are admin proof/test/script fixtures, not user Evaluate intake

--- a/__tests__/lib/evaluation/englishVariantPropagation.test.ts
+++ b/__tests__/lib/evaluation/englishVariantPropagation.test.ts
@@ -1,0 +1,207 @@
+import OpenAI from 'openai';
+import { buildPass1UserPrompt } from '@/lib/evaluation/pipeline/prompts/pass1-craft';
+import { buildPass2UserPrompt } from '@/lib/evaluation/pipeline/prompts/pass2-editorial';
+import { buildPass3UserPrompt } from '@/lib/evaluation/pipeline/prompts/pass3-synthesis';
+import { buildPass3bUserPrompt } from '@/lib/evaluation/pipeline/prompts/pass3b-longform';
+import { normalizeEnglishVariant, englishVariantLabel } from '@/lib/evaluation/englishVariant';
+import { hydrateLedgerCandidates, type HydrationOpportunity } from '@/lib/revision/candidateHydration';
+import { enrichDiagnosticFields, type EnrichmentOpportunity } from '@/lib/revision/diagnosticEnrichment';
+import { buildPass4UserPrompt } from '@/lib/revision/prompts/pass4-voice-rewrite';
+import { CRITERIA_KEYS } from '@/schemas/criteria-keys';
+import type { SynthesizedCriterion } from '@/lib/evaluation/pipeline/types';
+
+jest.mock('openai');
+
+const MockOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>;
+let mockCreate: jest.Mock;
+const originalOpenAiKey = process.env.OPENAI_API_KEY;
+
+const CANADIAN_CONTRACT = 'AUTHOR-FACING LANGUAGE CONTRACT — Canadian English';
+const EXACT_QUOTE = '“The color of the harbor looked wrong,” Mara said.';
+
+function expectCanadianContract(prompt: string) {
+  expect(prompt).toContain(CANADIAN_CONTRACT);
+  expect(prompt).toContain('All RevisionGrade-generated author-facing output MUST use Canadian English');
+  expect(prompt).toContain('NEVER alter manuscript text, quotations, excerpts, evidence snippets');
+  expect(prompt).toContain('Do NOT silently fall back to American English unless Canadian English is the selected variant.');
+}
+
+function makeCriteria(): SynthesizedCriterion[] {
+  return CRITERIA_KEYS.map((key) => ({
+    key,
+    craft_score: 7,
+    editorial_score: 7,
+    final_score_0_10: 7,
+    score_delta: 0,
+    final_rationale: `Rationale for ${key}.`,
+    fit_summary: `Fit for ${key}.`,
+    gap_summary: `Gap for ${key}.`,
+    pressure_points: [],
+    decision_points: [],
+    consequence_status: 'landed',
+    evidence: [{ snippet: `Evidence for ${key}.` }],
+    recommendations: [],
+  }));
+}
+
+describe('English variant propagation into generated output prompts', () => {
+  beforeEach(() => {
+    mockCreate = jest.fn();
+    MockOpenAI.mockImplementation(() => ({
+      chat: { completions: { create: mockCreate } },
+    }) as unknown as OpenAI);
+    process.env.OPENAI_API_KEY = 'sk-test';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env.OPENAI_API_KEY = originalOpenAiKey;
+  });
+
+  it('normalizes and labels supported Evaluate-time variants', () => {
+    expect(normalizeEnglishVariant('ca')).toBe('ca');
+    expect(englishVariantLabel('ca')).toBe('Canadian English');
+    expect(normalizeEnglishVariant('nonsense')).toBe('us');
+    expect(englishVariantLabel('nonsense')).toBe('American English');
+  });
+
+  it('injects Canadian English into Pass 1 without altering quoted manuscript text', () => {
+    const prompt = buildPass1UserPrompt({
+      manuscriptText: EXACT_QUOTE,
+      workType: 'novel',
+      title: 'Harbour Test',
+      englishVariant: 'ca',
+    });
+
+    expectCanadianContract(prompt);
+    expect(prompt).toContain(EXACT_QUOTE);
+  });
+
+  it('injects Canadian English into Pass 2 without altering quoted manuscript text', () => {
+    const prompt = buildPass2UserPrompt({
+      manuscriptText: EXACT_QUOTE,
+      workType: 'novel',
+      title: 'Harbour Test',
+      englishVariant: 'ca',
+    });
+
+    expectCanadianContract(prompt);
+    expect(prompt).toContain(EXACT_QUOTE);
+  });
+
+  it('injects Canadian English into Pass 3 synthesis without altering quoted manuscript text', () => {
+    const prompt = buildPass3UserPrompt({
+      comparisonPacketJson: JSON.stringify({ quote: EXACT_QUOTE }),
+      pass2aStructuredContext: {
+        character_ledger: [],
+        scene_index: [],
+        timeline_anchors: [],
+      },
+      manuscriptText: EXACT_QUOTE,
+      title: 'Harbour Test',
+      englishVariant: 'ca',
+    });
+
+    expectCanadianContract(prompt);
+    expect(prompt).toContain(EXACT_QUOTE);
+  });
+
+  it('injects Canadian English into Pass 3B/DREAM prompt without altering quoted manuscript samples', () => {
+    const prompt = buildPass3bUserPrompt({
+      title: 'Harbour Test',
+      wordCount: 90000,
+      chapterCount: 30,
+      workType: 'novel',
+      criteria: makeCriteria(),
+      pass2aStructuredContext: {
+        character_ledger: [],
+        scene_index: [],
+        timeline_anchors: [],
+      },
+      chunkSample: [{ chunk_index: 0, content: EXACT_QUOTE }],
+      englishVariant: 'ca',
+    });
+
+    expectCanadianContract(prompt);
+    expect(prompt).toContain(EXACT_QUOTE);
+  });
+
+  it('injects Canadian English into Revise Queue candidate hydration prompts', async () => {
+    const opportunity: HydrationOpportunity = {
+      opportunity_id: 'rol:canadian001',
+      evidence_anchor: EXACT_QUOTE,
+      rationale: 'The scene needs a concrete bridge beat before the emotional turn.',
+      revision_operation: 'insert_after_selected_passage',
+      english_variant: 'ca',
+      manuscript_context: EXACT_QUOTE,
+    };
+    mockCreate.mockResolvedValueOnce({
+      choices: [{
+        message: {
+          content: JSON.stringify({
+            results: [{
+              id: 'rol:canadian001',
+              candidate_a: 'Mara waited by the rain-streaked window until the harbour lights steadied in the glass.',
+              candidate_b: 'She kept one hand on the sill, listening as the gulls thinned into the afternoon fog.',
+              candidate_c: 'For a breath, she let the cold off the water settle before she answered him.',
+            }],
+          }),
+        },
+      }],
+    });
+
+    await hydrateLedgerCandidates([opportunity], 'sk-test');
+
+    const userMessage = mockCreate.mock.calls[0][0].messages.find((m: { role: string }) => m.role === 'user').content;
+    expectCanadianContract(userMessage);
+    expect(userMessage).toContain(JSON.stringify(EXACT_QUOTE));
+  });
+
+  it('injects Canadian English into Revise Queue diagnostic enrichment prompts', async () => {
+    const opportunity: EnrichmentOpportunity = {
+      opportunity_id: 'rol:diagnostic001',
+      evidence_anchor: EXACT_QUOTE,
+      rationale: 'The passage states the emotional turn before staging the sensory cause.',
+      criterion: 'emotional_arc',
+      revision_operation: 'replace_selected_passage',
+      english_variant: 'ca',
+    };
+    mockCreate.mockResolvedValueOnce({
+      choices: [{
+        message: {
+          content: JSON.stringify({
+            symptom: 'The scene names the emotional pressure before the reader has enough staged sensory evidence to feel it.',
+            cause: 'The paragraph relies on summary timing instead of placing a concrete beat between perception and response.',
+            fix_direction: 'Stage one specific physical or sensory beat before the line of interpretation so the turn lands on the page.',
+            reader_effect: 'The reader experiences the emotional shift through observed action rather than accepting it as editorial explanation.',
+          }),
+        },
+      }],
+    });
+
+    await enrichDiagnosticFields([opportunity]);
+
+    const userMessage = mockCreate.mock.calls[0][0].messages[0].content;
+    expectCanadianContract(userMessage);
+    expect(userMessage).toContain(`"${EXACT_QUOTE}"`);
+  });
+
+  it('injects Canadian English into TrustedPath/Pass 4 rewrite prompts', () => {
+    const prompt = buildPass4UserPrompt({
+      originalPassage: EXACT_QUOTE,
+      englishVariant: 'ca',
+      editorialInstruction: 'Revise the passage to stage the emotional turn more concretely.',
+      symptom: 'The emotion is summarised before it is embodied.',
+      cause: 'The passage skips the sensory beat that would ground the feeling.',
+      mistakeProofing: 'Preserve names and factual sequence exactly.',
+      operation: 'replace',
+      voiceContext: `Before: ${EXACT_QUOTE}\nAfter: Mara closed the door.`,
+      location: 'Chapter 4',
+      trustedPathOnly: true,
+    });
+
+    expectCanadianContract(prompt);
+    expect(prompt).toContain(EXACT_QUOTE);
+    expect(prompt).toContain('Produce ONE manuscript-ready variant');
+  });
+});

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -12,6 +12,7 @@ import { computeEnrichment } from '@/lib/evaluation/enrichment/computeEnrichment
 import { routeNarrativeEvaluationPreflight } from '@/lib/evaluation/preflight/manuscriptTypeRouting';
 import { enforceApiRateLimit } from '@/lib/security/apiRateLimit';
 import { requireUser } from '@/lib/security/apiGuards';
+import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
 import {
   normalizeEvaluationMode,
   normalizeVoicePreservationMode,
@@ -164,6 +165,7 @@ export async function POST(req: Request) {
           ? body.voice_preservation_mode
           : undefined,
     );
+    const selectedEnglishVariant = normalizeEnglishVariant(body?.english_variant);
     const trimmedText = manuscriptTextInput.trim();
 
     let manuscriptId: number | null = null;
@@ -292,7 +294,7 @@ export async function POST(req: Request) {
           allow_industry_discovery: false,
           is_final: false,
           source: 'paste',
-          english_variant: 'us',
+          english_variant: selectedEnglishVariant,
           word_count: wordCount,
         })
         .select('id')
@@ -405,7 +407,7 @@ export async function POST(req: Request) {
         phase_status: 'queued',
         policy_family: policyFamilyForEvaluationMode(selectedEvaluationMode),
         voice_preservation_level: voicePreservationLevelForMode(selectedVoicePreservationMode),
-        english_variant: 'us',
+        english_variant: selectedEnglishVariant,
         queued_at: new Date().toISOString(),
         ...(Object.keys(instantEnrichment).length > 0 ? { progress: instantEnrichment } : {}),
       })

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -19,6 +19,7 @@ import { computeEnrichment, type EnrichmentResult } from "@/lib/evaluation/enric
 import { routeNarrativeEvaluationPreflight } from "@/lib/evaluation/preflight/manuscriptTypeRouting";
 import { createInitialVersion } from "@/lib/manuscripts/versions";
 import { attachFreeDiagnosticJob, claimFreeDiagnostic } from "@/lib/freeDiagnostic/claims";
+import { normalizeEnglishVariant } from "@/lib/evaluation/englishVariant";
 
 function isRateLimited(
   result: RateLimitResult
@@ -307,7 +308,7 @@ export async function POST(req: Request) {
     const author_name = body?.author_name;
     const manuscript_title = body?.manuscript_title;
     const manuscript_size = body?.manuscript_size;
-    const english_variant = typeof body?.english_variant === "string" && body.english_variant.trim() ? body.english_variant.trim().toLowerCase() : "us";
+    const english_variant = normalizeEnglishVariant(body?.english_variant);
     const sensitivity_mode = typeof body?.sensitivity_mode === "string" && ["STANDARD", "TRANSGRESSIVE", "TESTIMONY"].includes(body.sensitivity_mode) ? body.sensitivity_mode : "STANDARD";
     const voice_preservation_level = typeof body?.voice_preservation_level === "string" && ["maximum", "balanced", "polished"].includes(body.voice_preservation_level) ? body.voice_preservation_level : "balanced";
     const user_tier = body?.user_tier as "free" | "premium" | "agent" | undefined;
@@ -717,6 +718,7 @@ export async function POST(req: Request) {
       job_type: validatedJobType,
       sensitivity_mode,
       voice_preservation_level,
+      english_variant,
     });
 
     if (freeDiagnosticClaimId) {

--- a/app/api/revise/generate-rewrite/route.ts
+++ b/app/api/revise/generate-rewrite/route.ts
@@ -6,6 +6,7 @@ import {
   extractVoiceContext,
 } from "@/lib/revision/runPass4VoiceRewrite";
 import { recordLlmCostEvent } from "@/lib/cost/llmCostEvents";
+import { normalizeEnglishVariant } from "@/lib/evaluation/englishVariant";
 
 /**
  * POST /api/revise/generate-rewrite
@@ -59,7 +60,7 @@ export async function POST(req: Request) {
 
     const { data: versionData } = await supabase
       .from("evaluation_jobs")
-      .select("manuscript_version_id")
+      .select("manuscript_version_id, english_variant")
       .eq("id", evaluationJobId)
       .maybeSingle();
 
@@ -89,6 +90,7 @@ export async function POST(req: Request) {
     const result = await runPass4VoiceRewrite(
       {
         originalPassage,
+        englishVariant: normalizeEnglishVariant(versionData?.english_variant),
         editorialInstruction: editorialInstruction || "Revise this passage to address the diagnosed issue.",
         symptom: symptom || "",
         cause: cause || "",

--- a/app/api/workers/process-dream/route.ts
+++ b/app/api/workers/process-dream/route.ts
@@ -47,6 +47,7 @@ import { persistFinalExternalAudit } from '@/lib/evaluation/pipeline/finalExtern
 import { checkJobCancellation } from '@/lib/jobs/cancellationCheck';
 import type { ManuscriptChunkEvidence } from '@/lib/evaluation/pipeline/types';
 import { extractGenreExpectationMetadataFromEvaluationPayload } from '@/lib/evaluation/genreExpectationProfiles';
+import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
 
 // Force Node.js runtime (required for crypto module)
 export const runtime = 'nodejs';
@@ -70,6 +71,7 @@ const DREAM_OPENAI_TIMEOUT_MS = 750_000;
 type DreamJobRow = {
   id: string;
   manuscript_id: number;
+  english_variant: string | null;
   // word_count comes from manuscripts join, not evaluation_jobs (evaluation_jobs has no word_count column)
   word_count: number | null;
   manuscripts: {
@@ -278,6 +280,7 @@ async function findPendingDreamJobs(
       `
       id,
       manuscript_id,
+      english_variant,
       manuscripts!inner(user_id, title, work_type, word_count)
     `,
     )
@@ -299,6 +302,7 @@ async function findPendingDreamJobs(
   const pending = ((candidateJobs as unknown) as Array<{
     id: string;
     manuscript_id: number;
+    english_variant: string | null;
     manuscripts: Array<{ user_id: string; title: string | null; work_type: string | null; word_count: number | null }> | { user_id: string; title: string | null; work_type: string | null; word_count: number | null } | null;
   }>)
     .map((j): DreamJobRow => {
@@ -306,6 +310,7 @@ async function findPendingDreamJobs(
       return {
         id: j.id,
         manuscript_id: j.manuscript_id,
+        english_variant: j.english_variant,
         word_count: ms?.word_count ?? null,
         manuscripts: ms,
       };
@@ -663,6 +668,7 @@ async function processDreamJob(
     chapterIndex,
     jobId,
     genreExpectationContext,
+    englishVariant: normalizeEnglishVariant(job.english_variant),
   });
 
   console.log(`[DreamWorker] ${jobId}: DREAM synthesis complete — persisting artifact`);

--- a/lib/evaluation/englishVariant.ts
+++ b/lib/evaluation/englishVariant.ts
@@ -1,0 +1,34 @@
+export const ENGLISH_VARIANTS = ["us", "uk", "ca", "au", "za", "nz"] as const;
+
+export type EnglishVariant = (typeof ENGLISH_VARIANTS)[number];
+
+const ENGLISH_VARIANT_LABELS: Record<EnglishVariant, string> = {
+  us: "American English",
+  uk: "British English",
+  ca: "Canadian English",
+  au: "Australian English",
+  za: "South African English",
+  nz: "New Zealand English",
+};
+
+export function normalizeEnglishVariant(value: unknown): EnglishVariant {
+  if (typeof value !== "string") return "us";
+  const normalized = value.trim().toLowerCase();
+  return ENGLISH_VARIANTS.includes(normalized as EnglishVariant)
+    ? (normalized as EnglishVariant)
+    : "us";
+}
+
+export function englishVariantLabel(value: unknown): string {
+  return ENGLISH_VARIANT_LABELS[normalizeEnglishVariant(value)];
+}
+
+export function buildEnglishVariantPromptBlock(value: unknown): string {
+  const label = englishVariantLabel(value);
+
+  return `AUTHOR-FACING LANGUAGE CONTRACT — ${label}
+- All RevisionGrade-generated author-facing output MUST use ${label}: summaries, rationales, recommendations, executive verdicts, revision plans, candidate prose, headings that are part of the generated report, and any future editorial content produced from this prompt.
+- Do NOT silently fall back to American English unless ${label} is the selected variant.
+- NEVER alter manuscript text, quotations, excerpts, evidence snippets, anchor_snippet values, or author-provided content. Copy quoted/source text exactly as supplied, preserving original spelling, punctuation, and wording even when it differs from ${label}.
+- Apply the selected variant only to new system-generated editorial prose.`;
+}

--- a/lib/evaluation/pipeline/prompts/pass1-craft.ts
+++ b/lib/evaluation/pipeline/prompts/pass1-craft.ts
@@ -13,6 +13,7 @@ import {
   buildPromptInputWindow,
   summarizePromptCoverage,
 } from "../promptInput";
+import { buildEnglishVariantPromptBlock } from "@/lib/evaluation/englishVariant";
 
 export const PASS1_PROMPT_VERSION = "pass1-craft-v8-provenance-hardening";
 
@@ -84,6 +85,8 @@ export function buildPass1UserPrompt(params: {
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   scopeProfile?: SubmissionScopeProfile;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: string;
   /** Pre-built character ledger block from Pass 1A — injected before manuscript text. */
   characterLedgerBlock?: string;
 }): string {
@@ -99,9 +102,11 @@ export function buildPass1UserPrompt(params: {
   const ledgerSection = params.characterLedgerBlock
     ? `\n${params.characterLedgerBlock}\n`
     : "";
+  const englishVariantBlock = buildEnglishVariantPromptBlock(params.englishVariant);
   return `Evaluate this ${params.workType || "manuscript"} excerpt titled "${params.title}" on the CRAFT EXECUTION axis.
 
 Execution mode: ${executionMode}
+${englishVariantBlock}
 Word count: ${wordCount}
 ${buildCoverageDisclosure(coverage)}
 ${params.scopeProfile ? `Submission scope: ${params.scopeProfile.inputScale} (${params.scopeProfile.wordCount} words; ${params.scopeProfile.chunkCount} chunk(s); ${params.scopeProfile.scorableCount}/13 criteria non-NA for this scope).` : ""}${ledgerSection}

--- a/lib/evaluation/pipeline/prompts/pass2-editorial.ts
+++ b/lib/evaluation/pipeline/prompts/pass2-editorial.ts
@@ -18,6 +18,7 @@ import {
   buildPromptInputWindow,
   summarizePromptCoverage,
 } from "../promptInput";
+import { buildEnglishVariantPromptBlock } from "@/lib/evaluation/englishVariant";
 
 export const PASS2_PROMPT_VERSION = "pass2-editorial-v10-candidate-prose";
 
@@ -243,6 +244,8 @@ export function buildPass2UserPrompt(params: {
   title: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   scopeProfile?: SubmissionScopeProfile;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: string;
   /** Pre-built character ledger block from Pass 1A — injected before manuscript text. */
   characterLedgerBlock?: string;
   /** Author corrections from accepted_story_ledger_v1.governance_rail — MANDATORY if present. */
@@ -263,9 +266,11 @@ export function buildPass2UserPrompt(params: {
   const correctionsSection = params.authorCorrectionsBlock
     ? `\n${params.authorCorrectionsBlock}\n`
     : "";
+  const englishVariantBlock = buildEnglishVariantPromptBlock(params.englishVariant);
   return `Evaluate this ${params.workType || "manuscript"} excerpt titled "${params.title}" on the EDITORIAL/LITERARY INSIGHT axis.
 
 Execution mode: ${executionMode}
+${englishVariantBlock}
 Word count: ${wordCount}
 ${buildCoverageDisclosure(coverage)}
 ${params.scopeProfile ? `Submission scope: ${params.scopeProfile.inputScale} (${params.scopeProfile.wordCount} words; ${params.scopeProfile.chunkCount} chunk(s); ${params.scopeProfile.scorableCount}/13 criteria non-NA for this scope). Treat scope-limited criteria accordingly.` : ""}${correctionsSection}${ledgerSection}

--- a/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
+++ b/lib/evaluation/pipeline/prompts/pass3-synthesis.ts
@@ -19,6 +19,7 @@ import {
 import { buildCompactTemplateBlock, resolveTemplateKey } from "@/lib/evaluation/dreamTemplateLoader";
 import type { ResolvedExpectationContext } from "@/lib/evaluation/genreExpectationProfiles";
 import { buildDiagnosticSpinePromptBlock } from "@/lib/evaluation/diagnosticSpine";
+import { buildEnglishVariantPromptBlock } from "@/lib/evaluation/englishVariant";
 
 export const PASS3_PROMPT_VERSION = "pass3-synthesis-v21-rec-or-rationale-contract";
 
@@ -438,6 +439,7 @@ export function buildPass3UserPrompt(params: {
   pass2aStructuredContext: Pass2aStructuredContext;
   manuscriptText?: string;
   title: string;
+  englishVariant?: string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   scopeProfile?: SubmissionScopeProfile;
   /**
@@ -495,6 +497,7 @@ export function buildPass3UserPrompt(params: {
   const synthesisWindow = params.manuscriptText
     ? buildPromptInputWindow(params.manuscriptText, synthesisBudget)
     : "";
+  const englishVariantBlock = buildEnglishVariantPromptBlock(params.englishVariant);
   const synthesisCoverage = params.manuscriptText
     ? summarizePromptCoverage(params.manuscriptText, synthesisBudget)
     : null;
@@ -562,6 +565,8 @@ ${buildDiagnosticSpinePromptBlock()}
 
 
 Execution mode: ${executionMode}
+
+${englishVariantBlock}
 
 OUTPUT BUDGET BY STATE (STRICT):
 - agree (score_delta <= 1): emit { key, final_score_0_10, final_rationale (1-3 substantive sentences—NOT "Confirmed."), recommendations[] (with semantic fields) }

--- a/lib/evaluation/pipeline/prompts/pass3b-longform.ts
+++ b/lib/evaluation/pipeline/prompts/pass3b-longform.ts
@@ -29,6 +29,7 @@ import { CRITERIA_METADATA } from "@/schemas/criteria-keys";
 import type { CriterionKey } from "@/schemas/criteria-keys";
 import { buildCompactTemplateBlock, resolveTemplateKey } from "@/lib/evaluation/dreamTemplateLoader";
 import type { GenreExpectationMetadata } from "@/lib/evaluation/genreExpectationProfiles";
+import { buildEnglishVariantPromptBlock } from "@/lib/evaluation/englishVariant";
 
 export const PASS3B_PROMPT_VERSION = "pass3b-longform-v4-quality-calibration";
 
@@ -288,6 +289,8 @@ export function buildPass3bUserPrompt(params: {
   chapterIndex?: string | null;
   /** Canon-backed genre expectation contract from EvaluationResultV2 transparency metadata. */
   genreExpectationContext?: GenreExpectationMetadata | null;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: string;
 }): string {
   // Build the score grid summary so Pass 3b has all 13 scores in compact form
   const scoreSummary = params.criteria.map((c) => {
@@ -361,6 +364,7 @@ export function buildPass3bUserPrompt(params: {
 
   const templateKey = resolveTemplateKey(params.wordCount, params.mode?.includes('multi_layer'));
   const dreamTemplateBlock = buildCompactTemplateBlock(templateKey);
+  const englishVariantBlock = buildEnglishVariantPromptBlock(params.englishVariant);
 
   return `Produce the DREAM long-form evaluation document for the manuscript titled "${params.title}".
 ${dreamTemplateBlock ? `
@@ -369,6 +373,8 @@ The output document MUST conform to this canonical template. Use it as the struc
 ${dreamTemplateBlock}
 ` : ""}
 ${correctionsSection}
+${englishVariantBlock}
+
 MANUSCRIPT FACTS
 - Title: ${params.title}
 - Work type: ${params.workType}

--- a/lib/evaluation/pipeline/runPass1.ts
+++ b/lib/evaluation/pipeline/runPass1.ts
@@ -32,6 +32,7 @@ import {
   ChunkRoutingNotEngagedError,
 } from "./failures";
 import { annotateWeakCriteria, getPass1WeakCriteriaThreshold } from "./weakCriteriaCheck";
+import type { EnglishVariant } from "@/lib/evaluation/englishVariant";
 const PASS1_TEMPERATURE = 0.3;
 
 // Mirror of processor.ts STRUCTURAL_CHUNKING_THRESHOLD_WORDS. Kept duplicated
@@ -420,6 +421,8 @@ export interface RunPass1Options {
   isChunkUnit?: boolean;
   workType: string;
   title: string;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: EnglishVariant | string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   registry: CanonRegistry;
   // NOTE: model is intentionally absent — Pass1 model authority is not caller-controlled.
@@ -773,6 +776,7 @@ export async function runPass1(opts: RunPass1Options): Promise<SinglePassOutput>
     manuscriptText: opts.manuscriptText,
     workType: opts.workType,
     title: opts.title,
+    englishVariant: opts.englishVariant,
     executionMode: opts.executionMode,
     scopeProfile: opts.scopeProfile,
     characterLedgerBlock: opts.characterLedgerBlock,

--- a/lib/evaluation/pipeline/runPass2.ts
+++ b/lib/evaluation/pipeline/runPass2.ts
@@ -33,6 +33,7 @@ import {
   ChunkCountExceedsCapError,
   ChunkRoutingNotEngagedError,
 } from "./failures";
+import type { EnglishVariant } from "@/lib/evaluation/englishVariant";
 
 const PASS2_TEMPERATURE = 0.3;
 
@@ -404,6 +405,8 @@ export interface RunPass2Options {
   isChunkUnit?: boolean;
   workType: string;
   title: string;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: EnglishVariant | string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   registry: CanonRegistry;
   model?: string;
@@ -748,6 +751,7 @@ export async function runPass2(opts: RunPass2Options): Promise<SinglePassOutput>
     manuscriptText: opts.manuscriptText,
     workType: opts.workType,
     title: opts.title,
+    englishVariant: opts.englishVariant,
     executionMode: opts.executionMode,
     scopeProfile: opts.scopeProfile,
     characterLedgerBlock: opts.characterLedgerBlock,

--- a/lib/evaluation/pipeline/runPass3Synthesis.ts
+++ b/lib/evaluation/pipeline/runPass3Synthesis.ts
@@ -90,6 +90,7 @@ import {
 import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
 import type { CriterionKey } from "@/schemas/criteria-keys";
 import { pipelineLog } from "./pipelineLogger";
+import type { EnglishVariant } from "@/lib/evaluation/englishVariant";
 
 function countWords(text: string): number {
   const trimmed = text.trim();
@@ -374,6 +375,8 @@ export interface RunPass3Options {
   manuscriptText: string;
   manuscriptChunks?: ManuscriptChunkEvidence[];
   title: string;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: EnglishVariant | string;
   /** Structural canonical work type from intake routing. */
   workType?: string;
   /** Optional diagnosed genre signal if available upstream. */
@@ -812,6 +815,7 @@ export async function runPass3Synthesis(opts: RunPass3Options): Promise<Synthesi
     pass2aStructuredContext: opts.pass2aStructuredContext,
     manuscriptText: opts.manuscriptText,
     title: opts.title,
+    englishVariant: opts.englishVariant,
     executionMode: opts.executionMode,
     scopeProfile: opts.scopeProfile,
     perplexityChunkPacket: opts.perplexityChunkPacket,

--- a/lib/evaluation/pipeline/runPass3bLongform.ts
+++ b/lib/evaluation/pipeline/runPass3bLongform.ts
@@ -46,6 +46,7 @@ import type {
 import type { SubmissionScopeProfile } from "./submissionScope";
 import { CRITERIA_METADATA } from "@/schemas/criteria-keys";
 import type { GenreExpectationMetadata } from "@/lib/evaluation/genreExpectationProfiles";
+import { buildEnglishVariantPromptBlock, type EnglishVariant } from "@/lib/evaluation/englishVariant";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -221,6 +222,8 @@ export interface RunPass3bOptions {
   jobId?: string;
   /** Canon-backed genre expectation context from EvaluationResultV2 governance transparency. */
   genreExpectationContext?: GenreExpectationMetadata | null;
+  /** Evaluate-time selected English variant for generated author-facing output. */
+  englishVariant?: EnglishVariant | string;
 }
 
 export type TruthfulFallbackReport = {
@@ -675,6 +678,7 @@ function buildSynthesisPrompt(params: {
   criteria: SynthesizedCriterion[];
   chapterIndex?: string | null;
   genreExpectationContext?: GenreExpectationMetadata | null;
+  englishVariant?: EnglishVariant | string;
 }): string {
   const scoreSummary = params.criteria.map((c) => {
     const label = CRITERIA_METADATA[c.key as keyof typeof CRITERIA_METADATA]?.label ?? c.key;
@@ -706,9 +710,12 @@ function buildSynthesisPrompt(params: {
     ? `\nCHAPTER INDEX (authoritative — use these real chapter numbers in arc_map and revision_plan)\n${params.chapterIndex}\n`
     : "";
   const genreContractSection = formatGenreExpectationContractForPass3b(params.genreExpectationContext);
+  const englishVariantBlock = buildEnglishVariantPromptBlock(params.englishVariant);
 
   return `Produce the DREAM long-form evaluation document (EXCLUDING criterion_analyses — those are pre-computed below).
 ${correctionsSection}
+${englishVariantBlock}
+
 MANUSCRIPT FACTS
 - Title: ${params.title}
 - Word count: ${params.wordCount.toLocaleString()}
@@ -838,6 +845,7 @@ async function runPass3bChunked(
     criteria: opts.criteria,
     chapterIndex: opts.chapterIndex,
     genreExpectationContext: opts.genreExpectationContext,
+    englishVariant: opts.englishVariant,
   });
 
   const synthesisCompletion = await createCompletion({
@@ -945,6 +953,7 @@ export async function runPass3bLongform(
     authorCorrectionsBlock: opts.authorCorrectionsBlock,
     chapterIndex: opts.chapterIndex,
     genreExpectationContext: opts.genreExpectationContext,
+    englishVariant: opts.englishVariant,
   });
 
   console.log(`[Pass3b] request model=${selectedModel} max_tokens=${maxTokens} title="${opts.title}" words=${opts.wordCount} chunks=${opts.manuscriptChunks.length}`);

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -128,6 +128,7 @@ import {
   ManuscriptExceedsHardCeilingError,
 } from "./failures";
 import { getConfiguredChunkCap } from "./chunkCap";
+import type { EnglishVariant } from "@/lib/evaluation/englishVariant";
 
 // Below this word count we evaluate as a single structural unit (one chunk).
 // Above this, the chunked path MUST engage — see runPipeline guard below.
@@ -192,6 +193,8 @@ export interface RunPipelineOptions {
   /** Dependency injection for governance injection map loader (testing only). */
   _governanceInjectionMapLoader?: () => GovernanceInjectionMap;
   manuscriptId?: string;
+  /** Evaluate-time selected English variant for all generated author-facing output. */
+  englishVariant?: EnglishVariant | string;
   executionMode?: "TRUSTED_PATH" | "STUDIO";
   /** Dependency injection for lessons-learned engine (testing only). */
   _lessonsLearned?: {
@@ -1067,6 +1070,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       manuscriptChunks: opts.manuscriptChunks,
       workType: opts.workType,
       title: opts.title,
+      englishVariant: opts.englishVariant,
       executionMode: opts.executionMode,
       openaiApiKey: opts.openaiApiKey,
       jobId: opts.jobId,
@@ -1117,6 +1121,7 @@ export async function runPipeline(opts: RunPipelineOptions): Promise<PipelineRes
       manuscriptChunks: opts.manuscriptChunks,
       workType: opts.workType,
       title: opts.title,
+      englishVariant: opts.englishVariant,
       executionMode: opts.executionMode,
       model: opts.model,
       openaiApiKey: opts.openaiApiKey,

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -207,6 +207,7 @@ import {
 } from '@/lib/evaluation/phaseTimestamps';
 import { buildPhaseLogPatch } from '@/lib/evaluation/phaseLog';
 import { getConfiguredAppBaseUrl } from '@/lib/jobs/triggerWorker';
+import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // WAVE Phase 3 constants
@@ -4699,6 +4700,8 @@ export async function processEvaluationJob(
     progressState =
       job.progress && typeof job.progress === 'object' ? { ...job.progress } : {};
 
+    const selectedEnglishVariant = normalizeEnglishVariant((job as Record<string, unknown>).english_variant);
+
     expectedLeaseToken = typeof job.lease_token === 'string' ? job.lease_token : null;
     expectedClaimedBy = typeof job.claimed_by === 'string' ? job.claimed_by : null;
     let failureAlertManuscriptId =
@@ -5998,6 +6001,7 @@ export async function processEvaluationJob(
             openaiApiKey,
             perplexityApiKey: perplexityApiKey || undefined,
             manuscriptId: String(manuscriptWithContent.id),
+            englishVariant: selectedEnglishVariant,
             executionMode: 'TRUSTED_PATH',
             _passTimeoutMs: timeoutResolution.passTimeoutMs,
             _openAiTimeoutMs: timeoutResolution.openAiTimeoutMs,

--- a/lib/jobs/jobStore.memory.ts
+++ b/lib/jobs/jobStore.memory.ts
@@ -3,6 +3,7 @@ import { assertValidTransition } from "./transitions";
 import { debugLog } from "./logging";
 import { assertNotProductionMemoryStore } from "./guards";
 import { validateProgressSchema } from "./canon";
+import { normalizeEnglishVariant } from "@/lib/evaluation/englishVariant";
 
 // Production Safety: Ensure memory store is never used in production
 // Memory store is for tests/dev only - not concurrent-safe or durable
@@ -54,7 +55,7 @@ function getStore(): Map<string, Job> {
   return _store;
 }
 
-export function createJob(input: { manuscript_id: string; manuscript_version_id?: string; job_type: JobType; user_id: string; sensitivity_mode?: string; voice_preservation_level?: string }): Job {
+export function createJob(input: { manuscript_id: string; manuscript_version_id?: string; job_type: JobType; user_id: string; sensitivity_mode?: string; voice_preservation_level?: string; english_variant?: string }): Job {
   const store = getStore();
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
@@ -79,6 +80,7 @@ export function createJob(input: { manuscript_id: string; manuscript_version_id?
     created_at: now,
     updated_at: now,
     last_heartbeat: null,
+    english_variant: normalizeEnglishVariant(input.english_variant),
   };
 
   store.set(id, job);

--- a/lib/jobs/jobStore.supabase.ts
+++ b/lib/jobs/jobStore.supabase.ts
@@ -13,6 +13,7 @@ import {
 import { Job, JobStatus, JobType, PHASES, Phase, JOB_STATUS, JobProgress } from "./types";
 import { getLeaseTimeoutSeconds } from "./config";
 import { getLatestVersionForManuscript } from "@/lib/db/manuscriptVersions";
+import { normalizeEnglishVariant } from "@/lib/evaluation/englishVariant";
 
 const JOB_SELECT_FIELDS =
   "id, manuscript_id, user_id, job_type, status, validity_status, progress, created_at, updated_at, last_heartbeat, last_error, failure_envelope, manuscripts(user_id, title)";
@@ -169,6 +170,7 @@ export async function createJob(input: {
   job_type: JobType;
   sensitivity_mode?: string;
   voice_preservation_level?: string;
+  english_variant?: string;
 }): Promise<Job> {
   const now = new Date().toISOString();
   
@@ -246,7 +248,7 @@ export async function createJob(input: {
     },
     policy_family: input.sensitivity_mode === "TRANSGRESSIVE" ? "transgressive" : input.sensitivity_mode === "TESTIMONY" ? "testimony" : "standard",
     voice_preservation_level: input.voice_preservation_level ?? "balanced",
-    english_variant: "us",
+    english_variant: normalizeEnglishVariant(input.english_variant),
   };
 
   validateProgressWrite(payload.progress);

--- a/lib/jobs/types.ts
+++ b/lib/jobs/types.ts
@@ -114,6 +114,9 @@ export type JobRecord = {
 
   // Denormalized from manuscripts table for UI display
   manuscript_title?: string | null;
+
+  // Selected at Evaluate time; governs generated author-facing output language.
+  english_variant?: string | null;
 };
 
 export type GetJobApiResponse =

--- a/lib/revision/candidateHydration.ts
+++ b/lib/revision/candidateHydration.ts
@@ -16,6 +16,7 @@
  */
 
 import OpenAI from 'openai';
+import { buildEnglishVariantPromptBlock } from '@/lib/evaluation/englishVariant';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -47,6 +48,8 @@ export type HydrationOpportunity = {
   evaluation_mode?: string;
   /** Surrounding manuscript paragraph/chunk containing the anchor. Improves SLAE pass rate. */
   manuscript_context?: string;
+  /** Evaluate-time selected English variant for generated candidate prose. */
+  english_variant?: string;
 };
 
 export type HydrationCandidates = {
@@ -214,6 +217,7 @@ function operationInstruction(operation?: string): string {
 }
 
 function buildUserMessage(opportunities: HydrationOpportunity[]): string {
+  const englishVariantBlock = buildEnglishVariantPromptBlock(opportunities[0]?.english_variant);
   const items = opportunities
     .map(
       (o, i) =>
@@ -231,6 +235,8 @@ function buildUserMessage(opportunities: HydrationOpportunity[]): string {
     .join('\n---\n');
 
   return `For each opportunity below, produce exactly 3 distinct, manuscript-ready prose candidates.
+
+${englishVariantBlock}
 
 Hard rules:
 - Return prose only inside candidate_a/b/c. Do not return advice, diagnosis, rationale, summary, bullets, labels, or explanations.

--- a/lib/revision/candidateRegeneration.ts
+++ b/lib/revision/candidateRegeneration.ts
@@ -77,6 +77,7 @@ export type RegenCandidate = {
   revision_operation?: string;
   evaluation_mode?: string;
   manuscript_context?: string;
+  english_variant?: string;
 };
 
 export type RegenResult = {
@@ -119,6 +120,7 @@ export async function regenerateCandidatesForQualityFailed(
     revision_operation: opp.revision_operation,
     evaluation_mode: opp.evaluation_mode,
     manuscript_context: opp.manuscript_context,
+    english_variant: opp.english_variant,
   }));
 
   for (let attempt = 0; attempt < MAX_REGEN_ATTEMPTS; attempt++) {

--- a/lib/revision/diagnosticEnrichment.ts
+++ b/lib/revision/diagnosticEnrichment.ts
@@ -13,6 +13,7 @@
  */
 
 import OpenAI from 'openai';
+import { buildEnglishVariantPromptBlock } from '@/lib/evaluation/englishVariant';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -38,6 +39,8 @@ export type EnrichmentOpportunity = {
   cause?: string;
   fix_direction?: string;
   reader_effect?: string;
+  /** Evaluate-time selected English variant for generated diagnostic text. */
+  english_variant?: string;
 };
 
 export type EnrichmentResult = {
@@ -80,6 +83,7 @@ function buildEnrichmentPrompt(
   opportunity: EnrichmentOpportunity,
   missingFields: DiagnosticField[],
 ): string {
+  const englishVariantBlock = buildEnglishVariantPromptBlock(opportunity.english_variant);
   const fieldDescriptions: Record<DiagnosticField, string> = {
     symptom: 'SYMPTOM — the observable craft problem on the page that the reader experiences. Without this, the author cannot trust the recommendation because they do not know what problem it solves.',
     cause: 'CAUSE — the craft mechanism creating the problem. This explains WHY the issue exists at this location, not just WHAT the issue is.',
@@ -92,6 +96,8 @@ function buildEnrichmentPrompt(
     .join('\n');
 
   return `You are a senior literary editor producing diagnostic analysis for a Revise Queue card.
+
+${englishVariantBlock}
 
 A recommendation was produced but is INCOMPLETE. The following required diagnostic fields are MISSING:
 

--- a/lib/revision/opportunityLedger.ts
+++ b/lib/revision/opportunityLedger.ts
@@ -8,6 +8,7 @@ import {
 import { type SlaeGroundingStatus } from './slae';
 import { modeContractForMetadata, resolveRevisionModeContract } from './modeContract';
 import { extractGenreExpectationMetadataFromEvaluationPayload } from '@/lib/evaluation/genreExpectationProfiles';
+import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
 import {
   hydrateLedgerCandidates,
   HYDRATION_MODEL,
@@ -1833,7 +1834,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
 
   const { data: jobRow, error: jobReadError } = await supabase
     .from('evaluation_jobs')
-    .select('id, manuscript_id, evaluation_project_id, evaluation_result, policy_family, voice_preservation_level')
+    .select('id, manuscript_id, evaluation_project_id, evaluation_result, policy_family, voice_preservation_level, english_variant')
     .eq('id', jobId)
     .maybeSingle();
 
@@ -1864,6 +1865,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
     evaluationPayload,
     job: jobRow,
   });
+  const selectedEnglishVariant = normalizeEnglishVariant(jobRow.english_variant);
   const genreExpectationContext = extractGenreExpectationMetadataFromEvaluationPayload(evaluationPayload);
 
   let ledgerQualityReportContent: unknown = null;
@@ -2058,6 +2060,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
         cause: o.cause,
         fix_direction: o.fix_direction,
         reader_effect: o.reader_effect,
+        english_variant: selectedEnglishVariant,
       }));
 
       const enrichmentResult = await enrichDiagnosticFields(enrichmentInput);
@@ -2136,6 +2139,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
           revision_operation: o.revision_operation,
           evaluation_mode: modeContract.evaluation_mode,
           manuscript_context: manuscriptContext,
+          english_variant: selectedEnglishVariant,
         });
       }
 
@@ -2202,6 +2206,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
                 revision_operation: o.revision_operation,
                 evaluation_mode: modeContract.evaluation_mode,
                 manuscript_context: findChunkForAnchor(o.evidence_anchor),
+                english_variant: selectedEnglishVariant,
               }));
               try {
                 const regenResult = await regenerateCandidatesForQualityFailed(regenInput, openaiApiKey);

--- a/lib/revision/prompts/pass4-voice-rewrite.ts
+++ b/lib/revision/prompts/pass4-voice-rewrite.ts
@@ -12,6 +12,8 @@
  * Max tokens: 2000 per call
  */
 
+import { buildEnglishVariantPromptBlock } from "@/lib/evaluation/englishVariant";
+
 export const PASS4_REWRITE_VERSION = "pass4-voice-rewrite-v1";
 
 export const PASS4_SYSTEM_PROMPT = `You are a revision prose generator working in the author's voice.
@@ -60,6 +62,8 @@ RULES:
 export interface Pass4RewriteInput {
   /** The original passage that needs revision */
   originalPassage: string;
+   /** Evaluate-time selected English variant for generated rewrite candidates. */
+   englishVariant?: string;
   /** The editorial instruction / fix direction */
   editorialInstruction: string;
   /** The diagnosed symptom */
@@ -79,6 +83,7 @@ export interface Pass4RewriteInput {
 }
 
 export function buildPass4UserPrompt(input: Pass4RewriteInput): string {
+   const englishVariantBlock = buildEnglishVariantPromptBlock(input.englishVariant);
   const variantInstruction = input.trustedPathOnly
     ? `Produce ONE manuscript-ready variant (the recommended fix) that addresses the diagnosed issue while maintaining the author's voice. Output as JSON:
 {
@@ -91,7 +96,9 @@ export function buildPass4UserPrompt(input: Pass4RewriteInput): string {
   "c": "full replacement text for variant C"
 }`;
 
-  return `VOICE CONTEXT (study this to match the author's style):
+   return `${englishVariantBlock}
+
+VOICE CONTEXT (study this to match the author's style):
 """
 ${input.voiceContext}
 """

--- a/lib/revision/workbenchQueue.ts
+++ b/lib/revision/workbenchQueue.ts
@@ -1158,7 +1158,7 @@ export async function getWorkbenchQueue(input: { manuscriptId?: string; evaluati
 
   const { data: job, error: jobError } = await supabase
     .from('evaluation_jobs')
-    .select('id, status, manuscript_id, manuscript_version_id, policy_family, voice_preservation_level')
+    .select('id, status, manuscript_id, manuscript_version_id, policy_family, voice_preservation_level, english_variant')
     .eq('id', evaluationJobId)
     .eq('manuscript_id', manuscriptNumericId)
     .maybeSingle()


### PR DESCRIPTION
## Summary
- add a shared English variant normalization/prompt contract helper
- persist the Evaluate-time english_variant through job creation and processing
- inject the selected variant into Pass 1, Pass 2, Pass 3, Pass 3B/DREAM, Revise Queue hydration/enrichment, and TrustedPath rewrite prompts
- preserve manuscript quotes/excerpts/evidence exactly while applying the variant only to generated editorial prose

## Verification
- static diagnostics clean for changed files
- git diff --check
- npm test -- --runInBand --runTestsByPath __tests__/lib/evaluation/englishVariantPropagation.test.ts __tests__/lib/evaluation/reportHeaderPolicy.test.ts __tests__/lib/revision/candidateHydration.test.ts lib/evaluation/pipeline/__tests__/pass3-dual-model-prompt.test.ts

## Audit notes
- grep audit confirms helper interpolation/pass-through for Pass 1, Pass 2, Pass 3, Pass 3B non-chunked, DREAM/chunked, Revise hydration, Revise enrichment, and Pass 4
- remaining hard-coded english_variant: "us" occurrences are admin proof/test/script fixtures, not user Evaluate intake