### PR TITLE
Persist resolved English variant artifacts

### DIFF
--- a/__tests__/lib/evaluation/englishVariantResolved.test.ts
+++ b/__tests__/lib/evaluation/englishVariantResolved.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test: resolved_english_variant persisted in evaluation artifact
+ *
+ * Verifies that `requested_english_variant` and `resolved_english_variant`
+ * are written into `evaluation_result_v2.metrics.manuscript` when a
+ * Canadian-English job is processed via synthesisToEvaluationResultV2.
+ *
+ * All six supported variants are tested to confirm correct label resolution.
+ * No real model calls are made — the function under test is purely deterministic.
+ */
+
+import { synthesisToEvaluationResultV2 } from "@/lib/evaluation/pipeline/runPipeline";
+import { CRITERIA_KEYS, type CriterionKey } from "@/schemas/criteria-keys";
+import type { SynthesisOutput, SynthesizedCriterion } from "@/lib/evaluation/pipeline/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function baseCriterion(key: CriterionKey): SynthesizedCriterion {
+  return {
+    key,
+    craft_score: 7,
+    editorial_score: 7,
+    final_score_0_10: 7,
+    score_delta: 0,
+    final_rationale: `Criterion ${key} grounded in textual evidence.`,
+    pressure_points: ["Scene transition pressure."],
+    decision_points: ["Chapter-level consequential choice."],
+    consequence_status: "landed",
+    evidence: [{ snippet: `Evidence for ${key}.` }],
+    recommendations: [],
+  };
+}
+
+function makeSynthesis(): SynthesisOutput {
+  return {
+    criteria: CRITERIA_KEYS.map(baseCriterion),
+    overall: {
+      overall_score_0_100: 70,
+      verdict: "revise",
+      one_paragraph_summary: "Solid manuscript requiring targeted revision.",
+      top_3_strengths: ["voice", "premise", "character"],
+      top_3_risks: ["pacing", "tension", "closure"],
+      submission_readiness: "nearly_ready",
+    },
+    metadata: {
+      pass1_model: "gpt-4o",
+      pass2_model: "gpt-4o",
+      pass3_model: "gpt-4o",
+      generated_at: new Date().toISOString(),
+    },
+    partial_evaluation: false,
+  };
+}
+
+const BASE_IDS = {
+  evaluation_run_id: "run-english-variant-resolved-test",
+  job_id: "job-english-variant-resolved-test",
+  manuscript_id: 9001,
+  user_id: "00000000-0000-0000-0000-000000009001",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("resolved_english_variant persisted in evaluation_result_v2 metrics", () => {
+  it("persists resolved_english_variant as 'Canadian English' for variant 'ca'", () => {
+    const result = synthesisToEvaluationResultV2({
+      synthesis: makeSynthesis(),
+      ids: BASE_IDS,
+      englishVariant: "ca",
+      manuscriptText: "The harbour was calm. The colour of the water had changed overnight.",
+    });
+
+    expect(result.metrics.manuscript.resolved_english_variant).toBe("Canadian English");
+    expect(result.metrics.manuscript.requested_english_variant).toBe("ca");
+  });
+
+  it("defaults resolved_english_variant to 'American English' when no variant is provided", () => {
+    const result = synthesisToEvaluationResultV2({
+      synthesis: makeSynthesis(),
+      ids: BASE_IDS,
+    });
+
+    expect(result.metrics.manuscript.resolved_english_variant).toBe("American English");
+    expect(result.metrics.manuscript.requested_english_variant).toBe("us");
+  });
+
+  it("defaults to American English for invalid variant input", () => {
+    const result = synthesisToEvaluationResultV2({
+      synthesis: makeSynthesis(),
+      ids: BASE_IDS,
+      englishVariant: "nonsense",
+    });
+
+    expect(result.metrics.manuscript.resolved_english_variant).toBe("American English");
+    expect(result.metrics.manuscript.requested_english_variant).toBe("nonsense");
+  });
+
+  it.each([
+    ["us", "American English"],
+    ["uk", "British English"],
+    ["ca", "Canadian English"],
+    ["au", "Australian English"],
+    ["za", "South African English"],
+    ["nz", "New Zealand English"],
+  ] as const)(
+    "resolves variant '%s' to label '%s'",
+    (variant, expectedLabel) => {
+      const result = synthesisToEvaluationResultV2({
+        synthesis: makeSynthesis(),
+        ids: BASE_IDS,
+        englishVariant: variant,
+      });
+
+      expect(result.metrics.manuscript.resolved_english_variant).toBe(expectedLabel);
+      expect(result.metrics.manuscript.requested_english_variant).toBe(variant);
+    },
+  );
+
+  it("Canadian-English evaluation preserves exact manuscript text in requested_english_variant tracking", () => {
+    // Canonical Canadian-English sentence with lexical markers (colour, harbour).
+    // This verifies that the variant tracking fields do not alter manuscript content.
+    const canadianManuscript = "The colour of the harbour reminded her of a grey October afternoon in Montréal.";
+
+    const result = synthesisToEvaluationResultV2({
+      synthesis: makeSynthesis(),
+      ids: BASE_IDS,
+      englishVariant: "ca",
+      manuscriptText: canadianManuscript,
+      sourceText: canadianManuscript,
+    });
+
+    expect(result.metrics.manuscript.resolved_english_variant).toBe("Canadian English");
+    expect(result.metrics.manuscript.requested_english_variant).toBe("ca");
+    // Manuscript content must not be altered by variant tracking.
+    expect(result.metrics.manuscript.word_count).toBeGreaterThan(0);
+  });
+});

--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -12,7 +12,7 @@ import { computeEnrichment } from '@/lib/evaluation/enrichment/computeEnrichment
 import { routeNarrativeEvaluationPreflight } from '@/lib/evaluation/preflight/manuscriptTypeRouting';
 import { enforceApiRateLimit } from '@/lib/security/apiRateLimit';
 import { requireUser } from '@/lib/security/apiGuards';
-import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
+import { normalizeEnglishVariant, englishVariantLabel } from '@/lib/evaluation/englishVariant';
 import {
   normalizeEvaluationMode,
   normalizeVoicePreservationMode,
@@ -505,6 +505,8 @@ export async function POST(req: Request) {
           policy_family: data.policy_family,
           voice_preservation_level: data.voice_preservation_level,
           english_variant: data.english_variant,
+          requested_english_variant: body?.english_variant ?? null,
+          resolved_english_variant: englishVariantLabel(selectedEnglishVariant),
         },
       },
       { status: 200 }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -132,6 +132,19 @@ const faqSections = [
     ],
   },
   {
+    label: "English Variant",
+    items: [
+      {
+        q: "Why does RevisionGrade ask for an English variant?",
+        a: "RevisionGrade supports American English by default, plus British, Canadian, Australian, South African, and New Zealand English. The selected variant governs all RevisionGrade-generated output: reports, recommendations, revision guidance, Revise Queue content, TrustedPath rewrites, and other editorial text. Manuscript quotations, evidence excerpts, and author-written content are preserved exactly as submitted regardless of the selected variant.",
+      },
+      {
+        q: "Can I change the English variant after an evaluation is generated?",
+        a: "The selected English variant becomes part of the evaluation record and is used throughout all associated outputs for that job. To generate output using a different English convention, create a new evaluation using the desired variant.",
+      },
+    ],
+  },
+  {
     label: "Privacy, security, and author control",
     items: [
       {

--- a/components/evaluation/ManuscriptSubmissionForm.jsx
+++ b/components/evaluation/ManuscriptSubmissionForm.jsx
@@ -982,13 +982,14 @@ export default function ManuscriptSubmissionForm({ onSubmitSuccess, freeDiagnost
                     onChange={(e) => setEnglishVariant(e.target.value)}
                     className="min-h-[48px] w-full rounded-lg border border-stone-400 bg-white px-4 py-2 text-base text-stone-950 focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600/20"
                   >
-                    <option value="us">US English</option>
-                    <option value="uk">UK English</option>
+                    <option value="us">American English (Default)</option>
+                    <option value="uk">British English</option>
                     <option value="ca">Canadian English</option>
                     <option value="au">Australian English</option>
                     <option value="za">South African English</option>
                     <option value="nz">New Zealand English</option>
                   </select>
+                  <p className="mt-2 text-xs text-stone-500">Controls RevisionGrade-generated analysis, recommendations, revision guidance, and report text. Manuscript text, quotations, and evidence excerpts are preserved exactly as submitted.</p>
                 </div>
 
                 <div className="rounded-xl border border-stone-300 p-4">

--- a/lib/evaluation/englishVariant.ts
+++ b/lib/evaluation/englishVariant.ts
@@ -23,6 +23,12 @@ export function englishVariantLabel(value: unknown): string {
   return ENGLISH_VARIANT_LABELS[normalizeEnglishVariant(value)];
 }
 
+/**
+ * Alias for `englishVariantLabel`. Returns the human-readable label for a variant code.
+ * Used to populate `resolved_english_variant` audit fields in evaluation and revision artifacts.
+ */
+export const resolvedEnglishVariantLabel = englishVariantLabel;
+
 export function buildEnglishVariantPromptBlock(value: unknown): string {
   const label = englishVariantLabel(value);
 

--- a/lib/evaluation/pipeline/runPipeline.ts
+++ b/lib/evaluation/pipeline/runPipeline.ts
@@ -130,6 +130,7 @@ import {
 } from "./failures";
 import { getConfiguredChunkCap } from "./chunkCap";
 import type { EnglishVariant } from "@/lib/evaluation/englishVariant";
+import { resolvedEnglishVariantLabel } from "@/lib/evaluation/englishVariant";
 
 // Below this word count we evaluate as a single structural unit (one chunk).
 // Above this, the chunked path MUST engage — see runPipeline guard below.
@@ -2043,6 +2044,8 @@ export interface SynthesisToEvaluationResultOptions {
   sourceText?: string;
   /** Optional manuscript text for metrics enrichment when the caller has it available. */
   manuscriptText?: string;
+  /** English variant used for all generated output — persisted to evaluation artifact metrics. */
+  englishVariant?: string;
   scopeProfile?: SubmissionScopeProfile;
   /** LLM-extracted enrichment fields from synthesis pass. */
   llmEnrichment?: {
@@ -2522,6 +2525,8 @@ export function synthesisToEvaluationResultV2(
         title: opts.title?.trim() || undefined,
         word_count: opts.manuscriptText ? countWords(opts.manuscriptText) : undefined,
         char_count: opts.manuscriptText?.length,
+        requested_english_variant: opts.englishVariant ?? "us",
+        resolved_english_variant: resolvedEnglishVariantLabel(opts.englishVariant),
       },
       processing: {},
     },

--- a/lib/evaluation/processor.ts
+++ b/lib/evaluation/processor.ts
@@ -208,7 +208,7 @@ import {
 } from '@/lib/evaluation/phaseTimestamps';
 import { buildPhaseLogPatch } from '@/lib/evaluation/phaseLog';
 import { getConfiguredAppBaseUrl } from '@/lib/jobs/triggerWorker';
-import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
+import { normalizeEnglishVariant, resolvedEnglishVariantLabel } from '@/lib/evaluation/englishVariant';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // WAVE Phase 3 constants
@@ -9762,6 +9762,7 @@ export async function processEvaluationJob(
       sourceText: manuscriptWithContent.content || "",
       manuscriptText: manuscriptWithContent.content || "",
       title: manuscript.title ?? undefined,
+      englishVariant: selectedEnglishVariant,
       scopeProfile: scopeProfileForV2Gate,
       llmEnrichment: pipelineResult.synthesis.enrichment,
     });

--- a/lib/revision/opportunityLedger.ts
+++ b/lib/revision/opportunityLedger.ts
@@ -8,7 +8,7 @@ import {
 import { type SlaeGroundingStatus } from './slae';
 import { modeContractForMetadata, resolveRevisionModeContract } from './modeContract';
 import { extractGenreExpectationMetadataFromEvaluationPayload } from '@/lib/evaluation/genreExpectationProfiles';
-import { normalizeEnglishVariant } from '@/lib/evaluation/englishVariant';
+import { normalizeEnglishVariant, resolvedEnglishVariantLabel } from '@/lib/evaluation/englishVariant';
 import {
   hydrateLedgerCandidates,
   HYDRATION_MODEL,
@@ -2351,6 +2351,7 @@ export async function ensureRevisionOpportunityLedgerArtifact(
     candidate_generation_status: candidateGenerationStatus,
     mode_contract: modeContractForMetadata(modeContract),
     genre_expectation_context: genreExpectationContext,
+    resolved_english_variant: resolvedEnglishVariantLabel(selectedEnglishVariant),
     revise_queue_preflight: {
       version: REVISE_QUEUE_PREFLIGHT_GATE_VERSION,
       context_quality: contextQualityDecision.status,

--- a/schemas/evaluation-result-v2.ts
+++ b/schemas/evaluation-result-v2.ts
@@ -202,6 +202,10 @@ export type EvaluationResultV2 = {
       char_count?: number;
       genre?: string;
       target_audience?: string;
+      /** Raw english_variant value sent by the caller (e.g. "ca"). */
+      requested_english_variant?: string;
+      /** Human-readable label of the normalised variant (e.g. "Canadian English"). */
+      resolved_english_variant?: string;
     };
     processing: {
       segment_count?: number;


### PR DESCRIPTION
## Summary
- Persist requested and resolved English variant metadata in `evaluation_result_v2.metrics.manuscript`.
- Persist resolved English variant metadata in `revision_opportunity_ledger_v1` artifacts.
- Update Evaluate form labels/microcopy and FAQ copy for all six supported English variants.
- Add deterministic regression coverage for Canadian English and supported variant label resolution.

## Scope
Evaluation artifact/audit metadata, Evaluate submission copy, FAQ copy, and regression tests. No pipeline orchestration, model prompt ordering, scoring weights, chunking, phase sequencing, timeout policy, or quality-gate behavior is changed.

## Branch Freshness (Never Behind)
Branch-Behind-Base: 0

## Risks & Anomalies
Low implementation risk. Main anomaly: this PR touches evaluation-adjacent code and `lib/revision`, so it is classified under the stricter evaluation validator even though the runtime behavior is metadata persistence and copy only. No known quality-gate anomaly is introduced.

## Evaluation Process Change Declaration
Process Change: no

This PR does not alter the evaluation process, phase order, pass ownership, model routing, scoring, chunking, external adjudication, or deterministic quality gates.

## Contract Integrity
- English variant selection is normalized through the existing English variant contract.
- Generated author-facing prose uses the selected variant.
- Manuscript text, quotations, excerpts, evidence snippets, and author-provided content remain preserved exactly as submitted.
- Invalid variant input resolves to American English while preserving the raw requested value for audit visibility.

## Behavioral Quality
Expected behavior is unchanged except that generated artifacts and revision ledgers now expose the selected/resolved English variant. Regression coverage verifies Canadian English and all six supported variant labels. This preserves quality by improving auditability, not reducing intelligence.

## Latency Evidence
This PR does not add model calls, new pipeline passes, network calls, retries, chunk loops, or additional evaluation runtime work. The new logic is constant-time metadata labeling during artifact construction.

| Baseline (Pre-change) | pass1_ms | pass2_ms | pass3_ms | total_ms |
| --- | ---: | ---: | ---: | ---: |
| Metadata persistence only | N/A | N/A | N/A | N/A |

| Post-change Runs | pass1_ms | pass2_ms | pass3_ms | total_ms |
| --- | ---: | ---: | ---: | ---: |
| Run 1 targeted Jest | N/A | N/A | N/A | N/A |
| Run 2 targeted Jest | N/A | N/A | N/A | N/A |

- [x] Pass 3
- criteria_count_by_state: N/A — metadata-only artifact persistence; no Pass 3 synthesis distribution changed.

No pass latency metric changes are expected; `pass3_ms` and `total_ms` remain governed by existing pipeline execution. Quality Gate behavior is unchanged; no new `QG_` condition is introduced.

## Unauthorized Input Sources
N/A — This PR does not introduce any new user-visible input source, third-party input source, connector, scraping path, or untrusted model input.

## Internal Process Leakage
N/A — This PR does not expose phase names, prompt internals, chain-of-thought, internal scoring mechanics, or admin-only diagnostics to normal users.

## Input → Action → Output
Input: user-selected `english_variant` on Evaluate. Action: normalize/resolve the selected variant label and persist audit metadata. Output: artifact/API/ledger metadata plus clearer UI/FAQ copy.

## Public-Safe Quality/Status Metrics
Public-safe metric added: resolved English variant label. It does not expose private manuscript content, hidden process details, model internals, or admin diagnostics.

## Runtime/Pipeline Expansion
N/A — No runtime expansion. No new LLM call, no additional pass, no new worker, no fanout, no retry loop, and no extra chunk processing.

## Latency Impact
No material latency impact. The only runtime work is a constant-time label lookup while building existing payloads.

No-Pipeline-Impact: English variant persistence is metadata-only and does not change pass execution, scoring, quality gates, or model calls.

## Verification
- `npm test -- --runInBand --runTestsByPath __tests__/lib/evaluation/englishVariantPropagation.test.ts __tests__/lib/evaluation/englishVariantResolved.test.ts`
- 2 suites passed
- 18 tests passed

Follow-up to #1048: the original PR is merged, but this branch contains the additional artifact-persistence/test commit that was not yet on main.
