### PR TITLE
fix: document-type classifier audit-only + report type label threshold

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -171,6 +171,7 @@ export async function POST(req: Request) {
     let manuscriptId: number | null = null;
     let sourceManuscriptText: string | null = null;
     let sourceManuscriptWordCount: number | undefined;
+    let narrativePreflightAudit: Record<string, unknown> = {};
 
     if (manuscriptIdInput !== undefined && manuscriptIdInput !== null) {
       // Reject ambiguous input: both manuscript_id and new text together is a contract violation.
@@ -217,17 +218,11 @@ export async function POST(req: Request) {
       }
 
       const preflightDecision = routeNarrativeEvaluationPreflight(existingText);
-      if (!preflightDecision.allowed) {
-        return Response.json(
-          {
-            ok: false,
-            error: preflightDecision.userMessage,
-            code: 'NARRATIVE_EVALUATION_PREFLIGHT_REJECTED',
-            manuscript_type: preflightDecision.detectedType,
-          },
-          { status: 422 }
-        );
-      }
+      // Audit-only: record detected type in job progress but never block submission.
+      narrativePreflightAudit = {
+        narrative_preflight_detected_type: preflightDecision.detectedType,
+        ...(preflightDecision.allowed ? {} : { narrative_preflight_classifier_flagged: true }),
+      };
 
       sourceManuscriptText = existingText;
       sourceManuscriptWordCount =
@@ -253,17 +248,11 @@ export async function POST(req: Request) {
 
     if (!manuscriptId && trimmedText.length > 0) {
       const preflightDecision = routeNarrativeEvaluationPreflight(trimmedText);
-      if (!preflightDecision.allowed) {
-        return Response.json(
-          {
-            ok: false,
-            error: preflightDecision.userMessage,
-            code: 'NARRATIVE_EVALUATION_PREFLIGHT_REJECTED',
-            manuscript_type: preflightDecision.detectedType,
-          },
-          { status: 422 }
-        );
-      }
+      // Audit-only: record detected type in job progress but never block submission.
+      narrativePreflightAudit = {
+        narrative_preflight_detected_type: preflightDecision.detectedType,
+        ...(preflightDecision.allowed ? {} : { narrative_preflight_classifier_flagged: true }),
+      };
     }
 
     // Step 1: Create manuscript
@@ -409,7 +398,9 @@ export async function POST(req: Request) {
         voice_preservation_level: voicePreservationLevelForMode(selectedVoicePreservationMode),
         english_variant: selectedEnglishVariant,
         queued_at: new Date().toISOString(),
-        ...(Object.keys(instantEnrichment).length > 0 ? { progress: instantEnrichment } : {}),
+        ...(Object.keys(instantEnrichment).length > 0 || Object.keys(narrativePreflightAudit).length > 0
+          ? { progress: { ...instantEnrichment, ...narrativePreflightAudit } }
+          : {}),
       })
       .select()
       .single();

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -316,6 +316,7 @@ export async function POST(req: Request) {
     let resolvedManuscriptWordCount: number | null = null;
     let intakeManuscriptText = "";
     let sourceVersionId: string | null = null;
+    let narrativePreflightAudit: Record<string, unknown> = {};
 
     if (!manuscript_id && !manuscript_text) {
       logger.warn("Job creation validation failed", {
@@ -458,19 +459,11 @@ export async function POST(req: Request) {
       }
 
       const preflightDecision = routeNarrativeEvaluationPreflight(trimmedText);
-      if (!preflightDecision.allowed) {
-        return NextResponse.json(
-          {
-            ok: false,
-            error: preflightDecision.userMessage,
-            code: "NARRATIVE_EVALUATION_PREFLIGHT_REJECTED",
-            manuscript_type: preflightDecision.detectedType,
-            details: preflightDecision.details,
-            trace_id,
-          },
-          { status: 422 }
-        );
-      }
+      // Audit-only: record detected type in job progress but never block submission.
+      narrativePreflightAudit = {
+        narrative_preflight_detected_type: preflightDecision.detectedType,
+        ...(preflightDecision.allowed ? {} : { narrative_preflight_classifier_flagged: true }),
+      };
 
       const encodedText = encodeURIComponent(trimmedText);
       const fileUrl = `data:text/plain;charset=utf-8,${encodedText}`;
@@ -568,19 +561,11 @@ export async function POST(req: Request) {
       }
 
       const preflightDecision = routeNarrativeEvaluationPreflight(intakeManuscriptText);
-      if (!preflightDecision.allowed) {
-        return NextResponse.json(
-          {
-            ok: false,
-            error: preflightDecision.userMessage,
-            code: "NARRATIVE_EVALUATION_PREFLIGHT_REJECTED",
-            manuscript_type: preflightDecision.detectedType,
-            details: preflightDecision.details,
-            trace_id,
-          },
-          { status: 422 }
-        );
-      }
+      // Audit-only: record detected type in job progress but never block submission.
+      narrativePreflightAudit = {
+        narrative_preflight_detected_type: preflightDecision.detectedType,
+        ...(preflightDecision.allowed ? {} : { narrative_preflight_classifier_flagged: true }),
+      };
 
       try {
         const sourceVersion = await createInitialVersion({
@@ -734,7 +719,7 @@ export async function POST(req: Request) {
     await seedJobIntakeProgress({
       job,
       manuscriptWordCount: resolvedManuscriptWordCount ?? immediateManuscriptWordCount,
-      instantEnrichment,
+      instantEnrichment: { ...instantEnrichment, ...narrativePreflightAudit },
       submittedAuthorName: typeof author_name === "string" && author_name.trim().length > 0 ? author_name.trim() : null,
       submittedProjectTitle: typeof manuscript_title === "string" && manuscript_title.trim().length > 0 ? manuscript_title.trim() : null,
       fastTrackPhase0: shouldFastTrackPhase0,

--- a/app/evaluate/[jobId]/page.tsx
+++ b/app/evaluate/[jobId]/page.tsx
@@ -159,7 +159,7 @@ export default async function EvaluationReportPage({ params }: PageProps) {
           <dl className="grid gap-x-8 gap-y-5 text-sm sm:grid-cols-2 md:grid-cols-3">
             <HeaderField label="Author Name" value={submittedAuthorName ?? "Not provided"} />
             <HeaderField label="Project Name" value={submittedProjectTitle ?? manuscriptTitle ?? "Not provided"} />
-            <HeaderField label="Report Type" value="Short-Form Evaluation" />
+            <HeaderField label="Report Type" value={wordCount && wordCount >= 25000 ? "Full-Length Evaluation" : "Short-Form Evaluation"} />
             <HeaderField label="Genre" value="Not specified" />
             <HeaderField label="Shelf" value="Not available" />
             <HeaderField label="Submitted Word Count" value={wordCount ? wordCount.toLocaleString() : "Calculating"} />

--- a/tests/api/evaluate-route-input-contract.test.ts
+++ b/tests/api/evaluate-route-input-contract.test.ts
@@ -125,12 +125,10 @@ describe("POST /api/evaluate input contract", () => {
     );
   });
 
-  test("rejects short non-fiction letter submissions with a clean preflight message", async () => {
-    let evalJobsCalls = 0;
+  test("classifier is audit-only: letter-style submissions are not rejected with 422", async () => {
     const supabase = {
       from: jest.fn((table: string) => {
         if (table === "evaluation_jobs") {
-          evalJobsCalls++;
           return makeAbuseLimitStub();
         }
         return {};
@@ -151,14 +149,9 @@ describe("POST /api/evaluate input contract", () => {
     });
 
     const response = await POST(req);
-    const json = (await response.json()) as { ok: boolean; error: string; code: string };
 
-    expect(response.status).toBe(422);
-    expect(json.ok).toBe(false);
-    expect(json.code).toBe("NARRATIVE_EVALUATION_PREFLIGHT_REJECTED");
-    expect(json.error).toMatch(/letter|essay|synopsis|non-fiction/i);
-    expect(evalJobsCalls).toBe(2);
-    expect(supabase.from).toHaveBeenCalledWith("evaluation_jobs");
+    // Classifier is audit-only — must never return 422 for document type.
+    expect(response.status).not.toBe(422);
   });
 
   test("accepts text-only input and creates manuscript + evaluation job", async () => {

--- a/tests/api/jobs-route-input-contract.test.ts
+++ b/tests/api/jobs-route-input-contract.test.ts
@@ -262,7 +262,45 @@ describe("POST /api/jobs input contract", () => {
     expect(updatePayload?.progress?.submitted_project_title).toBe("Let the River Decide");
   });
 
-  test("rejects unsupported letter-style submissions before job creation", async () => {
+  test("classifier is audit-only: letter-style submissions create a job and record flagged type", async () => {
+    const updateMock = jest.fn(() => ({
+      eq: jest.fn(async () => ({ error: null })),
+    }));
+
+    const supabase = {
+      from: jest.fn((table: string) => {
+        if (table === "manuscripts") {
+          return {
+            insert: jest.fn(() => ({
+              select: () => ({
+                single: async () => ({ data: { id: 400 }, error: null }),
+              }),
+            })),
+          };
+        }
+        if (table === "evaluation_jobs") {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                in: jest.fn(() => ({
+                  limit: jest.fn(async () => ({ data: [], error: null })),
+                })),
+              })),
+            })),
+            update: updateMock,
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+    mockCreateAdminClient.mockReturnValue(supabase as never);
+    mockCreateJob.mockResolvedValue({
+      id: "job-letter",
+      manuscript_id: 400,
+      job_type: "evaluate_full",
+      status: "queued",
+    } as never);
+
     const req = new Request("https://localhost:3000/api/jobs", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -275,13 +313,17 @@ describe("POST /api/jobs input contract", () => {
     });
 
     const response = await POST(req);
-    const json = (await response.json()) as { ok: boolean; code: string; error: string };
+    const json = (await response.json()) as { ok: boolean; job_id: string };
 
-    expect(response.status).toBe(422);
-    expect(json.ok).toBe(false);
-    expect(json.code).toBe("NARRATIVE_EVALUATION_PREFLIGHT_REJECTED");
-    expect(json.error).toMatch(/letter|essay|synopsis|non-fiction/i);
-    expect(mockCreateJob).not.toHaveBeenCalled();
+    // Classifier is audit-only — never returns 422 for document type.
+    expect(response.status).toBe(201);
+    expect(json.ok).toBe(true);
+    expect(mockCreateJob).toHaveBeenCalled();
+
+    // Audit flag recorded in progress.
+    const updatePayload = (updateMock.mock.calls as unknown[][])[0]?.[0] as { progress?: Record<string, unknown> } | undefined;
+    expect(updatePayload?.progress?.narrative_preflight_classifier_flagged).toBe(true);
+    expect(updatePayload?.progress?.narrative_preflight_detected_type).toBe("business_letter");
   });
 
   test("kicks off the evaluation worker after successful job creation", async () => {


### PR DESCRIPTION
## Summary

- **Classifier audit-only**: `routeNarrativeEvaluationPreflight` still runs on every submission but never blocks with 422. Detected type and `classifier_flagged` are persisted in job progress for observability only.
- **Report Type label fix**: `< 25,000 words → Short-Form Evaluation`, `≥ 25,000 words → Full-Length Evaluation`

## Files changed

| File | Change |
|---|---|
| `app/api/jobs/route.ts` | Removed 422 block; persists audit metadata |
| `app/api/evaluate/route.ts` | Removed 422 block; persists audit metadata |
| `app/evaluate/[jobId]/page.tsx` | Report Type threshold fix |
| `tests/api/jobs-route-input-contract.test.ts` | Asserts job creation + audit metadata (not 422) |
| `tests/api/evaluate-route-input-contract.test.ts` | Asserts audit-only behavior |

## Tests

2 suites / 21 tests passed in clean worktree from `origin/main`.