### PR TITLE
fix: keep withheld cards out of visible queue

### DIFF
--- a/app/workbench-v2/page.tsx
+++ b/app/workbench-v2/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import Link from "next/link";
-import { getWorkbenchQueue, type WorkbenchOpportunity, type WorkbenchQueuePayload } from "@/lib/revision/workbenchQueue";
+import { getWorkbenchQueue } from "@/lib/revision/workbenchQueue";
 import ReviseCockpitClientWorkflowV2 from "@/components/revision/ReviseCockpitClientWorkflowV2";
 import TrustedPathWorkbenchButton from "@/components/revision/TrustedPathWorkbenchButton";
 import ResetQueueButton from "@/components/revision/ResetQueueButton";
@@ -11,46 +11,6 @@ import { resolveWorkbenchRouteTargetForUser } from "@/lib/revision/workbenchQueu
 import SupportAccessToggle from "@/components/reports/SupportAccessToggle";
 import ReportConcernForm from "@/components/reports/ReportConcernForm";
 import styles from "./workbench-v2.module.css";
-
-function countVisibleOpportunities(opportunities: WorkbenchOpportunity[]) {
-  const totals: WorkbenchQueuePayload["totals"] = { must: 0, should: 0, could: 0 };
-  const scopes: WorkbenchQueuePayload["scopes"] = { Line: 0, Passage: 0, Scene: 0, Chapter: 0, Structural: 0, Manuscript: 0 };
-  const criteria: Record<string, number> = {};
-
-  for (const opportunity of opportunities) {
-    totals[opportunity.severity] += 1;
-    scopes[opportunity.scope] += 1;
-    criteria[opportunity.criterion] = (criteria[opportunity.criterion] ?? 0) + 1;
-  }
-
-  return { totals, scopes, criteria };
-}
-
-function operationalizeWorkbenchPayload(payload: WorkbenchQueuePayload): WorkbenchQueuePayload {
-  if (!payload.ok || payload.opportunities.length > 0) {
-    return payload;
-  }
-
-  const reviewable = [...(payload.needsTargeting ?? []), ...(payload.withheldUnsupported ?? [])];
-  if (reviewable.length === 0) {
-    return payload;
-  }
-
-  const { totals, scopes, criteria } = countVisibleOpportunities(reviewable);
-
-  return {
-    ...payload,
-    opportunities: reviewable,
-    needsTargeting: [],
-    withheldUnsupported: [],
-    totals,
-    scopes,
-    criteria,
-    synthesis: payload.synthesis
-      ? { ...payload.synthesis, admitted: reviewable.length, held: 0 }
-      : payload.synthesis,
-  };
-}
 
 export default async function WorkbenchV2Page({ searchParams }: { searchParams?: Promise<Record<string, string | string[] | undefined>> }) {
   const params = (await searchParams) ?? {};
@@ -66,7 +26,7 @@ export default async function WorkbenchV2Page({ searchParams }: { searchParams?:
     }
   }
 
-  const payload = operationalizeWorkbenchPayload(await getWorkbenchQueue({ manuscriptId, evaluationJobId }));
+  const payload = await getWorkbenchQueue({ manuscriptId, evaluationJobId });
 
   const finalReviewHref = manuscriptId && evaluationJobId
     ? `/workbench/final-review?${new URLSearchParams({ manuscriptId, evaluationJobId }).toString()}`


### PR DESCRIPTION
Closes #1221.

## Summary
Removes the workbench-v2 payload promotion path that moved `needsTargeting` / `withheldUnsupported` cards into the visible `opportunities` queue when no opportunities passed admission.

Behavior after this PR:
- Admission-failed cards remain withheld.
- `synthesis.held` stays accurate from `getWorkbenchQueue`.
- Existing empty-state UI handles zero admitted opportunities.

## Scope
- UI-only change in `app/workbench-v2/page.tsx`.
- Removes the local operationalization shim and uses the canonical `getWorkbenchQueue` payload directly.
- Scope intentionally excludes #1220, #1225, and #1222.

## Branch Freshness (Never Behind)
Branch-Behind-Base: 0

## Visual Evidence
N/A — behavior is queue-admission semantics, not a visual layout change. The existing empty-state UI remains the visible surface when zero opportunities are admitted.

## Accessibility
N/A — no markup, focus behavior, labels, contrast, keyboard flow, or ARIA behavior changed.

## Browser Targets
N/A — server-side payload shaping only; no browser-specific rendering logic changed.

## Risks & Anomalies
Risk is limited to removing the fallback promotion path. This is intended: withheld / unsupported cards must remain withheld and not appear in the visible revision queue.

## Unauthorized Input Sources
No unauthorized input sources added. The page continues to consume only the canonical workbench queue payload.

## Internal Process Leakage
No internal process leakage added. The visible queue no longer exposes withheld admission-failed cards as actionable opportunities.

## Input → Action → Output
Input: canonical `getWorkbenchQueue` payload. Action: pass payload directly to the V2 workbench client. Output: visible queue contains only admitted opportunities; withheld cards remain in withheld fields.

## Public-Safe Quality/Status Metrics
Public-safe status remains represented through existing empty-state and queue UI. No private quality-gate internals are newly exposed.

## Runtime/Pipeline Expansion
No runtime or pipeline expansion. This removes local page-level promotion logic and preserves canonical queue authority.

## Latency Impact
No added latency. The change removes local recount / reshaping work and does not add network calls, model calls, database calls, or retries.

No-Pipeline-Impact: UI route no longer promotes withheld cards; evaluation, Revise pipeline, renderer, certification, and persistence behavior are unchanged.