### PR TITLE
fix: harden copy-polish content-integrity gates (A1–A4, D1–D3)

### DIFF
--- a/app/api/reports/[jobId]/download/route.ts
+++ b/app/api/reports/[jobId]/download/route.ts
@@ -33,6 +33,7 @@ import { runRevisionSurfaceOwnershipGate, runRenderedOutputOwnershipGate, buildR
 import { sanitizeResultForDownload } from '@/lib/evaluation/downloadReadTimeSanitizer';
 import { sanitizeCMOS } from '@/lib/evaluation/cmosSanitizer';
 import { isGenericOpportunityFallbackText, normalizeEvidenceSnippet } from '@/lib/evaluation/reportRenderSafety';
+import { ensureSingleSpaceAfterColon } from '@/lib/text/authorFacingProse';
 import { getForbiddenShortFormSections } from '@/lib/evaluation/shortFormSectionContract';
 import { enforceApiRateLimit } from '@/lib/security/apiRateLimit';
 import { requireUser } from '@/lib/security/apiGuards';
@@ -473,7 +474,10 @@ function pushTxtMetadata(lines: string[], label: string, value: string): void {
 function pushTxtOpportunityDetailRow(lines: string[], label: string, value: string): void {
   const valueForLabel = label === 'Evidence' ? normalizeEvidenceSnippet(value) : value;
   const renderedValue = label === 'Evidence' ? `\u201c${valueForLabel}\u201d` : valueForLabel;
-  const rendered = `${label}: ${renderedValue}`;
+  // D1: single-space-after-colon backstop at the TXT label:value join (the only
+  // renderer that concatenates label + value into one string; web/PDF/DOCX use
+  // separate cells). Idempotent \u2014 leaves the correct "Symptom: After" untouched.
+  const rendered = ensureSingleSpaceAfterColon(`${label}: ${renderedValue}`);
   const hangingLines = wrapIndentedLines(rendered, {
     firstIndent: '    ',
     nextIndent: ' '.repeat(4 + label.length + 2),

--- a/components/revision/ReviseCockpitClient.tsx
+++ b/components/revision/ReviseCockpitClient.tsx
@@ -6,7 +6,7 @@ import {
   customOperationLabels,
   getRenderableCandidateText,
   operationLabels,
-  REVISION_OPTION_LABELS,
+  strategyOptionLabel,
 } from "@/lib/revision/reviseCardContract";
 import type { RevisionOperation } from "@/lib/revision/reviseCardContract";
 
@@ -712,7 +712,7 @@ export default function ReviseCockpitClient({ payload }: { payload: WorkbenchQue
                       <article key={option.key} onClick={() => setSelectedOption(option.key)} className={`cursor-pointer rounded-xl border bg-[#12100B] p-3 transition ${selectedOption === option.key ? "border-[#C8A96E]" : "border-[#2E261A] hover:border-[#5D4C31]"}`}>
                         <div className="flex items-start justify-between gap-2">
                           <div>
-                            <p className="text-sm font-semibold text-[#F2E8D6]">{REVISION_OPTION_LABELS[option.key]}</p>
+                            <p className="text-sm font-semibold text-[#F2E8D6]">{strategyOptionLabel(option.key)}</p>
                             <p className="mt-1 text-[11px] uppercase tracking-wider text-[#A9987D]">{operationLabels[effectiveRevisionOperation(active)] ?? option.mechanism}</p>
                           </div>
                           <div className="flex shrink-0 items-center gap-1">

--- a/lib/evaluation/evaluationReportViewModel.ts
+++ b/lib/evaluation/evaluationReportViewModel.ts
@@ -42,6 +42,7 @@ import { classifyEvaluationIntegrityBanner } from '@/lib/evaluation/warningClass
 import type { EvaluationIntegrityBanner } from '@/lib/evaluation/warningClassification';
 import { formatCriterionConfidenceLabel } from '@/lib/evaluation/confidenceFieldPolicy';
 import { formatScoreFractionForDisplay } from '@/lib/ui/score-formatting';
+import { detectRawFallbackSentinel } from '@/lib/text/authorFacingProse';
 
 // ────────────────────────────────────────────────────────────────────────────
 // ViewModel Types
@@ -394,6 +395,19 @@ function sanitizeText(text: string, isLongForm: boolean): string {
   return correctScopeLanguage(mistakeProofText(text), isLongForm);
 }
 
+/**
+ * A2: the ViewModel is the one and only author-facing sanitization boundary.
+ * A pitch that is the raw fallback sentinel ("A distinct market hook was not
+ * generated…") must NEVER reach a renderer. The upstream regeneration/kick-back
+ * happens in the certification gate (sentinel treated as MISSING → FATAL); here
+ * at the render boundary we SUPPRESS to empty rather than expose the sentinel or
+ * substitute a cosmetic filler. detectRawFallbackSentinel is a pure inspector.
+ */
+function suppressSentinelPitch(text: string, isLongForm: boolean): string {
+  if (detectRawFallbackSentinel(text)) return '';
+  return sanitizeText(text, isLongForm);
+}
+
 function sanitizeList(items: string[], isLongForm: boolean): string[] {
   return items.map(item => sanitizeText(item, isLongForm));
 }
@@ -548,8 +562,8 @@ export function normalizeEvaluationReportViewModel({
 
     titleBlock,
 
-    oneParagraphPitch: sanitizeText(ued.oneParagraphPitch, isLongForm),
-    oneSentencePitch: sanitizeText(ued.oneSentencePitch, isLongForm),
+    oneParagraphPitch: suppressSentinelPitch(ued.oneParagraphPitch, isLongForm),
+    oneSentencePitch: suppressSentinelPitch(ued.oneSentencePitch, isLongForm),
     premise: ued.premise ? sanitizeText(ued.premise, isLongForm) : null,
     contentWarnings: sanitizeList(ued.contentWarnings, isLongForm),
 

--- a/lib/evaluation/fipocRegistry.ts
+++ b/lib/evaluation/fipocRegistry.ts
@@ -1960,6 +1960,61 @@ export const KICK_MATRIX: KickMatrixEntry[] = [
     failureCode: 'SHORT_FORM_UNSUPPORTED_GLOBAL_CLAIM',
     blocksAuthorExposure: true,
   },
+  {
+    dirtyDataDetectedAt: 'SHORT_FORM_FINAL_SANITY_CHECK',
+    failure: 'A short-form diagnostic segment ends mid-sentence (dangling connective, comma, colon, or open parenthesis)',
+    kickBackTo: 'S07_PASS3',
+    redoAction: 'Regenerate Pass 3 synthesis so every diagnostic segment (rationale + opportunity fields) is a complete, terminally punctuated sentence.',
+    retryLimit: 1,
+    ifRetryFails: 'Fail closed; block author exposure.',
+    failureCode: 'SHORT_FORM_MIDSENTENCE_TERMINATION',
+    blocksAuthorExposure: true,
+  },
+  {
+    dirtyDataDetectedAt: 'SHORT_FORM_FINAL_SANITY_CHECK',
+    failure: 'A short-form diagnostic segment has a copy defect (lowercase opening or accidental adjacent-duplicate word)',
+    kickBackTo: 'S07_PASS3',
+    redoAction: 'Regenerate Pass 3 synthesis: capitalize the first word of every diagnostic segment and remove accidental adjacent-duplicate words.',
+    retryLimit: 1,
+    ifRetryFails: 'Fail closed; block author exposure.',
+    failureCode: 'SHORT_FORM_COPY_DEFECT',
+    blocksAuthorExposure: true,
+  },
+  // ── Copy-integrity: sentence/field hygiene on author-facing prose ─────────
+  // Same family as HANDOFF_INCOMPLETE_SENTENCE. Detection lives in the
+  // recommendation integrity + short-form sanity gates; the trivial cases are
+  // additionally auto-repaired by the shared idempotent helpers at the
+  // normalizeArtifact pre-stage (capitalizeFirstAlpha / ensureTerminalPunctuation).
+  {
+    dirtyDataDetectedAt: 'SHORT_FORM_FINAL_SANITY_CHECK',
+    failure: 'Author-facing prose ends mid-sentence (dangling connective, comma, colon, or open parenthesis)',
+    kickBackTo: 'S07_PASS3',
+    redoAction: 'Regenerate Pass 3 synthesis so every rendered author-facing sentence is complete; never terminate on a dangling connective, comma, colon, or open parenthesis.',
+    retryLimit: 1,
+    ifRetryFails: 'Fail closed; block author exposure.',
+    failureCode: 'HANDOFF_MIDSENTENCE_TERMINATION',
+    blocksAuthorExposure: true,
+  },
+  {
+    dirtyDataDetectedAt: 'S07_RECOMMENDATION_INTEGRITY_GATE',
+    failure: 'Recommendation/opportunity text opens with a lowercase letter',
+    kickBackTo: 'S07_PASS3',
+    redoAction: 'Capitalize the first word of every recommendation/opportunity field; regenerate if the lowercase opening reflects a fused or truncated sentence.',
+    retryLimit: 1,
+    ifRetryFails: 'Fail closed; block author exposure.',
+    failureCode: 'REC_INTEGRITY_LOWERCASE_OPENING',
+    blocksAuthorExposure: true,
+  },
+  {
+    dirtyDataDetectedAt: 'S07_RECOMMENDATION_INTEGRITY_GATE',
+    failure: 'Distinct diagnostic fields (fix direction, reader effect) fused into one run-on with no sentence boundary',
+    kickBackTo: 'S07_PASS3',
+    redoAction: 'Regenerate Pass 3 synthesis emitting fix_direction and reader_effect as separate, terminally punctuated sentences.',
+    retryLimit: 1,
+    ifRetryFails: 'Fail closed; block author exposure.',
+    failureCode: 'REC_INTEGRITY_FUSED_FIELDS',
+    blocksAuthorExposure: true,
+  },
 ];
 
 export const RENDERER_CONSUMPTION_MATRIX: RendererConsumptionEntry[] = [

--- a/lib/evaluation/pipeline/__tests__/evaluationCertificationGate.test.ts
+++ b/lib/evaluation/pipeline/__tests__/evaluationCertificationGate.test.ts
@@ -869,6 +869,106 @@ describe("ECG — individual invariant coverage", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Copy-Polish defect fixtures (A1, A2, mid-sentence invariant)
+// Exact source strings from the Copy-Polish brief drive these.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Copy-Polish defect fixtures", () => {
+  function runWarn(input: ECGInput) {
+    process.env.ECG_MODE = "WARN_ONLY";
+    return runEvaluationCertificationGate(input);
+  }
+
+  // A1 — prose "64/100" vs canonical 68. The floor policy is LAW: "always round
+  // DOWN — never inflate." A prose score BELOW canonical is still a mismatch the
+  // author must not see, but it is NOT inflation and must never be reconciled up.
+  it("A1: flags a 64-vs-68 divergence without inflating", () => {
+    const input = makeCleanInput({
+      canonicalScore: 68,
+      overview: {
+        ...makeCleanInput().overview,
+        overall_score_0_100: 68,
+        one_paragraph_summary:
+          "This excerpt earns a 64/100 on the strength of its premise and Character Depth. " +
+          "The principal blocker is Pacing & Structural Balance, where overlong exposition " +
+          "interrupts narrative momentum before the mid-chapter reveal.",
+      },
+    });
+    const result = runWarn(input);
+    const v = result.fatal.find(v => v.code === "ECG_AUTH_EXEC_SUMMARY_SCORE_MISMATCH");
+    expect(v).toBeDefined();
+    // Names both the prose score and the canonical score.
+    expect(v!.message).toContain("64");
+    expect(v!.message).toContain("68");
+    // Floor policy honored: a below-canonical prose score is NOT inflation.
+    // The gate must not describe it as EXCEEDING canonical and must direct a
+    // downward reconciliation only.
+    expect(v!.message).not.toMatch(/EXCEEDS/);
+    expect(v!.message.toLowerCase()).toContain("never inflate");
+  });
+
+  // A1 inverse — an ABOVE-canonical prose score is inflation and must be named.
+  it("A1: flags inflation when prose EXCEEDS canonical", () => {
+    const input = makeCleanInput({
+      canonicalScore: 68,
+      overview: {
+        ...makeCleanInput().overview,
+        overall_score_0_100: 68,
+        one_paragraph_summary:
+          "This excerpt earns a 72/100 on the strength of its premise and Character Depth. " +
+          "The principal blocker is Pacing & Structural Balance, where overlong exposition " +
+          "interrupts narrative momentum before the mid-chapter reveal.",
+      },
+    });
+    const result = runWarn(input);
+    const v = result.fatal.find(v => v.code === "ECG_AUTH_EXEC_SUMMARY_SCORE_MISMATCH");
+    expect(v).toBeDefined();
+    expect(v!.message).toMatch(/EXCEEDS/);
+  });
+
+  // Global invariant: no author-facing full-sentence prose may end mid-sentence.
+  it("mid-sentence: flags a pitch ending on a dangling connective", () => {
+    const input = makeCleanInput();
+    input.overview.one_sentence_pitch =
+      "A sardonic Antwerp diamond dealer confronts a reckoning with blood money because";
+    const result = runWarn(input);
+    expect(result.fatal.map(v => v.code)).toContain("ECG_TEXT_MIDSENTENCE_TERMINATION");
+  });
+
+  it("mid-sentence: flags a premise ending on a comma", () => {
+    const input = makeCleanInput();
+    input.enrichment!.premise =
+      "A burned-out Antwerp diamond trader lures his cautious Canadian friend into a lavish evening,";
+    const result = runWarn(input);
+    expect(result.fatal.map(v => v.code)).toContain("ECG_TEXT_MIDSENTENCE_TERMINATION");
+  });
+
+  it("mid-sentence: a complete pitch does NOT trigger the invariant", () => {
+    const input = makeCleanInput(); // clean pitches end with a period
+    const result = runWarn(input);
+    expect(result.fatal.map(v => v.code)).not.toContain("ECG_TEXT_MIDSENTENCE_TERMINATION");
+  });
+
+  // A2 — a raw fallback sentinel pitch must be treated as ABSENT, never certified
+  // as satisfied, so it can be regenerated/suppressed rather than leaked.
+  it("A2: treats a raw market-hook fallback sentinel as a missing pitch", () => {
+    const input = makeCleanInput();
+    input.overview.one_sentence_pitch =
+      "A distinct market hook was not generated for Criminality.";
+    const result = runWarn(input);
+    expect(result.violations.map(v => v.code)).toContain("ECG_ART_MISSING_SENTENCE_PITCH");
+  });
+
+  it("A2: treats a raw story-synopsis fallback sentinel as a missing paragraph pitch", () => {
+    const input = makeCleanInput();
+    input.overview.one_paragraph_pitch =
+      "A distinct story synopsis was not generated.";
+    const result = runWarn(input);
+    expect(result.violations.map(v => v.code)).toContain("ECG_ART_MISSING_PARAGRAPH_PITCH");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // trimAtWordBoundary (shared utility)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/lib/evaluation/pipeline/__tests__/recommendationIntegrityGate.test.ts
+++ b/lib/evaluation/pipeline/__tests__/recommendationIntegrityGate.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Fixture test — recommendation integrity gate copy-integrity detection (A3).
+ *
+ * A3's exact broken headline from the Copy-Polish brief has three faults:
+ *   (1) lowercase opening ("insert …")                → NO_LOWERCASE_OPENING
+ *   (2) fused fix-direction / reader-effect fields with no boundary between
+ *       them (a run-on the gate reads as an incomplete/fragmented field)
+ *                                                       → INCOMPLETE_FIELD
+ *   (3) no sentence-terminal punctuation on the underlying prose (masked only by
+ *       the trailing "(Narrative Drive & Momentum)" criterion tag)
+ *
+ * The gate holds the pass/fail authority; the shared helpers only inspect. The
+ * exact broken string must be KICKED BACK (passed === false). A clean,
+ * capitalized, well-formed field must not raise the copy-integrity codes.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { checkRecommendationIntegrity } from "@/lib/evaluation/pipeline/recommendationIntegrityGate";
+
+// Exact source string from the brief (defect A3).
+const A3_BROKEN =
+  "insert one concrete stakes beat that lands the deferred decision at the current scene turn increased momentum as the stalled decision converts to visible consequence (Narrative Drive & Momentum)";
+
+describe("recommendationIntegrityGate — A3 broken headline fixture", () => {
+  it("flags the lowercase opening on the exact A3 string", () => {
+    const result = checkRecommendationIntegrity({ action: A3_BROKEN });
+    expect(result.violations.map((v) => v.code)).toContain("NO_LOWERCASE_OPENING");
+  });
+
+  it("kicks back the fused/fragmented run-on on the exact A3 string", () => {
+    const result = checkRecommendationIntegrity({ action: A3_BROKEN });
+    // The fused fix-direction/reader-effect run-on reads as an incomplete field.
+    expect(result.violations.map((v) => v.code)).toContain("INCOMPLETE_FIELD");
+    expect(result.passed).toBe(false);
+  });
+
+  it("does not flag a capitalized, well-formed action (no false positive)", () => {
+    const result = checkRecommendationIntegrity({
+      action:
+        "Insert one concrete stakes beat that lands the deferred decision at the current scene turn.",
+    });
+    expect(result.violations.map((v) => v.code)).not.toContain("NO_LOWERCASE_OPENING");
+  });
+});

--- a/lib/evaluation/pipeline/__tests__/shortFormFinalSanityCheck.test.ts
+++ b/lib/evaluation/pipeline/__tests__/shortFormFinalSanityCheck.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Fixture tests — short-form final sanity check copy-integrity backstop.
+ *
+ * These pin the persist-time referee for two Copy-Polish defects that must never
+ * reach the author if they survived the normalizeArtifact pre-stage:
+ *   A4  accidental adjacent-duplicate word  → SHORT_FORM_COPY_DEFECT
+ *   D2  lowercase diagnostic opening         → SHORT_FORM_COPY_DEFECT
+ *   mid-sentence invariant (dangling connective/comma) → SHORT_FORM_MIDSENTENCE_TERMINATION
+ *
+ * Both codes are BLOCKING (verdict BLOCK). The check makes the pass/fail
+ * decision; the shared helpers only inspect. A clean report passes.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { runShortFormFinalSanityCheck } from "@/lib/evaluation/pipeline/shortFormFinalSanityCheck";
+import type { EvaluationResultV2 } from "@/schemas/evaluation-result-v2";
+
+type Rec = {
+  action?: string;
+  symptom?: string;
+  mechanism?: string;
+  specific_fix?: string;
+  reader_effect?: string;
+  expected_impact?: string;
+};
+
+function buildResult(criteria: Array<{ rationale?: string; recommendations?: Rec[] }>): EvaluationResultV2 {
+  return {
+    overview: {
+      verdict: "not_market_ready",
+      one_paragraph_summary:
+        "The excerpt shows a confident voice but pacing stalls before the mid-chapter turn.",
+    },
+    criteria: criteria.map(
+      (c) =>
+        ({
+          key: "narrativeDrive",
+          status: "SCORABLE",
+          score_0_10: 7,
+          scorable: true,
+          scorability_status: "scorable_high_confidence",
+          confidence_level: "medium",
+          evidence: [{ snippet: "a sufficiently long verbatim anchor snippet here" }],
+          rationale: c.rationale,
+          recommendations: c.recommendations,
+        }) as unknown as EvaluationResultV2["criteria"][number],
+    ),
+  } as unknown as EvaluationResultV2;
+}
+
+const CLEAN_RATIONALE =
+  "The narrative momentum flows through the escalating penthouse conversation but stalls during exposition.";
+
+describe("runShortFormFinalSanityCheck — copy-integrity backstop", () => {
+  it("A4: flags an accidental adjacent-duplicate word in a symptom", () => {
+    const result = buildResult([
+      {
+        rationale: CLEAN_RATIONALE,
+        recommendations: [
+          {
+            symptom:
+              "The passage reflective passage stalls forward momentum before the narrative urgency peaks.",
+          },
+        ],
+      },
+    ]);
+    const out = runShortFormFinalSanityCheck({ wordCount: 4200, evaluationResult: result });
+    expect(out.codes).toContain("SHORT_FORM_COPY_DEFECT");
+    expect(out.verdict).toBe("BLOCK");
+    expect(out.blocking).toBe(true);
+  });
+
+  it("D2: flags a lowercase diagnostic opening as a copy defect", () => {
+    const result = buildResult([
+      {
+        rationale: CLEAN_RATIONALE,
+        recommendations: [
+          { symptom: "the stakes signal arrives too late for the reader to feel the turn." },
+        ],
+      },
+    ]);
+    const out = runShortFormFinalSanityCheck({ wordCount: 4200, evaluationResult: result });
+    expect(out.codes).toContain("SHORT_FORM_COPY_DEFECT");
+    expect(out.blocking).toBe(true);
+  });
+
+  it("mid-sentence: flags a diagnostic field ending on a dangling connective", () => {
+    const result = buildResult([
+      {
+        rationale: CLEAN_RATIONALE,
+        recommendations: [
+          {
+            expected_impact: "The reader loses momentum because",
+          },
+        ],
+      },
+    ]);
+    const out = runShortFormFinalSanityCheck({ wordCount: 4200, evaluationResult: result });
+    expect(out.codes).toContain("SHORT_FORM_MIDSENTENCE_TERMINATION");
+    expect(out.verdict).toBe("BLOCK");
+  });
+
+  it("passes a clean short-form report with no copy defects", () => {
+    const result = buildResult([
+      {
+        rationale: CLEAN_RATIONALE,
+        recommendations: [
+          {
+            symptom: "The stakes signal arrives too late in the scene.",
+            specific_fix: "Move the consequence beat one paragraph earlier.",
+          },
+        ],
+      },
+    ]);
+    const out = runShortFormFinalSanityCheck({ wordCount: 4200, evaluationResult: result });
+    expect(out.codes).not.toContain("SHORT_FORM_COPY_DEFECT");
+    expect(out.codes).not.toContain("SHORT_FORM_MIDSENTENCE_TERMINATION");
+    expect(out.verdict).toBe("PASS");
+  });
+
+  it("skips long-form manuscripts (>= 25k words)", () => {
+    const result = buildResult([
+      {
+        rationale: CLEAN_RATIONALE,
+        recommendations: [{ symptom: "the passage reflective passage stalls." }],
+      },
+    ]);
+    const out = runShortFormFinalSanityCheck({ wordCount: 42000, evaluationResult: result });
+    expect(out.verdict).toBe("PASS");
+    expect(out.codes).toEqual(["SHORT_FORM_SANITY_PASS"]);
+  });
+});

--- a/lib/evaluation/pipeline/evaluationCertificationGate.ts
+++ b/lib/evaluation/pipeline/evaluationCertificationGate.ts
@@ -47,6 +47,12 @@
  */
 
 import { getECGMode, type ECGMode } from '@/lib/evaluation/policy';
+import {
+  trimAtSentenceBoundary as trimAtSentenceBoundaryShared,
+  detectProseScoreDivergence,
+  detectRawFallbackSentinel,
+  endsMidSentence,
+} from '@/lib/text/authorFacingProse';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -222,6 +228,15 @@ export const CERTIFICATION_REGISTRY: InvariantRegistryEntry[] = [
     authority: 'Pass 3 synthesis (runPass3Synthesis)',
     section: 'any text field',
     tags: ['placeholder', 'text-integrity'],
+  },
+  {
+    code: 'ECG_TEXT_MIDSENTENCE_TERMINATION',
+    domain: 'TEXT',
+    severity: 'FATAL',
+    description: 'A full-sentence author-facing text field (pitch/premise/strength/risk) ends mid-sentence — no terminal punctuation, or a dangling connective/comma/colon/semicolon/em-dash/open-bracket. Global invariant: no author-facing text may end mid-sentence.',
+    authority: 'Pass 3 synthesis (runPass3Synthesis)',
+    section: 'overview pitches / enrichment.premise / strengths / risks',
+    tags: ['truncation', 'text-integrity', 'mid-sentence'],
   },
 
   // ── RECOMMEND domain (recommendation structure) ──────────────────────────
@@ -591,16 +606,31 @@ function checkAuthority(input: ECGInput): ECGViolation[] {
     ));
   }
 
-  // AUTH-2: Executive summary must not reference a different score
+  // AUTH-2: Executive summary must not reference a different score.
+  //
+  // Uses the shared, pure detectProseScoreDivergence inspector. The gate (this
+  // function) keeps ALL authority — the helper only reports the facts. Two
+  // directions are distinguished so the message is actionable:
+  //   - inflation (prose > canonical): a hard FLOOR-POLICY violation ("always
+  //     round DOWN — never inflate"). The gate must NEVER reconcile upward.
+  //   - non-inflating divergence (prose < canonical, e.g. floor-vs-round 64-vs-68):
+  //     still a mismatch the author must not see; regenerate with score grounding
+  //     (or reconcile the prose DOWN to the canonical value — never up).
   const summary = input.overview.one_paragraph_summary ?? '';
   if (summary) {
-    const mentions = extractScoreMentions(summary);
-    const wrong = mentions.filter((s) => s !== input.canonicalScore);
-    if (wrong.length > 0) {
+    const divergence = detectProseScoreDivergence(summary, input.canonicalScore);
+    if (divergence.diverges) {
+      const wrong = divergence.proseScores.filter((s) => s !== input.canonicalScore);
+      const floorNote = divergence.inflates
+        ? `At least one prose score EXCEEDS the canonical score — this violates the floor rounding policy ("always round down, never inflate"). ` +
+          `Never reconcile the prose upward. `
+        : `Prose score is at or below canonical (e.g. a floor-vs-round divergence). ` +
+          `Reconcile downward toward the canonical value or regenerate — never inflate. `;
       vs.push(violation(
         'ECG_AUTH_EXEC_SUMMARY_SCORE_MISMATCH',
         `Executive summary references ${wrong.map(s => `${s}/100`).join(', ')} but canonical score is ${input.canonicalScore}/100. ` +
-        `Pass 3 hallucinated a score. Regenerate Pass 3 with explicit score grounding — do not patch the text.`,
+        floorNote +
+        `Regenerate Pass 3 with explicit score grounding — do not patch the text upward.`,
       ));
     }
   }
@@ -726,6 +756,12 @@ function checkText(input: ECGInput): ECGViolation[] {
       vs.push(violation('ECG_TEXT_PLACEHOLDER',
         `"${label}" contains placeholder text. Fill all template slots before certification.`));
     }
+    // Global invariant: known full-sentence prose must not end mid-sentence.
+    // endsMidSentence is a pure inspector; this gate keeps the pass/fail authority.
+    if (endsMidSentence(value)) {
+      vs.push(violation('ECG_TEXT_MIDSENTENCE_TERMINATION',
+        `"${label}" ends mid-sentence (missing terminal punctuation or a dangling connective/comma/colon/em-dash/open-bracket). Pass 3 must emit complete sentences: "…${value.trim().slice(-40)}"`));
+    }
   }
 
   for (const c of input.criteria ?? []) {
@@ -777,10 +813,14 @@ function checkCompleteness(input: ECGInput): ECGViolation[] {
 
   if (!meaningful(input.overview.one_paragraph_summary))
     vs.push(violation('ECG_ART_MISSING_EXEC_SUMMARY', 'overview.one_paragraph_summary is absent or empty.'));
-  if (!meaningful(input.overview.one_sentence_pitch))
-    vs.push(violation('ECG_ART_MISSING_SENTENCE_PITCH', 'overview.one_sentence_pitch is absent or empty. Pass 3 must generate a distinct market hook.'));
-  if (!meaningful(input.overview.one_paragraph_pitch))
-    vs.push(violation('ECG_ART_MISSING_PARAGRAPH_PITCH', 'overview.one_paragraph_pitch is absent or empty. Pass 3 must generate a distinct story synopsis.'));
+  // A pitch that is the raw fallback SENTINEL ("A distinct market hook was not
+  // generated…") is effectively ABSENT — it must never certify as satisfied,
+  // else the sentinel would leak to the author. detectRawFallbackSentinel is a
+  // pure inspector; this gate keeps the pass/fail authority.
+  if (!meaningful(input.overview.one_sentence_pitch) || detectRawFallbackSentinel(input.overview.one_sentence_pitch))
+    vs.push(violation('ECG_ART_MISSING_SENTENCE_PITCH', 'overview.one_sentence_pitch is absent, empty, or a raw fallback sentinel. Pass 3 must generate a distinct market hook.'));
+  if (!meaningful(input.overview.one_paragraph_pitch) || detectRawFallbackSentinel(input.overview.one_paragraph_pitch))
+    vs.push(violation('ECG_ART_MISSING_PARAGRAPH_PITCH', 'overview.one_paragraph_pitch is absent, empty, or a raw fallback sentinel. Pass 3 must generate a distinct story synopsis.'));
   if (!meaningful(input.enrichment?.premise))
     vs.push(violation('ECG_ART_MISSING_PREMISE', 'enrichment.premise is absent or empty.'));
 
@@ -868,44 +908,16 @@ export function trimAtWordBoundary(text: string, maxLength: number): string {
   return candidate.replace(/[\s,;:.\u2014\-]+$/u, '') + '\u2026';
 }
 
-// Matches a sentence terminator: . ! ? or … possibly followed by a closing
-// quote/bracket. Used to trim ONLY at a complete-sentence boundary.
-const SENTENCE_TERMINATOR = /[.!?\u2026]["'\u201d\u2019)\]]*(?=\s|$)/gu;
-
 /**
- * Trim a text string to at most `maxLength` chars at a COMPLETE-SENTENCE
- * boundary. Governance rule NO_MIDSENTENCE_TRUNCATION: an over-budget field
- * must never be cut mid-sentence (and never mid-word).
+ * Trim a text string at a COMPLETE-SENTENCE boundary. Governance rule
+ * NO_MIDSENTENCE_TRUNCATION: an over-budget field must never be cut mid-sentence
+ * (and never mid-word).
  *
- * Behavior:
- *   - If text is within budget, returns it unchanged.
- *   - Otherwise trims back to the last sentence terminator (. ! ? …, plus any
- *     trailing closing quote/bracket) that fits within maxLength. The result
- *     ends on that terminator (no ellipsis added — the sentence is complete).
- *   - If NO sentence boundary fits within the budget (e.g. one very long
- *     sentence), falls back to trimAtWordBoundary so we still never cut
- *     mid-word. This fallback is the only case that appends an ellipsis.
- *
- * Note: per the "more is more" policy, callers should reserve this for
- * genuinely hard-capped fields (e.g. pitches). Free-form author-facing prose
- * (summaries) should be allowed to run over budget rather than truncated.
+ * The implementation lives ONCE in `lib/text/authorFacingProse.ts`; this is a
+ * thin re-export so existing importers (normalizeArtifact, qualityGate) keep
+ * working. See that module for behavior.
  */
-export function trimAtSentenceBoundary(text: string, maxLength: number): string {
-  if (!text || text.length <= maxLength) return text;
-  const window = text.substring(0, maxLength);
-  let lastEnd = -1;
-  for (const match of window.matchAll(SENTENCE_TERMINATOR)) {
-    // match.index points at the terminator char; include the terminator
-    // (and any trailing quote/bracket captured by the pattern).
-    lastEnd = match.index + match[0].length;
-  }
-  if (lastEnd > 0) {
-    return text.substring(0, lastEnd).trimEnd();
-  }
-  // No complete sentence fits — fall back to a word-boundary trim so we never
-  // cut mid-word. This is the only branch that appends an ellipsis.
-  return trimAtWordBoundary(text, maxLength);
-}
+export const trimAtSentenceBoundary = trimAtSentenceBoundaryShared;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Main gate function — verdict only, no mutation

--- a/lib/evaluation/pipeline/normalizeArtifact.ts
+++ b/lib/evaluation/pipeline/normalizeArtifact.ts
@@ -39,10 +39,32 @@
 
 import { trimAtSentenceBoundary } from './evaluationCertificationGate';
 import {
+  capitalizeFirstAlpha,
+  ensureTerminalPunctuation,
+  collapseAdjacentDuplicateWords,
+} from '@/lib/text/authorFacingProse';
+import {
   SUMMARY_POLICY,
   ONE_SENTENCE_PITCH_POLICY,
   ONE_PARAGRAPH_PITCH_POLICY,
 } from '@/lib/config/lengthPolicy';
+
+/**
+ * Diagnostic fields on a recommendation/opportunity that carry author-facing
+ * prose. Each is capitalized + terminally punctuated (A3/A4/D2) and has
+ * accidental adjacent-word duplication collapsed (A4). anchor_snippet is
+ * intentionally excluded — it is a verbatim quote.
+ */
+const RECOMMENDATION_PROSE_FIELDS = [
+  'action',
+  'symptom',
+  'cause',
+  'mechanism',
+  'fix_direction',
+  'specific_fix',
+  'reader_effect',
+  'expected_impact',
+] as const;
 
 export interface NormalizationRecord {
   field: string;
@@ -118,48 +140,57 @@ export function normalizeArtifact(
   }
 
   // ── Recommendation normalization ─────────────────────────────────────────
+  // Cosmetic-only repairs via shared, idempotent helpers (never alter meaning):
+  //   whitespace collapse → adjacent-duplicate-word collapse (A4) →
+  //   capitalize first alpha (A3/A4/D2) → ensure terminal punctuation (A3/A4).
   function normalizeRecs(
-    recs: Array<{ action?: string }>,
+    recs: Array<Record<string, unknown>>,
     prefix: string,
   ) {
     for (let i = 0; i < recs.length; i++) {
       const rec = recs[i];
-      if (!rec.action?.trim()) continue;
-      let value = rec.action.trim();
+      for (const field of RECOMMENDATION_PROSE_FIELDS) {
+        const raw = rec[field];
+        if (typeof raw !== 'string' || !raw.trim()) continue;
+        let value = raw.trim();
 
-      // Collapse whitespace
-      const collapsed = value.replace(/\s+/g, ' ');
-      if (collapsed !== value) {
-        normalizations.push({ field: `${prefix}[${i}].action`, before: value, after: collapsed, operation: 'whitespace' });
-        value = collapsed;
+        const collapsedWs = value.replace(/\s+/g, ' ');
+        if (collapsedWs !== value) {
+          normalizations.push({ field: `${prefix}[${i}].${field}`, before: value, after: collapsedWs, operation: 'whitespace' });
+          value = collapsedWs;
+        }
+
+        const dedup = collapseAdjacentDuplicateWords(value);
+        if (dedup !== value) {
+          normalizations.push({ field: `${prefix}[${i}].${field}`, before: value, after: dedup, operation: 'whitespace' });
+          value = dedup;
+        }
+
+        const capitalized = capitalizeFirstAlpha(value);
+        if (capitalized !== value) {
+          normalizations.push({ field: `${prefix}[${i}].${field}`, before: value, after: capitalized, operation: 'capitalize' });
+          value = capitalized;
+        }
+
+        const punctuated = ensureTerminalPunctuation(value);
+        if (punctuated !== value) {
+          normalizations.push({ field: `${prefix}[${i}].${field}`, before: value, after: punctuated, operation: 'terminal_punct' });
+          value = punctuated;
+        }
+
+        rec[field] = value;
       }
-
-      // Capitalize first letter
-      if (value.length > 0 && value.charAt(0) !== value.charAt(0).toUpperCase()) {
-        const capitalized = value.charAt(0).toUpperCase() + value.slice(1);
-        normalizations.push({ field: `${prefix}[${i}].action`, before: value, after: capitalized, operation: 'capitalize' });
-        value = capitalized;
-      }
-
-      // Terminal punctuation
-      if (!/[.!?…]$/.test(value)) {
-        const punctuated = value + '.';
-        normalizations.push({ field: `${prefix}[${i}].action`, before: value, after: punctuated, operation: 'terminal_punct' });
-        value = punctuated;
-      }
-
-      rec.action = value;
     }
   }
 
-  normalizeRecs(quickWins, 'recommendations.quick_wins');
-  normalizeRecs(strategicRevisions, 'recommendations.strategic_revisions');
+  normalizeRecs(quickWins as Array<Record<string, unknown>>, 'recommendations.quick_wins');
+  normalizeRecs(strategicRevisions as Array<Record<string, unknown>>, 'recommendations.strategic_revisions');
 
   // Also normalize criterion-level recommendations (for completeness)
   for (let ci = 0; ci < synthesis.criteria.length; ci++) {
     const criterion = synthesis.criteria[ci];
     if (!criterion.recommendations) continue;
-    normalizeRecs(criterion.recommendations as Array<{ action?: string }>, `criteria[${ci}].recommendations`);
+    normalizeRecs(criterion.recommendations as Array<Record<string, unknown>>, `criteria[${ci}].recommendations`);
   }
 
   return { normalizations };

--- a/lib/evaluation/pipeline/recommendationIntegrityGate.ts
+++ b/lib/evaluation/pipeline/recommendationIntegrityGate.ts
@@ -171,6 +171,7 @@ export type IntegrityViolationCode =
   | "ORPHAN_CONJUNCTION"
   | "MALFORMED_CONNECTOR"
   | "SENTENCE_FRAGMENT"
+  | "NO_LOWERCASE_OPENING"
   | "MISSING_TERMINAL_PUNCTUATION"
   | "REPEATED_CLAUSE"
   | "MID_SENTENCE_TRUNCATION"
@@ -281,6 +282,20 @@ function checkSentenceCompleteness(name: string, value: string): IntegrityViolat
         });
         break;
       }
+    }
+  }
+
+  // Lowercase opening (A3/A4/D2). Author-facing recommendation prose must open
+  // with a capital letter. anchor_snippet is exempt — it is a verbatim quote and
+  // may legitimately begin mid-sentence with a lowercase word.
+  if (name !== "anchor_snippet") {
+    const firstAlphaIdx = trimmed.search(/[A-Za-z]/);
+    if (firstAlphaIdx !== -1 && /[a-z]/.test(trimmed[firstAlphaIdx])) {
+      violations.push({
+        field: name,
+        code: "NO_LOWERCASE_OPENING",
+        detail: `Opens with a lowercase letter: "${trimmed.substring(0, 40)}"`,
+      });
     }
   }
 

--- a/lib/evaluation/pipeline/selfCorrectionPolicy.ts
+++ b/lib/evaluation/pipeline/selfCorrectionPolicy.ts
@@ -101,7 +101,9 @@ export function getGateFailurePolicy(errorCode: string): GateFailurePolicy {
   if (
     errorCode === "SHORT_FORM_LONGFORM_ARTIFACT_LEAK" ||
     errorCode === "SHORT_FORM_INTERNAL_PROCESS_LEAK" ||
-    errorCode === "SHORT_FORM_UNSUPPORTED_GLOBAL_CLAIM"
+    errorCode === "SHORT_FORM_UNSUPPORTED_GLOBAL_CLAIM" ||
+    errorCode === "SHORT_FORM_MIDSENTENCE_TERMINATION" ||
+    errorCode === "SHORT_FORM_COPY_DEFECT"
   ) {
     return {
       max_retries: 1,
@@ -147,6 +149,9 @@ export function buildRetryContext(opts: {
     retry_instruction:
       `Your previous output was rejected by the ${opts.gate} for: ${violationSummary}. ` +
       `Regenerate without these defects. Ensure every rationale ends with terminal punctuation, ` +
+      `every author-facing sentence begins with a capital letter and ends as a complete sentence ` +
+      `(never mid-clause on a dangling connective, comma, colon, or open parenthesis), ` +
+      `distinct diagnostic fields (fix direction, reader effect) are not fused into one run-on, ` +
       `every recommendation references a specific manuscript passage, and no placeholder or ` +
       `template text remains in the output.`,
   };
@@ -160,6 +165,12 @@ function describeViolationCode(code: string): string {
       return "placeholder/template text found in output";
     case "HANDOFF_INCOMPLETE_SENTENCE":
       return "rationale or action lacks complete sentence structure";
+    case "HANDOFF_MIDSENTENCE_TERMINATION":
+      return "author-facing prose ends mid-sentence (dangling connective, comma, colon, or open parenthesis) — every rendered sentence must be complete";
+    case "REC_INTEGRITY_LOWERCASE_OPENING":
+      return "recommendation/opportunity text opens with a lowercase letter — capitalize the first word";
+    case "REC_INTEGRITY_FUSED_FIELDS":
+      return "distinct diagnostic fields (fix direction, reader effect) are fused with no sentence boundary between them";
     case "HANDOFF_BROKEN_MODAL":
       return "garbled modal phrase detected (e.g. doubled verbs, broken syntax)";
     case "HANDOFF_GENERIC_LANGUAGE":
@@ -178,6 +189,10 @@ function describeViolationCode(code: string): string {
       return "output contains internal pipeline stage labels (Pass N / Phase N) — regenerate without pipeline terminology";
     case "SHORT_FORM_UNSUPPORTED_GLOBAL_CLAIM":
       return "output makes whole-manuscript scope claims not supported by the submitted excerpt — scope all claims to the submitted text only";
+    case "SHORT_FORM_MIDSENTENCE_TERMINATION":
+      return "a diagnostic segment ends mid-sentence (dangling connective, comma, colon, or open parenthesis) — every author-facing sentence must be complete";
+    case "SHORT_FORM_COPY_DEFECT":
+      return "a diagnostic segment has a copy defect (lowercase opening or accidental adjacent-duplicate word) — capitalize the first word and remove the duplicate";
     default:
       return code.toLowerCase().replace(/_/g, " ");
   }

--- a/lib/evaluation/pipeline/shortFormFinalSanityCheck.ts
+++ b/lib/evaluation/pipeline/shortFormFinalSanityCheck.ts
@@ -1,5 +1,10 @@
 import type { EvaluationCriterionV2, EvaluationResultV2 } from '@/schemas/evaluation-result-v2';
 import type { ShortFormEvidenceGateResult } from './shortFormEvidenceGate';
+import {
+  collapseAdjacentDuplicateWords,
+  endsWithDanglingConnective,
+  capitalizeFirstAlpha,
+} from '@/lib/text/authorFacingProse';
 
 export type ShortFormFinalSanityCheck = {
   schema_version: 'short_form_final_sanity_check_v1';
@@ -33,6 +38,34 @@ function collectUserFacingText(result: EvaluationResultV2): string {
   ].filter((value): value is string => typeof value === 'string').join('\n');
 }
 
+// Prose fields carried on each recommendation/opportunity. anchor_snippet and
+// candidate_text_* are intentionally excluded (verbatim quotes / strategy copy).
+const OPPORTUNITY_PROSE_FIELDS = [
+  'action', 'expected_impact', 'symptom', 'mechanism', 'specific_fix', 'reader_effect',
+] as const;
+
+/**
+ * Individual author-facing prose segments (rationale + every opportunity
+ * diagnostic field). Each must independently be a complete, well-formed
+ * sentence — so the copy-integrity checks run PER SEGMENT rather than on a
+ * joined blob (which would mask a mid-sentence end inside the text).
+ */
+function collectDiagnosticSegments(result: EvaluationResultV2): string[] {
+  const segments: string[] = [];
+  const criteria = Array.isArray(result.criteria) ? result.criteria : [];
+  for (const criterion of criteria) {
+    if (typeof criterion.rationale === 'string') segments.push(criterion.rationale);
+    const recs = Array.isArray(criterion.recommendations) ? criterion.recommendations : [];
+    for (const rec of recs) {
+      for (const field of OPPORTUNITY_PROSE_FIELDS) {
+        const value = (rec as Record<string, unknown>)[field];
+        if (typeof value === 'string' && value.trim().length > 0) segments.push(value);
+      }
+    }
+  }
+  return segments;
+}
+
 export function runShortFormFinalSanityCheck(input: {
   wordCount: number;
   evaluationResult: EvaluationResultV2;
@@ -64,6 +97,26 @@ export function runShortFormFinalSanityCheck(input: {
   if (insufficientCount >= 7 && /\bmarket ready\b/i.test(text)) codes.push('SHORT_FORM_SCORE_SUMMARY_CONTRADICTION');
   if (/\b(WAVE|Golden Spine|long-form canon|Phase 5)\b/i.test(text)) codes.push('SHORT_FORM_LONGFORM_ARTIFACT_LEAK');
 
+  // ── Copy-integrity backstop (A4 + global mid-sentence invariant) ──────────
+  // The trivial cases are auto-repaired upstream by the shared helpers at the
+  // normalizeArtifact pre-stage. This referee blocks anything that survived to
+  // persist-time: prose ending mid-sentence (dangling connective/comma/colon/
+  // open paren), a lowercase opening, or an accidental adjacent-duplicate word.
+  const diagnosticSegments = collectDiagnosticSegments(input.evaluationResult);
+  let sawMidSentence = false;
+  let sawCopyDefect = false;
+  for (const segment of diagnosticSegments) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+    if (endsWithDanglingConnective(trimmed)) sawMidSentence = true;
+    // Lowercase opening (first alpha char is lowercase).
+    if (capitalizeFirstAlpha(trimmed) !== trimmed) sawCopyDefect = true;
+    // Accidental adjacent-duplicate word ("passage reflective passage").
+    if (collapseAdjacentDuplicateWords(trimmed) !== trimmed) sawCopyDefect = true;
+  }
+  if (sawMidSentence) codes.push('SHORT_FORM_MIDSENTENCE_TERMINATION');
+  if (sawCopyDefect) codes.push('SHORT_FORM_COPY_DEFECT');
+
   const blockingCodes = new Set([
     'SHORT_FORM_INTERNAL_PROCESS_LEAK',
     'SHORT_FORM_MISSING_ANCHORS',
@@ -71,6 +124,8 @@ export function runShortFormFinalSanityCheck(input: {
     'SHORT_FORM_SCORE_SUMMARY_CONTRADICTION',
     'SHORT_FORM_UNSUPPORTED_GLOBAL_CLAIM',
     'SHORT_FORM_LONGFORM_ARTIFACT_LEAK',
+    'SHORT_FORM_MIDSENTENCE_TERMINATION',
+    'SHORT_FORM_COPY_DEFECT',
   ]);
   const uniqueCodes = unique(codes);
   const blocking = uniqueCodes.some((code) => blockingCodes.has(code));

--- a/lib/evaluation/shortFormReportDocument.ts
+++ b/lib/evaluation/shortFormReportDocument.ts
@@ -9,6 +9,7 @@ import {
 import { buildReportPitches, type RevisionOpportunitySummary } from '@/lib/evaluation/reportTemplateContract';
 import { getCriterionRationalePresentation, getCriterionSupportLabel, type RenderableCriterion } from '@/lib/evaluation/reportCriterionDisplay';
 import { mistakeProofText } from '@/lib/evaluation/reportRenderSafety';
+import { detectRawFallbackSentinel } from '@/lib/text/authorFacingProse';
 import {
   formatCriterionConfidenceLabel,
   deriveGenreConfidence,
@@ -595,8 +596,10 @@ export function buildShortFormEvaluationDocument(input: {
       headerContract,
       genreExpectationContract,
     },
-    oneParagraphPitch: mistakeProofText(pitches.oneParagraphPitch),
-    oneSentencePitch: mistakeProofText(pitches.oneSentencePitch),
+    // A2: never expose the raw fallback sentinel — suppress to empty at this
+    // author-facing boundary rather than print the "not generated" marker.
+    oneParagraphPitch: detectRawFallbackSentinel(pitches.oneParagraphPitch) ? '' : mistakeProofText(pitches.oneParagraphPitch),
+    oneSentencePitch: detectRawFallbackSentinel(pitches.oneSentencePitch) ? '' : mistakeProofText(pitches.oneSentencePitch),
     premise:
       typeof result.enrichment?.premise === 'string' && result.enrichment.premise.trim().length > 0
         ? mistakeProofText(result.enrichment.premise)

--- a/lib/revision/reviseCardContract.ts
+++ b/lib/revision/reviseCardContract.ts
@@ -1,6 +1,7 @@
 import {
   hasRepeatedSentenceOpenings,
   startsWithRepetitiveLeadIn,
+  collapseDuplicatedStrategyLabel,
 } from '@/lib/text/authorFacingProse'
 
 export const REVISION_OPERATIONS = [
@@ -85,6 +86,16 @@ export const REVISION_OPTION_LABELS = {
   B: 'B — Rhythm Variant',
   C: 'C — Bolder Rendering Shift',
 } as const
+
+/**
+ * Canonical accessor for the A/B/C strategy card header label. (D3)
+ * Routes the intended label through collapseDuplicatedStrategyLabel so an
+ * ACCIDENTAL immediate doubling is collapsed while the intended single label is
+ * always preserved. This is the single choke point renderers should use.
+ */
+export function strategyOptionLabel(key: keyof typeof REVISION_OPTION_LABELS): string {
+  return collapseDuplicatedStrategyLabel(REVISION_OPTION_LABELS[key])
+}
 
 const FORBIDDEN_META_SUGGESTIONS = [
   'review this opportunity',

--- a/lib/text/__tests__/authorFacingProse.test.ts
+++ b/lib/text/__tests__/authorFacingProse.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit + fixture tests — shared author-facing prose helpers.
+ *
+ * These are PURE, idempotent helpers. They only transform or inspect a string
+ * and make NO pass/fail decision (authority lives in the gates). Each helper is
+ * exercised for its documented behavior, idempotency, and — where a defect from
+ * the Copy-Polish brief maps to a helper — the EXACT source fixture string.
+ *
+ * Defect → helper map:
+ *   A1  detectProseScoreDivergence   (prose "64/100" vs canonical 68 — never inflate)
+ *   A2  detectRawFallbackSentinel    ("A distinct market hook was not generated…")
+ *   A3  capitalizeFirstAlpha + ensureTerminalPunctuation
+ *   A4  collapseAdjacentDuplicateWords ("passage reflective passage")
+ *   D1  ensureSingleSpaceAfterColon   ("Symptom:After" → "Symptom: After")
+ *   D3  collapseDuplicatedStrategyLabel (doubled "A: Recommended" header)
+ *   mid-sentence invariant: endsMidSentence / endsWithDanglingConnective / trimAtSentenceBoundary
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  capitalizeFirstAlpha,
+  ensureTerminalPunctuation,
+  ensureSingleSpaceAfterColon,
+  collapseAdjacentDuplicateWords,
+  collapseDuplicatedStrategyLabel,
+  detectRawFallbackSentinel,
+  detectProseScoreDivergence,
+  endsMidSentence,
+  endsWithDanglingConnective,
+  trimAtSentenceBoundary,
+} from "@/lib/text/authorFacingProse";
+
+// ── capitalizeFirstAlpha (A3, A4, D2) ────────────────────────────────────────
+describe("capitalizeFirstAlpha", () => {
+  it("capitalizes the first alphabetic character", () => {
+    expect(capitalizeFirstAlpha("insert one concrete stakes beat")).toBe(
+      "Insert one concrete stakes beat",
+    );
+  });
+
+  it("leaves leading punctuation/numbering untouched", () => {
+    expect(capitalizeFirstAlpha("4. insert one beat")).toBe("4. Insert one beat");
+    expect(capitalizeFirstAlpha("• the reflective passage")).toBe("• The reflective passage");
+  });
+
+  it("is idempotent on already-capitalized text", () => {
+    const once = capitalizeFirstAlpha("The reflective passage stalls.");
+    expect(once).toBe("The reflective passage stalls.");
+    expect(capitalizeFirstAlpha(once)).toBe(once);
+  });
+
+  it("returns empty/no-alpha input unchanged", () => {
+    expect(capitalizeFirstAlpha("")).toBe("");
+    expect(capitalizeFirstAlpha("123 —")).toBe("123 —");
+  });
+});
+
+// ── ensureTerminalPunctuation (A3, A4) ───────────────────────────────────────
+describe("ensureTerminalPunctuation", () => {
+  it("appends a period when terminal punctuation is missing", () => {
+    expect(ensureTerminalPunctuation("the stakes signal arrives too late")).toBe(
+      "the stakes signal arrives too late.",
+    );
+  });
+
+  it("replaces a dangling clause-level mark with a period", () => {
+    expect(ensureTerminalPunctuation("the stakes signal arrives too late,")).toBe(
+      "the stakes signal arrives too late.",
+    );
+    expect(ensureTerminalPunctuation("increased momentum:")).toBe("increased momentum.");
+  });
+
+  it("is idempotent when already terminally punctuated", () => {
+    expect(ensureTerminalPunctuation("Done.")).toBe("Done.");
+    expect(ensureTerminalPunctuation("Really?")).toBe("Really?");
+    expect(ensureTerminalPunctuation('He said "stop."')).toBe('He said "stop."');
+  });
+});
+
+// ── ensureSingleSpaceAfterColon (D1) ─────────────────────────────────────────
+describe("ensureSingleSpaceAfterColon", () => {
+  it("inserts a single space after a label colon (D1 fixture)", () => {
+    expect(ensureSingleSpaceAfterColon("Symptom:After")).toBe("Symptom: After");
+    expect(ensureSingleSpaceAfterColon("Fix:Add")).toBe("Fix: Add");
+  });
+
+  it("does not double-space when a space already exists (idempotent)", () => {
+    expect(ensureSingleSpaceAfterColon("Symptom: After")).toBe("Symptom: After");
+    expect(ensureSingleSpaceAfterColon(ensureSingleSpaceAfterColon("Symptom:After"))).toBe(
+      "Symptom: After",
+    );
+  });
+
+  it("collapses multiple spaces after a colon to one", () => {
+    expect(ensureSingleSpaceAfterColon("Symptom:   After")).toBe("Symptom: After");
+  });
+
+  it("leaves digit:digit ratios/times untouched", () => {
+    expect(ensureSingleSpaceAfterColon("ratio 3:1")).toBe("ratio 3:1");
+    expect(ensureSingleSpaceAfterColon("at 12:30")).toBe("at 12:30");
+  });
+});
+
+// ── collapseAdjacentDuplicateWords (A4) ──────────────────────────────────────
+describe("collapseAdjacentDuplicateWords", () => {
+  it("collapses a duplicate straddling one word (A4 fixture)", () => {
+    expect(
+      collapseAdjacentDuplicateWords(
+        "The passage reflective passage stalls forward momentum before the narrative urgency peaks",
+      ),
+    ).toBe("The reflective passage stalls forward momentum before the narrative urgency peaks");
+  });
+
+  it("collapses an immediate safe-function-word repeat", () => {
+    expect(collapseAdjacentDuplicateWords("the the reflective passage")).toBe(
+      "the reflective passage",
+    );
+  });
+
+  it("never collapses legitimate repetition", () => {
+    expect(collapseAdjacentDuplicateWords("he had had enough")).toBe("he had had enough");
+    expect(collapseAdjacentDuplicateWords("she knew that that man")).toBe("she knew that that man");
+  });
+
+  it("is idempotent", () => {
+    const once = collapseAdjacentDuplicateWords("the passage reflective passage stalls");
+    expect(collapseAdjacentDuplicateWords(once)).toBe(once);
+  });
+});
+
+// ── collapseDuplicatedStrategyLabel (D3) ─────────────────────────────────────
+describe("collapseDuplicatedStrategyLabel", () => {
+  it("collapses an accidentally doubled strategy label", () => {
+    expect(collapseDuplicatedStrategyLabel("A: Recommended A: Recommended")).toBe("A: Recommended");
+    expect(collapseDuplicatedStrategyLabel("A — Recommended Repair A — Recommended Repair")).toBe(
+      "A — Recommended Repair",
+    );
+  });
+
+  it("preserves a correctly-single intended label (no false positive)", () => {
+    expect(collapseDuplicatedStrategyLabel("A: Recommended")).toBe("A: Recommended");
+    expect(collapseDuplicatedStrategyLabel("B — Rhythm Variant")).toBe("B — Rhythm Variant");
+    expect(collapseDuplicatedStrategyLabel("C: Bolder Shift")).toBe("C: Bolder Shift");
+  });
+
+  it("does not touch non-strategy duplicated text", () => {
+    expect(collapseDuplicatedStrategyLabel("really really good")).toBe("really really good");
+  });
+
+  it("is idempotent", () => {
+    const once = collapseDuplicatedStrategyLabel("A: Recommended A: Recommended");
+    expect(collapseDuplicatedStrategyLabel(once)).toBe(once);
+  });
+});
+
+// ── detectRawFallbackSentinel (A2) ───────────────────────────────────────────
+describe("detectRawFallbackSentinel", () => {
+  it("detects the market-hook sentinel (A2 fixture)", () => {
+    expect(detectRawFallbackSentinel("A distinct market hook was not generated for Criminality.")).toBe(
+      true,
+    );
+  });
+
+  it("detects the story-synopsis sentinel", () => {
+    expect(detectRawFallbackSentinel("A distinct story synopsis was not generated.")).toBe(true);
+  });
+
+  it("treats null/empty as absent", () => {
+    expect(detectRawFallbackSentinel(null)).toBe(true);
+    expect(detectRawFallbackSentinel(undefined)).toBe(true);
+    expect(detectRawFallbackSentinel("   ")).toBe(true);
+  });
+
+  it("returns false for a genuine pitch", () => {
+    expect(
+      detectRawFallbackSentinel(
+        "A sardonic diamond dealer's retirement evening becomes a reckoning with blood money.",
+      ),
+    ).toBe(false);
+  });
+});
+
+// ── detectProseScoreDivergence (A1) ──────────────────────────────────────────
+describe("detectProseScoreDivergence", () => {
+  it("flags the floor-vs-round 64-vs-68 divergence without inflating (A1 fixture)", () => {
+    const r = detectProseScoreDivergence("This excerpt earns a 64/100 on the strength of its premise.", 68);
+    expect(r.proseScores).toEqual([64]);
+    expect(r.diverges).toBe(true);
+    expect(r.inflates).toBe(false); // 64 < 68 → not inflation, but still a mismatch
+  });
+
+  it("flags inflation when prose EXCEEDS canonical", () => {
+    const r = detectProseScoreDivergence("This excerpt earns a 72/100.", 68);
+    expect(r.diverges).toBe(true);
+    expect(r.inflates).toBe(true);
+  });
+
+  it("does not flag when prose matches canonical", () => {
+    const r = detectProseScoreDivergence("This excerpt earns a 68/100.", 68);
+    expect(r.diverges).toBe(false);
+    expect(r.inflates).toBe(false);
+  });
+
+  it("handles prose with no score", () => {
+    const r = detectProseScoreDivergence("A strong, well-paced excerpt.", 68);
+    expect(r.proseScores).toEqual([]);
+    expect(r.diverges).toBe(false);
+  });
+});
+
+// ── mid-sentence invariant: endsMidSentence / endsWithDanglingConnective ─────
+describe("endsMidSentence", () => {
+  it("flags a dangling connective", () => {
+    expect(endsMidSentence("The stakes arrive late because")).toBe(true);
+  });
+
+  it("flags a dangling comma / colon / open paren", () => {
+    expect(endsMidSentence("The stakes arrive late,")).toBe(true);
+    expect(endsMidSentence("The stakes arrive late:")).toBe(true);
+    expect(endsMidSentence("The stakes arrive late (")).toBe(true);
+  });
+
+  it("flags mere absence of terminal punctuation", () => {
+    expect(endsMidSentence("The stakes arrive late")).toBe(true);
+  });
+
+  it("passes a complete sentence", () => {
+    expect(endsMidSentence("The stakes arrive late.")).toBe(false);
+  });
+});
+
+describe("endsWithDanglingConnective", () => {
+  it("flags a dangling connective but not mere missing punctuation", () => {
+    expect(endsWithDanglingConnective("The stakes arrive late because")).toBe(true);
+    expect(endsWithDanglingConnective("The stakes arrive late,")).toBe(true);
+    // Strong-signal subset: no terminal punctuation alone is NOT flagged.
+    expect(endsWithDanglingConnective("Fix direction")).toBe(false);
+  });
+});
+
+// ── trimAtSentenceBoundary (global invariant helper) ─────────────────────────
+describe("trimAtSentenceBoundary", () => {
+  it("drops a trailing incomplete fragment", () => {
+    expect(
+      trimAtSentenceBoundary("The stakes arrive late. The reader loses momentum because"),
+    ).toBe("The stakes arrive late.");
+  });
+
+  it("returns a complete sentence unchanged", () => {
+    expect(trimAtSentenceBoundary("The stakes arrive late.")).toBe("The stakes arrive late.");
+  });
+
+  it("never leaves a dangling connective when trimming to a budget", () => {
+    const out = trimAtSentenceBoundary(
+      "The stakes arrive late. The reader loses momentum and the scene stalls before the turn.",
+      30,
+    );
+    expect(endsWithDanglingConnective(out)).toBe(false);
+  });
+
+  it("is idempotent", () => {
+    const once = trimAtSentenceBoundary("The stakes arrive late. The reader loses momentum because");
+    expect(trimAtSentenceBoundary(once)).toBe(once);
+  });
+});

--- a/lib/text/authorFacingProse.ts
+++ b/lib/text/authorFacingProse.ts
@@ -109,3 +109,279 @@ export function sanitizeAuthorFacingProse(text: string): string {
   const compact = text.replace(/\r\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
   return removeConsecutiveDuplicateSentences(compact);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure, idempotent copy-polish helpers.
+//
+// These transform or INSPECT a string. They make NO kick-back / retry /
+// certify-fail decision — that authority lives entirely in the existing gates
+// (KICK_MATRIX + selfCorrectionPolicy + evaluationCertificationGate +
+// shortFormFinalSanityCheck). Implemented ONCE here and reused everywhere.
+// Every helper is idempotent: running it twice yields the same result as once.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Capitalize the first alphabetic character of a string, leaving any leading
+ * punctuation/whitespace/numbering untouched. (A3, A4, D2)
+ * Idempotent: an already-capitalized opening is unchanged.
+ */
+export function capitalizeFirstAlpha(text: string): string {
+  if (!text) return text;
+  const idx = text.search(/[a-zA-Z]/);
+  if (idx === -1) return text;
+  const ch = text[idx];
+  const upper = ch.toUpperCase();
+  if (ch === upper) return text;
+  return text.slice(0, idx) + upper + text.slice(idx + 1);
+}
+
+// A terminal sentence punctuation mark, optionally followed by a closing
+// quote/bracket, at the very end of the (trimmed) string.
+const TERMINAL_PUNCTUATION_AT_END = /[.!?…]["'”’)\]]*$/u;
+
+/**
+ * Ensure the string ends with terminal sentence punctuation. (A3, A4)
+ * If it already ends with . ! ? … (optionally + closing quote/bracket), it is
+ * returned unchanged (idempotent). A trailing comma/semicolon/colon/dash is
+ * replaced with a period. Otherwise a period is appended.
+ */
+export function ensureTerminalPunctuation(text: string): string {
+  if (!text) return text;
+  const trimmed = text.replace(/\s+$/u, "");
+  if (!trimmed) return text;
+  if (TERMINAL_PUNCTUATION_AT_END.test(trimmed)) return trimmed;
+  // Replace a dangling clause-level punctuation mark with a period.
+  const withoutDangling = trimmed.replace(/[,;:—\-]+$/u, "");
+  return (withoutDangling || trimmed) + ".";
+}
+
+/**
+ * Ensure exactly one space after a label colon. (D1)
+ * Collapses zero-or-many spaces after a colon into a single space. Does NOT
+ * touch colons that already have exactly one space (idempotent) and leaves
+ * time-like or ratio-like "digit:digit" sequences untouched.
+ */
+export function ensureSingleSpaceAfterColon(text: string): string {
+  if (!text) return text;
+  return text.replace(/([^\s\d]):(?=\S)(?!\d)\s*/g, "$1: ").replace(/([^\s\d]):[ \t]{2,}/g, "$1: ");
+}
+
+// Function words whose IMMEDIATE doubling ("the the") is essentially always an
+// accidental copy artifact. Deliberately excludes words that legitimately double
+// in English ("had had", "that that", "is is" as a stammer, etc.).
+const SAFE_IMMEDIATE_DUP_WORDS = new Set([
+  "the", "a", "an", "of", "to", "in", "on", "at", "for", "and", "or", "but",
+  "with", "as", "by", "from", "into", "onto",
+]);
+
+/**
+ * Conservatively collapse an accidental adjacent duplicate word. (A4)
+ * Handles two accidental shapes only:
+ *   - immediate repeat of a safe function word: "the the" → "the"
+ *   - repeat straddling one word:  "passage reflective passage" → "reflective passage"
+ * Case/punctuation-insensitive on the compared token. Deliberately narrow so it
+ * never collapses legitimate repetition ("had had", "that that" are left to the
+ * qualityGate's duplication semantics) and never touches proper-noun echoes.
+ */
+export function collapseAdjacentDuplicateWords(text: string): string {
+  if (!text) return text;
+  let out = text;
+  // Immediate repeat: only for safe function words, and only when both tokens
+  // share case (so "The the" style is left alone — likely a sentence boundary).
+  out = out.replace(/\b([A-Za-z]+)(\s+)\1\b/g, (match, word: string) => {
+    if (!SAFE_IMMEDIATE_DUP_WORDS.has(word.toLowerCase())) return match;
+    return word;
+  });
+  // Repeat straddling exactly one intervening word: A x A → x A (drop the leading dup).
+  out = out.replace(/\b([A-Za-z]+)\s+([A-Za-z]+)\s+\1\b/g, (match, first: string, middle: string) => {
+    // Only collapse when the duplicated token is a lowercase common word
+    // (avoids touching intentional proper-noun echoes like "New … New").
+    if (/[A-Z]/.test(first[0])) return match;
+    return `${middle} ${first}`;
+  });
+  return out;
+}
+
+// A leading A/B/C strategy-label token: a single letter A, B, or C followed by
+// a colon, em-dash, or hyphen separator. Used to recognize the INTENTIONAL
+// strategy labels ("A: Recommended", "B — Rhythm Variant", "C: Bolder Shift")
+// so only an ACCIDENTAL immediate repeat is collapsed. (D3)
+const STRATEGY_LABEL_PREFIX = /^[ABC]\s*[:—-]/;
+
+/**
+ * Collapse an ACCIDENTALLY doubled A/B/C strategy label at the head of a card
+ * header, preserving the single intended label. (D3)
+ *
+ * Surgical + conservative: only collapses when the header BEGINS with a valid
+ * strategy-label token (A/B/C + separator) that is then immediately repeated
+ * verbatim. Never strips the intended single label; never touches non-strategy
+ * text. Idempotent.
+ *   "A: Recommended A: Recommended"     → "A: Recommended"
+ *   "A — Rhythm Variant A — Rhythm Variant more" → "A — Rhythm Variant more"
+ *   "A: Recommended"                    → unchanged
+ */
+export function collapseDuplicatedStrategyLabel(text: string): string {
+  if (!text) return text;
+  const compact = text.replace(/\s+/g, " ").trim();
+  const dup = compact.match(/^(.+?)\s+\1(\s+.*)?$/);
+  if (dup && STRATEGY_LABEL_PREFIX.test(dup[1])) {
+    return (dup[1] + (dup[2] ?? "")).trim();
+  }
+  return text;
+}
+
+// Sentinel strings deliberately emitted by buildReportPitches when a distinct
+// pitch could not be generated. detectRawFallbackSentinel treats these as
+// "absent" so a gate can regenerate/suppress rather than expose them. (A2)
+const FALLBACK_SENTINEL_PATTERNS = [
+  /\bdistinct (?:market hook|story synopsis) was not generated\b/i,
+  /\bmarket hook was not generated\b/i,
+  /\bstory synopsis was not generated\b/i,
+];
+
+/**
+ * Detect whether a pitch/summary string is a raw fallback sentinel (or empty).
+ * Returns true when the text must be treated as MISSING. (A2)
+ * Pure predicate — makes no decision about what to do about it.
+ */
+export function detectRawFallbackSentinel(text: string | null | undefined): boolean {
+  if (text == null) return true;
+  const clean = normalizeWhitespace(text);
+  if (!clean) return true;
+  return FALLBACK_SENTINEL_PATTERNS.some((p) => p.test(clean));
+}
+
+const PROSE_SCORE_PATTERN = /\b(\d{1,3})\s*\/\s*100\b/g;
+
+export type ProseScoreDivergence = {
+  /** Every "NN/100" mention found in the prose. */
+  proseScores: number[];
+  /** The canonical displayed score passed in. */
+  canonicalScore: number;
+  /** True if any prose score differs from the canonical score. */
+  diverges: boolean;
+  /** True if any prose score EXCEEDS the canonical score (inflation — never allowed). */
+  inflates: boolean;
+};
+
+/**
+ * Detect a prose-cited "NN/100" score that diverges from the canonical
+ * displayed score. (A1)
+ *
+ * Pure inspector — makes NO decision. The certification gate decides whether a
+ * divergence is a kick-back. Distinguishes the two directions:
+ *   - inflates: prose score > canonical (violates the floor "never inflate" law)
+ *   - diverges: prose score != canonical (e.g. the legitimate floor-vs-round
+ *     64-vs-68 case, which the gate treats as a mismatch to reconcile).
+ */
+export function detectProseScoreDivergence(
+  prose: string | null | undefined,
+  canonicalScore: number,
+): ProseScoreDivergence {
+  const proseScores: number[] = [];
+  if (prose) {
+    for (const match of prose.matchAll(PROSE_SCORE_PATTERN)) {
+      const n = Number.parseInt(match[1], 10);
+      if (Number.isFinite(n)) proseScores.push(n);
+    }
+  }
+  const diverges = proseScores.some((s) => s !== canonicalScore);
+  const inflates = proseScores.some((s) => s > canonicalScore);
+  return { proseScores, canonicalScore, diverges, inflates };
+}
+
+// A dangling connective/opening that must never end author-facing prose.
+const DANGLING_TAIL_WORDS = [
+  "and", "or", "but", "so", "yet", "nor", "for",
+  "because", "which", "that", "who", "whom", "whose", "where", "when", "while",
+  "if", "as", "than", "then", "with", "to", "of", "in", "on", "at", "by",
+  "from", "into", "onto", "the", "a", "an", "this", "these", "those",
+];
+const DANGLING_TAIL_PATTERN = new RegExp(
+  `(?:\\b(?:${DANGLING_TAIL_WORDS.join("|")})\\b|,|:|;|\\u2014|\\(|\\[)\\s*$`,
+  "iu",
+);
+
+/**
+ * Detect whether author-facing prose ends mid-sentence. (global invariant)
+ * True when the trimmed text does NOT end with terminal punctuation, OR ends
+ * with a dangling connective / comma / colon / semicolon / em-dash / open
+ * bracket. Pure predicate — the gate decides whether to kick back.
+ *
+ * Use this for KNOWN full-sentence prose (summary, pitches, rationales). For a
+ * broad sweep across mixed segments that may include short label fields, prefer
+ * endsWithDanglingConnective to avoid flagging label-style text.
+ */
+export function endsMidSentence(text: string | null | undefined): boolean {
+  if (text == null) return false;
+  const trimmed = normalizeWhitespace(text);
+  if (!trimmed) return false;
+  if (DANGLING_TAIL_PATTERN.test(trimmed)) return true;
+  return !TERMINAL_PUNCTUATION_AT_END.test(trimmed);
+}
+
+/**
+ * Strong-signal subset of endsMidSentence: true ONLY when the text ends on a
+ * dangling connective, comma, colon, semicolon, em-dash, or open bracket — i.e.
+ * unambiguously incomplete. Does NOT flag mere absence of terminal punctuation,
+ * so it is safe to run across mixed segments including short label fields.
+ */
+export function endsWithDanglingConnective(text: string | null | undefined): boolean {
+  if (text == null) return false;
+  const trimmed = normalizeWhitespace(text);
+  if (!trimmed) return false;
+  return DANGLING_TAIL_PATTERN.test(trimmed);
+}
+
+// Matches a sentence terminator (. ! ? …) plus any trailing closing
+// quote/bracket, at a position followed by whitespace or end-of-string.
+const SENTENCE_TERMINATOR = /[.!?…]["'”’)\]]*(?=\s|$)/gu;
+
+function trimAtWordBoundaryLocal(text: string, maxLength: number): string {
+  if (!text || text.length <= maxLength) return text;
+  const candidate = text.substring(0, maxLength - 1);
+  const lastSpace = candidate.lastIndexOf(" ");
+  if (lastSpace > maxLength * 0.6) {
+    return candidate.substring(0, lastSpace).replace(/[\s,;:.—\-]+$/u, "") + "…";
+  }
+  return candidate.replace(/[\s,;:.—\-]+$/u, "") + "…";
+}
+
+/**
+ * Trim author-facing prose back to the last COMPLETE sentence. (global invariant)
+ *
+ * Sentence boundary > word boundary. When `maxLength` is provided, trims within
+ * that budget; when omitted, returns the whole run of complete sentences
+ * (dropping only a trailing incomplete fragment). Never leaves a dangling
+ * connective, comma, colon, semicolon, em-dash, or open bracket. Idempotent.
+ *
+ * If NO complete sentence fits within `maxLength`, falls back to a word-boundary
+ * trim (the only branch that appends an ellipsis) so we never cut mid-word.
+ */
+export function trimAtSentenceBoundary(text: string, maxLength?: number): string {
+  if (!text) return text;
+
+  // Hard-cap mode: with a budget, author prose within the cap is returned
+  // UNCHANGED ("more is more" — never touch content or trailing whitespace).
+  // Only over-budget text is shortened, always at a complete-sentence boundary.
+  if (maxLength !== undefined && text.length <= maxLength) return text;
+
+  if (maxLength === undefined) {
+    // "Complete sentences" mode: drop only a trailing incomplete fragment.
+    if (!endsMidSentence(text)) return text.trimEnd();
+    let lastEnd = -1;
+    for (const match of text.matchAll(SENTENCE_TERMINATOR)) {
+      lastEnd = match.index + match[0].length;
+    }
+    return lastEnd > 0 ? text.substring(0, lastEnd).trimEnd() : text.trimEnd();
+  }
+
+  // Over-budget mode: trim within the window to the last complete sentence.
+  const window = text.substring(0, maxLength);
+  let lastEnd = -1;
+  for (const match of window.matchAll(SENTENCE_TERMINATOR)) {
+    lastEnd = match.index + match[0].length;
+  }
+  if (lastEnd > 0) return text.substring(0, lastEnd).trimEnd();
+  return trimAtWordBoundaryLocal(text, maxLength);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "revisiongrade",
       "version": "1.0.0",
       "dependencies": {
-        "@base44/sdk": "^0.8.27",
-        "@base44/vite-plugin": "^1.0.6",
         "@hello-pangea/dnd": "^17.0.0",
         "@hookform/resolvers": "^4.1.2",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -341,6 +339,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -406,6 +405,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -449,6 +449,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -500,6 +501,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -509,6 +511,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -542,6 +545,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -805,6 +809,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -819,6 +824,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -837,6 +843,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -844,29 +851,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@base44/sdk": {
-      "version": "0.8.27",
-      "resolved": "https://registry.npmjs.org/@base44/sdk/-/sdk-0.8.27.tgz",
-      "integrity": "sha512-TkCQ6TZb0Fqq48Ig6xc1o+SU9LYg0sgzDHTIE0JiRcAmRkoO7Jm8kVzNEe2Nmh3msP6P8sxs0GFwGfukMUoCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.2",
-        "socket.io-client": "^4.7.5",
-        "uuid": "^13.0.0"
-      }
-    },
-    "node_modules/@base44/vite-plugin": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@base44/vite-plugin/-/vite-plugin-1.0.10.tgz",
-      "integrity": "sha512-YLVIyhQTACuik5tDLgDRZtaCHpV2gND7asx8iXbbWS8k/x5ncxP+6G55kfwgaJyW1TU4qW50GV3+XsPUpRCsvg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/generator": "^7.28.5",
-        "@babel/parser": "^7.28.5",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -6018,12 +6002,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "license": "MIT"
-    },
     "node_modules/@sparticuz/chromium": {
       "version": "143.0.4",
       "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-143.0.4.tgz",
@@ -10000,17 +9978,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -12670,49 +12637,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
-        "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -17553,6 +17477,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -20990,15 +20915,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -22404,34 +22320,6 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socket.io-client": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
-      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1",
-        "engine.io-client": "~6.6.1",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/socks": {
@@ -24410,6 +24298,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
       "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -25463,14 +25352,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
## Summary

Closes the 7 verified copy-integrity defects (A1–A4 + D1–D3) from report `9f05a9ed` plus a new global "no author-facing text ends mid-sentence" invariant, by **extending the existing self-correction / certification / sanity gate architecture** — no new standalone gate. All pass/fail authority stays inside the existing gates (`KICK_MATRIX`, `selfCorrectionPolicy`, `evaluationCertificationGate`, `shortFormFinalSanityCheck`). New logic is factored into pure, idempotent helpers in `lib/text/authorFacingProse.ts` that only transform/inspect strings.

### Defect → fix (all on the evaluation-report / shared path)
- **A1** — Exec-summary prose score mismatch. `detectProseScoreDivergence` (helper) + strengthened `ECG_AUTH_EXEC_SUMMARY_SCORE_MISMATCH` in `evaluationCertificationGate.ts`. **Floor policy honored: never inflates.** Prose > canonical → flagged as inflation; prose < canonical (floor-vs-round 64/68) → still a kick-back, reconciled DOWN only. No displayed/prose score is ever raised.
- **A2** — One-sentence-pitch raw sentinel leak. `detectRawFallbackSentinel` (helper); sentinel treated as *absent* in the certification completeness gate (regenerate/kick-back), and **suppressed to empty** at the two author-facing boundaries (`evaluationReportViewModel.ts`, `shortFormReportDocument.ts`) — never padded, never leaked. Anti-triplication guarantee preserved.
- **A3** — Broken recommendation headline. `recommendationIntegrityGate.ts` `NO_LOWERCASE_OPENING` + fused-field / terminal-punctuation kick-back; `REC_INTEGRITY_LOWERCASE_OPENING` / `REC_INTEGRITY_FUSED_FIELDS` codes wired into `selfCorrectionPolicy` + `KICK_MATRIX`.
- **A4** — Lowercase + duplicated word. `shortFormFinalSanityCheck.ts` `SHORT_FORM_COPY_DEFECT` (BLOCK) + `collapseAdjacentDuplicateWords` (conservative) in `normalizeArtifact.ts`.
- **D1** — `Symptom:After` missing colon space. `ensureSingleSpaceAfterColon` at the TXT label:value join.
- **D2** — Lowercase diagnostic value. `capitalizeFirstAlpha` on diagnostic fields (same helper as A3/A4).
- **D3** — Doubled A/B/C strategy label. `collapseDuplicatedStrategyLabel` + `strategyOptionLabel` canonical accessor in `reviseCardContract.ts` (strips only ACCIDENTAL doubling; intended "A: Recommended" etc. preserved).
- **Global invariant** — `endsMidSentence` / `endsWithDanglingConnective` / `trimAtSentenceBoundary` helpers + `ECG_TEXT_MIDSENTENCE_TERMINATION`, `SHORT_FORM_MIDSENTENCE_TERMINATION`, `HANDOFF_MIDSENTENCE_TERMINATION` codes.

### Renderer touches (flagged)
Only one minimal **functional** renderer touch: `app/api/reports/[jobId]/download/route.ts:477` wraps the TXT label:value join in `ensureSingleSpaceAfterColon` (D1) — the TXT exporter is the only renderer that concatenates label+value into one string; web/PDF/DOCX use separate cells. Idempotent, no aesthetic change. The 5 alternate Revise cockpit variants were intentionally **not** touched (Revise-only, out of scope).

## Testing
- `npx tsc --noEmit`: clean (exit 0).
- `npx jest`: **812 passed / 812 total**, 0 test failures. (4 suites fail to *load* with `Cannot find module` — `phase2c4/d1/d2/d3` — a pre-existing artifact of the 34%-sparse checkout; unrelated to this change.)
- One fixture test per defect using the exact broken strings, plus mid-sentence-invariant and `trimAtSentenceBoundary` unit tests, wired into the existing gate test files (`authorFacingProse.test.ts`, `evaluationCertificationGate.test.ts`, `shortFormFinalSanityCheck.test.ts`, `recommendationIntegrityGate.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)