### PR TITLE
fix(ci): resolve pre-existing TXT blank-line and parity pitch fixture failures

### DIFF
--- a/app/api/reports/[jobId]/download/route.ts
+++ b/app/api/reports/[jobId]/download/route.ts
@@ -1046,7 +1046,11 @@ function renderTxtFromViewModel(vm: EvaluationReportViewModel, jobId = ''): stri
   lines.push('');
   pushWrapped(lines, vm.disclaimer);
 
-  return enforceTxtWidth(lines).join('\n');
+  // Collapse any run of 3+ newlines (consecutive blank lines) to exactly 2.
+  // Individual sections may each push a trailing blank line; when two optional
+  // sections are adjacent or a section body is empty the blanks stack. This
+  // normalisation is presentation-only: content is never removed.
+  return enforceTxtWidth(lines).join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 

--- a/tests/lib/evaluation/reportRenderParity.test.ts
+++ b/tests/lib/evaluation/reportRenderParity.test.ts
@@ -201,6 +201,8 @@ describe('report render parity manifest builder', () => {
         overall_score_0_100: 82,
         verdict: 'revise',
         one_paragraph_summary: 'Measured parity summary appears in every renderer output.',
+        one_sentence_pitch: 'A forensic editor proves every renderer preserves the same story hook.',
+        one_paragraph_pitch: 'A forensic editor validates renderer parity across web, PDF, DOCX, and TXT outputs to prove the canonical evaluation reaches every surface unchanged.',
         top_3_strengths: ['Measured voice strength', 'Clean scene intent', 'Useful premise'],
         top_3_risks: ['Measured pacing risk', 'Thin midpoint pressure', 'Soft closing turn'],
       },


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures on `origin/main` that were blocking PR #1226 (final architecture roadmap). Both failures were confirmed to exist on `origin/main` before any roadmap changes.

## Scope

- `app/api/reports/[jobId]/download/route.ts` — TXT renderer: collapse runs of 3+ consecutive newlines to 2 at the final assembly boundary. Presentation-only; no content removed, no section order changed, no PDF/DOCX/HTML touched.
- `tests/lib/evaluation/reportRenderParity.test.ts` — parity test fixture: add `one_sentence_pitch` and `one_paragraph_pitch` to `overview` so the required parity fields are present in the test result and reach all four renderer surfaces.

## Branch Freshness (Never Behind)

Branch-Behind-Base: 0

## CI/Infra Scope

No CI workflows modified. Fixes two pre-existing test failures only.

## Rollback Plan

Revert commit `a1d52df8`.

## Affected Workflows

Fixes `ci` workflow job that ran `surfaceParityGate.test.ts` and `reportRenderParity.test.ts`.

## Risks & Anomalies

Low. Blank-line normalisation is post-join presentation-only. Fixture change adds the fields the parity contract already requires but the fixture omitted.

## Unauthorized Input Sources

None. Both failures confirmed pre-existing by running exact `origin/main` code with stash verification.

## Internal Process Leakage

None. Changes are confined to TXT presentation boundary and test fixture.

## Input → Action → Output

Input: two confirmed pre-existing test failures on `origin/main`.
Action: normalise TXT trailing blank lines at assembly boundary; supply missing pitch fields in parity fixture.
Output: both tests pass; CI unblocked for PR #1226.

## Public-Safe Quality/Status Metrics

- `surfaceParityGate.test.ts`: 46/46 pass.
- `reportRenderParity.test.ts`: 7/7 pass.
- `git diff --check`: clean.

## Runtime/Pipeline Expansion

None.

## Latency Impact

None.

No-Pipeline-Impact: true

## Follow-up work

- Audit `FIELD_REGISTRY` canonical paths: currently lists `enrichment.one_sentence_pitch` but builder reads from `overview.one_sentence_pitch`. Align in a separate targeted PR.